### PR TITLE
fix: update initialization method to use window.init on DOMContentLoaded

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -202,11 +202,13 @@ class Maidr:
                 script.type = 'text/javascript';
                 script.src = 'https://cdn.jsdelivr.net/npm/maidr/dist/maidr.min.js';
                 script.addEventListener('load', function() {{
-                    initializeMaidr("{maidr_id}");
+                    window.init("{maidr_id}");
                 }});
                 document.head.appendChild(script);
             }} else {{
-                initializeMaidr("{maidr_id}");
+                document.addEventListener('DOMContentLoaded', function (e) {{
+                    window.init("{maidr_id}");
+                }});
             }}
         """
 


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
This PR fixes the issue where only the first plot had the aria-label maidr instruction on how to activate.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules