### PR TITLE
fix: replace caching for Poetry dependencies in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
+        with:
+            virtualenvs-create: true
+            virtualenvs-in-project: true
+            installer-parallel: true
+
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         id: setup-python
@@ -44,12 +52,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: poetry
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python-version }}
+          cache: poetry
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
@@ -50,15 +51,7 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Load cached venv
-        uses: actions/cache@v4
-        id: cached-poetry-dependencies
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           poetry install
           python -m pip install pytest-github-actions-annotate-failures

--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -42,7 +42,7 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
     def __init__(self, ax: Axes, **kwargs):
         super().__init__(ax, PlotType.LINE)
 
-    def _get_selector(self) -> str | list[str]:
+    def _get_selector(self) -> Union[str, List[str]]:
         if Environment.get_engine() == "js":
             return "g[maidr='true'] > path"
         return ["g[maidr='true'] > path"]


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
Currently, when running the PyMaidr CI it fails with this error - _"The virtual environment found in /home/runner/work/py-maidr/py-maidr/.venv seems to be broken."_ This happened because wrong .venv is being restored when restoring from cache. To fix this we can use setup-python’s built‑in cache stores which is immune to interpreter mismatches and is officially recommended by GitHub.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules