### PR TITLE
fix: address multiline plot highlight

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -65,7 +65,7 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
 
         return selectors
 
-    def _extract_plot_data(self) -> list:
+    def _extract_plot_data(self) -> Union[List[List[dict]], None]:
         plot = self.extract_lines(self.ax)
         data = self._extract_line_data(plot)
 

--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -66,24 +66,16 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
         return selectors
 
     def _extract_plot_data(self) -> Union[List[List[dict]], None]:
-        plot = self.extract_lines(self.ax)
-        data = self._extract_line_data(plot)
+        data = self._extract_line_data()
 
         if data is None:
-            raise ExtractionError(self.type, plot)
+            raise ExtractionError(self.type, None)
 
         return data
 
-    def _extract_line_data(
-        self, plot: Union[List[Line2D], None]
-    ) -> Union[List[List[dict]], None]:
+    def _extract_line_data(self) -> Union[List[List[dict]], None]:
         """
         Extract data from all line objects and return as separate arrays.
-
-        Parameters
-        ----------
-        plot : list[Line2D] | None
-            List of Line2D objects to extract data from.
 
         Returns
         -------
@@ -91,11 +83,11 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
             List of lists, where each inner list contains dictionaries with x,y coordinates
             and line identifiers for one line, or None if the plot data is invalid.
         """
-        if plot is None or len(plot) == 0:
+        all_lines = self.ax.get_lines()
+        if not all_lines:
             return None
 
         all_lines_data = []
-        all_lines = self.ax.get_lines()
 
         for line in all_lines:
             xydata = line.get_xydata()

--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -8,6 +8,7 @@ from maidr.core.enum.plot_type import PlotType
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.exception.extraction_error import ExtractionError
 from maidr.util.mixin.extractor_mixin import LineExtractorMixin
+import uuid
 
 
 class MultiLinePlot(MaidrPlot, LineExtractorMixin):
@@ -42,9 +43,29 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
         super().__init__(ax, PlotType.LINE)
 
     def _get_selector(self) -> Union[str, List[str]]:
-        return ["g[maidr='true'] > path"]
+        # Return selectors for all lines that have data
+        all_lines = self.ax.get_lines()
+        if not all_lines:
+            return ["g[maidr='true'] > path"]
 
-    def _extract_plot_data(self) -> list[dict]:
+        selectors = []
+        for line in all_lines:
+            # Only create selectors for lines that have data (same logic as _extract_line_data)
+            xydata = line.get_xydata()
+            if xydata is None or not xydata.size:  # type: ignore
+                continue
+            gid = line.get_gid()
+            if gid:
+                selectors.append(f"g[id='{gid}'] path")
+            else:
+                selectors.append("g[maidr='true'] > path")
+
+        if not selectors:
+            return ["g[maidr='true'] > path"]
+
+        return selectors
+
+    def _extract_plot_data(self) -> list:
         plot = self.extract_lines(self.ax)
         data = self._extract_line_data(plot)
 
@@ -55,9 +76,9 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
 
     def _extract_line_data(
         self, plot: Union[List[Line2D], None]
-    ) -> Union[List[dict], None]:
+    ) -> Union[List[List[dict]], None]:
         """
-        Extract data from multiple line objects.
+        Extract data from all line objects and return as separate arrays.
 
         Parameters
         ----------
@@ -66,38 +87,39 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
 
         Returns
         -------
-        list[dict] | None
-            List of dictionaries containing x,y coordinates and line identifiers,
-            or None if the plot data is invalid.
+        list[list[dict]] | None
+            List of lists, where each inner list contains dictionaries with x,y coordinates
+            and line identifiers for one line, or None if the plot data is invalid.
         """
         if plot is None or len(plot) == 0:
             return None
 
-        all_line_data = []
+        all_lines_data = []
+        all_lines = self.ax.get_lines()
 
-        # Process each line in the plot
-        for i, line in enumerate(plot):
-            if line.get_xydata() is None:
+        for line in all_lines:
+            xydata = line.get_xydata()
+            if xydata is None or not xydata.size:  # type: ignore
                 continue
 
-            # Tag the element for highlighting
             self._elements.append(line)
 
-            # Extract data from this line
+            # Assign unique GID to each line if not already set
+            if line.get_gid() is None:
+                unique_gid = f"maidr-{uuid.uuid4()}"
+                line.set_gid(unique_gid)
 
             label: str = line.get_label()  # type: ignore
             line_data = [
                 {
                     MaidrKey.X: float(x),
                     MaidrKey.Y: float(y),
-                    # Replace labels starting with '_child'
-                    # with an empty string to exclude
-                    # internal or non-relevant labels from being used as identifiers.
                     MaidrKey.FILL: (label if not label.startswith("_child") else ""),
                 }
                 for x, y in line.get_xydata()  # type: ignore
             ]
-            if len(line_data) > 0:
-                all_line_data.append(line_data)
 
-        return all_line_data if all_line_data else None
+            if line_data:
+                all_lines_data.append(line_data)
+
+        return all_lines_data if all_lines_data else None

--- a/maidr/patch/lineplot.py
+++ b/maidr/patch/lineplot.py
@@ -7,29 +7,39 @@ from matplotlib.lines import Line2D
 from maidr.core.enum import PlotType
 from maidr.patch.common import common
 from maidr.core.enum.smooth_keywords import SMOOTH_KEYWORDS
+from maidr.core.context_manager import ContextManager
+from maidr.core.figure_manager import FigureManager
 
 
 def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
     """
-    Wrapper function for line plotting functions in matplotlib and seaborn.
-
-    Parameters
-    ----------
-    wrapped : callable
-        The wrapped function (plot or lineplot)
-    instance : object
-        The object to which the wrapped function belongs
-    args : tuple
-        Positional arguments passed to the wrapped function
-    kwargs : dict
-        Keyword arguments passed to the wrapped function
-
-    Returns
-    -------
-    Axes | list[Line2D]
-        The result of the wrapped function after processing
+    Wrapper for line plotting functions that creates a single MAIDR plot per axes to handle
+    multiline plots (matplotlib) and single-call plots (seaborn) correctly by preventing
+    multiple MAIDR layers and using internal context to avoid cyclic processing.
     """
-    return common(PlotType.LINE, wrapped, instance, args, kwargs)
+    # Don't proceed if the call is made internally by the patched function.
+    if ContextManager.is_internal_context():
+        return wrapped(*args, **kwargs)
+
+    # Set the internal context to avoid cyclic processing.
+    with ContextManager.set_internal_context():
+        # Patch the plotting function.
+        plot = wrapped(*args, **kwargs)
+
+    # Get the axes from the plot result (works for both matplotlib and seaborn)
+    ax = FigureManager.get_axes(plot)
+    if ax is None:
+        # If we can't get axes from plot, try from instance
+        ax = instance if isinstance(instance, Axes) else getattr(instance, "axes", None)
+
+    # Check if a MAIDR plot already exists for this axes
+    if ax is not None and not hasattr(ax, "_maidr_plot_created"):
+        # Create MAIDR plot only once for this axes using common()
+        common(PlotType.LINE, lambda *a, **k: plot, instance, args, kwargs)
+        # Mark that a MAIDR plot has been created for this axes
+        setattr(ax, "_maidr_plot_created", True)
+
+    return plot
 
 
 # Patch matplotlib function.


### PR DESCRIPTION

## Description

Issue:

The multiline plot functionality had a data format mismatch between the backend and frontend:
Backend Output: Multiple MAIDR layers (one per line) with individual data arrays
Frontend Expectation: Single layer with multiple data arrays (one per line)

The patch was creating separate MAIDR plots for each plt.plot() call, resulting in:
1. Multiple layers in the output JSON
2. Each layer containing all lines' data and frontend unable to process the nested structure correctly

Solution

1. Modified the lineplot patch to create one MAIDR plot per axes instead of per line call:
2. Added axes-level tracking: Used _maidr_plot_created flag to prevent multiple MAIDR plots
3. Updated data extraction: Modified MultiLinePlot to extract all lines as separate arrays within a single layer
4. Fixed selector generation: Ensured unique GIDs for each line element to enable individual highlighting

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


## Changes Made
<!-- Describe the specific changes made in this pull request. -->

maidr/patch/lineplot.py

Added axes-level tracking: Used _maidr_plot_created flag to prevent multiple MAIDR plots per axes

maidr/core/plot/lineplot.py

Fixed data extraction: Modified _extract_line_data() to return all lines as separate arrays within single layer