### PR TITLE
fix: address pyshiny initialization in maidr

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -206,9 +206,7 @@ class Maidr:
                 }});
                 document.head.appendChild(script);
             }} else {{
-                document.addEventListener('DOMContentLoaded', function (e) {{
-                    window.init("{maidr_id}");
-                }});
+                window.init("{maidr_id}");
             }}
         """
 


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Recent py-maidr had an issue with Shiny. If you change colors or distribnution types of histograms in this example file, nothing is displayed. Only the initial plot is shown. This was fix in this PR by removing the DOMContentLoaded event wrapper around the window.init() call.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update