### PR TITLE
ci: remove redundant github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,6 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v9.21.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          verbosity: 3
           changelog: true
           commit: true
           push: true
@@ -116,14 +115,3 @@ jobs:
           # Use a clean environment for building
           uv build --no-cache
           uv publish
-
-      - name: Publish package distributions to GitHub Releases
-        id: github-release
-        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
-        # See https://github.com/actions/runner/issues/1173
-        if: steps.release.outputs.released == 'true'
-        uses: python-semantic-release/upload-to-gh-release@main
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.release.outputs.tag }}
-          root_options: "-vv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ commit_parser = "conventional"
 logging_use_named_masks = false
 major_on_zero = false
 tag_format = "v{version}"
-version_variables = ["maidr/__init__.py:__version__", "pyproject.toml:project.version"]
+version_variables = ["maidr/__init__.py:__version__", "pyproject.toml:version"]
 
 [tool.semantic_release.branches.main]
 match = "(main|master)"


### PR DESCRIPTION

## Description

[tool.semantic_release.publish]
dist_glob_patterns = ["dist/*"]
upload_to_vcs_release = true

This action already publishes to github releases, and the last step is redundant. So removing that part.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
