### PR TITLE
feat: add dodged bar plot support along with an matplotlib example

### DIFF
--- a/example/dodged/matplotlib/example_mpl_dodged.py
+++ b/example/dodged/matplotlib/example_mpl_dodged.py
@@ -1,0 +1,46 @@
+"""
+Dodged Bar Plot Example.
+
+This example demonstrates how to create a dodged (grouped) bar plot with Matplotlib,
+displaying data for different penguin species for two categories: 'Below' and 'Above'
+average body masses.
+
+Example:
+    $ python example_mpl_dodged.py
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import maidr
+
+species: tuple[str, str, str] = (
+    "Adelie\n $\\mu=3700.66g$",
+    "Chinstrap\n $\\mu=3733.09g$",
+    "Gentoo\n $\\mu=5076.02g$",
+)
+weight_counts: dict[str, np.ndarray] = {
+    "Below": np.array([70, 31, 58]),
+    "Above": np.array([82, 37, 66]),
+}
+
+x: np.ndarray = np.arange(len(species))
+total_groups: int = len(weight_counts)
+width: float = 0.35
+
+fig, ax = plt.subplots()
+
+offsets: list[float] = [(-width / 2) + i * width for i in range(total_groups)]
+
+for offset, (category, counts) in zip(offsets, weight_counts.items()):
+    positions = x + offset
+    p = ax.bar(positions, counts, width, label=category)
+
+# Set x-axis labels and title
+ax.set_xticks(x)
+ax.set_xticklabels(species)
+ax.set_title("Dodged Bar Plot: Penguin Weight Counts")
+ax.legend(loc="upper right")
+
+# Show plot using maidr.show
+maidr.show(p)

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from numbers import Number
+from typing import Any, Callable, Dict, Tuple, Union
+
+import numpy as np
 import wrapt
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
@@ -8,12 +12,55 @@ from maidr.core.enum import PlotType
 from maidr.patch.common import common
 
 
-def bar(wrapped, instance, args, kwargs) -> Axes | BarContainer:
+def bar(
+    wrapped: Callable, instance: Any, args: Tuple[Any, ...], kwargs: Dict[str, Any]
+) -> Union[Axes, BarContainer]:
+    """
+    Patch function for bar plots.
+
+    This function patches the bar plotting functions to identify whether the
+    plot should be rendered as a normal, stacked, or dodged bar plot.
+    It uses the 'bottom' keyword to identify stacked bar plots. If 'bottom'
+    is not provided and the x positions (first positional argument) are numeric,
+    then a dodged plot is assumed.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original function to be wrapped.
+    instance : Any
+        The instance of the class where the function is being patched.
+    args : tuple
+        Positional arguments passed to the original function.
+        For a dodged plot, the first argument (x positions) should be numeric.
+    kwargs : dict
+        Keyword arguments passed to the original function.
+
+    Returns
+    -------
+    Union[Axes, BarContainer]
+        The axes or bar container returned by the original function.
+
+    Examples
+    --------
+    >>> # For a dodged (grouped) bar plot, pass numeric x positions:
+    >>> x_positions = np.arange(3)
+    >>> ax.bar(x_positions, heights, width, label='Group')  # Dodged bar plot.
+    """
     plot_type = PlotType.BAR
     if "bottom" in kwargs:
         bottom = kwargs.get("bottom")
         if bottom is not None:
             plot_type = PlotType.STACKED
+    elif args:
+        x = args[0]
+        is_numeric = False
+        if isinstance(x, np.ndarray) and np.issubdtype(x.dtype, np.number):
+            is_numeric = True
+        elif isinstance(x, (list, tuple)) and x and isinstance(x[0], Number):
+            is_numeric = True
+        if is_numeric:
+            plot_type = PlotType.DODGED
 
     return common(plot_type, wrapped, instance, args, kwargs)
 


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
This change adds a numeric check for the x positions in bar plots, allowing automatic detection of dodged (grouped) bar plots when x is numeric. By inspecting whether x is a NumPy array of a numeric dtype (or a numeric Python list/tuple), the code now updates the plot type to PlotType.DODGED. This ensures better handling of grouped bar plots, making it more convenient for users to visualize their data.

closes #135 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
