### PR TITLE
ci: update virtualenv to higher than 20.26.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3765,13 +3765,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.26.3"
+version = "20.28.1"
 description = "Virtual Python Environment builder"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "virtualenv-20.26.3-py3-none-any.whl", hash = "sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589"},
-    {file = "virtualenv-20.26.3.tar.gz", hash = "sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a"},
+    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
+    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
 ]
 
 [package.dependencies]
@@ -3991,4 +3991,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "a626d151f8bc70e15bdbd1501a24760dc1ead740c88966b53b18739777f6e373"
+content-hash = "5908f5dbb5e3246e65059e52b1d0abe979cc467f1b1c41cfba0c0ddc1f7617fd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ lxml = ">=5.1.0"
 htmltools = ">=0.5"
 jupyter = "^1.0.0"
 wrapt = "^1.16.0"
+virtualenv = "^20.26.6"
 
 [tool.poetry.group.dev.dependencies]
 black = "23.3.0"


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description

This PR aims to address a CVE-2024-53899 vulnerability detected on py_maidr.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Vulnerability patch

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description
The Github autoscan of the py_maidr repository identified a CVE-2024-53899 vulnerability with the repository. Upon further investigation, it was revealed that the issue is with **virtualenv** before **20.26.6**  as it allows command injection through the activation scripts for a virtual environment. 

## Related Issues
https://github.com/advisories/GHSA-rqc4-2hc7-8c8v - Github Advisory's account of CVE-2024-53899.

## Changes Made
Virtualenv has been bumped up to 20.28.1.