### PR TITLE
fix(boxplot): enhance outlier handling by separting outliers

### DIFF
--- a/example/box/matplotlib/example_mpl_box.py
+++ b/example/box/matplotlib/example_mpl_box.py
@@ -5,16 +5,16 @@ import maidr
 
 # Generating random data for three different groups
 data_group1 = np.random.normal(100, 10, 200)
-# Add high outliers to data_group1
-data_group1 = np.append(data_group1, [150, 160, 155])
+# Add outliers to data_group1
+data_group1 = np.append(data_group1, [150, 160, 50, 40])
 
 data_group2 = np.random.normal(90, 20, 200)
-# Add low outliers to data_group2
-data_group2 = np.append(data_group2, [10, 5, 15])
+# Add outliers to data_group2
+data_group2 = np.append(data_group2, [180, 190, 10, 20])
 
 data_group3 = np.random.normal(80, 30, 200)
-# Add both high and low outliers to data_group3
-data_group3 = np.append(data_group3, [180, 190, 0, -10])
+# Add outliers to data_group3
+data_group3 = np.append(data_group3, [200, 210, -10, -20])
 
 # Combine these different datasets into a list
 data_to_plot = [data_group1, data_group2, data_group3]
@@ -28,6 +28,16 @@ def boxplot(is_vert: bool):
     colors = ["lightblue", "lightgreen", "tan"]
     for patch, color in zip(bp["boxes"], colors):
         patch.set_facecolor(color)
+
+    # Color outliers
+    outlier_color = "red"
+    for flier in bp["fliers"]:
+        flier.set(
+            marker="o",
+            markerfacecolor=outlier_color,
+            markeredgecolor=outlier_color,
+            alpha=0.5,
+        )
 
     if is_vert:
         plt.xticks(ticks=[1, 2, 3], labels=["Group 1", "Group 2", "Group 3"])

--- a/example/box/matplotlib/example_mpl_box.py
+++ b/example/box/matplotlib/example_mpl_box.py
@@ -5,8 +5,16 @@ import maidr
 
 # Generating random data for three different groups
 data_group1 = np.random.normal(100, 10, 200)
+# Add high outliers to data_group1
+data_group1 = np.append(data_group1, [150, 160, 155])
+
 data_group2 = np.random.normal(90, 20, 200)
+# Add low outliers to data_group2
+data_group2 = np.append(data_group2, [10, 5, 15])
+
 data_group3 = np.random.normal(80, 30, 200)
+# Add both high and low outliers to data_group3
+data_group3 = np.append(data_group3, [180, 190, 0, -10])
 
 # Combine these different datasets into a list
 data_to_plot = [data_group1, data_group2, data_group3]

--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -204,10 +204,10 @@ class BoxPlot(
                     MaidrKey.LOWER_OUTLIER.value: [
                         f"g[id='{outlier}'] > g > :nth-child(-n+{lower_outliers_count} of use:not([visibility='hidden']))"
                     ],
-                    MaidrKey.MIN.value: "g[id=" + min + "] > path",
-                    MaidrKey.MAX.value: "g[id=" + max + "] > path",
-                    MaidrKey.Q2.value: "g[id=" + median + "] > path",
-                    MaidrKey.IQ.value: "g[id=" + box + "] > path",
+                    MaidrKey.MIN.value: f"g[id='{min}'] > path",
+                    MaidrKey.MAX.value: f"g[id='{max}'] > path",
+                    MaidrKey.Q2.value: f"g[id='{median}'] > path",
+                    MaidrKey.IQ.value: f"g[id='{box}'] > path",
                     MaidrKey.UPPER_OUTLIER.value: [
                         f"g[id='{outlier}'] > g > :nth-child(n+{lower_outliers_count + 1} of use:not([visibility='hidden']))"
                     ],

--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -178,19 +178,40 @@ class BoxPlot(
             "boxes": [],
             "outliers": [],
         }
+        self.lower_outliers_count = []
 
     def _get_selector(self) -> list[dict]:
         mins, maxs, medians, boxes, outliers = self.elements_map.values()
         selector = []
-        for min, max, median, box, outlier in zip(mins, maxs, medians, boxes, outliers):
+
+        for (
+            min,
+            max,
+            median,
+            box,
+            outlier,
+            lower_outliers_count,
+        ) in zip(
+            mins,
+            maxs,
+            medians,
+            boxes,
+            outliers,
+            self.lower_outliers_count,
+        ):
             selector.append(
                 {
-                    MaidrKey.LOWER_OUTLIER.value: ["g[id=" + outlier + "] > g > use"],
+                    # MaidrKey.LOWER_OUTLIER.value: ["g[id=" + outlier + "] > g > use"],
+                    MaidrKey.LOWER_OUTLIER.value: [
+                        f"g[id='{outlier}'] > g > :nth-child(-n+{lower_outliers_count} of use:not([visibility='hidden']))"
+                    ],
                     MaidrKey.MIN.value: "g[id=" + min + "] > path",
                     MaidrKey.MAX.value: "g[id=" + max + "] > path",
                     MaidrKey.Q2.value: "g[id=" + median + "] > path",
                     MaidrKey.IQ.value: "g[id=" + box + "] > path",
-                    MaidrKey.UPPER_OUTLIER.value: ["g[id=" + outlier + "] > g > use"],
+                    MaidrKey.UPPER_OUTLIER.value: [
+                        f"g[id='{outlier}'] > g > :nth-child(n+{lower_outliers_count + 1} of use:not([visibility='hidden']))"
+                    ],
                 }
             )
         return selector if self._orientation == "vert" else list(reversed(selector))
@@ -216,6 +237,9 @@ class BoxPlot(
         caps = self._bxp_extractor.extract_caps(bxp_stats["caps"])
         medians = self._bxp_extractor.extract_medians(bxp_stats["medians"])
         outliers = self._bxp_extractor.extract_outliers(bxp_stats["fliers"], caps)
+
+        for outlier in outliers:
+            self.lower_outliers_count.append(len(outlier[MaidrKey.LOWER_OUTLIER.value]))
 
         caps_elements = self._bxp_elements_extractor.extract_caps(bxp_stats["caps"])
         bxp_maidr = []

--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -201,7 +201,6 @@ class BoxPlot(
         ):
             selector.append(
                 {
-                    # MaidrKey.LOWER_OUTLIER.value: ["g[id=" + outlier + "] > g > use"],
                     MaidrKey.LOWER_OUTLIER.value: [
                         f"g[id='{outlier}'] > g > :nth-child(-n+{lower_outliers_count} of use:not([visibility='hidden']))"
                     ],


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
This PR fixes the boxplot highlight issue where outliers (upper and lower) were highlight together instead of being highlighted separately. This pull request introduces a more precise method for selecting lower and upper outlier elements within our SVG visualizations. Previously, both lower and upper outliers shared a common, less specific selector. This change differentiates them based on their order and visibility within a shared outlier group, leveraging modern CSS selector capabilities.

## Motivation
The primary motivation is to enable more accurate and distinct identification and styling of lower versus upper outliers, which was not directly possible with the previous undifferentiated selector. This change assumes that all outlier points are grouped under a common SVG group element (identified by the outlier variable), and within this group, the first N visible outlier elements are lower outliers, while the subsequent visible elements are upper outliers.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules