### PR TITLE
fix: remove iframe in support of iframeless rendering

### DIFF
--- a/docs/_environment
+++ b/docs/_environment
@@ -1,0 +1,1 @@
+IS_QUARTO=True

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -9,10 +9,12 @@ import webbrowser
 from typing import Literal
 
 from htmltools import HTML, HTMLDocument, Tag, tags
+from IPython.display import Javascript, display
 from lxml import etree
 from matplotlib.figure import Figure
 
 from maidr.core.context_manager import HighlightContextManager
+from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.plot import MaidrPlot
 from maidr.util.environment import Environment
 
@@ -42,6 +44,7 @@ class Maidr:
         """Create a new Maidr for the given ``matplotlib.figure.Figure``."""
         self._fig = fig
         self._plots = []
+        self.maidr_id = None
 
     @property
     def fig(self) -> Figure:
@@ -91,6 +94,8 @@ class Maidr:
             Environment.is_interactive_shell() and not Environment.is_notebook()
         ):
             return self._open_plot_in_browser()
+        if Environment.is_notebook():
+            Javascript("Jupyter.keyboard_manager.disable();")
         return html.show(renderer)
 
     def clear(self):
@@ -119,8 +124,11 @@ class Maidr:
             svg = self._get_svg()
         maidr = f"\nlet maidr = {json.dumps(self._flatten_maidr(), indent=2)}\n"
 
+        # In SVG we will replace maidr=id with the unique id.
+        svg = svg.replace('maidr="true"', f'maidr="{self.maidr_id}"')
+
         # Inject plot's svg and MAIDR structure into html tag.
-        return Maidr._inject_plot(svg, maidr)
+        return Maidr._inject_plot(svg, maidr, self.maidr_id)
 
     def _create_html_doc(self) -> HTMLDocument:
         """Create an HTML document from Tag objects."""
@@ -129,6 +137,14 @@ class Maidr:
     def _flatten_maidr(self) -> dict | list[dict]:
         """Return a single plot schema or a list of schemas from the Maidr instance."""
         maidr = [plot.schema for plot in self._plots]
+
+        # Replace the selector having maidr='true' with maidr={self.maidr_id}
+        for plot in maidr:
+            if MaidrKey.SELECTOR in plot:
+                plot[MaidrKey.SELECTOR] = plot[MaidrKey.SELECTOR].replace(
+                    "maidr='true'", f"maidr='{self.maidr_id}'"
+                )
+
         return maidr if len(maidr) != 1 else maidr[0]
 
     def _get_svg(self) -> HTML:
@@ -164,6 +180,7 @@ class Maidr:
 
     def _set_maidr_id(self, maidr_id: str) -> None:
         """Set a unique identifier to each ``MaidrPlot``."""
+        self.maidr_id = maidr_id
         for maidr in self._plots:
             maidr.set_id(maidr_id)
 
@@ -173,77 +190,35 @@ class Maidr:
         return str(uuid.uuid4())
 
     @staticmethod
-    def _inject_plot(plot: HTML, maidr: str) -> Tag:
+    def _inject_plot(plot: HTML, maidr: str, maidr_id) -> Tag:
         """Embed the plot and associated MAIDR scripts into the HTML structure."""
-        base_html = tags.html(
-            tags.head(
-                tags.meta(charset="UTF-8"),
-                tags.title("MAIDR"),
-                tags.link(
-                    rel="stylesheet",
-                    href="https://cdn.jsdelivr.net/npm/maidr/dist/maidr_style.min.css",
-                ),
-                tags.script(
-                    type="text/javascript",
-                    src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.min.js",
-                ),
-            ),
-            tags.body(
-                tags.div(plot),
-            ),
-        )
-
-        def generate_iframe_script(unique_id: str) -> str:
-            resizing_script = f"""
-                function resizeIframe() {{
-                    let iframe = document.getElementById('{unique_id}');
-
-                    if (iframe && iframe.contentWindow && iframe.contentWindow.document) {{
-                        let iframeDocument = iframe.contentWindow.document;
-                        let brailleContainer = iframeDocument.getElementById('braille-input');
-
-                        iframe.style.height = 'auto';
-
-                        let height = iframeDocument.body.scrollHeight;
-                        if (brailleContainer && brailleContainer === iframeDocument.activeElement) {{
-                            height += 100;
-                        }}else{{
-                            height += 50
-                        }}
-
-                        iframe.style.height = (height) + 'px';
-                        iframe.style.width = iframeDocument.body.scrollWidth + 'px';
-                    }}
+        script_check = f"""
+            function initializeMaidr(maidrId) {{
+                if (window.init) {{
+                    window.init(maidrId);
                 }}
-                let iframe = document.getElementById('{unique_id}');
-                resizeIframe();
-                iframe.onload = function() {{
-                    resizeIframe();
-                    iframe.contentWindow.addEventListener('resize', resizeIframe);
-                }};
-                iframe.contentWindow.document.addEventListener('focusin', () => {{
-                    resizeIframe();
+            }}
+
+            if (!document.querySelector('script[src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.min.js"]')) {{
+                var script = document.createElement('script');
+                script.type = 'text/javascript';
+                script.src = 'https://cdn.jsdelivr.net/npm/maidr/dist/maidr.min.js';
+                script.addEventListener('load', function() {{
+                    initializeMaidr("{maidr_id}");
                 }});
-                iframe.contentWindow.document.addEventListener('focusout', () => {{
-                    resizeIframe();
-                }});
-            """
-            return resizing_script
+                document.head.appendChild(script);
+            }} else {{
+                initializeMaidr("{maidr_id}");
+            }}
+        """
 
-        unique_id = "iframe_" + Maidr._unique_id()
-
-        resizing_script = generate_iframe_script(unique_id)
-
-        # Embed the rendering into an iFrame for proper working of JS library.
-        base_html = tags.iframe(
-            id=unique_id,
-            srcdoc=str(base_html.get_html_string()),
-            width="100%",
-            height="100%",
-            scrolling="no",
-            style="background-color: #fff; position: relative; border: none",
-            frameBorder=0,
-            onload=resizing_script,
+        base_html = tags.div(
+            tags.link(
+                rel="stylesheet",
+                href="https://cdn.jsdelivr.net/npm/maidr/dist/maidr_style.min.css",
+            ),
+            tags.script(script_check, type="text/javascript"),
+            tags.div(plot),
         )
 
         return base_html

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -219,8 +219,11 @@ class Maidr:
             tags.div(plot),
         )
 
-        # Render the plot inside an iframe if in a Jupyter notebook Or Google Colab
-        if Environment.is_notebook():
+        is_quarto = os.getenv("IS_QUARTO") == "True"
+
+        # Render the plot inside an iframe if in a Jupyter notebook, Google Colab
+        # or VSCode notebook. No need for iframe if this is a Quarto document.
+        if Environment.is_notebook() and not is_quarto:
             unique_id = "iframe_" + Maidr._unique_id()
 
             def generate_iframe_script(unique_id: str) -> str:

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -221,7 +221,6 @@ class Maidr:
 
         # Render the plot inside an iframe if in a Jupyter notebook Or Google Colab
         if Environment.is_notebook():
-
             unique_id = "iframe_" + Maidr._unique_id()
 
             def generate_iframe_script(unique_id: str) -> str:

--- a/maidr/util/environment.py
+++ b/maidr/util/environment.py
@@ -30,6 +30,17 @@ class Environment:
             return False
 
     @staticmethod
+    def is_vscode_notebook() -> bool:
+        """Return True if the environment is a VSCode notebook."""
+        try:
+            if "VSCODE_PID" in os.environ or "VSCODE_JUPYTER" in os.environ:
+                return True
+            else:
+                return False
+        except ImportError:
+            return False
+
+    @staticmethod
     def get_renderer() -> str:
         """Return renderer which can be ipython or browser."""
         try:


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
This pull request introduces an iframe-free solution. However, it cannot be fully implemented yet because keybindings in Jupyter Notebook, Google Colab, and VSCode's IPython Notebook still need to be fixed. Once we resolve the keybindings issue, we can remove the conditional check that currently renders maidr inside an iframe, and the solution will function seamlessly. For now, plots on these platforms will continue to be rendered within an iframe.

NOTE: It's very crucial to first merge the maidr.js PR before merging this PR
https://github.com/xability/maidr/pull/637

addesses #108 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes
1. Added maidr_id attribute to handle unique identifiers for Maidr instances.
2. Updated _inject_plot method to include maidr_id in the SVG.
3. Added a new method is_vscode_notebook to check if the environment is a VSCode notebook, this will be used for future purposes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
