### PR TITLE
fix: address categorical x-values in line plot

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -114,13 +114,18 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
             elif not label.startswith("_child"):
                 line_type = label
 
+            # Use the new method to extract data with categorical labels
+            line_coords = LineExtractorMixin.extract_line_data_with_categorical_labels(self.ax, line)
+            if line_coords is None:
+                continue
+
             line_data = [
                 {
-                    MaidrKey.X: float(x),
-                    MaidrKey.Y: float(y),
+                    MaidrKey.X: x,
+                    MaidrKey.Y: y,
                     **({MaidrKey.FILL: line_type} if line_type else {}),
                 }
-                for x, y in line.get_xydata()  # type: ignore
+                for x, y in line_coords
             ]
 
             if line_data:


### PR DESCRIPTION

## Description

In line plots, Text values get represented as integers in line.getxydata() [Matplotlib internal representation]. So introduced a fix to address this.

Test example:

```
import seaborn as sns
import pandas as pd
import matplotlib.pyplot as plt

# Just import maidr package 
import maidr 

temp_data = {
    'temperature': [70,79,79,72,73,77,76],
    'day': ['Mon','Tues','Wed','Thurs','Fri','Sat','Sun']
}
df = pd.DataFrame(temp_data)
plt.figure(figsize=(6, 6))

# Assign the plot to a variable 
line_plot = sns.lineplot( 
    x="day", y="temperature", data=df, errorbar="sd", palette="Blues_d"
)
plt.title("Average temp in a week")
plt.xlabel("Day")
plt.ylabel("Temperature (F)")

# plt.show()

# Use maidr.show() to display your plot 
maidr.show(line_plot) 

```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

