### PR TITLE
feat: emit figure-wide title and axes labels in the MAIDR schema

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -401,10 +401,11 @@ class Maidr:
         - ``Figure.supxlabel`` -> ``axes.x.label``
         - ``Figure.supylabel`` -> ``axes.y.label``
 
-        Only authored (non-empty) values are emitted, so figures without
-        figure-level text keep their existing schema unchanged. The ``axes``
-        value follows the canonical per-axis ``AxisConfig`` form (only
-        ``label`` applies at the figure level).
+        Only authored values are emitted, so figures without figure-level
+        text keep their existing schema unchanged. Whitespace-only strings
+        count as unauthored, matching the maidr JS engine's trimmed
+        "authored" check. The ``axes`` value follows the canonical per-axis
+        ``AxisConfig`` form (only ``label`` applies at the figure level).
 
         Returns
         -------
@@ -413,15 +414,15 @@ class Maidr:
         """
         metadata: dict = {}
 
-        suptitle = self._fig.get_suptitle()
+        suptitle = self._fig.get_suptitle().strip()
         if suptitle:
             metadata[MaidrKey.TITLE] = suptitle
 
         figure_axes: dict = {}
-        supxlabel = self._fig.get_supxlabel()
+        supxlabel = self._fig.get_supxlabel().strip()
         if supxlabel:
             figure_axes[MaidrKey.X] = MaidrPlot._axis_config(label=supxlabel)
-        supylabel = self._fig.get_supylabel()
+        supylabel = self._fig.get_supylabel().strip()
         if supylabel:
             figure_axes[MaidrKey.Y] = MaidrPlot._axis_config(label=supylabel)
         if figure_axes:

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -430,8 +430,8 @@ class Maidr:
 
         return metadata
 
-    def _flatten_maidr(self) -> dict | list[dict]:
-        """Return a single plot schema or a list of schemas from the Maidr instance."""
+    def _flatten_maidr(self) -> dict:
+        """Return the top-level MAIDR schema for this figure."""
         # Handle DODGED/STACKED plots: only keep one plot per subplot position
         # because GroupedBarPlot extracts all containers from the axes itself
         if self.plot_type in (PlotType.DODGED, PlotType.STACKED):

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -420,10 +420,10 @@ class Maidr:
         figure_axes: dict = {}
         supxlabel = self._fig.get_supxlabel()
         if supxlabel:
-            figure_axes[MaidrKey.X] = {MaidrKey.LABEL: supxlabel}
+            figure_axes[MaidrKey.X] = MaidrPlot._axis_config(label=supxlabel)
         supylabel = self._fig.get_supylabel()
         if supylabel:
-            figure_axes[MaidrKey.Y] = {MaidrKey.LABEL: supylabel}
+            figure_axes[MaidrKey.Y] = MaidrPlot._axis_config(label=supylabel)
         if figure_axes:
             metadata[MaidrKey.AXES] = figure_axes
 

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -390,6 +390,45 @@ class Maidr:
 
         return merged_plots
 
+    def _figure_metadata(self) -> dict:
+        """
+        Extract figure-wide metadata for the top-level MAIDR schema.
+
+        Maps matplotlib's figure-level artists onto the top-level MAIDR
+        schema fields used by multi-panel figures:
+
+        - ``Figure.suptitle`` -> ``title``
+        - ``Figure.supxlabel`` -> ``axes.x.label``
+        - ``Figure.supylabel`` -> ``axes.y.label``
+
+        Only authored (non-empty) values are emitted, so figures without
+        figure-level text keep their existing schema unchanged. The ``axes``
+        value follows the canonical per-axis ``AxisConfig`` form (only
+        ``label`` applies at the figure level).
+
+        Returns
+        -------
+        dict
+            A sparse mapping with optional ``title`` and ``axes`` keys.
+        """
+        metadata: dict = {}
+
+        suptitle = self._fig.get_suptitle()
+        if suptitle:
+            metadata[MaidrKey.TITLE] = suptitle
+
+        figure_axes: dict = {}
+        supxlabel = self._fig.get_supxlabel()
+        if supxlabel:
+            figure_axes[MaidrKey.X] = {MaidrKey.LABEL: supxlabel}
+        supylabel = self._fig.get_supylabel()
+        if supylabel:
+            figure_axes[MaidrKey.Y] = {MaidrKey.LABEL: supylabel}
+        if figure_axes:
+            metadata[MaidrKey.AXES] = figure_axes
+
+        return metadata
+
     def _flatten_maidr(self) -> dict | list[dict]:
         """Return a single plot schema or a list of schemas from the Maidr instance."""
         # Handle DODGED/STACKED plots: only keep one plot per subplot position
@@ -469,6 +508,7 @@ class Maidr:
 
         return {
             "id": Maidr._unique_id(),
+            **self._figure_metadata(),
             "subplots": subplot_grid,
         }
 

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, cast
 
 from htmltools import HTML, HTMLDocument, Tag, tags
 
+from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.plotly_plot import PlotlyPlot
 from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
 from maidr.util.dependencies import (
@@ -295,6 +296,49 @@ class PlotlyMaidr:
         del self._plots
         del self._fig
 
+    def _figure_metadata(self) -> dict:
+        """
+        Extract figure-wide metadata for the top-level MAIDR schema.
+
+        Maps Plotly's figure-level layout title onto the top-level MAIDR
+        schema fields used by multi-panel figures:
+
+        - ``layout.title.text`` -> ``title``
+        - ``layout.title.subtitle.text`` -> ``subtitle`` (Plotly's native
+          subtitle, the analog of ggplot2's ``labs(subtitle=...)``;
+          authorable since plotly.js 2.35 / plotly.py 5.24)
+
+        Only authored values are emitted, so figures without figure-level
+        text keep their existing schema unchanged. Whitespace-only strings
+        count as unauthored, matching the maidr JS engine's trimmed
+        "authored" check. Plotly has no figure-level caption concept, so
+        ``caption`` is never emitted.
+
+        Returns
+        -------
+        dict
+            A sparse mapping with optional ``title`` and ``subtitle`` keys.
+        """
+        metadata: dict = {}
+
+        layout = self._fig.to_dict().get("layout", {})
+        title = layout.get("title", "")
+        if not isinstance(title, dict):
+            title = {"text": title}
+
+        title_text = str(title.get("text") or "").strip()
+        if title_text:
+            metadata[MaidrKey.TITLE] = title_text
+
+        subtitle = title.get("subtitle") or {}
+        if not isinstance(subtitle, dict):
+            subtitle = {"text": subtitle}
+        subtitle_text = str(subtitle.get("text") or "").strip()
+        if subtitle_text:
+            metadata[MaidrKey.SUBTITLE] = subtitle_text
+
+        return metadata
+
     def _flatten_maidr(self) -> dict:
         """Build the MAIDR schema from all extracted plots.
 
@@ -348,6 +392,7 @@ class PlotlyMaidr:
 
         return {
             "id": self.maidr_id,
+            **self._figure_metadata(),
             "subplots": subplot_grid,
         }
 

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -306,13 +306,19 @@ class PlotlyMaidr:
         - ``layout.title.text`` -> ``title``
         - ``layout.title.subtitle.text`` -> ``subtitle`` (Plotly's native
           subtitle, the analog of ggplot2's ``labs(subtitle=...)``;
-          authorable since plotly.js 2.35 / plotly.py 5.24)
+          authorable since plotly.js 2.35)
 
         Only authored values are emitted, so figures without figure-level
         text keep their existing schema unchanged. Whitespace-only strings
         count as unauthored, matching the maidr JS engine's trimmed
         "authored" check. Plotly has no figure-level caption concept, so
         ``caption`` is never emitted.
+
+        Reads ``self._fig.layout.title`` directly rather than going through
+        ``Figure.to_dict()``, which would re-serialize every trace's data
+        arrays just to reach two layout strings. ``getattr`` guards keep
+        this safe on plotly versions whose ``Title`` object predates
+        ``subtitle``.
 
         Returns
         -------
@@ -321,19 +327,14 @@ class PlotlyMaidr:
         """
         metadata: dict = {}
 
-        layout = self._fig.to_dict().get("layout", {})
-        title = layout.get("title", "")
-        if not isinstance(title, dict):
-            title = {"text": title}
+        layout_title = getattr(self._fig.layout, "title", None)
 
-        title_text = str(title.get("text") or "").strip()
+        title_text = str(getattr(layout_title, "text", None) or "").strip()
         if title_text:
             metadata[MaidrKey.TITLE] = title_text
 
-        subtitle = title.get("subtitle") or {}
-        if not isinstance(subtitle, dict):
-            subtitle = {"text": subtitle}
-        subtitle_text = str(subtitle.get("text") or "").strip()
+        subtitle = getattr(layout_title, "subtitle", None)
+        subtitle_text = str(getattr(subtitle, "text", None) or "").strip()
         if subtitle_text:
             metadata[MaidrKey.SUBTITLE] = subtitle_text
 

--- a/tests/core/test_axes_schema.py
+++ b/tests/core/test_axes_schema.py
@@ -153,3 +153,26 @@ class TestGroupedBarAxesZ:
             assert axes["z"]["label"] == "grp"
         finally:
             plt.close(fig)
+
+
+class TestFigureLevelCanonicalShape:
+    """The figure-wide `axes` emitted at the top of the MAIDR schema is
+    built via the same `_axis_config` helper as per-plot axes and must
+    stay bound by the same canonical contract."""
+
+    def test_figure_wide_axes_follow_canonical_shape(self):
+        fig, axs = plt.subplots(1, 2)
+        try:
+            axs[0].bar(["a", "b"], [1, 2])
+            axs[1].bar(["a", "b"], [3, 4])
+            fig.supxlabel("Year")
+            fig.supylabel("Revenue")
+
+            m = FigureManager.get_maidr(fig)
+            schema = _stringify_keys(m._flatten_maidr())
+
+            _assert_canonical_axes(schema["axes"])
+            assert schema["axes"]["x"]["label"] == "Year"
+            assert schema["axes"]["y"]["label"] == "Revenue"
+        finally:
+            plt.close(fig)

--- a/tests/core/test_figure_metadata.py
+++ b/tests/core/test_figure_metadata.py
@@ -93,6 +93,21 @@ def test_only_authored_axis_is_emitted():
         plt.close(fig)
 
 
+def test_only_authored_y_axis_is_emitted():
+    fig, axs = plt.subplots(1, 2)
+    try:
+        axs[0].bar(["a", "b"], [1, 2])
+        axs[1].bar(["a", "b"], [3, 4])
+        fig.supylabel("Revenue")
+
+        schema = _flattened_schema(fig)
+
+        assert "title" not in schema
+        assert schema["axes"] == {"y": {"label": "Revenue"}}
+    finally:
+        plt.close(fig)
+
+
 def test_suptitle_alone_emits_title_without_axes():
     fig, ax = plt.subplots()
     try:

--- a/tests/core/test_figure_metadata.py
+++ b/tests/core/test_figure_metadata.py
@@ -1,0 +1,107 @@
+"""Tests for figure-wide metadata in the top-level MAIDR schema.
+
+The maidr JS engine reads optional top-level ``title`` and
+``axes: {x: {label}, y: {label}}`` fields on the ``maidr`` object for
+multi-panel figures (announced at the figure "lobby" with figure ->
+focused-subplot precedence). These tests verify that matplotlib's
+figure-level artists are mapped onto those fields:
+
+- ``Figure.suptitle``  -> ``title``
+- ``Figure.supxlabel`` -> ``axes.x.label``
+- ``Figure.supylabel`` -> ``axes.y.label``
+
+and that figures without figure-level text keep their prior schema shape
+(no ``title`` / ``axes`` keys at the top level).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+def _stringify_keys(d: dict) -> dict:
+    """Normalize MaidrKey enum keys to plain strings for assertions."""
+    out = {}
+    for k, v in d.items():
+        key = k.value if hasattr(k, "value") else k
+        out[key] = _stringify_keys(v) if isinstance(v, dict) else v
+    return out
+
+
+def _flattened_schema(fig) -> dict:
+    m = FigureManager.get_maidr(fig)
+    return _stringify_keys(m._flatten_maidr())
+
+
+def test_multi_panel_emits_figure_wide_title_and_axes():
+    fig, axs = plt.subplots(1, 2)
+    try:
+        axs[0].bar(["a", "b"], [1, 2])
+        axs[1].bar(["a", "b"], [3, 4])
+        fig.suptitle("Sales by Region")
+        fig.supxlabel("Year")
+        fig.supylabel("Revenue")
+
+        schema = _flattened_schema(fig)
+
+        assert schema["title"] == "Sales by Region"
+        assert schema["axes"] == {
+            "x": {"label": "Year"},
+            "y": {"label": "Revenue"},
+        }
+        # Grid structure is unchanged.
+        assert len(schema["subplots"]) == 1
+        assert len(schema["subplots"][0]) == 2
+    finally:
+        plt.close(fig)
+
+
+def test_no_figure_level_text_omits_title_and_axes():
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(["a", "b"], [1, 2])
+
+        schema = _flattened_schema(fig)
+
+        assert "title" not in schema
+        assert "axes" not in schema
+        assert "id" in schema
+        assert "subplots" in schema
+    finally:
+        plt.close(fig)
+
+
+def test_only_authored_axis_is_emitted():
+    fig, axs = plt.subplots(2, 1)
+    try:
+        axs[0].bar(["a", "b"], [1, 2])
+        axs[1].bar(["a", "b"], [3, 4])
+        fig.supxlabel("Quarter")
+
+        schema = _flattened_schema(fig)
+
+        assert "title" not in schema
+        assert schema["axes"] == {"x": {"label": "Quarter"}}
+    finally:
+        plt.close(fig)
+
+
+def test_suptitle_alone_emits_title_without_axes():
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(["a", "b"], [1, 2])
+        fig.suptitle("Overview")
+
+        schema = _flattened_schema(fig)
+
+        assert schema["title"] == "Overview"
+        assert "axes" not in schema
+    finally:
+        plt.close(fig)

--- a/tests/core/test_figure_metadata.py
+++ b/tests/core/test_figure_metadata.py
@@ -12,6 +12,11 @@ figure-level artists are mapped onto those fields:
 
 and that figures without figure-level text keep their prior schema shape
 (no ``title`` / ``axes`` keys at the top level).
+
+The Plotly counterpart lives in ``tests/plotly/test_plotly_maidr.py``
+(``TestPlotlyFigureMetadata``); note the paths are asymmetric by design —
+Plotly maps ``layout.title.subtitle`` to a top-level ``subtitle``, while
+matplotlib has no native subtitle/caption artist and never emits either.
 """
 
 from __future__ import annotations

--- a/tests/core/test_figure_metadata.py
+++ b/tests/core/test_figure_metadata.py
@@ -105,3 +105,49 @@ def test_suptitle_alone_emits_title_without_axes():
         assert "axes" not in schema
     finally:
         plt.close(fig)
+
+
+def test_whitespace_only_figure_text_counts_as_unauthored():
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(["a", "b"], [1, 2])
+        fig.suptitle("   ")
+        fig.supxlabel(" \t ")
+
+        schema = _flattened_schema(fig)
+
+        assert "title" not in schema
+        assert "axes" not in schema
+    finally:
+        plt.close(fig)
+
+
+def test_figure_metadata_survives_svg_embedding():
+    """The extra top-level keys must round-trip through the SVG `maidr`
+    attribute JSON embedding used by render()/save_html()."""
+    import json
+
+    from lxml import etree
+
+    fig, axs = plt.subplots(1, 2)
+    try:
+        axs[0].bar(["a", "b"], [1, 2])
+        axs[1].bar(["a", "b"], [3, 4])
+        fig.suptitle("Sales by Region")
+        fig.supxlabel("Year")
+        fig.supylabel("Revenue")
+
+        m = FigureManager.get_maidr(fig)
+        svg = str(m._get_svg(embed_data=True))
+
+        root = etree.fromstring(svg.encode(), parser=None)
+        embedded = json.loads(root.attrib["maidr"])
+
+        assert embedded["title"] == "Sales by Region"
+        assert embedded["axes"] == {
+            "x": {"label": "Year"},
+            "y": {"label": "Revenue"},
+        }
+        assert embedded["id"] == root.attrib["id"]
+    finally:
+        plt.close(fig)

--- a/tests/core/test_figure_metadata.py
+++ b/tests/core/test_figure_metadata.py
@@ -137,6 +137,35 @@ def test_whitespace_only_figure_text_counts_as_unauthored():
         plt.close(fig)
 
 
+def test_figure_and_subplot_axis_labels_coexist():
+    """A figure-wide supxlabel/supylabel and per-axes xlabel/ylabel live at
+    different nesting levels and must both be emitted unchanged."""
+    import json
+
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(["a", "b"], [1, 2])
+        ax.set_xlabel("Local X")
+        ax.set_ylabel("Local Y")
+        fig.supxlabel("Global X")
+        fig.supylabel("Global Y")
+
+        m = FigureManager.get_maidr(fig)
+        # JSON round-trip normalizes MaidrKey enum keys to plain strings
+        # at every nesting level (dicts inside the subplots lists too).
+        schema = json.loads(json.dumps(m._flatten_maidr()))
+
+        assert schema["axes"] == {
+            "x": {"label": "Global X"},
+            "y": {"label": "Global Y"},
+        }
+        layer_axes = schema["subplots"][0][0]["layers"][0]["axes"]
+        assert layer_axes["x"]["label"] == "Local X"
+        assert layer_axes["y"]["label"] == "Local Y"
+    finally:
+        plt.close(fig)
+
+
 def test_figure_metadata_survives_svg_embedding():
     """The extra top-level keys must round-trip through the SVG `maidr`
     attribute JSON embedding used by render()/save_html()."""

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -153,3 +153,55 @@ class TestPlotlyMaidr:
         pm = PlotlyMaidr(plotly_bar_fig)
         assert len(pm._plots) == 1
         assert isinstance(pm._plots[0], PlotlyBarPlot)
+
+
+class TestPlotlyFigureMetadata:
+    """Figure-wide layout title/subtitle mapped onto the top-level schema."""
+
+    def test_layout_title_and_subtitle_emitted(self):
+        fig = go.Figure(go.Bar(x=["a", "b"], y=[1, 2]))
+        fig.update_layout(
+            title={
+                "text": "Sales by Region",
+                "subtitle": {"text": "Fiscal year 2025"},
+            }
+        )
+
+        pm = PlotlyMaidr(fig)
+        schema = pm._flatten_maidr()
+
+        assert schema["title"] == "Sales by Region"
+        assert schema["subtitle"] == "Fiscal year 2025"
+
+    def test_title_without_subtitle(self):
+        fig = go.Figure(go.Bar(x=["a", "b"], y=[1, 2]))
+        fig.update_layout(title="Overview")
+
+        pm = PlotlyMaidr(fig)
+        schema = pm._flatten_maidr()
+
+        assert schema["title"] == "Overview"
+        assert "subtitle" not in schema
+
+    def test_no_layout_title_omits_metadata(self):
+        fig = go.Figure(go.Bar(x=["a", "b"], y=[1, 2]))
+
+        pm = PlotlyMaidr(fig)
+        schema = pm._flatten_maidr()
+
+        assert "title" not in schema
+        assert "subtitle" not in schema
+        assert "id" in schema
+        assert "subplots" in schema
+
+    def test_whitespace_only_title_counts_as_unauthored(self):
+        fig = go.Figure(go.Bar(x=["a", "b"], y=[1, 2]))
+        fig.update_layout(
+            title={"text": "   ", "subtitle": {"text": " \t "}}
+        )
+
+        pm = PlotlyMaidr(fig)
+        schema = pm._flatten_maidr()
+
+        assert "title" not in schema
+        assert "subtitle" not in schema

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -156,7 +156,14 @@ class TestPlotlyMaidr:
 
 
 class TestPlotlyFigureMetadata:
-    """Figure-wide layout title/subtitle mapped onto the top-level schema."""
+    """Figure-wide layout title/subtitle mapped onto the top-level schema.
+
+    The matplotlib counterpart lives in ``tests/core/test_figure_metadata.py``;
+    the paths are asymmetric by design — matplotlib maps
+    ``suptitle``/``supxlabel``/``supylabel`` to top-level ``title``/``axes``,
+    while Plotly maps ``layout.title``/``layout.title.subtitle`` to
+    ``title``/``subtitle`` (it has no figure-margin axis label artists).
+    """
 
     def test_layout_title_and_subtitle_emitted(self):
         fig = go.Figure(go.Bar(x=["a", "b"], y=[1, 2]))
@@ -253,3 +260,23 @@ class TestPlotlyFigureMetadata:
         assert embedded["title"] == "Sales by Region"
         assert embedded["subtitle"] == "Fiscal year 2025"
         assert embedded["id"] == pm.maidr_id
+
+    def test_legacy_title_without_subtitle_attribute(self):
+        """The getattr guard must handle plotly versions whose Title
+        object predates the `subtitle` attribute (plotly.js < 2.35)."""
+        from types import SimpleNamespace
+
+        from maidr.core.enum.maidr_key import MaidrKey
+
+        fig = go.Figure(go.Bar(x=["a", "b"], y=[1, 2]))
+        pm = PlotlyMaidr(fig)
+
+        class _LegacyTitle:
+            text = "Overview"
+            # deliberately no `subtitle` attribute
+
+        pm._fig = SimpleNamespace(layout=SimpleNamespace(title=_LegacyTitle()))
+
+        metadata = pm._figure_metadata()
+
+        assert metadata == {MaidrKey.TITLE: "Overview"}

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -205,3 +205,26 @@ class TestPlotlyFigureMetadata:
 
         assert "title" not in schema
         assert "subtitle" not in schema
+
+    def test_multi_subplot_title_and_subtitle_emitted(self):
+        """The lobby motivation case: layout title/subtitle on a
+        make_subplots figure land at the top level next to the grid."""
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(rows=1, cols=2)
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=1)
+        fig.add_trace(go.Bar(x=["a", "b"], y=[3, 4]), row=1, col=2)
+        fig.update_layout(
+            title={
+                "text": "Sales by Region",
+                "subtitle": {"text": "Fiscal year 2025"},
+            }
+        )
+
+        pm = PlotlyMaidr(fig)
+        schema = pm._flatten_maidr()
+
+        assert schema["title"] == "Sales by Region"
+        assert schema["subtitle"] == "Fiscal year 2025"
+        assert len(schema["subplots"]) == 1
+        assert len(schema["subplots"][0]) == 2

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -228,3 +228,28 @@ class TestPlotlyFigureMetadata:
         assert schema["subtitle"] == "Fiscal year 2025"
         assert len(schema["subplots"]) == 1
         assert len(schema["subplots"][0]) == 2
+
+    def test_figure_metadata_survives_html_embedding(self):
+        """The top-level title/subtitle must round-trip through the
+        `var maidrSchema = {...}` JSON embedded in the init script,
+        which is the path the JS engine actually consumes for Plotly."""
+        import json
+
+        fig = go.Figure(go.Bar(x=["a", "b"], y=[1, 2]))
+        fig.update_layout(
+            title={
+                "text": "Sales by Region",
+                "subtitle": {"text": "Fiscal year 2025"},
+            }
+        )
+
+        pm = PlotlyMaidr(fig)
+        html_str = str(pm.render().get_html_string())
+
+        marker = "var maidrSchema = "
+        start = html_str.index(marker) + len(marker)
+        embedded, _ = json.JSONDecoder().raw_decode(html_str[start:])
+
+        assert embedded["title"] == "Sales by Region"
+        assert embedded["subtitle"] == "Fiscal year 2025"
+        assert embedded["id"] == pm.maidr_id


### PR DESCRIPTION
# Pull Request

## Description

xability/maidr#639 taught the maidr JS engine to read optional **figure-wide metadata** on the top-level `maidr` object for multi-panel figures: a figure `title` and shared `axes: { x: { label }, y: { label } }`. At the multi-panel figure lobby, the full L-chord (`l t` / `l s` / `l c` / `l x` / `l y` / `l z`) announces these figure-wide values when authored (e.g. "Figure X label is Year"), otherwise it falls back to the focused subplot.

py-maidr previously emitted only `{ id, subplots }` at the top level, so figure-level text that users already author was silently dropped from the schema. This PR maps each supported library's native figure-level concepts onto the top-level schema fields:

**matplotlib/seaborn**
- `Figure.suptitle` → `title`
- `Figure.supxlabel` → `axes.x.label`
- `Figure.supylabel` → `axes.y.label`

**Plotly**
- `layout.title.text` → `title`
- `layout.title.subtitle.text` → `subtitle` (Plotly's native subtitle, the analog of ggplot2's `labs(subtitle=...)`; authorable since plotly.js 2.35 — guarded with `getattr` so older plotly installs are unaffected)

## Related Issues

- Upstream engine support: xability/maidr#639

## Changes Made

- **`maidr/core/maidr.py`**: new `Maidr._figure_metadata()` helper extracts `fig.get_suptitle()` / `get_supxlabel()` / `get_supylabel()` (all available on matplotlib ≥ 3.8, our floor) and `_flatten_maidr()` merges the result into the top-level schema. The `axes` value is built via the sanctioned `MaidrPlot._axis_config()` helper (only `label` applies at the figure level).
- **`maidr/plotly/plotly_maidr.py`**: new `PlotlyMaidr._figure_metadata()` maps `layout.title.text` / `layout.title.subtitle.text` onto top-level `title` / `subtitle`, merged into `_flatten_maidr()` the same way. Reads `fig.layout.title` via attribute access rather than `Figure.to_dict()`, which would re-serialize every trace's data arrays just to reach two layout strings.
- Only authored values are emitted, and whitespace-only strings count as unauthored — matching the JS engine's trimmed `isAuthored*` semantics — so figures without figure-level text keep their existing schema byte-for-byte. Older bundled `maidr.js` versions simply ignore the unknown keys, so this is fully backward compatible.
- **`tests/core/test_figure_metadata.py`**: multi-panel figure emitting all three fields, omission when nothing is authored, single-authored-axis cases (x-only and y-only), `suptitle` alone, whitespace-only-is-unauthored, coexistence of figure-wide and per-subplot axis labels at their respective nesting levels, and an end-to-end round-trip through the SVG `maidr`-attribute JSON embedding.
- **`tests/plotly/test_plotly_maidr.py`**: layout title + subtitle emission (single-panel and `make_subplots` multi-panel), title-only, no-title omission, and whitespace-only-is-unauthored.

**Not mapped (no native source):** matplotlib has no subtitle/caption artist, Plotly has no caption concept, and the Altair path delegates all schema construction to the upstream `vegalite.js` adapter — so `caption` is never emitted and matplotlib figures never emit `subtitle`. Anything heuristic (e.g. scraping `fig.text()` positions) was deliberately avoided.

## Screenshots (if applicable)

N/A — schema-only change.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

- Verified with the full suite: `uv run pytest` (168 passed) and `ruff check` clean on the changed files.
- Once a maidr.js release containing xability/maidr#639 lands, the routine bundled-`maidr.js` bump will make the lobby announcements pick these fields up automatically; the emitted JSON is forward-compatible today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHqdtUFU3vEwW5zpg14cjz