### PR TITLE
fix: remove redundant _child0 label as a fill parameter for line plot

### DIFF
--- a/example/multiline/matplotlib/example_mpl_multiline.py
+++ b/example/multiline/matplotlib/example_mpl_multiline.py
@@ -3,8 +3,6 @@ import numpy as np
 
 import maidr
 
-# import maidr
-
 """
 Creates a multiline plot showing basic data trends.
 

--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -90,6 +90,8 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
                 {
                     MaidrKey.X: float(x),
                     MaidrKey.Y: float(y),
+                    # Replace labels starting with '_child' with an empty string to exclude
+                    # internal or non-relevant labels from being used as identifiers.
                     MaidrKey.FILL: (label if not label.startswith("_child") else ""),
                 }
                 for x, y in line.get_xydata()  # type: ignore

--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -7,7 +7,6 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.exception.extraction_error import ExtractionError
-from maidr.util.environment import Environment
 from maidr.util.mixin.extractor_mixin import LineExtractorMixin
 
 
@@ -85,11 +84,13 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
             self._elements.append(line)
 
             # Extract data from this line
+
+            label: str = line.get_label()  # type: ignore
             line_data = [
                 {
                     MaidrKey.X: float(x),
                     MaidrKey.Y: float(y),
-                    MaidrKey.FILL: line.get_label(),
+                    MaidrKey.FILL: (label if not label.startswith("_child") else ""),
                 }
                 for x, y in line.get_xydata()  # type: ignore
             ]


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
This PR fixes the issue where a redundant _child0 is added as a fill parameter to the line plots when using maidr-ts. To fix this a check if added to ensure this is not added if the label is not provided.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules