### PR TITLE
fix: address bull and bear logic gap

### DIFF
--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -39,6 +39,7 @@ class CandlestickPlot(MaidrPlot):
         self._maidr_wick_collection = kwargs.get("_maidr_wick_collection", None)
         self._maidr_body_collection = kwargs.get("_maidr_body_collection", None)
         self._maidr_date_nums = kwargs.get("_maidr_date_nums", None)
+        self._maidr_original_data = kwargs.get("_maidr_original_data", None)  # Store original data
 
         # Store the GID for proper selector generation
         self._maidr_gid = None
@@ -62,16 +63,16 @@ class CandlestickPlot(MaidrPlot):
             self._elements = [body_collection, wick_collection]
 
             # Use the utility class to extract data
-            return MplfinanceDataExtractor.extract_candlestick_data(
-                body_collection, wick_collection, self._maidr_date_nums
+            data = MplfinanceDataExtractor.extract_candlestick_data(
+                body_collection, wick_collection, self._maidr_date_nums, self._maidr_original_data
             )
+            return data
 
         # Fallback to original detection method
         if not self.axes:
             return []
 
         ax_ohlc = self.axes[0]
-        candles = []
 
         # Look for Rectangle patches (original_flavor candlestick)
         body_rectangles = []
@@ -93,9 +94,10 @@ class CandlestickPlot(MaidrPlot):
                     rect.set_gid(self._maidr_gid)
 
             # Use the utility class to extract data
-            return MplfinanceDataExtractor.extract_rectangle_candlestick_data(
-                body_rectangles, self._maidr_date_nums
+            data = MplfinanceDataExtractor.extract_rectangle_candlestick_data(
+                body_rectangles, self._maidr_date_nums, self._maidr_original_data
             )
+            return data
 
         return []
 
@@ -131,11 +133,14 @@ class CandlestickPlot(MaidrPlot):
         """Initialize the MAIDR schema dictionary with basic plot information."""
         title = "Candlestick Chart"
 
+        # Extract the plot data
+        plot_data = self._extract_plot_data()
+
         maidr_schema = {
             MaidrKey.TYPE: self.type,
             MaidrKey.TITLE: title,
             MaidrKey.AXES: self._extract_axes_data(),
-            MaidrKey.DATA: self._extract_plot_data(),
+            MaidrKey.DATA: plot_data,
         }
 
         # Include selector only if the plot supports highlighting.

--- a/maidr/patch/mplfinance.py
+++ b/maidr/patch/mplfinance.py
@@ -32,7 +32,7 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
     if not (isinstance(result, tuple) and len(result) >= 2):
         return result if original_returnfig else None
 
-    fig, axes = result[0], result[1]
+    _, axes = result[0], result[1]
     ax_list = axes if isinstance(axes, list) else [axes]
 
     # Enhanced axis identification using content-based detection
@@ -92,6 +92,7 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
                 _maidr_wick_collection=wick_collection,
                 _maidr_body_collection=body_collection,
                 _maidr_date_nums=date_nums,
+                _maidr_original_data=data,
             )
             common(
                 PlotType.CANDLESTICK,

--- a/maidr/util/mplfinance_utils.py
+++ b/maidr/util/mplfinance_utils.py
@@ -62,6 +62,7 @@ class MplfinanceDataExtractor:
         body_collection: Any,
         wick_collection: Any,
         date_nums: Optional[List[float]] = None,
+        original_data: Optional[Any] = None,
     ) -> List[dict]:
         """
         Extract candlestick data from mplfinance collections.
@@ -74,6 +75,8 @@ class MplfinanceDataExtractor:
             LineCollection containing candlestick wicks
         date_nums : Optional[List[float]], default=None
             List of matplotlib date numbers corresponding to the candles
+        original_data : Optional[Any], default=None
+            Original DataFrame with OHLC data for accurate bull/bear classification
 
         Returns
         -------
@@ -85,7 +88,6 @@ class MplfinanceDataExtractor:
 
         candles = []
         paths = body_collection.get_paths()
-        face_colors = body_collection.get_facecolor()
 
         for i, path in enumerate(paths):
             if len(path.vertices) >= 4:
@@ -109,8 +111,10 @@ class MplfinanceDataExtractor:
                         x_center
                     )
 
-                # Determine if this is an up or down candle based on color
-                is_up = MplfinanceDataExtractor._is_up_candle(face_colors, i)
+                # Determine if this is an up or down candle using original data
+                is_up = MplfinanceDataExtractor._determine_bull_bear_from_data(
+                    original_data, i, date_str
+                )
 
                 # Extract OHLC values
                 (
@@ -132,13 +136,16 @@ class MplfinanceDataExtractor:
                     "close": round(close_val, 2),
                     "volume": 0,  # Volume is handled separately
                 }
+
                 candles.append(candle_data)
 
         return candles
 
     @staticmethod
     def extract_rectangle_candlestick_data(
-        body_rectangles: List[Rectangle], date_nums: Optional[List[float]] = None
+        body_rectangles: List[Rectangle],
+        date_nums: Optional[List[float]] = None,
+        original_data: Optional[Any] = None,
     ) -> List[dict]:
         """
         Extract candlestick data from Rectangle patches (original_flavor).
@@ -149,6 +156,8 @@ class MplfinanceDataExtractor:
             List of Rectangle patches representing candlestick bodies
         date_nums : Optional[List[float]], default=None
             List of matplotlib date numbers corresponding to the candles
+        original_data : Optional[Any], default=None
+            Original DataFrame with OHLC data for accurate bull/bear classification
 
         Returns
         -------
@@ -180,10 +189,11 @@ class MplfinanceDataExtractor:
 
             y_bottom = rect.get_y()
             height = rect.get_height()
-            face_color = rect.get_facecolor()
 
-            # Determine if this is an up or down candle based on color
-            is_up_candle = MplfinanceDataExtractor._is_up_candle_from_color(face_color)
+            # Determine if this is an up or down candle using original data
+            is_up_candle = MplfinanceDataExtractor._determine_bull_bear_from_data(
+                original_data, i, date_str
+            )
 
             # Extract OHLC values from rectangle
             (
@@ -211,9 +221,60 @@ class MplfinanceDataExtractor:
                 "close": round(close_price, 2),
                 "volume": 0,
             }
+
             candles.append(candle_data)
 
         return candles
+
+    @staticmethod
+    def _determine_bull_bear_from_data(original_data: Any, index: int, date_str: str) -> bool:
+        """
+        Determine if a candle is bullish (up) or bearish (down) using original OHLC data.
+
+        This is the most robust method as it uses the actual data rather than colors.
+
+        Parameters
+        ----------
+        original_data : Any
+            Original DataFrame with OHLC data
+        index : int
+            Index of the candle
+        date_str : str
+            Date string for the candle
+
+        Returns
+        -------
+        bool
+            True if bullish (close > open), False if bearish (close < open)
+        """
+        # Default to bullish if no data available
+        if original_data is None:
+            return True
+
+        try:
+            # Try to access the original data
+            if hasattr(original_data, 'iloc'):
+                # It's a pandas DataFrame/Series
+                if index < len(original_data):
+                    row = original_data.iloc[index]
+                    if 'Close' in row and 'Open' in row:
+                        is_bullish = row['Close'] > row['Open']
+                        return is_bullish
+
+            elif hasattr(original_data, '__getitem__'):
+                # It's a dictionary or similar
+                if 'Close' in original_data and 'Open' in original_data:
+                    closes = original_data['Close']
+                    opens = original_data['Open']
+                    if index < len(closes) and index < len(opens):
+                        is_bullish = closes[index] > opens[index]
+                        return is_bullish
+
+        except (KeyError, IndexError, AttributeError):
+            pass
+
+        # Fallback to bullish if data access fails
+        return True  # Default to bullish
 
     @staticmethod
     def clean_axis_label(label: str) -> str:
@@ -268,7 +329,7 @@ class MplfinanceDataExtractor:
 
                     date_dt = pd.to_datetime(date_num, unit="D")
                     return date_dt.strftime("%Y-%m-%d")
-                except:
+                except (ValueError, TypeError):
                     pass
         except (ValueError, TypeError, OverflowError):
             pass
@@ -319,66 +380,6 @@ class MplfinanceDataExtractor:
 
         # Use the utility class for date conversion
         return MplfinanceDataExtractor._convert_date_num_to_string(x_center_num)
-
-    @staticmethod
-    def _is_up_candle(face_colors: Any, index: int) -> bool:
-        """
-        Determine if a candle is up based on face color.
-
-        Parameters
-        ----------
-        face_colors : Any
-            Face colors from the collection
-        index : int
-            Index of the candle
-
-        Returns
-        -------
-        bool
-            True if up candle, False if down candle
-        """
-        is_up = True  # Default to up candle
-        if hasattr(face_colors, "__len__") and len(face_colors) > index:
-            color = (
-                face_colors[index]
-                if hasattr(face_colors[index], "__len__")
-                else face_colors
-            )
-            if isinstance(color, (list, tuple, np.ndarray)):
-                if len(color) >= 3:
-                    # Dark colors typically indicate down candles
-                    if color[0] < 0.5 and color[1] < 0.5 and color[2] < 0.5:
-                        is_up = False
-        return is_up
-
-    @staticmethod
-    def _is_up_candle_from_color(face_color: Any) -> bool:
-        """
-        Determine if a candle is up based on face color (for Rectangle patches).
-
-        Parameters
-        ----------
-        face_color : Any
-            Face color of the rectangle
-
-        Returns
-        -------
-        bool
-            True if up candle, False if down candle
-        """
-        try:
-            if (
-                isinstance(face_color, (list, tuple, np.ndarray))
-                and len(face_color) >= 3
-            ):
-                # Green colors typically indicate up candles
-                if face_color[1] > face_color[0]:
-                    return True
-                else:
-                    return False
-        except (TypeError, IndexError):
-            pass
-        return True  # Default to up candle
 
     @staticmethod
     def _extract_ohlc_from_rectangle(


### PR DESCRIPTION

## Description

Problem: Candlestick bull/bear classification was unreliable because it used color-based logic that failed with different color schemes.

Solution: Replaced color logic with data-driven classification using actual Open/Close values.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


## Changes Made

1. Removed color-based methods (_is_up_candle, _is_up_candle_from_color)
2. Added robust data method (_determine_bull_bear_from_data) that uses Close > Open logic
3. Updated mplfinance patch to pass original DataFrame data to extraction functions

