### PR TITLE
fix: address type hints for _extract_line_data method in MultiLinePlot

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -1,3 +1,5 @@
+from typing import List, Union
+
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 
@@ -59,7 +61,9 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
 
         return data
 
-    def _extract_line_data(self, plot: list[Line2D] | None) -> list[dict] | None:
+    def _extract_line_data(
+        self, plot: Union[List[Line2D], None]
+    ) -> Union[List[dict], None]:
         """
         Extract data from multiple line objects.
 


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules