### PR TITLE
ci: bundle upstream maidr.js at release time, attribute to xabilitylab

### DIFF
--- a/.github/scripts/fetch-maidr-bundle.sh
+++ b/.github/scripts/fetch-maidr-bundle.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Resolve, download, and verify the bundled ``maidr.js`` / ``maidr.css``
+# assets from the jsDelivr CDN.  Shared by the release workflow
+# (``release.yml``, release-time refresh) and the manual refresh workflow
+# (``update-maidr-js.yml``) so the download + integrity-check logic lives in
+# exactly one place and cannot drift between the two.
+#
+# Usage:
+#   fetch-maidr-bundle.sh [VERSION] [DEST_DIR]
+#
+#   VERSION   maidr npm version to fetch.  Resolves the latest published
+#             version on npm when empty or omitted.
+#   DEST_DIR  directory to write ``maidr.js`` / ``maidr.css`` / ``VERSION``
+#             into.  Defaults to ``maidr/static``.
+#
+# The resolved version is written to ``<DEST_DIR>/VERSION`` and printed as the
+# final line of stdout so callers can capture it, e.g.
+# ``VERSION=$(fetch-maidr-bundle.sh)``.  All progress output goes to stderr to
+# keep stdout limited to the version string.
+set -euo pipefail
+
+VERSION="${1:-}"
+DEST_DIR="${2:-maidr/static}"
+
+if [ -z "$VERSION" ]; then
+  VERSION=$(curl -sL "https://registry.npmjs.org/maidr/latest" | jq -r '.version')
+fi
+if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+  echo "Failed to resolve maidr.js version" >&2
+  exit 1
+fi
+
+echo "Fetching bundled maidr.js v${VERSION} into ${DEST_DIR}" >&2
+mkdir -p "$DEST_DIR"
+curl -sSfL -o "$DEST_DIR/maidr.js" \
+  "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.js"
+curl -sSfL -o "$DEST_DIR/maidr.css" \
+  "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.css"
+printf "%s\n" "$VERSION" > "$DEST_DIR/VERSION"
+
+# Sanity-check the downloads and reject HTML error pages masquerading as
+# JS / CSS (e.g. a 200 response carrying a CDN error page).  The check is a
+# positive match: fail when the payload *starts* with an HTML marker.
+test -s "$DEST_DIR/maidr.js"
+test -s "$DEST_DIR/maidr.css"
+test -s "$DEST_DIR/VERSION"
+for asset in maidr.js maidr.css; do
+  if head -c 128 "$DEST_DIR/${asset}" | grep -qiE "^[[:space:]]*<!DOCTYPE|^[[:space:]]*<html"; then
+    echo "${asset} looks like an HTML error page" >&2
+    exit 1
+  fi
+done
+
+echo "$VERSION"

--- a/.github/scripts/fetch-maidr-bundle.sh
+++ b/.github/scripts/fetch-maidr-bundle.sh
@@ -31,6 +31,14 @@ if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
   exit 1
 fi
 
+# Validate the version shape before splicing it into the download URL.  This
+# rejects malformed or hostile values (e.g. a caller-supplied version) so
+# they cannot build an unintended jsDelivr path.
+if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+.][0-9A-Za-z.-]+)*$'; then
+  echo "Refusing to fetch: '$VERSION' is not a valid maidr version" >&2
+  exit 1
+fi
+
 echo "Fetching bundled maidr.js v${VERSION} into ${DEST_DIR}" >&2
 mkdir -p "$DEST_DIR"
 curl -sSfL -o "$DEST_DIR/maidr.js" \

--- a/.github/scripts/fetch-maidr-bundle.sh
+++ b/.github/scripts/fetch-maidr-bundle.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 #
 # Resolve, download, and verify the bundled ``maidr.js`` / ``maidr.css``
-# assets from the jsDelivr CDN.  Shared by the release workflow
-# (``release.yml``, release-time refresh) and the manual refresh workflow
-# (``update-maidr-js.yml``) so the download + integrity-check logic lives in
-# exactly one place and cannot drift between the two.
+# assets.  Shared by the release workflow (``release.yml``, release-time
+# refresh) and the manual refresh workflow (``update-maidr-js.yml``) so the
+# download + integrity-check logic lives in exactly one place and cannot
+# drift between the two.
+#
+# The assets are extracted from the official npm tarball, whose contents are
+# verified against the ``dist.integrity`` (SRI) / ``dist.shasum`` hash
+# published in the npm registry metadata.  This gives a real supply-chain
+# guarantee: a tampered CDN/registry response fails the hash check instead of
+# being written into the bundle (and, at release time, shipped to PyPI).
 #
 # Usage:
 #   fetch-maidr-bundle.sh [VERSION] [DEST_DIR]
@@ -23,33 +29,77 @@ set -euo pipefail
 VERSION="${1:-}"
 DEST_DIR="${2:-maidr/static}"
 
+REGISTRY="https://registry.npmjs.org/maidr"
+
 if [ -z "$VERSION" ]; then
-  VERSION=$(curl -sL "https://registry.npmjs.org/maidr/latest" | jq -r '.version')
+  VERSION=$(curl -sSfL "$REGISTRY/latest" | jq -r '.version')
 fi
 if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
   echo "Failed to resolve maidr.js version" >&2
   exit 1
 fi
 
-# Validate the version shape before splicing it into the download URL.  This
-# rejects malformed or hostile values (e.g. a caller-supplied version) so
-# they cannot build an unintended jsDelivr path.
+# Validate the version shape before splicing it into any URL.  This rejects
+# malformed or hostile values (e.g. a caller-supplied version) so they cannot
+# build an unintended request path.
 if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-+.][0-9A-Za-z.-]+)*$'; then
   echo "Refusing to fetch: '$VERSION' is not a valid maidr version" >&2
   exit 1
 fi
 
 echo "Fetching bundled maidr.js v${VERSION} into ${DEST_DIR}" >&2
+
+# Fetch the registry metadata for this exact version to get the tarball URL
+# and its published integrity hash.
+META=$(curl -sSfL "$REGISTRY/$VERSION")
+TARBALL=$(printf '%s' "$META" | jq -r '.dist.tarball // empty')
+INTEGRITY=$(printf '%s' "$META" | jq -r '.dist.integrity // empty')
+SHASUM=$(printf '%s' "$META" | jq -r '.dist.shasum // empty')
+if [ -z "$TARBALL" ]; then
+  echo "Failed to resolve npm tarball URL for maidr@$VERSION" >&2
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+# shellcheck disable=SC2064  # expand WORK now so the trap removes this dir
+trap "rm -rf '$WORK'" EXIT
+TGZ="$WORK/maidr.tgz"
+curl -sSfL -o "$TGZ" "$TARBALL"
+
+# Verify the tarball against the registry-published hash.  Prefer the SRI
+# ``integrity`` field (sha512); fall back to the legacy ``shasum`` (sha1).
+if [ -n "$INTEGRITY" ]; then
+  ALGO=${INTEGRITY%%-*}
+  EXPECTED=${INTEGRITY#*-}
+  ACTUAL=$(openssl dgst "-${ALGO}" -binary "$TGZ" | openssl base64 -A)
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "Integrity check failed for maidr@$VERSION tarball ($ALGO)" >&2
+    exit 1
+  fi
+  echo "Verified tarball ${ALGO} integrity" >&2
+elif [ -n "$SHASUM" ]; then
+  ACTUAL=$(sha1sum "$TGZ" | awk '{print $1}')
+  if [ "$ACTUAL" != "$SHASUM" ]; then
+    echo "Shasum check failed for maidr@$VERSION tarball" >&2
+    exit 1
+  fi
+  echo "Verified tarball shasum" >&2
+else
+  echo "No integrity/shasum in registry metadata for maidr@$VERSION" >&2
+  exit 1
+fi
+
+# Extract the bundled assets from the verified tarball.  npm tarballs place
+# published files under ``package/``.
+tar -xzf "$TGZ" -C "$WORK" package/dist/maidr.js package/dist/maidr.css
 mkdir -p "$DEST_DIR"
-curl -sSfL -o "$DEST_DIR/maidr.js" \
-  "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.js"
-curl -sSfL -o "$DEST_DIR/maidr.css" \
-  "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.css"
+cp "$WORK/package/dist/maidr.js" "$DEST_DIR/maidr.js"
+cp "$WORK/package/dist/maidr.css" "$DEST_DIR/maidr.css"
 printf "%s\n" "$VERSION" > "$DEST_DIR/VERSION"
 
-# Sanity-check the downloads and reject HTML error pages masquerading as
-# JS / CSS (e.g. a 200 response carrying a CDN error page).  The check is a
-# positive match: fail when the payload *starts* with an HTML marker.
+# Defense-in-depth sanity checks: non-empty, and not an HTML error page
+# masquerading as JS / CSS.  The check is a positive match: fail when the
+# payload *starts* with an HTML marker.
 test -s "$DEST_DIR/maidr.js"
 test -s "$DEST_DIR/maidr.css"
 test -s "$DEST_DIR/VERSION"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install commitlint dependencies
         run: npm install @commitlint/config-conventional
@@ -100,3 +100,21 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           failOnWarnings: 'false'
           commitDepth: 1
+
+  workflow-lint:
+    name: Lint workflows and shell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # shellcheck is pre-installed on the ubuntu-latest runner image.
+      - name: ShellCheck shell scripts
+        run: shellcheck .github/scripts/*.sh
+
+      # actionlint validates the workflow YAML and shellchecks inline `run`
+      # blocks, catching the class of shell/quoting bugs this repo has hit.
+      - name: actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,52 +121,25 @@ jobs:
           fi
           echo "Release pending (${LAST:-<none>} -> ${NEXT:-<unknown>}); refreshing bundle."
 
-          # Resolve the latest upstream maidr.js release on npm.
-          VERSION=$(curl -sL "https://registry.npmjs.org/maidr/latest" | jq -r '.version')
-          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-            echo "Failed to resolve upstream maidr.js version" >&2
-            exit 1
-          fi
+          # Resolve, download, and verify the latest upstream bundle via the
+          # shared script (also used by update-maidr-js.yml).
+          VERSION=$(.github/scripts/fetch-maidr-bundle.sh)
 
-          CURRENT=""
-          if [ -f maidr/static/VERSION ]; then
-            CURRENT=$(tr -d '[:space:]' < maidr/static/VERSION)
-          fi
-          if [ "$VERSION" = "$CURRENT" ]; then
-            echo "Bundle already at v$VERSION; nothing to refresh."
-            exit 0
-          fi
-
-          echo "Updating bundled maidr.js: ${CURRENT:-<none>} -> $VERSION"
-          mkdir -p maidr/static
-          curl -sSfL -o maidr/static/maidr.js \
-            "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.js"
-          curl -sSfL -o maidr/static/maidr.css \
-            "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.css"
-          printf "%s\n" "$VERSION" > maidr/static/VERSION
-
-          # Sanity-check the downloads and reject HTML error pages
-          # masquerading as JS / CSS.
-          test -s maidr/static/maidr.js
-          test -s maidr/static/maidr.css
-          test -s maidr/static/VERSION
-          for asset in maidr.js maidr.css; do
-            if head -c 128 "maidr/static/${asset}" | grep -qiE "^[[:space:]]*<!DOCTYPE|^[[:space:]]*<html"; then
-              echo "${asset} looks like an HTML error page" >&2; exit 1
-            fi
-          done
-
-          # Commit as xabilitylab so the refreshed bundle is attributed to
-          # the org account and lands in the release history / changelog.
-          # Scope the identity to this single commit (-c / --author) so it
-          # does not persist into the repo config and bleed into the
-          # semantic-release commit that follows.  Not pushed here --
+          # Commit as xabilitylab only when the bundle actually changed, so a
+          # release that is already on the newest upstream does not fail on an
+          # empty commit.  Scope the identity to this single commit (-c /
+          # --author) so it does not persist into the repo config and bleed
+          # into the semantic-release commit that follows.  Not pushed here --
           # semantic-release pushes the branch below.
           git add maidr/static/maidr.js maidr/static/maidr.css maidr/static/VERSION
-          git -c user.name="xabilitylab" \
-              -c user.email="187909674+xabilitylab@users.noreply.github.com" \
-              commit -m "chore: update bundled maidr.js to v${VERSION}" \
-              --author="xabilitylab <187909674+xabilitylab@users.noreply.github.com>"
+          if git diff --cached --quiet; then
+            echo "Bundle already at v${VERSION}; nothing to commit."
+          else
+            git -c user.name="xabilitylab" \
+                -c user.email="187909674+xabilitylab@users.noreply.github.com" \
+                commit -m "chore: update bundled maidr.js to v${VERSION}" \
+                --author="xabilitylab <187909674+xabilitylab@users.noreply.github.com>"
+          fi
 
       - name: Python Semantic Release
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,18 +151,22 @@ jobs:
           test -s maidr/static/maidr.css
           test -s maidr/static/VERSION
           for asset in maidr.js maidr.css; do
-            head -c 128 "maidr/static/${asset}" | grep -Eqv "^<!DOCTYPE|^<html" || {
-              echo "${asset} looks like an HTML error page" >&2; exit 1;
-            }
+            if head -c 128 "maidr/static/${asset}" | grep -qiE "^[[:space:]]*<!DOCTYPE|^[[:space:]]*<html"; then
+              echo "${asset} looks like an HTML error page" >&2; exit 1
+            fi
           done
 
           # Commit as xabilitylab so the refreshed bundle is attributed to
           # the org account and lands in the release history / changelog.
-          # Not pushed here -- semantic-release pushes the branch below.
-          git config user.name "xabilitylab"
-          git config user.email "187909674+xabilitylab@users.noreply.github.com"
+          # Scope the identity to this single commit (-c / --author) so it
+          # does not persist into the repo config and bleed into the
+          # semantic-release commit that follows.  Not pushed here --
+          # semantic-release pushes the branch below.
           git add maidr/static/maidr.js maidr/static/maidr.css maidr/static/VERSION
-          git commit -m "chore: update bundled maidr.js to v${VERSION}"
+          git -c user.name="xabilitylab" \
+              -c user.email="187909674+xabilitylab@users.noreply.github.com" \
+              commit -m "chore: update bundled maidr.js to v${VERSION}" \
+              --author="xabilitylab <187909674+xabilitylab@users.noreply.github.com>"
 
       - name: Python Semantic Release
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,73 @@ jobs:
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 
+      - name: Bundle latest upstream maidr.js into this release
+        # Pull the newest upstream ``maidr.js`` / ``maidr.css`` at release
+        # time so the exact assets shipped to PyPI (and recorded in the
+        # changelog) match the upstream release that was current when
+        # py-maidr cut its own release.  The refresh is committed locally
+        # as ``xabilitylab`` but intentionally *not* pushed here: the
+        # semantic-release step below pushes the branch, so this commit
+        # ships only when a release actually happens.  When no release is
+        # pending the commit is discarded with the runner, so the bundle
+        # never trickles onto ``main`` between releases.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Skip the refresh only when we are confident no release will be
+          # cut for this push.  On any uncertainty we fall through and let
+          # the semantic-release push gate whether the commit survives.
+          NEXT=$(uv run semantic-release version --print 2>/dev/null || true)
+          LAST=$(uv run semantic-release version --print-last-released 2>/dev/null || true)
+          if [ -n "$NEXT" ] && [ -n "$LAST" ] && [ "$NEXT" = "$LAST" ]; then
+            echo "No release pending (version stays at $LAST); skipping bundle refresh."
+            exit 0
+          fi
+          echo "Release pending (${LAST:-<none>} -> ${NEXT:-<unknown>}); refreshing bundle."
+
+          # Resolve the latest upstream maidr.js release on npm.
+          VERSION=$(curl -sL "https://registry.npmjs.org/maidr/latest" | jq -r '.version')
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "Failed to resolve upstream maidr.js version" >&2
+            exit 1
+          fi
+
+          CURRENT=""
+          if [ -f maidr/static/VERSION ]; then
+            CURRENT=$(tr -d '[:space:]' < maidr/static/VERSION)
+          fi
+          if [ "$VERSION" = "$CURRENT" ]; then
+            echo "Bundle already at v$VERSION; nothing to refresh."
+            exit 0
+          fi
+
+          echo "Updating bundled maidr.js: ${CURRENT:-<none>} -> $VERSION"
+          mkdir -p maidr/static
+          curl -sSfL -o maidr/static/maidr.js \
+            "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.js"
+          curl -sSfL -o maidr/static/maidr.css \
+            "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.css"
+          printf "%s\n" "$VERSION" > maidr/static/VERSION
+
+          # Sanity-check the downloads and reject HTML error pages
+          # masquerading as JS / CSS.
+          test -s maidr/static/maidr.js
+          test -s maidr/static/maidr.css
+          test -s maidr/static/VERSION
+          head -c 128 maidr/static/maidr.js | grep -Eqv "^<!DOCTYPE|^<html" || {
+            echo "maidr.js looks like an HTML error page" >&2; exit 1;
+          }
+
+          # Commit as xabilitylab so the refreshed bundle is attributed to
+          # the org account and lands in the release history / changelog.
+          # Not pushed here -- semantic-release pushes the branch below.
+          git config user.name "xabilitylab"
+          git config user.email "187909674+xabilitylab@users.noreply.github.com"
+          git add maidr/static/maidr.js maidr/static/maidr.css maidr/static/VERSION
+          git commit -m "chore: update bundled maidr.js to v${VERSION}"
+
       - name: Python Semantic Release
         id: release
         uses: python-semantic-release/python-semantic-release@v9.21.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Lint commit messages
         uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,6 @@ jobs:
         # ships only when a release actually happens.  When no release is
         # pending the commit is discarded with the runner, so the bundle
         # never trickles onto ``main`` between releases.
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -152,9 +150,11 @@ jobs:
           test -s maidr/static/maidr.js
           test -s maidr/static/maidr.css
           test -s maidr/static/VERSION
-          head -c 128 maidr/static/maidr.js | grep -Eqv "^<!DOCTYPE|^<html" || {
-            echo "maidr.js looks like an HTML error page" >&2; exit 1;
-          }
+          for asset in maidr.js maidr.css; do
+            head -c 128 "maidr/static/${asset}" | grep -Eqv "^<!DOCTYPE|^<html" || {
+              echo "${asset} looks like an HTML error page" >&2; exit 1;
+            }
+          done
 
           # Commit as xabilitylab so the refreshed bundle is attributed to
           # the org account and lands in the release history / changelog.

--- a/.github/workflows/update-maidr-js.yml
+++ b/.github/workflows/update-maidr-js.yml
@@ -1,9 +1,15 @@
 name: Update bundled maidr.js
 
-# Downloads the latest ``maidr.js`` / ``maidr.css`` from the jsDelivr CDN
-# into ``maidr/static/`` and commits the changes directly to ``main``.
-# This keeps the offline-bundled copy in sync with the upstream npm
-# release without requiring the files to be updated manually.
+# Manual escape hatch for refreshing the offline-bundled ``maidr.js`` /
+# ``maidr.css`` from the jsDelivr CDN into ``maidr/static/`` and committing
+# the changes directly to ``main``.
+#
+# The routine, automatic refresh happens at py-maidr *release* time (see
+# ``release.yml``), so the latest upstream release is bundled *into* each
+# py-maidr release rather than trickling onto ``main`` whenever upstream
+# publishes.  This workflow is kept only for on-demand refreshes between
+# releases and is therefore ``workflow_dispatch``-only -- there is no
+# scheduled trigger.
 #
 # The commit uses the ``chore:`` prefix so python-semantic-release
 # (configured in ``pyproject.toml``) does not treat a bundle refresh
@@ -17,12 +23,6 @@ on:
         description: "Explicit maidr.js version (defaults to latest on npm)"
         required: false
         default: ""
-  schedule:
-    # Run every day at 06:00 UTC so new npm releases land on ``main``
-    # within 24 hours.  The pre-download version check below makes the
-    # job a no-op when the bundle is already current, so the daily
-    # cadence adds no commit noise.
-    - cron: "0 6 * * *"
 
 permissions:
   contents: write
@@ -105,6 +105,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: update bundled maidr.js to v${{ steps.resolve.outputs.version }}"
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_user_name: "xabilitylab"
+          commit_user_email: "187909674+xabilitylab@users.noreply.github.com"
+          commit_author: "xabilitylab <187909674+xabilitylab@users.noreply.github.com>"
           file_pattern: "maidr/static/maidr.js maidr/static/maidr.css maidr/static/VERSION"

--- a/.github/workflows/update-maidr-js.yml
+++ b/.github/workflows/update-maidr-js.yml
@@ -35,78 +35,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Resolve maidr.js version
-        id: resolve
+      - name: Resolve, download and verify bundled assets
+        id: bundle
         run: |
           set -euo pipefail
-          if [ -n "${{ github.event.inputs.maidr_version }}" ]; then
-            VERSION="${{ github.event.inputs.maidr_version }}"
-          else
-            VERSION=$(curl -sL "https://registry.npmjs.org/maidr/latest" | jq -r '.version')
-          fi
-          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-            echo "Failed to resolve maidr.js version" >&2
-            exit 1
-          fi
+          # Resolve (or use the requested version), download, and verify the
+          # bundle via the shared script (also used by release.yml).
+          VERSION=$(.github/scripts/fetch-maidr-bundle.sh "${{ github.event.inputs.maidr_version }}")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Resolved maidr.js version: $VERSION"
-
-      - name: Read currently bundled version
-        id: current
-        run: |
-          set -euo pipefail
-          if [ -f maidr/static/VERSION ]; then
-            CURRENT=$(tr -d '[:space:]' < maidr/static/VERSION)
-          else
-            CURRENT=""
-          fi
-          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
-          echo "Currently bundled maidr.js version: ${CURRENT:-<none>}"
-
-      - name: Skip if already up-to-date
-        id: check
-        run: |
-          set -euo pipefail
-          if [ "${{ steps.resolve.outputs.version }}" = "${{ steps.current.outputs.version }}" ]; then
-            echo "Bundle is already at v${{ steps.resolve.outputs.version }}; nothing to do."
-            echo "needs_update=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Update needed: ${{ steps.current.outputs.version }} -> ${{ steps.resolve.outputs.version }}"
-            echo "needs_update=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Download bundled assets
-        if: steps.check.outputs.needs_update == 'true'
-        env:
-          VERSION: ${{ steps.resolve.outputs.version }}
-        run: |
-          set -euo pipefail
-          mkdir -p maidr/static
-          curl -sSfL -o maidr/static/maidr.js \
-            "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.js"
-          curl -sSfL -o maidr/static/maidr.css \
-            "https://cdn.jsdelivr.net/npm/maidr@${VERSION}/dist/maidr.css"
-          printf "%s\n" "$VERSION" > maidr/static/VERSION
-
-      - name: Verify downloaded assets
-        if: steps.check.outputs.needs_update == 'true'
-        run: |
-          set -euo pipefail
-          test -s maidr/static/maidr.js
-          test -s maidr/static/maidr.css
-          test -s maidr/static/VERSION
-          # Reject HTML error pages masquerading as JS / CSS.
-          for asset in maidr.js maidr.css; do
-            if head -c 128 "maidr/static/${asset}" | grep -qiE "^[[:space:]]*<!DOCTYPE|^[[:space:]]*<html"; then
-              echo "${asset} looks like an HTML error page" >&2; exit 1
-            fi
-          done
 
       - name: Commit updated bundle to main
-        if: steps.check.outputs.needs_update == 'true'
+        # git-auto-commit-action is a no-op when the download produced no
+        # change, so an already-current bundle simply commits nothing.
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore: update bundled maidr.js to v${{ steps.resolve.outputs.version }}"
+          commit_message: "chore: update bundled maidr.js to v${{ steps.bundle.outputs.version }}"
           commit_user_name: "xabilitylab"
           commit_user_email: "187909674+xabilitylab@users.noreply.github.com"
           commit_author: "xabilitylab <187909674+xabilitylab@users.noreply.github.com>"

--- a/.github/workflows/update-maidr-js.yml
+++ b/.github/workflows/update-maidr-js.yml
@@ -37,11 +37,16 @@ jobs:
 
       - name: Resolve, download and verify bundled assets
         id: bundle
+        env:
+          # Pass the dispatch input through the environment rather than
+          # interpolating ${{ ... }} into the script text, which would be a
+          # shell-injection surface in a job holding contents: write.
+          MAIDR_VERSION: ${{ github.event.inputs.maidr_version }}
         run: |
           set -euo pipefail
           # Resolve (or use the requested version), download, and verify the
           # bundle via the shared script (also used by release.yml).
-          VERSION=$(.github/scripts/fetch-maidr-bundle.sh "${{ github.event.inputs.maidr_version }}")
+          VERSION=$(.github/scripts/fetch-maidr-bundle.sh "$MAIDR_VERSION")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Commit updated bundle to main

--- a/.github/workflows/update-maidr-js.yml
+++ b/.github/workflows/update-maidr-js.yml
@@ -96,9 +96,11 @@ jobs:
           test -s maidr/static/maidr.css
           test -s maidr/static/VERSION
           # Reject HTML error pages masquerading as JS / CSS.
-          head -c 128 maidr/static/maidr.js | grep -Eqv "^<!DOCTYPE|^<html" || {
-            echo "maidr.js looks like an HTML error page" >&2; exit 1;
-          }
+          for asset in maidr.js maidr.css; do
+            if head -c 128 "maidr/static/${asset}" | grep -qiE "^[[:space:]]*<!DOCTYPE|^[[:space:]]*<html"; then
+              echo "${asset} looks like an HTML error page" >&2; exit 1
+            fi
+          done
 
       - name: Commit updated bundle to main
         if: steps.check.outputs.needs_update == 'true'


### PR DESCRIPTION
Move the automatic maidr.js bundle refresh from a standalone daily cron
onto py-maidr's own release. The release job now pulls the latest upstream
maidr.js/css before semantic-release runs and commits it locally so it
ships in the released PyPI artifact and its changelog; the commit is only
pushed when a release is actually cut. The former daily schedule in
update-maidr-js.yml is dropped, leaving it as a manual escape hatch.

Both auto-commits are now attributed to xabilitylab instead of the
triggering user's personal account.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P2oH45S6s566ssHQ62zsgL