### PR TITLE
fix: refactor axes in maidr payload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,24 @@ The `maidr/patch/` modules use `wrapt` to intercept matplotlib/seaborn plot call
 
 Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, COUNT, DODGED, HEAT, HIST, LINE, SCATTER, STACKED, SMOOTH, CANDLESTICK.
 
+### Canonical `axes` Payload
+
+Every emitted schema's `axes` object follows the canonical per-axis form:
+
+```python
+{
+    "x": {"label": "...", "min": ..., "max": ..., "tickStep": ..., "format": {...}},
+    "y": {"label": "...", ...},
+    "z": {"label": "..."},  # only when applicable (heatmap colorbar, hue/legend)
+}
+```
+
+- Keys of `axes` are a subset of `{x, y, z}`. No other keys are allowed.
+- Each value is an `AxisConfig` dict. `label` is a string; `min`/`max`/`tickStep` are numbers; `format` is a dict.
+- `format`, `min`, `max`, `tickStep`, `fill`, and `level` must **never** appear as siblings of `x`/`y`/`z`.
+- Use `MaidrPlot._axis_config(...)` / `PlotlyPlot._axis_config(...)` helpers to build an `AxisConfig` so only non-`None` fields are emitted.
+- `tests/core/test_axes_schema.py` enforces this contract across real emitters.
+
 ## Code Style
 
 - **Linter/Formatter**: Ruff (line-length 88), configured in pyproject.toml

--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -180,6 +180,24 @@ class BoxPlot(
         }
         self.lower_outliers_count = []
 
+    def _extract_axes_data(self) -> dict:
+        """
+        Extend the base per-axis ``AxisConfig`` mapping with a ``z`` axis whose
+        label is sourced from the legend title when a hue dimension is
+        present. Omitted otherwise (per-box ``z`` values remain in data).
+        """
+        axes_data = super()._extract_axes_data()
+
+        legend = self.ax.get_legend()
+        if legend is not None:
+            title = legend.get_title()
+            if title is not None:
+                z_label = title.get_text().strip()
+                if z_label:
+                    axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
+
+        return axes_data
+
     def _get_selector(self) -> list[dict]:
         mins, maxs, medians, boxes, outliers = self.elements_map.values()
         selector = []

--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -133,19 +133,25 @@ class CandlestickPlot(MaidrPlot):
 
     def _extract_axes_data(self) -> dict:
         """
-        Extract the plot's axes data including labels.
+        Extract the plot's axes data as canonical per-axis ``AxisConfig``
+        objects.
 
         Returns
         -------
         dict
-            Dictionary containing x and y axis labels.
+            ``{"x": {"label": ...}, "y": {"label": ...}}``.
         """
-        x_labels = self.ax.get_xlabel()
-        if not x_labels:
-            x_labels = self.extract_shared_xlabel(self.ax)
-        if not x_labels:
-            x_labels = "X"
-        return {MaidrKey.X: x_labels, MaidrKey.Y: self.ax.get_ylabel()}
+        x_label = self.ax.get_xlabel()
+        if not x_label:
+            x_label = self.extract_shared_xlabel(self.ax)
+        if not x_label:
+            x_label = "X"
+        y_label = self.ax.get_ylabel() or "Y"
+
+        return {
+            MaidrKey.X: self._axis_config(label=x_label),
+            MaidrKey.Y: self._axis_config(label=y_label),
+        }
 
     def _get_selector(self) -> Union[str, Dict[str, str]]:
         """Return selectors for highlighting candlestick elements."""
@@ -201,14 +207,26 @@ class CandlestickPlot(MaidrPlot):
         return "g[maidr='true'] > path, g[maidr='true'] > rect"
 
     def render(self) -> dict:
-        """Initialize the MAIDR schema dictionary with basic plot information."""
+        """
+        Initialize the MAIDR schema dictionary with basic plot information.
+
+        Preserves the per-axis ``format`` fields already populated by the base
+        ``render()`` — format is nested inside each ``AxisConfig``, not a
+        sibling of ``x``/``y``.
+        """
         base_schema = super().render()
         base_schema[MaidrKey.TITLE] = "Candlestick Chart"
-        # Update axes labels while preserving format from parent
+
+        # Preserve per-axis format (nested inside each AxisConfig) while
+        # refreshing labels through _extract_axes_data().
+        previous_axes = base_schema.get(MaidrKey.AXES, {}) or {}
         axes_data = self._extract_axes_data()
-        if MaidrKey.AXES in base_schema and MaidrKey.FORMAT in base_schema[MaidrKey.AXES]:
-            axes_data[MaidrKey.FORMAT] = base_schema[MaidrKey.AXES][MaidrKey.FORMAT]
+        for axis_key, axis_cfg in list(axes_data.items()):
+            prev = previous_axes.get(axis_key)
+            if isinstance(prev, dict) and MaidrKey.FORMAT in prev:
+                axis_cfg[MaidrKey.FORMAT] = prev[MaidrKey.FORMAT]
         base_schema[MaidrKey.AXES] = axes_data
+
         base_schema[MaidrKey.DATA] = self._extract_plot_data()
         if self._support_highlighting:
             base_schema[MaidrKey.SELECTOR] = self._get_selector()

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -20,12 +20,30 @@ class GroupedBarPlot(
         super().__init__(ax, plot_type)
 
     def _extract_axes_data(self) -> dict:
-        base_ax_schema = super()._extract_axes_data()
-        grouped_ax_schema = {
-            MaidrKey.X.value: self.ax.get_xlabel(),
-            MaidrKey.Y.value: self.ax.get_ylabel(),
-        }
-        return self.merge_dict(base_ax_schema, grouped_ax_schema)
+        """
+        Extend the base per-axis ``AxisConfig`` mapping with a ``z`` axis whose
+        label is sourced from the legend title (the hue/group column).
+
+        If no legend or no legend title is available, ``z`` is omitted —
+        per-point ``z`` values remain in the data payload.
+        """
+        axes_data = super()._extract_axes_data()
+
+        z_label = self._extract_z_label_from_legend()
+        if z_label:
+            axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
+
+        return axes_data
+
+    def _extract_z_label_from_legend(self) -> str:
+        """Return the legend title text (trimmed) or an empty string."""
+        legend = self.ax.get_legend()
+        if legend is None:
+            return ""
+        title = legend.get_title()
+        if title is None:
+            return ""
+        return title.get_text().strip()
 
     def _extract_plot_data(self):
         plot = self.extract_container(self.ax, BarContainer, include_all=True)

--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -33,13 +33,16 @@ class HeatPlot(
         return self.merge_dict(base_maidr, heat_maidr)
 
     def _extract_axes_data(self) -> dict:
-        base_ax_schema = super()._extract_axes_data()
-        heat_ax_schema = {
-            MaidrKey.X: self.ax.get_xlabel(),
-            MaidrKey.Y: self.ax.get_ylabel(),
-            MaidrKey.Z: self._z_label,
-        }
-        return self.merge_dict(base_ax_schema, heat_ax_schema)
+        """
+        Extend the base per-axis ``AxisConfig`` mapping with a ``z`` axis
+        describing the colormap / fill dimension.
+
+        The base class already supplies ``x`` and ``y`` as ``AxisConfig`` dicts
+        (``{"label": ...}``). Here we simply add ``z`` with its label.
+        """
+        axes_data = super()._extract_axes_data()
+        axes_data[MaidrKey.Z] = self._axis_config(label=self._z_label)
+        return axes_data
 
     def _extract_plot_data(self) -> dict:
         plot = self.extract_scalar_mappable(self.ax)

--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -41,6 +41,25 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
     def __init__(self, ax: Axes, **kwargs):
         super().__init__(ax, PlotType.LINE)
 
+    def _extract_axes_data(self) -> dict:
+        """
+        Extend the base per-axis ``AxisConfig`` mapping with a ``z`` axis
+        whose label is sourced from the legend title (multi-series column).
+
+        Omitted when there is no legend title.
+        """
+        axes_data = super()._extract_axes_data()
+
+        legend = self.ax.get_legend()
+        if legend is not None:
+            title = legend.get_title()
+            if title is not None:
+                z_label = title.get_text().strip()
+                if z_label:
+                    axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
+
+        return axes_data
+
     def _get_selector(self) -> Union[str, List[str]]:
         # Return selectors for all lines that have data
         all_lines = self.ax.get_lines()

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -60,15 +60,22 @@ class MaidrPlot(ABC, FormatExtractorMixin):
 
     def render(self) -> dict:
         """
-        Generate the MAIDR schema for this plot layer, including a unique id for layer identification.
+        Generate the MAIDR schema for this plot layer, including a unique id for
+        layer identification.
+
+        The ``axes`` payload follows the canonical per-axis ``AxisConfig`` form:
+        each of ``x``, ``y``, ``z`` (when present) is a dict that may contain
+        ``label``, ``min``, ``max``, ``tickStep``, and ``format``. ``format`` is
+        nested *inside* each axis, never emitted as a sibling.
         """
-        # Extract axes data first
+        # Extract axes data first (per-axis AxisConfig objects).
         axes_data = self._extract_axes_data()
 
-        # Extract and include format configuration inside axes if available.
+        # Merge per-axis format configuration into each AxisConfig under its own
+        # "format" key. The legacy sibling "axes.format" emission has been removed.
         format_config = self.extract_format(self.ax)
         if format_config:
-            axes_data[MaidrKey.FORMAT] = format_config
+            self._merge_format_into_axes(axes_data, format_config)
 
         # Generate a unique UUID for this layer to ensure each plot layer can be distinctly identified
         # in the MAIDR frontend. This supports robust layer switching.
@@ -85,6 +92,83 @@ class MaidrPlot(ABC, FormatExtractorMixin):
             maidr_schema[MaidrKey.SELECTOR] = self._get_selector()
 
         return maidr_schema
+
+    @staticmethod
+    def _axis_config(
+        label: str | None = None,
+        *,
+        min: float | None = None,
+        max: float | None = None,
+        tick_step: float | None = None,
+        format: dict | None = None,
+    ) -> dict:
+        """
+        Build a canonical ``AxisConfig`` dict, emitting only non-None properties.
+
+        Parameters
+        ----------
+        label : str, optional
+            Human-readable axis label.
+        min : float, optional
+            Numeric lower bound (numeric axes only).
+        max : float, optional
+            Numeric upper bound (numeric axes only).
+        tick_step : float, optional
+            Tick spacing (numeric axes only).
+        format : dict, optional
+            Per-axis ``AxisFormat`` object.
+
+        Returns
+        -------
+        dict
+            A sparse ``AxisConfig`` dict. May be empty.
+        """
+        cfg: dict = {}
+        if label is not None:
+            cfg[MaidrKey.LABEL] = label
+        if min is not None:
+            cfg[MaidrKey.MIN] = min
+        if max is not None:
+            cfg[MaidrKey.MAX] = max
+        if tick_step is not None:
+            cfg[MaidrKey.TICK_STEP] = tick_step
+        if format is not None:
+            cfg[MaidrKey.FORMAT] = format
+        return cfg
+
+    @staticmethod
+    def _merge_format_into_axes(axes_data: dict, format_config: dict) -> None:
+        """
+        Nest a per-axis format mapping ``{"x": {...}, "y": {...}}`` into each
+        corresponding ``AxisConfig`` inside ``axes_data``.
+
+        If an axis exists in ``format_config`` but not in ``axes_data``, a new
+        ``AxisConfig`` dict is created for it.
+        """
+        for axis_key, fmt in format_config.items():
+            # Normalize str-enum keys (e.g., MaidrKey.X) against plain "x"/"y"/"z".
+            key = axis_key.value if hasattr(axis_key, "value") else axis_key
+            target_key = None
+            for candidate in (key, MaidrKey.X, MaidrKey.Y, MaidrKey.Z):
+                if candidate in axes_data:
+                    ck = candidate.value if hasattr(candidate, "value") else candidate
+                    if ck == key:
+                        target_key = candidate
+                        break
+            if target_key is None:
+                # Map plain string back to enum for consistent key typing.
+                target_key = {
+                    "x": MaidrKey.X,
+                    "y": MaidrKey.Y,
+                    "z": MaidrKey.Z,
+                }.get(key, key)
+                axes_data[target_key] = {}
+            axis_cfg = axes_data[target_key]
+            if not isinstance(axis_cfg, dict):
+                # Defensive: legacy string slipped through; upgrade to AxisConfig.
+                axis_cfg = {MaidrKey.LABEL: axis_cfg}
+                axes_data[target_key] = axis_cfg
+            axis_cfg[MaidrKey.FORMAT] = fmt
 
     def _get_selector(self) -> str:
         """Return the CSS selector for highlighting elements."""
@@ -107,13 +191,29 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         return ""
 
     def _extract_axes_data(self) -> dict:
-        """Extract the plot's axes data"""
-        x_labels = self.ax.get_xlabel()
-        if not x_labels:
-            x_labels = self.extract_shared_xlabel(self.ax)
-        if not x_labels:
-            x_labels = "X"
-        return {MaidrKey.X: x_labels, MaidrKey.Y: self.ax.get_ylabel()}
+        """
+        Extract the plot's axes data as per-axis ``AxisConfig`` objects.
+
+        Returns
+        -------
+        dict
+            ``{"x": {"label": ...}, "y": {"label": ...}}``. Keys ``x`` and ``y``
+            are always present; subclasses may add ``z`` when appropriate.
+        """
+        x_label = self.ax.get_xlabel()
+        if not x_label:
+            x_label = self.extract_shared_xlabel(self.ax)
+        if not x_label:
+            x_label = "X"
+
+        y_label = self.ax.get_ylabel()
+        if not y_label:
+            y_label = "Y"
+
+        return {
+            MaidrKey.X: self._axis_config(label=x_label),
+            MaidrKey.Y: self._axis_config(label=y_label),
+        }
 
     @abstractmethod
     def _extract_plot_data(self) -> list | dict:
@@ -122,7 +222,14 @@ class MaidrPlot(ABC, FormatExtractorMixin):
 
     @property
     def schema(self) -> dict:
-        """Return the MAIDR schema of the plot as a dictionary."""
+        """Return the MAIDR schema of the plot as a dictionary.
+
+        The emitted ``axes`` payload follows the canonical per-axis form —
+        keys ⊆ ``{x, y, z}``; each value is an ``AxisConfig`` dict with
+        optional ``label``, ``min``, ``max``, ``tickStep``, and ``format``
+        fields. ``format``/``min``/``max``/``tickStep``/``fill``/``level``
+        never appear as siblings of ``x``/``y``/``z``.
+        """
         if not self._schema:
             self._schema = self.render()
         return self._schema

--- a/maidr/core/plot/mplfinance_barplot.py
+++ b/maidr/core/plot/mplfinance_barplot.py
@@ -122,14 +122,23 @@ class MplfinanceBarPlot(
         return [float(patch.get_height()) for patch in patches]
 
     def _extract_axes_data(self) -> dict:
-        """Extract axes data with mplfinance-specific cleaning."""
+        """Extract per-axis ``AxisConfig`` objects with mplfinance-specific cleaning.
+
+        For volume bar plots, the y-axis label is cleaned via
+        ``MplfinanceDataExtractor.clean_axis_label``. The axis shape remains
+        the canonical ``AxisConfig`` object form.
+        """
         ax_data = super()._extract_axes_data()
 
-        # For mplfinance volume plots, clean up the y-axis label
+        # For mplfinance volume plots, clean up the y-axis label in-place.
         if self._custom_patches:
-            y_label = ax_data.get("y")
-            if y_label:
-                ax_data["y"] = MplfinanceDataExtractor.clean_axis_label(y_label)
+            y_axis = ax_data.get(MaidrKey.Y)
+            if isinstance(y_axis, dict):
+                y_label = y_axis.get(MaidrKey.LABEL)
+                if y_label:
+                    y_axis[MaidrKey.LABEL] = (
+                        MplfinanceDataExtractor.clean_axis_label(y_label)
+                    )
 
         return ax_data
 
@@ -140,13 +149,24 @@ class MplfinanceBarPlot(
         return "g[maidr='true'] > path"
 
     def render(self) -> dict:
+        """
+        Build the MAIDR schema for the volume bar layer.
+
+        Preserves per-axis ``format`` fields (nested inside each
+        ``AxisConfig``) populated by the base ``render()`` while refreshing
+        labels through the mplfinance-specific ``_extract_axes_data``.
+        """
         base_schema = super().render()
         base_schema[MaidrKey.TITLE] = "Volume Bar Plot"
-        # Update axes labels while preserving format from parent
+
+        previous_axes = base_schema.get(MaidrKey.AXES, {}) or {}
         axes_data = self._extract_axes_data()
-        if MaidrKey.AXES in base_schema and MaidrKey.FORMAT in base_schema[MaidrKey.AXES]:
-            axes_data[MaidrKey.FORMAT] = base_schema[MaidrKey.AXES][MaidrKey.FORMAT]
+        for axis_key, axis_cfg in list(axes_data.items()):
+            prev = previous_axes.get(axis_key)
+            if isinstance(prev, dict) and MaidrKey.FORMAT in prev:
+                axis_cfg[MaidrKey.FORMAT] = prev[MaidrKey.FORMAT]
         base_schema[MaidrKey.AXES] = axes_data
+
         base_schema[MaidrKey.DATA] = self._extract_plot_data()
         if self._support_highlighting:
             base_schema[MaidrKey.SELECTOR] = self._get_selector()

--- a/maidr/core/plot/mplfinance_lineplot.py
+++ b/maidr/core/plot/mplfinance_lineplot.py
@@ -190,13 +190,24 @@ class MplfinanceLinePlot(MaidrPlot, LineExtractorMixin):
         return periods[0] if periods else ""
 
     def render(self) -> dict:
+        """
+        Build the MAIDR schema for the moving-average line layer.
+
+        Preserves per-axis ``format`` fields (nested inside each
+        ``AxisConfig``) populated by the base ``render()`` while refreshing
+        labels through ``_extract_axes_data``.
+        """
         base_schema = super().render()
         base_schema[MaidrKey.TITLE] = "Moving Average Line Plot"
-        # Update axes labels while preserving format from parent
+
+        previous_axes = base_schema.get(MaidrKey.AXES, {}) or {}
         axes_data = self._extract_axes_data()
-        if MaidrKey.AXES in base_schema and MaidrKey.FORMAT in base_schema[MaidrKey.AXES]:
-            axes_data[MaidrKey.FORMAT] = base_schema[MaidrKey.AXES][MaidrKey.FORMAT]
+        for axis_key, axis_cfg in list(axes_data.items()):
+            prev = previous_axes.get(axis_key)
+            if isinstance(prev, dict) and MaidrKey.FORMAT in prev:
+                axis_cfg[MaidrKey.FORMAT] = prev[MaidrKey.FORMAT]
         base_schema[MaidrKey.AXES] = axes_data
+
         base_schema[MaidrKey.DATA] = self._extract_plot_data()
         if self._support_highlighting:
             base_schema[MaidrKey.SELECTOR] = self._get_selector()

--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -19,12 +19,14 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin):
         return ["g[maidr='true'] > g > use"]
 
     def _extract_axes_data(self) -> dict:
-        """Extract axes data with grid navigation parameters.
+        """Extract axes data as canonical per-axis ``AxisConfig`` objects.
 
-        Returns per-axis objects containing label, min, max, and tickStep
-        when all values are valid. Falls back to simple string labels if
-        any grid parameter is missing or invalid (e.g., non-uniform ticks,
-        log scale), silently disabling grid navigation.
+        Always returns per-axis objects with ``label``. When the grid
+        navigation preconditions hold (linear scales, uniform ticks, valid
+        bounds), ``min``, ``max``, and ``tickStep`` are additionally included
+        on both axes. If any precondition fails, those numeric fields are
+        omitted on both axes, silently disabling grid navigation while still
+        complying with the canonical axes shape.
         """
         # Labels (with fallback matching base class behavior).
         x_label = self.ax.get_xlabel()
@@ -42,25 +44,29 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin):
         x_tick_step = self._compute_tick_step(self.ax.get_xticks())
         y_tick_step = self._compute_tick_step(self.ax.get_yticks())
 
-        # Validate — fall back to simple strings if grid config is invalid.
+        # If grid config is invalid, emit bare AxisConfig objects with labels
+        # only (no min/max/tickStep). This keeps the canonical per-axis shape.
         if not self._is_valid_grid_config(
             x_min, x_max, x_tick_step, y_min, y_max, y_tick_step
         ):
-            return {MaidrKey.X: x_label, MaidrKey.Y: y_label}
+            return {
+                MaidrKey.X: self._axis_config(label=x_label),
+                MaidrKey.Y: self._axis_config(label=y_label),
+            }
 
         return {
-            MaidrKey.X: {
-                MaidrKey.LABEL: x_label,
-                MaidrKey.MIN: float(x_min),
-                MaidrKey.MAX: float(x_max),
-                MaidrKey.TICK_STEP: float(x_tick_step),
-            },
-            MaidrKey.Y: {
-                MaidrKey.LABEL: y_label,
-                MaidrKey.MIN: float(y_min),
-                MaidrKey.MAX: float(y_max),
-                MaidrKey.TICK_STEP: float(y_tick_step),
-            },
+            MaidrKey.X: self._axis_config(
+                label=x_label,
+                min=float(x_min),
+                max=float(x_max),
+                tick_step=float(x_tick_step),
+            ),
+            MaidrKey.Y: self._axis_config(
+                label=y_label,
+                min=float(y_min),
+                max=float(y_max),
+                tick_step=float(y_tick_step),
+            ),
         }
 
     @staticmethod

--- a/maidr/plotly/heatmap.py
+++ b/maidr/plotly/heatmap.py
@@ -52,7 +52,12 @@ class PlotlyHeatmapPlot(PlotlyPlot):
         return result
 
     def _extract_axes_data(self) -> dict:
-        """Extract axes data, including z label for heatmaps."""
+        """Extract per-axis ``AxisConfig`` objects, including ``z`` for heatmaps.
+
+        The ``z`` axis label is sourced from the trace's colorbar title
+        (formerly emitted as ``axes.fill``). Emitted as a canonical
+        ``AxisConfig`` dict ``{"label": ...}``.
+        """
         base = super()._extract_axes_data()
         # Add z label from colorbar title if available
         colorbar = self._trace.get("colorbar", {})
@@ -64,5 +69,5 @@ class PlotlyHeatmapPlot(PlotlyPlot):
             elif title:
                 z_label = str(title)
         if z_label:
-            base[MaidrKey.Z] = z_label
+            base[MaidrKey.Z] = self._axis_config(label=z_label)
         return base

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -141,8 +141,36 @@ class PlotlyPlot(ABC):
                     return text
         return None
 
+    @staticmethod
+    def _axis_config(
+        label: str | None = None,
+        *,
+        min: float | None = None,
+        max: float | None = None,
+        tick_step: float | None = None,
+        format: dict | None = None,
+    ) -> dict:
+        """Build a canonical per-axis ``AxisConfig`` dict (only non-None keys)."""
+        cfg: dict = {}
+        if label is not None:
+            cfg[MaidrKey.LABEL] = label
+        if min is not None:
+            cfg[MaidrKey.MIN] = min
+        if max is not None:
+            cfg[MaidrKey.MAX] = max
+        if tick_step is not None:
+            cfg[MaidrKey.TICK_STEP] = tick_step
+        if format is not None:
+            cfg[MaidrKey.FORMAT] = format
+        return cfg
+
     def _extract_axes_data(self) -> dict:
-        """Extract axes labels and format configuration from the layout."""
+        """Extract axes labels and format configuration as per-axis
+        ``AxisConfig`` objects.
+
+        ``format`` is nested inside each ``AxisConfig`` — never emitted as a
+        sibling of ``x``/``y``/``z``.
+        """
         xaxis = self._layout.get(self._xaxis_name, {})
         yaxis = self._layout.get(self._yaxis_name, {})
 
@@ -154,16 +182,18 @@ class PlotlyPlot(ABC):
         if isinstance(y_label, dict):
             y_label = y_label.get("text", "")
 
-        axes_data: dict = {
-            MaidrKey.X: str(x_label) if x_label else "X",
-            MaidrKey.Y: str(y_label) if y_label else "Y",
+        format_config = self._extract_format(xaxis, yaxis) or {}
+
+        return {
+            MaidrKey.X: self._axis_config(
+                label=str(x_label) if x_label else "X",
+                format=format_config.get("x"),
+            ),
+            MaidrKey.Y: self._axis_config(
+                label=str(y_label) if y_label else "Y",
+                format=format_config.get("y"),
+            ),
         }
-
-        format_config = self._extract_format(xaxis, yaxis)
-        if format_config:
-            axes_data[MaidrKey.FORMAT] = format_config
-
-        return axes_data
 
     @staticmethod
     def _extract_format(
@@ -243,7 +273,14 @@ class PlotlyPlot(ABC):
 
     @property
     def schema(self) -> dict:
-        """Return the MAIDR schema of the plot as a dictionary."""
+        """Return the MAIDR schema of the plot as a dictionary.
+
+        The emitted ``axes`` payload follows the canonical per-axis form —
+        keys ⊆ ``{x, y, z}``; each value is an ``AxisConfig`` dict with
+        optional ``label``, ``min``, ``max``, ``tickStep``, and ``format``
+        fields. ``format``/``min``/``max``/``tickStep``/``fill``/``level``
+        never appear as siblings of ``x``/``y``/``z``.
+        """
         if not self._schema:
             self._schema = self.render()
         return self._schema

--- a/maidr/plotly/scatter.py
+++ b/maidr/plotly/scatter.py
@@ -15,12 +15,15 @@ class PlotlyScatterPlot(PlotlyPlot):
         return f"{self._subplot_css_prefix()}.trace.scatter .point"
 
     def _extract_axes_data(self) -> dict:
-        """Extract axes data with grid navigation parameters.
+        """Extract axes data as canonical per-axis ``AxisConfig`` objects.
 
-        Returns per-axis objects containing label, min, max, and tickStep
-        when all values are valid. Falls back to simple string labels if
-        any grid parameter is missing or invalid (e.g., non-uniform ticks,
-        log scale), silently disabling grid navigation.
+        Always returns per-axis objects with ``label`` (and ``format`` when
+        available). When the grid navigation preconditions hold (linear
+        scales, uniform ticks, valid bounds), ``min``, ``max``, and
+        ``tickStep`` are additionally included on both axes. If any
+        precondition fails, those numeric fields are omitted (silently
+        disabling grid navigation) while still complying with the canonical
+        axes shape.
         """
         xaxis = self._layout.get(self._xaxis_name, {})
         yaxis = self._layout.get(self._yaxis_name, {})
@@ -28,6 +31,11 @@ class PlotlyScatterPlot(PlotlyPlot):
         # Get labels
         x_label = self._get_axis_label(xaxis, "X")
         y_label = self._get_axis_label(yaxis, "Y")
+
+        # Per-axis format (nested into each AxisConfig).
+        format_config = self._extract_format(xaxis, yaxis) or {}
+        x_fmt = format_config.get("x")
+        y_fmt = format_config.get("y")
 
         # Get range: explicit from layout OR compute from trace data
         x_data = self._trace.get("x", [])
@@ -39,25 +47,31 @@ class PlotlyScatterPlot(PlotlyPlot):
         x_tick_step = self._get_tick_step(xaxis)
         y_tick_step = self._get_tick_step(yaxis)
 
-        # Validate - fall back to simple labels if invalid
+        # If grid config is invalid, emit bare AxisConfig objects (no
+        # min/max/tickStep). This keeps the canonical per-axis shape.
         if not self._is_valid_grid_config(
             xaxis, yaxis, x_min, x_max, x_tick_step, y_min, y_max, y_tick_step
         ):
-            return {MaidrKey.X: x_label, MaidrKey.Y: y_label}
+            return {
+                MaidrKey.X: self._axis_config(label=x_label, format=x_fmt),
+                MaidrKey.Y: self._axis_config(label=y_label, format=y_fmt),
+            }
 
         return {
-            MaidrKey.X: {
-                MaidrKey.LABEL: x_label,
-                MaidrKey.MIN: float(x_min),
-                MaidrKey.MAX: float(x_max),
-                MaidrKey.TICK_STEP: float(x_tick_step),
-            },
-            MaidrKey.Y: {
-                MaidrKey.LABEL: y_label,
-                MaidrKey.MIN: float(y_min),
-                MaidrKey.MAX: float(y_max),
-                MaidrKey.TICK_STEP: float(y_tick_step),
-            },
+            MaidrKey.X: self._axis_config(
+                label=x_label,
+                min=float(x_min),
+                max=float(x_max),
+                tick_step=float(x_tick_step),
+                format=x_fmt,
+            ),
+            MaidrKey.Y: self._axis_config(
+                label=y_label,
+                min=float(y_min),
+                max=float(y_max),
+                tick_step=float(y_tick_step),
+                format=y_fmt,
+            ),
         }
 
     @staticmethod

--- a/maidr/util/format_config.py
+++ b/maidr/util/format_config.py
@@ -647,8 +647,15 @@ def extract_axis_format(ax: Optional[Axes]) -> Dict[str, Dict[str, Any]]:
     Returns
     -------
     Dict[str, Dict[str, Any]]
-        Dictionary with 'x' and/or 'y' keys containing format configurations.
-        Only includes axes where a format could be detected.
+        Dictionary with 'x' and/or 'y' keys containing ``AxisFormat``
+        configurations. Only includes axes where a format could be detected.
+
+    Notes
+    -----
+    The returned mapping is consumed by ``MaidrPlot.render()`` and nested into
+    the per-axis ``AxisConfig`` objects of the MAIDR schema — i.e.
+    ``axes[x|y|z].format``. It is never emitted as a sibling of
+    ``x``/``y``/``z`` inside ``axes`` (the legacy shape has been removed).
 
     Examples
     --------

--- a/maidr/util/mixin/format_extractor_mixin.py
+++ b/maidr/util/mixin/format_extractor_mixin.py
@@ -24,12 +24,19 @@ class FormatExtractorMixin:
 
     Examples
     --------
+    The returned mapping is intended to be **nested into each per-axis
+    ``AxisConfig``** object under its ``format`` key. It must NOT be placed as
+    a sibling of ``x``/``y`` inside ``axes`` (that legacy shape has been
+    removed).
+
     >>> class MyPlot(MaidrPlot, FormatExtractorMixin):
     ...     def render(self):
     ...         schema = super().render()
     ...         format_config = self.extract_format(self.ax)
     ...         if format_config:
-    ...             schema["format"] = format_config
+    ...             # Nest per-axis: axes["x"]["format"] = format_config["x"]
+    ...             for axis_key, fmt in format_config.items():
+    ...                 schema["axes"][axis_key]["format"] = fmt
     ...         return schema
     """
 
@@ -49,8 +56,10 @@ class FormatExtractorMixin:
         Returns
         -------
         Dict[str, Dict[str, Any]] or None
-            Dictionary with 'x' and/or 'y' keys containing format configurations,
-            or None if no formats could be detected.
+            Dictionary with 'x' and/or 'y' keys containing ``AxisFormat``
+            configurations, or None if no formats could be detected. The caller
+            is responsible for nesting these into the corresponding
+            ``axes[x|y|z].format`` fields of the MAIDR schema.
 
         Notes
         -----

--- a/tests/core/test_axes_schema.py
+++ b/tests/core/test_axes_schema.py
@@ -1,0 +1,155 @@
+"""Tests that the canonical ``axes`` payload shape is emitted by real plots.
+
+The MAIDR schema's ``axes`` object must follow the canonical per-axis form:
+
+- Keys are a subset of ``{x, y, z}``.
+- Each value is an ``AxisConfig`` dict (never a bare string).
+- ``format``/``min``/``max``/``tickStep``/``fill``/``level`` never appear as
+  siblings of ``x``/``y``/``z``.
+
+These tests exercise real matplotlib/seaborn emitters end-to-end so the
+contract is enforced without a runtime validator.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+FORBIDDEN_TOP_LEVEL_KEYS = ("format", "min", "max", "tickStep", "fill", "level")
+ALLOWED_AXIS_CONFIG_KEYS = {"label", "min", "max", "tickStep", "format"}
+
+
+def _stringify_keys(d: dict) -> dict:
+    """Normalize MaidrKey enum keys to plain strings for assertions."""
+    out = {}
+    for k, v in d.items():
+        key = k.value if hasattr(k, "value") else k
+        out[key] = _stringify_keys(v) if isinstance(v, dict) else v
+    return out
+
+
+def _first_schema(fig) -> dict:
+    m = FigureManager.get_maidr(fig)
+    plot = m._plots[0]
+    return _stringify_keys(plot.schema)
+
+
+def _assert_canonical_axes(axes: dict) -> None:
+    """Assert an ``axes`` dict adheres to the canonical contract."""
+    assert isinstance(axes, dict), f"axes must be a dict, got {type(axes).__name__}"
+
+    # Keys are a subset of {x, y, z}.
+    assert set(axes.keys()) <= {"x", "y", "z"}, f"unexpected axes keys: {axes.keys()}"
+
+    # No forbidden sibling keys.
+    for forbidden in FORBIDDEN_TOP_LEVEL_KEYS:
+        assert forbidden not in axes, (
+            f"'{forbidden}' must not be a sibling of x/y/z"
+        )
+
+    # Each value is an AxisConfig dict with only allowed keys.
+    for axis_key, cfg in axes.items():
+        assert isinstance(cfg, dict), (
+            f"axes['{axis_key}'] must be a dict, got {type(cfg).__name__}"
+        )
+        for cfg_key in cfg.keys():
+            assert cfg_key in ALLOWED_AXIS_CONFIG_KEYS, (
+                f"axes['{axis_key}']['{cfg_key}'] is not an allowed AxisConfig key"
+            )
+
+
+class TestMatplotlibCanonicalShape:
+    def test_bar(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.bar(["a", "b", "c"], [1, 2, 3])
+            ax.set_xlabel("Category")
+            ax.set_ylabel("Count")
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            assert axes["x"]["label"] == "Category"
+            assert axes["y"]["label"] == "Count"
+        finally:
+            plt.close(fig)
+
+    def test_scatter_emits_per_axis_object(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.scatter([1, 2, 3], [4, 5, 6])
+            ax.set_xlabel("X")
+            ax.set_ylabel("Y")
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            assert isinstance(axes["x"], dict)
+            assert isinstance(axes["y"], dict)
+            assert axes["x"]["label"] == "X"
+            assert axes["y"]["label"] == "Y"
+        finally:
+            plt.close(fig)
+
+    def test_heatmap_has_z_axis_config(self):
+        fig, ax = plt.subplots()
+        try:
+            data = np.arange(9).reshape(3, 3)
+            sns.heatmap(data, ax=ax)
+            ax.set_xlabel("Col")
+            ax.set_ylabel("Row")
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            assert "z" in axes
+            if "label" in axes["z"]:
+                assert isinstance(axes["z"]["label"], str)
+        finally:
+            plt.close(fig)
+
+    def test_no_format_sibling_with_currency_axis(self):
+        from matplotlib.ticker import FuncFormatter
+
+        fig, ax = plt.subplots()
+        try:
+            ax.bar(["a", "b"], [1000, 2000])
+            ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _pos: f"${v:,.0f}"))
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            # If format was detected, it's nested inside y AxisConfig
+            if isinstance(axes.get("y"), dict) and "format" in axes["y"]:
+                assert isinstance(axes["y"]["format"], dict)
+        finally:
+            plt.close(fig)
+
+
+class TestGroupedBarAxesZ:
+    def test_extract_axes_has_z_from_legend(self):
+        # Exercise GroupedBarPlot._extract_axes_data directly.
+        from maidr.core.enum.plot_type import PlotType
+        from maidr.core.plot.grouped_barplot import GroupedBarPlot
+
+        fig, ax = plt.subplots()
+        try:
+            ax.bar(["A", "B"], [1, 2], label="g1")
+            ax.bar(["A", "B"], [3, 4], label="g2")
+            ax.set_xlabel("cat")
+            ax.set_ylabel("val")
+            ax.legend(title="grp")
+
+            plot = GroupedBarPlot(ax, PlotType.DODGED)
+            axes = _stringify_keys(plot._extract_axes_data())
+
+            _assert_canonical_axes(axes)
+            assert axes["z"]["label"] == "grp"
+        finally:
+            plt.close(fig)

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -37,6 +37,25 @@ class TestPlotlyBarPlot:
         assert MaidrKey.AXES in schema
         assert MaidrKey.DATA in schema
 
+    def test_axes_uses_canonical_per_axis_shape(self):
+        trace = {"type": "bar", "x": ["A"], "y": [1]}
+        layout = {"xaxis": {"title": "Cat"}, "yaxis": {"title": "Val"}}
+        plot = PlotlyBarPlot(trace, layout)
+        axes = plot.schema[MaidrKey.AXES]
+
+        # Per-axis AxisConfig objects (never bare strings)
+        assert isinstance(axes[MaidrKey.X], dict)
+        assert isinstance(axes[MaidrKey.Y], dict)
+        assert axes[MaidrKey.X][MaidrKey.LABEL] == "Cat"
+        assert axes[MaidrKey.Y][MaidrKey.LABEL] == "Val"
+        # No forbidden sibling keys (format/min/max/tickStep/fill/level)
+        for forbidden in ("format", "min", "max", "tickStep", "fill", "level"):
+            assert forbidden not in axes
+            # also in enum form
+            assert not any(
+                (k.value if hasattr(k, "value") else k) == forbidden for k in axes
+            )
+
     def test_horizontal_bar(self):
         trace = {
             "type": "bar",
@@ -71,6 +90,39 @@ class TestPlotlyScatterPlot:
 
         assert isinstance(data[0][MaidrKey.X], float)
         assert isinstance(data[0][MaidrKey.Y], int)
+
+    def test_scatter_axes_canonical_per_axis(self):
+        trace = {"type": "scatter", "x": [1.0, 2.0, 3.0], "y": [4.0, 5.0, 6.0]}
+        layout = {
+            "xaxis": {"title": "X"},
+            "yaxis": {"title": "Y"},
+        }
+        plot = PlotlyScatterPlot(trace, layout)
+        axes = plot.schema[MaidrKey.AXES]
+
+        assert isinstance(axes[MaidrKey.X], dict)
+        assert isinstance(axes[MaidrKey.Y], dict)
+        # Grid-nav invalid (no explicit range/dtick): labels only.
+        assert axes[MaidrKey.X][MaidrKey.LABEL] == "X"
+        assert axes[MaidrKey.Y][MaidrKey.LABEL] == "Y"
+
+    def test_scatter_axes_grid_config_nested(self):
+        trace = {"type": "scatter", "x": [0, 10], "y": [0, 10]}
+        layout = {
+            "xaxis": {"title": "X", "range": [0, 10], "dtick": 1},
+            "yaxis": {"title": "Y", "range": [0, 10], "dtick": 2},
+        }
+        plot = PlotlyScatterPlot(trace, layout)
+        axes = plot.schema[MaidrKey.AXES]
+
+        # min/max/tickStep nested inside each AxisConfig, not siblings.
+        assert axes[MaidrKey.X][MaidrKey.MIN] == 0.0
+        assert axes[MaidrKey.X][MaidrKey.MAX] == 10.0
+        assert axes[MaidrKey.X][MaidrKey.TICK_STEP] == 1.0
+        assert axes[MaidrKey.Y][MaidrKey.TICK_STEP] == 2.0
+        # No sibling numeric fields at top of axes.
+        for forbidden in ("min", "max", "tickStep", "format", "fill", "level"):
+            assert forbidden not in axes
 
 
 class TestPlotlyLinePlot:
@@ -172,6 +224,29 @@ class TestPlotlyHeatmapPlot:
         assert MaidrKey.POINTS in data
         assert MaidrKey.X not in data
         assert MaidrKey.Y not in data
+
+    def test_axes_z_is_axis_config_dict(self):
+        trace = {
+            "type": "heatmap",
+            "z": [[1, 2], [3, 4]],
+            "colorbar": {"title": {"text": "Intensity"}},
+        }
+        layout = {"xaxis": {"title": "Col"}, "yaxis": {"title": "Row"}}
+        plot = PlotlyHeatmapPlot(trace, layout)
+        axes = plot.schema[MaidrKey.AXES]
+
+        # z must be a dict (AxisConfig), never a bare string
+        assert isinstance(axes[MaidrKey.Z], dict)
+        assert axes[MaidrKey.Z][MaidrKey.LABEL] == "Intensity"
+        assert isinstance(axes[MaidrKey.X], dict)
+        assert isinstance(axes[MaidrKey.Y], dict)
+
+    def test_axes_omits_z_when_no_colorbar_title(self):
+        trace = {"type": "heatmap", "z": [[1, 2], [3, 4]]}
+        plot = PlotlyHeatmapPlot(trace, {})
+        axes = plot.schema[MaidrKey.AXES]
+
+        assert MaidrKey.Z not in axes
 
 
 class TestPlotlyHistogramPlot:


### PR DESCRIPTION
## Description

Migrates the MAIDR schema axes payload to the canonical per-axis AxisConfig form. Hard break — no deprecation path.

Before: {"axes": {"x": "X label", "y": "Y label", "format": {...}, "fill": "hue"}}

After: {"axes": {"x": {"label": "X", "format": {...}}, "y": {"label": "Y"}, "z": 
  {"label": "hue"}}}

Contract

  - Keys of axes ⊆ {x, y, z}
  - Each value is an AxisConfig dict with optional label, min, max, tickStep, format
  - format/min/max/tickStep/fill/level never appear as siblings of x/y/z

Migration

Consumers reading schema.axes.format / schema.axes.fill / schema.axes.level must now read from schema.axes.x.format, schema.axes.y.format, or schema.axes.z.label respectively. Heatmap z changed from bare string to {label: str}. Scatter always emits dicts (never bare strings).


Added (1):
  - tests/core/test_axes_schema.py — end-to-end emitter shape tests (bar, scatter,
  heatmap, grouped-bar, currency format) via shared _assert_canonical_axes() helper

Modified — core base (1):
  - maidr/core/plot/maidr_plot.py — rewrote _extract_axes_data() and render(); added
  _axis_config() + _merge_format_into_axes() helpers; updated schema docstring

Modified — matplotlib/seaborn plot subclasses (8):
  - maidr/core/plot/scatterplot.py — removed string fallback; always emits AxisConfig
  - maidr/core/plot/heatmap.py — axes.z changed from bare string to {label}
  - maidr/core/plot/grouped_barplot.py — adds z AxisConfig from legend title
  - maidr/core/plot/boxplot.py — adds z from legend title when hue present
  - maidr/core/plot/lineplot.py — adds z from legend title for multi-line
  - maidr/core/plot/candlestick.py — custom render() override preserves nested format
  - maidr/core/plot/mplfinance_barplot.py — cleans y-label inside AxisConfig; preserves
  nested format
  - maidr/core/plot/mplfinance_lineplot.py — render() preserves nested format

Modified — Plotly emitters (3):
  - maidr/plotly/plotly_plot.py — added _axis_config() helper; _extract_axes_data()
  emits per-axis objects with nested format; updated schema docstring
  - maidr/plotly/scatter.py — removed string fallback; always emits AxisConfig with
  nested format + grid-nav fields
  - maidr/plotly/heatmap.py — z emitted as {label} instead of bare string

Modified — utilities (2):
  - maidr/util/format_config.py — docstring updated to reflect nested format
  - maidr/util/mixin/format_extractor_mixin.py — class/method docstrings updated;
  example shows nesting

Modified — tests (1):
  - tests/plotly/test_plotly_plots.py — +5 tests for Plotly bar/scatter/heatmap
  canonical shape and nested grid-nav numerics

Modified — docs (2):
  - CHANGELOG.md — Unreleased breaking-change entry with migration notes
  - CLAUDE.md — new "Canonical axes Payload" architecture section

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

