### PR TITLE
fix: address reg plot multi-line detection

### DIFF
--- a/maidr/core/enum/smooth_keywords.py
+++ b/maidr/core/enum/smooth_keywords.py
@@ -2,8 +2,11 @@
 SMOOTH_KEYWORDS = [
     "smooth",
     "lowess",
+    "loess",
     "regression",
     "linear regression",
+    "linear fit",
+    "fit",
     "kde",
     "density",
     "gaussian",

--- a/maidr/util/regression_line_utils.py
+++ b/maidr/util/regression_line_utils.py
@@ -1,5 +1,6 @@
 from matplotlib.lines import Line2D
 import numpy as np
+from maidr.core.enum.smooth_keywords import SMOOTH_KEYWORDS
 
 
 def find_regression_line(axes):
@@ -17,3 +18,29 @@ def find_regression_line(axes):
         ),
         None,
     )
+
+
+def find_smooth_lines_by_label(axes):
+    """
+    Helper to find all smooth/regression lines (Line2D) in the given axes by checking their labels.
+
+    Parameters
+    ----------
+    axes : matplotlib.axes.Axes
+        The matplotlib axes object to search for smooth lines.
+
+    Returns
+    -------
+    list
+        List of Line2D objects that have labels matching smooth keywords.
+    """
+    smooth_lines = []
+    for line in axes.get_lines():
+        if isinstance(line, Line2D):
+            label = line.get_label() or ""
+            label_str = str(label)
+            if any(key in label_str.lower() for key in SMOOTH_KEYWORDS):
+                smooth_lines.append(line)
+            elif label_str.startswith("_child"):
+                smooth_lines.append(line)
+    return smooth_lines

--- a/maidr/util/regression_line_utils.py
+++ b/maidr/util/regression_line_utils.py
@@ -1,9 +1,11 @@
 from matplotlib.lines import Line2D
+from matplotlib.axes import Axes
 import numpy as np
+from typing import List
 from maidr.core.enum.smooth_keywords import SMOOTH_KEYWORDS
 
 
-def find_regression_line(axes):
+def find_regression_line(axes: Axes) -> Line2D | None:
     """
     Helper to find the regression line (Line2D) in the given axes.
     """
@@ -20,9 +22,12 @@ def find_regression_line(axes):
     )
 
 
-def find_smooth_lines_by_label(axes):
+def find_smooth_lines_by_label(axes: Axes) -> List[Line2D]:
     """
     Helper to find all smooth/regression lines (Line2D) in the given axes by checking their labels.
+
+    This function detects smooth lines by examining their labels for smooth-related keywords
+    or generic '_child' labels that are commonly created by seaborn's regplot function.
 
     Parameters
     ----------
@@ -31,16 +36,34 @@ def find_smooth_lines_by_label(axes):
 
     Returns
     -------
-    list
-        List of Line2D objects that have labels matching smooth keywords.
+    List[Line2D]
+        List of Line2D objects that have labels matching smooth keywords or generic '_child' labels.
+
+    Examples
+    --------
+    >>> import matplotlib.pyplot as plt
+    >>> import seaborn as sns
+    >>>
+    >>> fig, ax = plt.subplots()
+    >>> # Create a regplot with smooth line
+    >>> sns.regplot(x=[1, 2, 3], y=[1, 2, 3], ax=ax, lowess=True)
+    >>>
+    >>> # Find smooth lines
+    >>> smooth_lines = find_smooth_lines_by_label(ax)
+    >>> print(f"Found {len(smooth_lines)} smooth lines")
     """
     smooth_lines = []
     for line in axes.get_lines():
         if isinstance(line, Line2D):
             label = line.get_label() or ""
             label_str = str(label)
+
+            # Check if label matches smooth keywords
             if any(key in label_str.lower() for key in SMOOTH_KEYWORDS):
                 smooth_lines.append(line)
+            # Also check for seaborn regplot lines with generic labels (like '_child0', '_child1')
             elif label_str.startswith("_child"):
+                # Lines with _child labels are likely smooth lines from seaborn regplot
                 smooth_lines.append(line)
+
     return smooth_lines

--- a/maidr/util/regression_line_utils.py
+++ b/maidr/util/regression_line_utils.py
@@ -1,11 +1,11 @@
 from matplotlib.lines import Line2D
 from matplotlib.axes import Axes
 import numpy as np
-from typing import List
+from typing import List, Union
 from maidr.core.enum.smooth_keywords import SMOOTH_KEYWORDS
 
 
-def find_regression_line(axes: Axes) -> Line2D | None:
+def find_regression_line(axes: Axes) -> Union[Line2D, None]:
     """
     Helper to find the regression line (Line2D) in the given axes.
     """


### PR DESCRIPTION
## Description

Problem: When using sns.regplot with multiple smooth lines (e.g., linear regression + LOWESS), only one smooth line was being detected and registered as a MAIDR layer.

Solution:

Enhanced find_smooth_lines_by_label() utility function to detect smooth lines with generic _child labels (created by seaborn's regplot)
Modified regplot patch to process all detected smooth lines and register each as a separate MAIDR layer

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Changes Made

Changes:

maidr/patch/regplot.py: Refactored to use utility function and handle multiple smooth lines

