### PR TITLE
fix: address iframe tag issue in `save_html()`

### DIFF
--- a/maidr/api.py
+++ b/maidr/api.py
@@ -40,7 +40,7 @@ def save_html(
     if isinstance(ax, list):
         for axes in ax:
             maidr = FigureManager.get_maidr(axes.get_figure())
-            htmls.append(maidr.render())
+            htmls.append(maidr._create_html_tag(use_iframe=False))
         htmls[-1].save_html(file, libdir=lib_dir, include_version=include_version)
         return htmls[-1]
     else:

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -40,7 +40,7 @@ def save_html(
     if isinstance(ax, list):
         for axes in ax:
             maidr = FigureManager.get_maidr(axes.get_figure())
-            htmls.append(maidr._create_html_tag(use_iframe=False))
+            htmls.append(maidr._create_html_doc(use_iframe=False))
         htmls[-1].save_html(file, libdir=lib_dir, include_version=include_version)
         return htmls[-1]
     else:

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -41,8 +41,9 @@ def save_html(
         for axes in ax:
             maidr = FigureManager.get_maidr(axes.get_figure())
             htmls.append(maidr._create_html_doc(use_iframe=False))
-        htmls[-1].save_html(file, libdir=lib_dir, include_version=include_version)
-        return htmls[-1]
+        return htmls[-1].save_html(
+            file, libdir=lib_dir, include_version=include_version
+        )
     else:
         maidr = FigureManager.get_maidr(ax.get_figure())
         return maidr.save_html(file, lib_dir=lib_dir, include_version=include_version)


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


## Related Issues
Closes #190 

## Changes Made

Address an issue where iframe is used for maidr.show rendering when saved in IPython notebooks

Core Changes (maidr/core/maidr.py)
1. Added use_iframe parameter to _inject_plot() method (default: True)
2. Modified _create_html_tag() and _create_html_doc() to accept use_iframe parameter
3. Updated save_html() to use use_iframe=False (always direct HTML)
4. Updated show() and render() to use use_iframe=True (maintains iframe for display)
