### PR TITLE
fix: add new selector logic for candlestick plots

### DIFF
--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -7,6 +7,7 @@ import numpy as np
 from maidr.core.enum import PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.core.enum.maidr_key import MaidrKey
+from maidr.exception import ExtractionError
 from maidr.util.mplfinance_utils import MplfinanceDataExtractor
 
 
@@ -180,7 +181,7 @@ class CandlestickPlot(MaidrPlot):
                 except Exception:
                     pass
             if N is None:
-                N = 10  # fallback
+                raise ExtractionError(PlotType.CANDLESTICK, self._maidr_wick_collection)
 
             selectors = {
                 "body": f"g[id='{self._maidr_body_gid}'] > path",

--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.patches import Rectangle
+import numpy as np
 
 from maidr.core.enum import PlotType
 from maidr.core.plot import MaidrPlot
@@ -41,12 +42,17 @@ class CandlestickPlot(MaidrPlot):
         self._maidr_date_nums = kwargs.get("_maidr_date_nums", None)
         self._maidr_original_data = kwargs.get("_maidr_original_data", None)  # Store original data
 
-        # Store the GID for proper selector generation
+        # Store the GID for proper selector generation (legacy/shared)
         self._maidr_gid = None
+        # Modern-path separate gids for body and wick
+        self._maidr_body_gid = None
+        self._maidr_wick_gid = None
         if self._maidr_body_collection:
             self._maidr_gid = self._maidr_body_collection.get_gid()
+            self._maidr_body_gid = self._maidr_gid
         elif self._maidr_wick_collection:
             self._maidr_gid = self._maidr_wick_collection.get_gid()
+            self._maidr_wick_gid = self._maidr_gid
 
     def _extract_plot_data(self) -> list[dict]:
         """Extract candlestick data from the plot."""
@@ -56,8 +62,11 @@ class CandlestickPlot(MaidrPlot):
         wick_collection = self._maidr_wick_collection
 
         if body_collection and wick_collection:
-            # Store the GID from the body collection for highlighting
-            self._maidr_gid = body_collection.get_gid()
+            # Store the GIDs from the collections (modern path)
+            self._maidr_body_gid = body_collection.get_gid()
+            self._maidr_wick_gid = wick_collection.get_gid()
+            # Keep legacy gid filled for backward compatibility
+            self._maidr_gid = self._maidr_body_gid or self._maidr_wick_gid
 
             # Use the original collections for highlighting
             self._elements = [body_collection, wick_collection]
@@ -92,6 +101,30 @@ class CandlestickPlot(MaidrPlot):
                 # Set GID on all rectangles
                 for rect in body_rectangles:
                     rect.set_gid(self._maidr_gid)
+            # Keep a dedicated body gid for legacy dict selectors
+            self._maidr_body_gid = getattr(self, "_maidr_body_gid", None) or self._maidr_gid
+
+            # Assign a shared gid to wick Line2D (vertical 2-point lines) on the same axis
+            wick_lines = []
+            for line in ax_ohlc.get_lines():
+                try:
+                    xydata = line.get_xydata()
+                    if xydata is None:
+                        continue
+                    xy_arr = np.asarray(xydata)
+                    if xy_arr.ndim == 2 and xy_arr.shape[0] == 2 and xy_arr.shape[1] >= 2:
+                        x0 = float(xy_arr[0, 0])
+                        x1 = float(xy_arr[1, 0])
+                        if abs(x0 - x1) < 1e-10:
+                            wick_lines.append(line)
+                except Exception:
+                    continue
+            if wick_lines:
+                if not getattr(self, "_maidr_wick_gid", None):
+                    import uuid
+                    self._maidr_wick_gid = f"maidr-{uuid.uuid4()}"
+                for line in wick_lines:
+                    line.set_gid(self._maidr_wick_gid)
 
             # Use the utility class to extract data
             data = MplfinanceDataExtractor.extract_rectangle_candlestick_data(
@@ -117,17 +150,57 @@ class CandlestickPlot(MaidrPlot):
             x_labels = "X"
         return {MaidrKey.X: x_labels, MaidrKey.Y: self.ax.get_ylabel()}
 
-    def _get_selector(self) -> str:
-        """Return the CSS selector for highlighting candlestick elements in the SVG output."""
-        # Use the stored GID if available, otherwise fall back to generic selector
-        if self._maidr_gid:
-            # Use the full GID as the id attribute (since that's what's in the SVG)
-            selector = (
-                f"g[id='{self._maidr_gid}'] > path, g[id='{self._maidr_gid}'] > rect"
-            )
-        else:
-            selector = "g[maidr='true'] > path, g[maidr='true'] > rect"
-        return selector
+    def _get_selector(self):
+        """Return selectors for highlighting candlestick elements.
+
+        - Modern path (collections present): return a dict with separate selectors for body, wickLow, wickHigh
+        - Legacy path: return a dict with body and shared wick selectors (no open/close keys)
+        """
+        # Modern path: build structured selectors using separate gids
+        if self._maidr_body_collection and self._maidr_wick_collection and self._maidr_body_gid and self._maidr_wick_gid:
+            # Determine candle count N
+            N = None
+            if self._maidr_original_data is not None:
+                try:
+                    N = len(self._maidr_original_data)
+                except Exception:
+                    N = None
+            if N is None and hasattr(self._maidr_wick_collection, "get_paths"):
+                try:
+                    wick_paths = len(list(self._maidr_wick_collection.get_paths()))
+                    if wick_paths % 2 == 0 and wick_paths > 0:
+                        N = wick_paths // 2
+                except Exception:
+                    pass
+            if N is None and hasattr(self._maidr_body_collection, "get_paths"):
+                try:
+                    body_paths = len(list(self._maidr_body_collection.get_paths()))
+                    if body_paths > 0:
+                        N = body_paths
+                except Exception:
+                    pass
+            if N is None:
+                N = 10  # fallback
+
+            selectors = {
+                "body": f"g[id='{self._maidr_body_gid}'] > path",
+                "wickLow": f"g[id='{self._maidr_wick_gid}'] > path:nth-child(-n+{N})",
+                "wickHigh": f"g[id='{self._maidr_wick_gid}'] > path:nth-child(n+{N + 1})",
+            }
+            return selectors
+
+        # Legacy path: build shared-id selectors; omit open/close
+        legacy_selectors = {}
+        if getattr(self, "_maidr_body_gid", None) or self._maidr_gid:
+            body_gid = getattr(self, "_maidr_body_gid", None) or self._maidr_gid
+            legacy_selectors["body"] = f"g[id='{body_gid}'] > path"
+        if getattr(self, "_maidr_wick_gid", None):
+            legacy_selectors["wick"] = f"g[id='{self._maidr_wick_gid}'] > path"
+        if legacy_selectors:
+            return legacy_selectors
+
+        # Fallback
+        return "g[maidr='true'] > path, g[maidr='true'] > rect"
 
     def render(self) -> dict:
         """Initialize the MAIDR schema dictionary with basic plot information."""

--- a/maidr/patch/candlestick.py
+++ b/maidr/patch/candlestick.py
@@ -2,6 +2,7 @@ import wrapt
 from typing import Any, Callable, Dict, Tuple
 from matplotlib.patches import Rectangle
 from mplfinance import original_flavor
+import numpy as np
 
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum.plot_type import PlotType
@@ -46,10 +47,35 @@ def candlestick(
         # Patch the plotting function.
         plot = wrapped(*args, **kwargs)
 
+    original_data = None
+    date_nums = None
+    if len(args) >= 2:
+        try:
+            quotes = args[1]
+            if quotes is not None:
+                arr = np.asarray(quotes)
+                if arr.ndim == 2 and arr.shape[1] >= 5 and arr.size > 0:
+                    date_nums = arr[:, 0].tolist()
+                    original_data = {
+                        "Open": arr[:, 1].tolist(),
+                        "High": arr[:, 2].tolist(),
+                        "Low": arr[:, 3].tolist(),
+                        "Close": arr[:, 4].tolist(),
+                    }
+        except Exception:
+            pass
+
     axes = []
     for ax in plot:
         axes.append(FigureManager.get_axes(ax))
-    FigureManager.create_maidr(axes, PlotType.CANDLESTICK)
+
+    extra_kwargs: Dict[str, Any] = {}
+    if original_data is not None:
+        extra_kwargs["_maidr_original_data"] = original_data
+    if date_nums is not None:
+        extra_kwargs["_maidr_date_nums"] = date_nums
+
+    FigureManager.create_maidr(axes, PlotType.CANDLESTICK, **extra_kwargs)
 
     return plot
 

--- a/maidr/patch/mplfinance.py
+++ b/maidr/patch/mplfinance.py
@@ -83,9 +83,10 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
         )
 
         if wick_collection and body_collection:
-            gid = f"maidr-{uuid.uuid4()}"
-            wick_collection.set_gid(gid)
-            body_collection.set_gid(gid)
+            wick_gid = f"maidr-{uuid.uuid4()}"
+            body_gid = f"maidr-{uuid.uuid4()}"
+            wick_collection.set_gid(wick_gid)
+            body_collection.set_gid(body_gid)
 
             candlestick_kwargs = dict(
                 kwargs,
@@ -93,6 +94,8 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
                 _maidr_body_collection=body_collection,
                 _maidr_date_nums=date_nums,
                 _maidr_original_data=data,
+                _maidr_wick_gid=wick_gid,
+                _maidr_body_gid=body_gid,
             )
             common(
                 PlotType.CANDLESTICK,


### PR DESCRIPTION
## Description

Objective: Implement new granular selector schema for candlestick plot highlighting

Problem: Previous candlestick plots used single selector for all elements, limiting frontend highlighting granularity.

Solution:

Modern Pipeline (mplfinance.plot()): Separate selectors for body, wickLow, wickHigh using nth-child CSS targeting
Legacy Pipeline (original_flavor): Simplified selectors for body and wick with shared GIDs
Conditional selector generation based on pipeline detection

Impact:

Enables precise frontend highlighting of individual candlestick components
Maintains backward compatibility between modern and legacy pipelines
Enhanced user accessibility through granular element selection

Objective: Fix incorrect bull/bear candlestick classification in legacy original_flavor pipeline

Problem: Legacy candlestick plots defaulted all candles to "bullish" due to missing OHLC data extraction, causing incorrect open/close value assignment.


## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
