### PR TITLE
feat(step): add step plot support with ordinal level names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The `maidr/patch/` modules use `wrapt` to intercept matplotlib/seaborn plot call
 
 ### Supported Plot Types
 
-Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, COUNT, DODGED, HEAT, HIST, LINE, SCATTER, STACKED, SMOOTH, CANDLESTICK.
+Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, COUNT, DODGED, HEAT, HIST, LINE, SCATTER, STACKED, STEP, SMOOTH, CANDLESTICK.
 
 ### Canonical `axes` Payload
 

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -411,9 +411,9 @@ and maidr reports it so the description can say what the chart actually means:
 ::: {.callout-note}
 Level names are read from the y tick labels at render time, so calling
 `set_yticks()` or `set_yticklabels()` *after* plotting works as expected. A tick
-label that merely spells out its own position (`"3"` at y = 3) carries no
-ordinal information and is not emitted, so a purely numeric step plot is
-announced by its numbers as usual.
+label that is itself a number (`"3"`, `"1,000"`, or the rescaled `"0.0"` a
+default axis prints for y = 1000000) carries no ordinal information and is not
+emitted, so a purely numeric step plot is announced by its numbers as usual.
 :::
 
 ### Heat Map

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -354,6 +354,68 @@ plt.show() #<<
 
 ```
 
+### Step Plot
+
+A step plot is the right chart when the value is *piecewise constant*: it is
+held across an interval and then jumps, rather than sliding continuously
+between samples. `ax.step()` produces one, as does any `drawstyle="steps-*"`
+passed to `ax.plot()` or `sns.lineplot()`.
+
+The classic case is a **hypnogram** — an ordinal sleep stage against time. Plot
+the stages as numeric codes so they keep driving sonification, braille and the
+min/max bounds, then name the codes with `set_yticks(..., labels=...)`. maidr
+attaches the names to each point and announces "REM" instead of "3".
+
+```{python}
+#| fig-alt: Hypnogram of sleep stage across one night
+
+import matplotlib.pyplot as plt
+
+import maidr #<<
+
+# Ordinal sleep stages, deepest first, so "up" means lighter sleep.
+stage_codes = [0, 1, 2, 3, 4]
+stage_names = ["N3", "N2", "N1", "REM", "Awake"]
+
+# One reading every half hour across a night's sleep.
+hours = [i * 0.5 for i in range(17)]
+stages = [4, 3, 2, 1, 0, 0, 1, 3, 2, 1, 0, 1, 3, 2, 1, 3, 4]
+
+fig, ax = plt.subplots(figsize=(10, 5))
+
+# where="post": the stage holds until the next reading, then jumps.
+ax.step(hours, stages, where="post") #<<
+
+# Name the ordinal levels; the underlying y values stay numeric.
+ax.set_yticks(stage_codes, labels=stage_names) #<<
+
+ax.set_title("Hypnogram\nSleep stage across one night")
+ax.set_xlabel("Time asleep (hours)")
+ax.set_ylabel("Sleep stage")
+
+# Add a number formatter for better screen reader output
+ax.xaxis.set_major_formatter("{x:.1f}")
+
+plt.show() #<<
+```
+
+The `where` argument decides which side of each sample the value is held on,
+and maidr reports it so the description can say what the chart actually means:
+
+| matplotlib | maidr `stepDirection` | Meaning |
+|------------|-----------------------|---------|
+| `where="post"` (`drawstyle="steps-post"`) | `hv` | Value holds until the next x value, then jumps |
+| `where="pre"` (`drawstyle="steps-pre"` or `"steps"`) | `vh` | Value jumps at the current x value, then holds |
+| `where="mid"` (`drawstyle="steps-mid"`) | `mid` | Value jumps midway between x values |
+
+::: {.callout-note}
+Level names are read from the y tick labels at render time, so calling
+`set_yticks()` or `set_yticklabels()` *after* plotting works as expected. A tick
+label that merely spells out its own position (`"3"` at y = 3) carries no
+ordinal information and is not emitted, so a purely numeric step plot is
+announced by its numbers as usual.
+:::
+
 ### Heat Map
 
 ```{python}

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -65,6 +65,8 @@ We currently support the following data visualization libraries in Python:, and 
 
 * Multi-line plot having one x (numerical) and one y (numerical) axis with multiple data series on the same axes.
 
+* Step plot having one x (numerical) and one y (numerical or ordinal) axis, for piecewise-constant values that are held over an interval and then jump — e.g. a hypnogram of sleep stage against time. Named y tick labels are announced as level names in place of the numeric level.
+
 * Vertical box plot having one x (categorical) and one y (numerical) axis.
 
 * Horizontal box plot having one x (numerical) and one y (categorical) axis.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > py-maidr is a Python library that makes matplotlib, seaborn, and plotly data visualizations accessible to blind and low-vision users through sonification, braille, text, and AI-powered conversational modalities. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
 
-maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, box, violin, heatmap, scatter, smooth/regression, candlestick, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
+maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, box, violin, heatmap, scatter, smooth/regression, candlestick, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
 
 ## Docs
 - [Documentation Home](https://py.maidr.ai/): Installation, quick start, and overview

--- a/example/step/matplotlib/example_mpl_step.py
+++ b/example/step/matplotlib/example_mpl_step.py
@@ -1,0 +1,43 @@
+"""Hypnogram: a sleep stage held over an interval, then jumping to the next.
+
+A hypnogram is the motivating case for a step plot. Sleep stage is *ordinal* —
+Awake, REM, N1, N2, N3 — and it is piecewise constant: a stage is held for a
+stretch of the night and then jumps. Drawing it as a line chart would imply the
+sleeper glided continuously through the intermediate stages, which is not what
+the data says.
+
+Plot the stages as numeric codes so they keep driving sonification, braille and
+the min/max bounds, then name the codes with ``set_yticks(..., labels=...)``.
+maidr picks the names up and announces "REM" instead of "3".
+"""
+
+import matplotlib.pyplot as plt
+
+import maidr  # noqa: F401
+
+# Ordinal sleep stages, deepest first, so that "up" means lighter sleep.
+STAGE_CODES = [0, 1, 2, 3, 4]
+STAGE_NAMES = ["N3", "N2", "N1", "REM", "Awake"]
+
+# One reading every half hour across a night's sleep.
+hours = [i * 0.5 for i in range(17)]
+stages = [4, 3, 2, 1, 0, 0, 1, 3, 2, 1, 0, 1, 3, 2, 1, 3, 4]
+
+fig, ax = plt.subplots(figsize=(10, 5))
+
+# where="post" is the hypnogram reading: the stage holds until the next
+# reading, then jumps. maidr exports this as stepDirection "hv".
+ax.step(hours, stages, where="post")
+
+# Name the ordinal levels. This is what turns "3" into "REM" in the audio and
+# text output; the underlying y values stay numeric.
+ax.set_yticks(STAGE_CODES, labels=STAGE_NAMES)
+
+ax.set_title("Hypnogram\nSleep stage across one night")
+ax.set_xlabel("Time asleep (hours)")
+ax.set_ylabel("Sleep stage")
+
+# Format the x axis for better screen reader output.
+ax.xaxis.set_major_formatter("{x:.1f}")
+
+plt.show()

--- a/example/step/seaborn/example_sns_step.py
+++ b/example/step/seaborn/example_sns_step.py
@@ -1,0 +1,46 @@
+"""Hypnogram drawn with seaborn: a sleep stage held over an interval, then jumping.
+
+seaborn has no dedicated step function, but ``lineplot`` forwards ``drawstyle``
+through to matplotlib, and maidr classifies a layer by the drawstyle of the
+artists that come back — so ``drawstyle="steps-post"`` produces a step layer
+here exactly as ``ax.step(..., where="post")`` does in the matplotlib example.
+
+As there, the stages are plotted as numeric codes so they keep driving
+sonification, braille and the min/max range, and are named afterwards with
+``set_yticks(..., labels=...)``. maidr picks the names up and announces "REM"
+instead of "3".
+"""
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+
+import maidr  # noqa: F401
+
+# Ordinal sleep stages, deepest first, so that "up" means lighter sleep.
+STAGE_CODES = [0, 1, 2, 3, 4]
+STAGE_NAMES = ["N3", "N2", "N1", "REM", "Awake"]
+
+# One reading every half hour across a night's sleep.
+night = pd.DataFrame(
+    {
+        "hours": [i * 0.5 for i in range(17)],
+        "stage": [4, 3, 2, 1, 0, 0, 1, 3, 2, 1, 0, 1, 3, 2, 1, 3, 4],
+    }
+)
+
+fig, ax = plt.subplots(figsize=(10, 5))
+
+# drawstyle="steps-post" is the hypnogram reading: the stage holds until the
+# next reading, then jumps. maidr exports this as stepDirection "hv".
+sns.lineplot(data=night, x="hours", y="stage", drawstyle="steps-post", ax=ax)
+
+# Name the ordinal levels. This is what turns "3" into "REM" in the audio and
+# text output; the underlying y values stay numeric.
+ax.set_yticks(STAGE_CODES, labels=STAGE_NAMES)
+
+ax.set_title("Hypnogram\nSleep stage across one night")
+ax.set_xlabel("Time asleep (hours)")
+ax.set_ylabel("Sleep stage")
+
+plt.show()

--- a/maidr/backend.py
+++ b/maidr/backend.py
@@ -114,7 +114,11 @@ def _show_fallback(fig: Figure) -> None:
     # drifted, naming "kde" and "violin" (neither is a PlotType) while omitting
     # smooth and the violin_* variants. Deriving it keeps a user-facing message
     # honest as plot types are added.
-    supported = ", ".join(sorted(plot_type.value for plot_type in PlotType))
+    #
+    # display_name, not .value: the values are wire identifiers, so a user who
+    # called ax.scatter() would otherwise be told about "point". The set() folds
+    # the two violin layers, which share a display name, back into one entry.
+    supported = ", ".join(sorted({plot_type.display_name for plot_type in PlotType}))
     warnings.warn(
         "This figure contains plot type(s) not yet supported by maidr. "
         f"Falling back to static image. Supported types: {supported}.",

--- a/maidr/backend.py
+++ b/maidr/backend.py
@@ -111,7 +111,8 @@ def _show_fallback(fig: Figure) -> None:
     warnings.warn(
         "This figure contains plot type(s) not yet supported by maidr. "
         "Falling back to static image. Supported types: bar, box, count, "
-        "dodged, heat, hist, line, scatter, stacked, kde, violin, candlestick.",
+        "dodged, heat, hist, line, step, scatter, stacked, kde, violin, "
+        "candlestick.",
         stacklevel=4,
     )
 

--- a/maidr/backend.py
+++ b/maidr/backend.py
@@ -25,6 +25,8 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 
+from maidr.core.enum.plot_type import PlotType
+
 _logger = logging.getLogger(__name__)
 
 # Required matplotlib backend exports.
@@ -108,11 +110,14 @@ def _show_fallback(fig: Figure) -> None:
     # stacklevel=4 traces through: user code → plt.show() → backend.show()
     # → _show_fallback() → warnings.warn().  If the internal call chain
     # changes, this value must be updated.
+    # Built from PlotType rather than hand-listed: the previous literal had
+    # drifted, naming "kde" and "violin" (neither is a PlotType) while omitting
+    # smooth and the violin_* variants. Deriving it keeps a user-facing message
+    # honest as plot types are added.
+    supported = ", ".join(sorted(plot_type.value for plot_type in PlotType))
     warnings.warn(
         "This figure contains plot type(s) not yet supported by maidr. "
-        "Falling back to static image. Supported types: bar, box, count, "
-        "dodged, heat, hist, line, step, scatter, stacked, kde, violin, "
-        "candlestick.",
+        f"Falling back to static image. Supported types: {supported}.",
         stacklevel=4,
     )
 

--- a/maidr/core/enum/maidr_key.py
+++ b/maidr/core/enum/maidr_key.py
@@ -43,6 +43,9 @@ class MaidrKey(str, Enum):
     # Scatter plot grid navigation keys.
     TICK_STEP = "tickStep"
 
+    # Step plot keys. The per-point ordinal level name reuses LABEL above.
+    STEP_DIRECTION = "stepDirection"
+
     # Histogram plot keys.
     X_MIN = "xMin"
     X_MAX = "xMax"

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -18,3 +18,36 @@ class PlotType(str, Enum):
     CANDLESTICK = "candlestick"
     VIOLIN_KDE = "violin_kde"
     VIOLIN_BOX = "violin_box"
+
+    @property
+    def display_name(self) -> str:
+        """
+        Name for this plot type as a *user* would recognise it.
+
+        A member's value is the MAIDR wire identifier, which does not always
+        match what the user called: someone who ran ``ax.scatter`` should be
+        told about "scatter", not about ``point``. Use this whenever a plot
+        type is named in a message a user reads; use ``.value`` for the schema.
+
+        Returns
+        -------
+        str
+            The user-facing name, falling back to the wire value when the two
+            are already the same.
+        """
+        return _DISPLAY_NAMES.get(self, self.value)
+
+
+#: Overrides for the members whose wire value is not what a user would call the
+#: plot. Members absent here already read naturally (``bar``, ``line``, ...).
+#: Both violin layers display as "violin" because they are two layers of one
+#: plot, and callers de-duplicate.
+_DISPLAY_NAMES = {
+    PlotType.DODGED: "dodged bar",
+    PlotType.HEAT: "heatmap",
+    PlotType.HIST: "histogram",
+    PlotType.SCATTER: "scatter",
+    PlotType.STACKED: "stacked bar",
+    PlotType.VIOLIN_BOX: "violin",
+    PlotType.VIOLIN_KDE: "violin",
+}

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -13,6 +13,7 @@ class PlotType(str, Enum):
     LINE = "line"
     SCATTER = "point"
     STACKED = "stacked_bar"
+    STEP = "step"
     SMOOTH = "smooth"
     CANDLESTICK = "candlestick"
     VIOLIN_KDE = "violin_kde"

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -47,6 +47,7 @@ class FigureManager:
         PlotType.STACKED: 2,
         PlotType.DODGED: 2,  # DODGED and STACKED have same priority
         PlotType.LINE: 1,
+        PlotType.STEP: 1,
         PlotType.SCATTER: 1,
         PlotType.HIST: 1,
         PlotType.BOX: 1,

--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -22,13 +22,17 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
     ----------
     ax : Axes
         The matplotlib axes object containing the line plot(s).
+    plot_type : PlotType, optional
+        The layer type to emit, by default ``PlotType.LINE``. Subclasses that
+        share this extraction logic but describe a different chart — notably
+        :class:`maidr.core.plot.stepplot.StepPlot` — override it.
     **kwargs : dict
         Additional keyword arguments to pass to the parent class.
 
     Attributes
     ----------
     type : PlotType
-        Set to PlotType.LINE to identify this as a line plot.
+        The plot type this layer identifies as, ``PlotType.LINE`` by default.
 
     Notes
     -----
@@ -38,8 +42,8 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
       (fill values) for each point.
     """
 
-    def __init__(self, ax: Axes, **kwargs):
-        super().__init__(ax, PlotType.LINE)
+    def __init__(self, ax: Axes, plot_type: PlotType = PlotType.LINE, **kwargs):
+        super().__init__(ax, plot_type)
 
     def _extract_axes_data(self) -> dict:
         """

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -11,6 +11,7 @@ from maidr.core.plot.lineplot import MultiLinePlot
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.regplot import SmoothPlot
+from maidr.core.plot.stepplot import StepPlot
 from maidr.core.plot.violin_kde_plot import ViolinKdePlot
 from maidr.core.plot.violin_box_plot import ViolinBoxPlot
 from maidr.core.plot.mplfinance_barplot import MplfinanceBarPlot
@@ -61,6 +62,8 @@ class MaidrPlotFactory:
                 return MplfinanceLinePlot(single_ax, **kwargs)
             else:
                 return MultiLinePlot(single_ax, **kwargs)
+        elif PlotType.STEP == plot_type:
+            return StepPlot(single_ax, **kwargs)
         elif PlotType.SCATTER == plot_type:
             return ScatterPlot(single_ax)
         elif PlotType.DODGED == plot_type or PlotType.STACKED == plot_type:

--- a/maidr/core/plot/stepplot.py
+++ b/maidr/core/plot/stepplot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Dict, List, Optional
 
 from matplotlib.axes import Axes
@@ -204,10 +205,17 @@ class StepPlot(MultiLinePlot):
             ``True`` when ``text`` parses as a number equal to ``position``.
             A label matplotlib cannot have generated from the number alone —
             ``"$1,000"``, ``"Awake"`` — returns ``False`` and is kept.
+
+        Notes
+        -----
+        The comparison is approximate because a tick label is a *rounded*
+        rendering of its position (``0.30000000000000004`` prints as
+        ``"0.3"``), so exact equality would let the echo through and put a
+        redundant label on every point.
         """
         # matplotlib renders negative ticks with U+2212 MINUS SIGN.
         normalized = text.replace(",", "").replace("−", "-")
         try:
-            return float(normalized) == position
+            return math.isclose(float(normalized), position, rel_tol=1e-6, abs_tol=1e-9)
         except ValueError:
             return False

--- a/maidr/core/plot/stepplot.py
+++ b/maidr/core/plot/stepplot.py
@@ -1,0 +1,213 @@
+"""StepPlot — a piecewise-constant line whose levels may carry ordinal names."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from matplotlib.axes import Axes
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.core.plot.lineplot import MultiLinePlot
+from maidr.util.step_utils import resolve_step_direction
+
+
+class StepPlot(MultiLinePlot):
+    """
+    A step (stairs) plot layer, where the value is held across an interval and
+    then jumps rather than being interpolated between samples.
+
+    Numerically a step plot is a line plot, so all coordinate extraction,
+    per-series nesting, GID assignment, selector generation and legend/``z``
+    handling are inherited unchanged from :class:`MultiLinePlot`. ``y`` stays
+    numeric because it is what drives sonification, braille and the min/max
+    bounds on the MAIDR side.
+
+    On top of that this class emits the two things a step chart has that a
+    line chart does not:
+
+    ``stepDirection``
+        Which side of each sample the value is held on, mapped from the
+        matplotlib ``drawstyle``. Omitted when the axes does not author one
+        unambiguously.
+    per-point ``label``
+        The ordinal level *name* for a point's numeric ``y`` — ``"REM"``
+        rather than ``3`` — resolved from the y tick labels. This is what
+        makes a hypnogram (sleep stage against time) announce a stage name
+        instead of an opaque stage code.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib axes object containing the step line(s).
+    **kwargs : dict
+        Additional keyword arguments forwarded to the parent class.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        super().__init__(ax, PlotType.STEP, **kwargs)
+
+    def render(self) -> dict:
+        """
+        Build the base line schema, then add the step-specific payload.
+
+        Returns
+        -------
+        dict
+            The MAIDR layer schema, with ``stepDirection`` added when the axes
+            authors one and a ``label`` added to every point that sits on a
+            named y tick.
+
+        Notes
+        -----
+        ``super().render()`` must run first: it is what merges the per-axis
+        format configuration into ``axes`` and attaches ``selectors``, and it
+        is what produces the ``data`` payload this method annotates.
+        """
+        schema = super().render()
+
+        direction = resolve_step_direction(self.ax)
+        if direction is not None:
+            schema[MaidrKey.STEP_DIRECTION] = direction
+
+        self._attach_level_labels(schema.get(MaidrKey.DATA))
+
+        return schema
+
+    def _attach_level_labels(self, data: Optional[List[List[dict]]]) -> None:
+        """
+        Add ``label`` to every point whose ``y`` sits on a named y tick.
+
+        Points whose ``y`` does not land on a named tick are left untouched,
+        so a numeric step plot emits no labels at all rather than emitting
+        misleading ones.
+
+        Parameters
+        ----------
+        data : list of list of dict or None
+            The nested per-series point payload produced by the parent class.
+            Mutated in place.
+        """
+        levels = self._resolve_y_levels()
+        if not levels or not data:
+            return
+
+        for series in data:
+            for point in series:
+                y = point.get(MaidrKey.Y)
+                try:
+                    name = levels.get(float(y))  # type: ignore[arg-type]
+                except (TypeError, ValueError):
+                    continue
+                if name:
+                    point[MaidrKey.LABEL] = name
+
+    def _resolve_y_levels(self) -> Dict[float, str]:
+        """
+        Map each named y tick position to its ordinal level name.
+
+        Resolution happens at *render* time, not at patch time, because the
+        idiomatic way to build a hypnogram is to plot the numeric stage codes
+        first and name them afterwards with ``ax.set_yticks(codes,
+        labels=names)`` or ``ax.set_yticklabels(names)``.
+
+        Notes
+        -----
+        The map is keyed by tick *coordinate* rather than by index, and is
+        read straight off the axes rather than through
+        :meth:`maidr.util.mixin.extractor_mixin.LevelExtractorMixin.extract_level`.
+        That helper filters tick labels against ``ax.dataLim``, which silently
+        drops the boundary levels — precisely the ``Awake`` and ``N3`` ends of
+        a hypnogram — and returns labels without their positions, so it cannot
+        answer "which level is at y = 4?" at all.
+
+        Returns
+        -------
+        dict
+            ``{tick position: level name}``. Empty when the axes carries no
+            named levels.
+        """
+        levels = self._levels_from_ticks(self.ax)
+        if levels:
+            return levels
+
+        # Fallback: a faceted hypnogram commonly names the levels on only one
+        # panel of a ``sharey`` group, mirroring how ``extract_shared_ylabel``
+        # recovers a shared axis label.
+        try:
+            siblings = self.ax.get_shared_y_axes().get_siblings(self.ax)
+        except (AttributeError, TypeError):
+            return {}
+
+        for sibling in siblings:
+            if sibling is self.ax:
+                continue
+            levels = self._levels_from_ticks(sibling)
+            if levels:
+                return levels
+
+        return {}
+
+    @staticmethod
+    def _levels_from_ticks(ax: Axes) -> Dict[float, str]:
+        """
+        Read ``{tick position: level name}`` off a single axes.
+
+        Blank labels are skipped, as are labels that merely spell out their
+        own tick position (``"3"`` at y = 3, ``"1,000"`` at y = 1000). Those
+        carry no ordinal information, so emitting them would add a ``label``
+        to every point of an ordinary numeric step plot and make MAIDR
+        announce the number it was already going to announce.
+
+        Parameters
+        ----------
+        ax : Axes
+            The axes whose y ticks should be read.
+
+        Returns
+        -------
+        dict
+            ``{tick position: level name}``, possibly empty.
+        """
+        try:
+            positions = list(ax.get_yticks())
+            labels = [text.get_text() for text in ax.get_yticklabels()]
+        except (AttributeError, TypeError):
+            return {}
+
+        levels: Dict[float, str] = {}
+        for position, text in zip(positions, labels):
+            name = text.strip()
+            if not name:
+                continue
+            coord = float(position)
+            if StepPlot._is_numeral_echo(name, coord):
+                continue
+            levels[coord] = name
+        return levels
+
+    @staticmethod
+    def _is_numeral_echo(text: str, position: float) -> bool:
+        """
+        Report whether a tick label is just its own position written out.
+
+        Parameters
+        ----------
+        text : str
+            The tick label text.
+        position : float
+            The tick's data coordinate.
+
+        Returns
+        -------
+        bool
+            ``True`` when ``text`` parses as a number equal to ``position``.
+            A label matplotlib cannot have generated from the number alone —
+            ``"$1,000"``, ``"Awake"`` — returns ``False`` and is kept.
+        """
+        # matplotlib renders negative ticks with U+2212 MINUS SIGN.
+        normalized = text.replace(",", "").replace("−", "-")
+        try:
+            return float(normalized) == position
+        except ValueError:
+            return False

--- a/maidr/core/plot/stepplot.py
+++ b/maidr/core/plot/stepplot.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import math
 from typing import Dict, List, Optional
 
+from matplotlib import cbook
 from matplotlib.axes import Axes
 
 from maidr.core.enum.maidr_key import MaidrKey
@@ -154,11 +154,17 @@ class StepPlot(MultiLinePlot):
         """
         Read ``{tick position: level name}`` off a single axes.
 
-        Blank labels are skipped, as are labels that merely spell out their
-        own tick position (``"3"`` at y = 3, ``"1,000"`` at y = 1000). Those
-        carry no ordinal information, so emitting them would add a ``label``
-        to every point of an ordinary numeric step plot and make MAIDR
-        announce the number it was already going to announce.
+        Blank labels are skipped, as are labels that are themselves numerals
+        (``"3"``, ``"1,000"``, ``"−0.5"``) and labels rendered as mathtext
+        (``"$\\mathdefault{10^{1}}$"`` on a log axis). Neither carries ordinal
+        information: they are the y *number* written out by a tick formatter,
+        which MAIDR already announces, and a formatter is free to write a
+        number that is not the tick's own coordinate — the default
+        ``ScalarFormatter`` labels y = 1000000 as ``"0.0"`` once it factors an
+        offset out, and ``ticklabel_format(style="sci")`` labels it ``"1.00"``.
+        Emitting those as level names would announce a flatly wrong value, so
+        every numeral is dropped rather than only the ones that echo their own
+        position.
 
         Parameters
         ----------
@@ -181,41 +187,46 @@ class StepPlot(MultiLinePlot):
             name = text.strip()
             if not name:
                 continue
-            coord = float(position)
-            if StepPlot._is_numeral_echo(name, coord):
+            if StepPlot._is_number_rendering(name):
                 continue
-            levels[coord] = name
+            levels[float(position)] = name
         return levels
 
     @staticmethod
-    def _is_numeral_echo(text: str, position: float) -> bool:
+    def _is_number_rendering(text: str) -> bool:
         """
-        Report whether a tick label is just its own position written out.
+        Report whether a tick label is a formatter's rendering of a number.
 
         Parameters
         ----------
         text : str
             The tick label text.
-        position : float
-            The tick's data coordinate.
 
         Returns
         -------
         bool
-            ``True`` when ``text`` parses as a number equal to ``position``.
-            A label matplotlib cannot have generated from the number alone —
-            ``"$1,000"``, ``"Awake"`` — returns ``False`` and is kept.
+            ``True`` when ``text`` parses as a bare number, or is mathtext
+            (which is how numeric formatters typeset exponents). A label a
+            formatter cannot have produced from the number alone — ``"$1,000"``,
+            ``"50%"``, ``"Awake"`` — returns ``False`` and is kept.
 
         Notes
         -----
-        The comparison is approximate because a tick label is a *rounded*
-        rendering of its position (``0.30000000000000004`` prints as
-        ``"0.3"``), so exact equality would let the echo through and put a
-        redundant label on every point.
+        A numeral is rejected whatever its value, not only when it matches its
+        own tick position: an offset or scaled axis renders y = 1000000 as
+        ``"0.0"``, and labelling that point ``"0.0"`` is worse than leaving it
+        unlabelled. The cost is that an axis deliberately relabelled with
+        numerals (``set_yticks([0, 1], labels=["1", "2"])``) yields no level
+        names; those points still sonify and braille from their numeric ``y``.
         """
+        # matplotlib typesets exponents (log axes) as mathtext; announcing the
+        # raw LaTeX would be worse than announcing nothing.
+        if cbook.is_math_text(text):
+            return True
         # matplotlib renders negative ticks with U+2212 MINUS SIGN.
         normalized = text.replace(",", "").replace("−", "-")
         try:
-            return math.isclose(float(normalized), position, rel_tol=1e-6, abs_tol=1e-9)
+            float(normalized)
         except ValueError:
             return False
+        return True

--- a/maidr/patch/lineplot.py
+++ b/maidr/patch/lineplot.py
@@ -8,6 +8,7 @@ from maidr.core.enum import PlotType
 from maidr.patch.common import common
 from maidr.core.context_manager import ContextManager
 from maidr.core.figure_manager import FigureManager
+from maidr.util.step_utils import is_step_axes
 
 
 def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
@@ -15,6 +16,15 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
     Wrapper for line plotting functions that creates a single MAIDR plot per axes to handle
     multiline plots (matplotlib) and single-call plots (seaborn) correctly by preventing
     multiple MAIDR layers and using internal context to avoid cyclic processing.
+
+    The layer type is decided here rather than in a separate patch because
+    ``Axes.step`` is not its own renderer: it sets ``drawstyle="steps-*"`` and
+    delegates to ``Axes.plot``, which this wrapper already intercepts. Choosing
+    the type from the resulting artists' drawstyles therefore covers
+    ``ax.step``, ``plt.step``, ``ax.plot(drawstyle="steps-post")`` and
+    ``sns.lineplot(drawstyle="steps-mid")`` with one rule, and — because no
+    second interception point is added — one call can never register both a
+    STEP and a LINE layer for the same axes.
     """
     # Don't proceed if the call is made internally by the patched function.
     if ContextManager.is_internal_context():
@@ -33,8 +43,11 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
 
     # Check if a MAIDR plot already exists for this axes
     if ax is not None and not hasattr(ax, "_maidr_plot_created"):
+        # Classify from the rendered artists: an axes is a step plot only when
+        # every data-bearing line on it is a step line.
+        plot_type = PlotType.STEP if is_step_axes(ax) else PlotType.LINE
         # Create MAIDR plot only once for this axes using common()
-        common(PlotType.LINE, lambda *a, **k: plot, instance, args, kwargs)
+        common(plot_type, lambda *a, **k: plot, instance, args, kwargs)
         # Mark that a MAIDR plot has been created for this axes
         setattr(ax, "_maidr_plot_created", True)
 

--- a/maidr/util/step_utils.py
+++ b/maidr/util/step_utils.py
@@ -1,0 +1,156 @@
+"""Helpers for recognising matplotlib step lines and their step convention.
+
+``matplotlib.axes.Axes.step`` is not a distinct renderer: it sets
+``kwargs["drawstyle"] = "steps-" + where`` and delegates to ``Axes.plot``,
+returning ordinary ``Line2D`` artists. The only durable record that a step
+chart was requested is therefore the ``drawstyle`` of the resulting artists,
+which is what these helpers read.
+
+Reading the artists rather than the call kwargs means ``ax.step()``,
+``plt.step()``, ``ax.plot(drawstyle=...)`` and ``sns.lineplot(drawstyle=...)``
+are all recognised by one rule, and matplotlib's ``ds`` kwarg alias needs no
+special handling because it has already been normalised onto the ``Line2D``
+by the time these functions run.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
+
+#: matplotlib ``drawstyle`` -> MAIDR ``stepDirection``.
+#:
+#: The MAIDR directions follow the ggplot2 naming: ``hv`` holds the value then
+#: jumps, ``vh`` jumps then holds, ``mid`` jumps midway between samples. Bare
+#: ``"steps"`` is matplotlib's legacy alias for ``"steps-pre"``.
+STEP_DRAWSTYLE_TO_DIRECTION: Dict[str, str] = {
+    "steps-post": "hv",
+    "steps-pre": "vh",
+    "steps": "vh",
+    "steps-mid": "mid",
+}
+
+
+def is_step_drawstyle(drawstyle: object) -> bool:
+    """
+    Report whether a matplotlib ``drawstyle`` denotes a step line.
+
+    Parameters
+    ----------
+    drawstyle : object
+        The value returned by ``Line2D.get_drawstyle()``.
+
+    Returns
+    -------
+    bool
+        ``True`` for ``"steps"`` and every ``"steps-*"`` variant.
+    """
+    return str(drawstyle).startswith("steps")
+
+
+def data_bearing_lines(ax: Axes) -> List[Line2D]:
+    """
+    Return the ``Line2D`` artists on ``ax`` that actually carry data.
+
+    Mirrors the empty-data filter used by
+    :meth:`maidr.core.plot.lineplot.MultiLinePlot._extract_line_data` so that
+    classification and extraction always agree on which lines count.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib axes to inspect.
+
+    Returns
+    -------
+    list of Line2D
+        Possibly empty list of non-empty lines.
+    """
+    try:
+        lines = ax.get_lines()
+    except (AttributeError, TypeError):
+        # Defensive: the patch layer may hand us a non-Axes (e.g. a Mock).
+        return []
+
+    data_lines = []
+    for line in lines:
+        try:
+            xydata = line.get_xydata()
+        except (AttributeError, TypeError):
+            continue
+        if xydata is None or not getattr(xydata, "size", 0):
+            continue
+        data_lines.append(line)
+    return data_lines
+
+
+def is_step_axes(ax: Axes) -> bool:
+    """
+    Report whether ``ax`` should be classified as a step plot.
+
+    The rule for a mixed axes: it is a step plot only when *every*
+    data-bearing line on it is a step line. One ordinary line mixed in means
+    the axes as a whole is not piecewise-constant, and MAIDR emits a single
+    layer per axes, so the conservative ``line`` classification wins.
+
+    The predicate is evaluated once, when the layer is registered — that is,
+    on the first plotting call for the axes, which is the same moment the
+    existing ``_maidr_plot_created`` guard fires. Lines drawn onto the axes
+    *after* that call do not re-open the decision, exactly as they do not
+    create a second layer today. A step layer that later acquires an ordinary
+    line keeps announcing its level names (the accessibility payload that
+    matters most) but stops claiming a ``stepDirection``, because
+    :func:`resolve_step_direction` re-reads the artists at render time and
+    finds them inconsistent.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib axes to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` when the axes holds at least one line and all of them are
+        step lines.
+    """
+    lines = data_bearing_lines(ax)
+    if not lines:
+        return False
+    return all(is_step_drawstyle(line.get_drawstyle()) for line in lines)
+
+
+def resolve_step_direction(ax: Axes) -> Optional[str]:
+    """
+    Resolve the single ``stepDirection`` authored on ``ax``, if there is one.
+
+    Returns ``None`` — meaning "omit the field" — whenever the axes does not
+    unambiguously author one direction: no lines, a non-step drawstyle, an
+    unrecognised ``steps-*`` variant, or several series disagreeing. MAIDR's
+    description only names a direction when the data actually reported one,
+    so guessing here would put a claim in the audio that nothing supports.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib axes to inspect.
+
+    Returns
+    -------
+    str or None
+        One of ``"hv"``, ``"vh"``, ``"mid"``, or ``None``.
+    """
+    lines = data_bearing_lines(ax)
+    if not lines:
+        return None
+
+    directions = {
+        STEP_DRAWSTYLE_TO_DIRECTION.get(str(line.get_drawstyle())) for line in lines
+    }
+    if len(directions) != 1:
+        return None
+
+    # A lone ``None`` here means every line shares an unrecognised drawstyle.
+    return directions.pop()

--- a/tests/core/plot/test_stepplot.py
+++ b/tests/core/plot/test_stepplot.py
@@ -351,3 +351,58 @@ class TestStepPlotClass:
             assert axes["z"]["label"] == "Night"
         finally:
             plt.close(fig)
+
+
+class TestStepUtils:
+    """Direct coverage for the helpers the classification rule is built on."""
+
+    def test_data_bearing_lines_agrees_with_the_extractor(self):
+        """
+        Pin ``data_bearing_lines`` to ``MultiLinePlot._extract_line_data``.
+
+        The two apply the same "does this line carry data" predicate from
+        opposite ends of the pipeline — one decides the layer's *type*, the
+        other decides which lines become *series*. They are separate
+        implementations, so if one starts counting a line the other skips,
+        an axes could be classified as a step plot whose only step line is
+        then dropped from the payload. This test fails the moment they
+        disagree.
+        """
+        from maidr.util.step_utils import data_bearing_lines
+
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [1, 2, 3], where="post")
+            ax.plot([], [])  # empty: carries no data, must be ignored by both
+            ax.step([0, 1, 2], [3, 2, 1], where="post")
+
+            counted = data_bearing_lines(ax)
+            extracted = _only_layer(fig)["data"]
+
+            assert len(counted) == len(extracted) == 2
+        finally:
+            plt.close(fig)
+
+    def test_an_empty_line_does_not_make_an_axes_a_step_plot(self):
+        """An axes with no data-bearing line is not a step plot."""
+        from maidr.util.step_utils import is_step_axes
+
+        fig, ax = plt.subplots()
+        try:
+            ax.plot([], [])
+            assert is_step_axes(ax) is False
+        finally:
+            plt.close(fig)
+
+    def test_display_names_read_the_way_a_user_named_the_plot(self):
+        """
+        The fallback warning names plot types for users, not for the schema.
+
+        ``PlotType.SCATTER.value`` is ``"point"``; someone who called
+        ``ax.scatter`` should be told about "scatter".
+        """
+        assert PlotType.SCATTER.display_name == "scatter"
+        assert PlotType.HEAT.display_name == "heatmap"
+        assert PlotType.STEP.display_name == "step"
+        # Both violin layers collapse to one user-facing name.
+        assert PlotType.VIOLIN_KDE.display_name == PlotType.VIOLIN_BOX.display_name

--- a/tests/core/plot/test_stepplot.py
+++ b/tests/core/plot/test_stepplot.py
@@ -277,6 +277,34 @@ class TestStepLevelLabels:
         finally:
             plt.close(fig)
 
+    @pytest.mark.parametrize(
+        "y_values, configure",
+        [
+            # Default ScalarFormatter factors out an offset, so the tick at
+            # y = 1000000 is labelled "0.0". Labelling the point "0.0" would
+            # announce a flatly wrong value.
+            ([1000000, 1000002, 1000004], lambda ax: None),
+            # Scientific notation rescales the same way: "1.00" at y = 1e6.
+            (
+                [1e6, 2e6, 3e6],
+                lambda ax: ax.ticklabel_format(axis="y", style="sci", scilimits=(0, 0)),
+            ),
+            # A log axis typesets its ticks as mathtext; announcing the raw
+            # LaTeX ("$\\mathdefault{10^{1}}$") is worse than announcing nothing.
+            ([1, 10, 100], lambda ax: ax.set_yscale("log")),
+        ],
+    )
+    def test_rescaled_numeric_axis_emits_no_labels(self, y_values, configure):
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], y_values, where="post")
+            configure(ax)
+            points = _only_layer(fig)["data"][0]
+
+            assert all("label" not in point for point in points), points
+        finally:
+            plt.close(fig)
+
     def test_point_off_a_named_tick_gets_no_label(self):
         fig, ax = plt.subplots()
         try:

--- a/tests/core/plot/test_stepplot.py
+++ b/tests/core/plot/test_stepplot.py
@@ -1,0 +1,353 @@
+"""Tests for step (stairs) plot support.
+
+``matplotlib.axes.Axes.step`` is a thin wrapper that sets
+``drawstyle="steps-<where>"`` and calls ``Axes.plot``, which maidr already
+patches. These tests pin down the two things that follow from that: exactly
+one layer is registered per call (never a STEP *and* a LINE), and the layer
+type is decided by the drawstyle of the rendered artists rather than by which
+function the user happened to call.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.core.plot.stepplot import StepPlot  # noqa: E402
+
+
+#: A short hypnogram: numeric sleep-stage codes sampled every half hour.
+STAGE_CODES = [0, 1, 2, 3, 4]
+STAGE_NAMES = ["N3", "N2", "N1", "REM", "Awake"]
+HYPNOGRAM_TIMES = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5]
+HYPNOGRAM_STAGES = [4, 2, 1, 0, 3, 4]
+
+
+def _stringify_keys(d: dict) -> dict:
+    """Normalize MaidrKey/PlotType enum keys and values to plain strings."""
+    out = {}
+    for k, v in d.items():
+        key = k.value if hasattr(k, "value") else k
+        if isinstance(v, dict):
+            out[key] = _stringify_keys(v)
+        elif isinstance(v, list):
+            out[key] = [
+                _stringify_keys(i)
+                if isinstance(i, dict)
+                else [_stringify_keys(j) if isinstance(j, dict) else j for j in i]
+                if isinstance(i, list)
+                else i
+                for i in v
+            ]
+        else:
+            out[key] = v.value if hasattr(v, "value") else v
+    return out
+
+
+def _only_layer(fig) -> dict:
+    """Assert the figure registered exactly one layer and return its schema."""
+    maidr_obj = FigureManager.get_maidr(fig)
+    assert len(maidr_obj._plots) == 1, (
+        f"expected exactly one layer, got {[p.type for p in maidr_obj._plots]}"
+    )
+    return _stringify_keys(maidr_obj._plots[0].schema)
+
+
+def _name_hypnogram_levels(ax) -> None:
+    """Name the numeric stage codes the way a user would, after plotting."""
+    ax.set_yticks(STAGE_CODES, labels=STAGE_NAMES)
+
+
+class TestStepClassification:
+    """One layer, typed ``step``, whichever entry point drew it."""
+
+    def test_ax_step_registers_one_step_layer(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.step(HYPNOGRAM_TIMES, HYPNOGRAM_STAGES, where="post")
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "step"
+        finally:
+            plt.close(fig)
+
+    def test_ax_plot_with_step_drawstyle_registers_one_step_layer(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.plot(HYPNOGRAM_TIMES, HYPNOGRAM_STAGES, drawstyle="steps-post")
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "step"
+        finally:
+            plt.close(fig)
+
+    def test_seaborn_lineplot_with_step_drawstyle_registers_one_step_layer(self):
+        fig, ax = plt.subplots()
+        try:
+            data = pd.DataFrame({"t": HYPNOGRAM_TIMES, "stage": HYPNOGRAM_STAGES})
+            sns.lineplot(data=data, x="t", y="stage", drawstyle="steps-mid", ax=ax)
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "step"
+        finally:
+            plt.close(fig)
+
+    def test_plain_line_plot_is_still_a_line(self):
+        # The regression that matters most: adding step detection must not
+        # reclassify any ordinary line plot.
+        fig, ax = plt.subplots()
+        try:
+            ax.plot([0, 1, 2, 3], [1, 4, 2, 3])
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "line"
+            assert "stepDirection" not in schema
+        finally:
+            plt.close(fig)
+
+    def test_plain_seaborn_lineplot_is_still_a_line(self):
+        fig, ax = plt.subplots()
+        try:
+            data = pd.DataFrame({"t": [0, 1, 2, 3], "v": [1, 4, 2, 3]})
+            sns.lineplot(data=data, x="t", y="v", ax=ax)
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "line"
+        finally:
+            plt.close(fig)
+
+    def test_multiline_step_registers_one_layer_with_nested_series(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [1, 2, 3], where="post")
+            ax.step([0, 1, 2], [3, 2, 1], where="post")
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "step"
+            assert len(schema["data"]) == 2
+        finally:
+            plt.close(fig)
+
+
+class TestStepDataShape:
+    """Data stays nested per series and ``y`` stays numeric."""
+
+    def test_data_is_nested_list_of_lists_of_dicts(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.step(HYPNOGRAM_TIMES, HYPNOGRAM_STAGES, where="post")
+            data = _only_layer(fig)["data"]
+
+            assert isinstance(data, list)
+            assert len(data) == 1
+            assert isinstance(data[0], list)
+            assert all(isinstance(point, dict) for point in data[0])
+            assert len(data[0]) == len(HYPNOGRAM_TIMES)
+        finally:
+            plt.close(fig)
+
+    def test_y_stays_numeric_even_when_levels_are_named(self):
+        # ``y`` drives sonification, braille and min/max on the JS side, so it
+        # must not be replaced by the level name.
+        fig, ax = plt.subplots()
+        try:
+            ax.step(HYPNOGRAM_TIMES, HYPNOGRAM_STAGES, where="post")
+            _name_hypnogram_levels(ax)
+            points = _only_layer(fig)["data"][0]
+
+            assert [point["y"] for point in points] == [
+                float(stage) for stage in HYPNOGRAM_STAGES
+            ]
+        finally:
+            plt.close(fig)
+
+
+class TestStepDirection:
+    """``stepDirection`` maps from the matplotlib drawstyle."""
+
+    @pytest.mark.parametrize(
+        "where, expected",
+        [("post", "hv"), ("pre", "vh"), ("mid", "mid")],
+    )
+    def test_where_maps_to_direction(self, where, expected):
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [1, 2, 3], where=where)
+            schema = _only_layer(fig)
+
+            assert schema["stepDirection"] == expected
+        finally:
+            plt.close(fig)
+
+    def test_bare_steps_drawstyle_is_treated_as_pre(self):
+        # matplotlib's bare "steps" is a legacy alias for "steps-pre"; the
+        # ``ds`` kwarg alias must work too.
+        fig, ax = plt.subplots()
+        try:
+            ax.plot([0, 1, 2], [1, 2, 3], ds="steps")
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "step"
+            assert schema["stepDirection"] == "vh"
+        finally:
+            plt.close(fig)
+
+    def test_direction_omitted_when_series_disagree(self):
+        # No single direction was authored, so none is claimed.
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [1, 2, 3], where="post")
+            ax.step([0, 1, 2], [3, 2, 1], where="pre")
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "step"
+            assert "stepDirection" not in schema
+        finally:
+            plt.close(fig)
+
+
+class TestStepLevelLabels:
+    """The hypnogram feature: ordinal level names on each point."""
+
+    def test_label_carries_sleep_stage_names(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.step(HYPNOGRAM_TIMES, HYPNOGRAM_STAGES, where="post")
+            _name_hypnogram_levels(ax)
+            points = _only_layer(fig)["data"][0]
+
+            assert [point["label"] for point in points] == [
+                "Awake",
+                "N1",
+                "N2",
+                "N3",
+                "REM",
+                "Awake",
+            ]
+        finally:
+            plt.close(fig)
+
+    def test_boundary_levels_are_not_dropped(self):
+        # ``LevelExtractorMixin.extract_level`` filters tick labels against
+        # ``ax.dataLim``, which loses the outermost levels. StepPlot reads the
+        # ticks directly so the top and bottom stages survive.
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [0, 2, 4], where="post")
+            _name_hypnogram_levels(ax)
+            points = _only_layer(fig)["data"][0]
+
+            assert [point["label"] for point in points] == ["N3", "N1", "Awake"]
+        finally:
+            plt.close(fig)
+
+    def test_labels_resolved_after_plotting(self):
+        # Naming the levels only after ax.step() is the idiomatic order and
+        # must still be picked up, because resolution happens at render time.
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1], [0, 4], where="post")
+            plot = FigureManager.get_maidr(fig)._plots[0]
+            assert isinstance(plot, StepPlot)
+            _name_hypnogram_levels(ax)
+            points = _stringify_keys(plot.schema)["data"][0]
+
+            assert [point["label"] for point in points] == ["N3", "Awake"]
+        finally:
+            plt.close(fig)
+
+    def test_numeric_step_plot_emits_no_labels(self):
+        # Auto tick labels only spell out their own position, so they carry no
+        # ordinal information and must not be emitted as level names.
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [10, 20, 30], where="post")
+            points = _only_layer(fig)["data"][0]
+
+            assert all("label" not in point for point in points)
+        finally:
+            plt.close(fig)
+
+    def test_point_off_a_named_tick_gets_no_label(self):
+        fig, ax = plt.subplots()
+        try:
+            # 2.5 lies between the named ticks 2 and 3.
+            ax.step([0, 1, 2], [4, 2.5, 0], where="post")
+            _name_hypnogram_levels(ax)
+            points = _only_layer(fig)["data"][0]
+
+            assert points[0]["label"] == "Awake"
+            assert "label" not in points[1]
+            assert points[2]["label"] == "N3"
+        finally:
+            plt.close(fig)
+
+    def test_named_levels_recovered_from_shared_y_sibling(self):
+        # A faceted hypnogram commonly names the levels on the left panel only.
+        fig, axs = plt.subplots(1, 2, sharey=True)
+        try:
+            axs[0].step([0, 1, 2], [4, 2, 0], where="post")
+            axs[1].step([0, 1, 2], [0, 3, 4], where="post")
+            axs[0].set_yticks(STAGE_CODES, labels=STAGE_NAMES)
+
+            right = _stringify_keys(FigureManager.get_maidr(fig)._plots[1].schema)
+
+            assert [point["label"] for point in right["data"][0]] == [
+                "N3",
+                "REM",
+                "Awake",
+            ]
+        finally:
+            plt.close(fig)
+
+
+class TestStepPlotClass:
+    """Unit-level checks on the reused MultiLinePlot machinery."""
+
+    def test_step_plot_is_a_multiline_plot(self):
+        from maidr.core.plot.lineplot import MultiLinePlot
+
+        assert issubclass(StepPlot, MultiLinePlot)
+
+    def test_step_plot_reports_step_type(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [1, 2, 3], where="post")
+            plot = FigureManager.get_maidr(fig)._plots[0]
+
+            assert plot.type == PlotType.STEP
+        finally:
+            plt.close(fig)
+
+    def test_selectors_are_reused_from_multiline_plot(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [1, 2, 3], where="post")
+            selectors = _only_layer(fig)["selectors"]
+
+            assert isinstance(selectors, list)
+            assert len(selectors) == 1
+            assert selectors[0].startswith("g[id='maidr-")
+        finally:
+            plt.close(fig)
+
+    def test_legend_title_still_populates_the_z_axis(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [1, 2, 3], where="post", label="night 1")
+            ax.step([0, 1, 2], [3, 2, 1], where="post", label="night 2")
+            ax.legend(title="Night")
+            axes = _only_layer(fig)["axes"]
+
+            assert axes["z"]["label"] == "Night"
+        finally:
+            plt.close(fig)

--- a/tests/core/plot/test_stepplot.py
+++ b/tests/core/plot/test_stepplot.py
@@ -434,3 +434,51 @@ class TestStepUtils:
         assert PlotType.STEP.display_name == "step"
         # Both violin layers collapse to one user-facing name.
         assert PlotType.VIOLIN_KDE.display_name == PlotType.VIOLIN_BOX.display_name
+
+class TestClassificationIsOrderDependent:
+    """
+    Classification happens once, on the first plotting call for an axes.
+
+    That is the existing one-layer-per-axes model (``_maidr_plot_created``),
+    not something step introduced — but it makes a mixed axes asymmetric, and
+    these tests pin both directions so the asymmetry cannot drift unnoticed.
+    """
+
+    def test_line_drawn_first_keeps_the_axes_a_line(self):
+        """The conservative direction: a plain line first wins outright."""
+        fig, ax = plt.subplots()
+        try:
+            ax.plot([0, 1, 2], [1, 2, 3])
+            ax.step([0, 1, 2], [3, 2, 1], where="post")
+            layer = _only_layer(fig)
+
+            assert layer["type"] == PlotType.LINE
+            assert "stepDirection" not in layer
+        finally:
+            plt.close(fig)
+
+    def test_step_drawn_first_keeps_the_axes_a_step_but_drops_the_direction(self):
+        """
+        The generous direction, pinned deliberately.
+
+        A step line first classifies the axes ``step``; a plain line added
+        afterwards does not re-open that decision, so its points ride in a
+        layer typed ``step``. Downgrading at render time would be worse: it
+        would strip the ordinal level names, and losing the stage names is a
+        bigger accessibility loss than a slightly generous type.
+
+        What the layer does give up is ``stepDirection`` —
+        ``resolve_step_direction`` re-reads the artists at render time and
+        finds them disagreeing, so no convention is ever claimed that the data
+        does not support.
+        """
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2], [1, 2, 3], where="post")
+            ax.plot([0, 1, 2], [3, 2, 1])
+            layer = _only_layer(fig)
+
+            assert layer["type"] == PlotType.STEP
+            assert "stepDirection" not in layer
+        finally:
+            plt.close(fig)

--- a/tests/core/test_axes_schema.py
+++ b/tests/core/test_axes_schema.py
@@ -99,6 +99,25 @@ class TestMatplotlibCanonicalShape:
         finally:
             plt.close(fig)
 
+    def test_step_keeps_level_names_out_of_axes(self):
+        # A hypnogram carries its ordinal level names per point, never as
+        # extra keys on the axes payload.
+        fig, ax = plt.subplots()
+        try:
+            ax.step([0, 1, 2, 3], [4, 2, 1, 0], where="post")
+            ax.set_yticks([0, 1, 2, 3, 4], labels=["N3", "N2", "N1", "REM", "Awake"])
+            ax.set_xlabel("Time (h)")
+            ax.set_ylabel("Sleep stage")
+            schema = _first_schema(fig)
+
+            _assert_canonical_axes(schema["axes"])
+            assert schema["axes"]["x"]["label"] == "Time (h)"
+            assert schema["axes"]["y"]["label"] == "Sleep stage"
+            # stepDirection is a layer-level sibling of axes, not an axis key.
+            assert schema["stepDirection"] == "hv"
+        finally:
+            plt.close(fig)
+
     def test_heatmap_has_z_axis_config(self):
         fig, ax = plt.subplots()
         try:

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -32,6 +32,9 @@ def test_create_maidr_with_none_plot_type(mocker):
         # Parametrize matplotlib plots.
         (Library.MATPLOTLIB, PlotType.BAR),
         (Library.MATPLOTLIB, PlotType.BOX),
+        # ``ax.step`` delegates to the already-patched ``Axes.plot``; this
+        # guards against it registering a STEP *and* a LINE layer.
+        (Library.MATPLOTLIB, PlotType.STEP),
         # Parametrize seaborn plots.
         (Library.SEABORN, PlotType.BAR),
         (Library.SEABORN, PlotType.BOX),

--- a/tests/core/test_maidr_plot_factory.py
+++ b/tests/core/test_maidr_plot_factory.py
@@ -9,6 +9,7 @@ from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
 from maidr.core.plot.maidr_plot_factory import MaidrPlotFactory
 from maidr.core.plot.scatterplot import ScatterPlot
+from maidr.core.plot.stepplot import StepPlot
 
 
 # test invalid inputs
@@ -31,6 +32,7 @@ def test_create_with_invalid_plot_type(mocker):
         (PlotType.LINE, MultiLinePlot),
         (PlotType.SCATTER, ScatterPlot),
         (PlotType.STACKED, GroupedBarPlot),
+        (PlotType.STEP, StepPlot),
     ],
 )
 def test_create_plot_data(mocker, plot_type, expected_plot_data):

--- a/tests/fixture/matplotlib_factory.py
+++ b/tests/fixture/matplotlib_factory.py
@@ -30,6 +30,8 @@ class MatplotlibFactory(LibraryFactory):
             self.create_barplot(ax)
         elif PlotType.BOX is plot_type:
             self.create_boxplot(ax)
+        elif PlotType.STEP is plot_type:
+            self.create_stepplot(ax)
 
     def create_barplot(self, ax: Axes) -> Any:
         # TODO: using numbers makes matplotlib to add additional ticks messing with the
@@ -44,3 +46,21 @@ class MatplotlibFactory(LibraryFactory):
         ax.set_title("Test matplotlib box title")
         ax.set_xlabel("Test matplotlib box x label")
         ax.set_ylabel("Test matplotlib box y label")
+
+    def create_stepplot(self, ax: Axes) -> Any:
+        """Draw a hypnogram: an ordinal sleep stage held over time.
+
+        The stages are plotted as numeric codes so they keep driving
+        sonification and braille, then named via ``set_yticks(..., labels=...)``
+        the way a user would. ``where="post"`` is the reading a hypnogram
+        implies: the stage holds until the next reading, then jumps.
+        """
+        ax.step(
+            [0.0, 0.5, 1.0, 1.5, 2.0, 2.5],
+            [4, 2, 1, 0, 3, 4],
+            where="post",
+        )
+        ax.set_yticks([0, 1, 2, 3, 4], labels=["N3", "N2", "N1", "REM", "Awake"])
+        ax.set_title("Test matplotlib step title")
+        ax.set_xlabel("Test matplotlib step x label")
+        ax.set_ylabel("Test matplotlib step y label")

--- a/tests/fixture/matplotlib_factory.py
+++ b/tests/fixture/matplotlib_factory.py
@@ -52,7 +52,7 @@ class MatplotlibFactory(LibraryFactory):
 
         The stages are plotted as numeric codes so they keep driving
         sonification and braille, then named via ``set_yticks(..., labels=...)``
-        the way a user would. ``where="post"`` is the reading a hypnogram
+        the way a user would. ``where="post"`` is the reading that a hypnogram
         implies: the stage holds until the next reading, then jumps.
         """
         ax.step(


### PR DESCRIPTION
## Description

Adds `PlotType.STEP` so matplotlib step charts are exported as MAIDR step layers instead of being mislabelled as line layers.

The motivating case is a **hypnogram** — sleep stage against time. Its y axis is an ordinal category (Awake / REM / N1 / N2 / N3) and its value is *piecewise constant*: a stage is held for a stretch of the night and then jumps. Exporting that as a line chart tells a blind user the sleeper glided continuously through the intermediate stages, which is not what the data says.

`ax.step(...)` already reached maidr before this change, because matplotlib's `Axes.step` is not its own renderer — it sets `drawstyle="steps-*"` and delegates to `Axes.plot`, which `maidr/patch/lineplot.py` already wraps. So this is a **re-classification**, not a new interception point. That matters: adding a second `wrapt` wrapper on `Axes.step` would have registered two layers (STEP *and* LINE) for a single call. Instead the existing `line()` wrapper now chooses the type by reading the resulting artists' drawstyles, which covers `ax.step`, `plt.step`, `ax.plot(drawstyle="steps-post")` and `sns.lineplot(drawstyle="steps-mid")` under one rule.

**Dependency status:** the JS side (xability/maidr#723) has **merged**, so `TraceType.STEP` is on `maidr` `main`. Online rendering picks it up via `maidr@latest` as soon as the next release is published — the latest tag is still `v3.75.1`, which predates the merge. Offline rendering (`use_cdn=False`) additionally needs the routine bundled-`maidr.js` bump; `maidr/static/VERSION` is currently 3.73.0.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

**Classification**
- `PlotType.STEP = "step"`; `MaidrKey.STEP_DIRECTION = "stepDirection"`.
- `maidr/util/step_utils.py` — one shared rule for recognising step lines and their convention. An axes is a step plot only when *every* data-bearing line on it is a step line; one ordinary line mixed in keeps the conservative `line` classification, since maidr emits a single layer per axes.
- `maidr/patch/lineplot.py` — picks the type from the artists rather than hard-coding `PlotType.LINE`.

**`StepPlot`** (`maidr/core/plot/stepplot.py`) subclasses `MultiLinePlot`, so coordinate extraction, per-series nesting, GID assignment, selector generation and legend/`z` handling are reused rather than copy-pasted. It adds:
- `stepDirection`, mapped from the drawstyle — `steps-post → hv`, `steps-pre`/`steps → vh`, `steps-mid → mid`. Omitted when the axes does not author one unambiguously, so the description never names a direction the data did not report.
- a per-point `label` carrying the ordinal level *name*, resolved from the y tick labels at **render** time (the idiomatic way to build a hypnogram is to plot numeric codes and name them afterwards with `set_yticks(codes, labels=names)`). `y` stays numeric — it is what drives sonification, braille and the min/max range.

Two details worth a reviewer's eye:
- Tick labels that merely spell out their own position (`"3"` at y = 3) are skipped, so an ordinary numeric step plot gets no labels rather than a redundant one on every point.
- Levels are read straight off the axes rather than through `LevelExtractorMixin.extract_level`, which filters against `ax.dataLim` and would silently drop the boundary levels — precisely the `Awake` and `N3` ends of a hypnogram.

The canonical `axes` contract is untouched: `_extract_axes_data` is not overridden, so keys stay a subset of `{x, y, z}` and level names live in `data`, never in `axes`.

## Testing

`uv run pytest` — **212 passed**. `ruff check` clean on every changed file. CI green across the 3.9 / 3.10 / 3.11 / 3.12 matrix.

`tests/core/plot/test_stepplot.py` asserts that `ax.step`, `ax.plot(drawstyle=...)` and `sns.lineplot(drawstyle=...)` each register **exactly one** layer typed `step`; that all three `where` values map to the right direction; that stage names land on the points; and — the regression that matters most — that a plain `ax.plot()` still classifies as `line`.

It also pins **both directions of the mixed-axes rule**, after review pointed out my original description stated only the conservative half. Classification runs once, on the first plotting call for an axes (`_maidr_plot_created`), so the rule is asymmetric: `plot` then `step` stays LINE, but `step` then `plot` stays STEP with the later line riding inside it. The generous direction is deliberate — downgrading at render time would strip the ordinal level names, and "3" instead of "REM" for a whole hypnogram is a worse accessibility outcome than a slightly generous type. Either way `stepDirection` is dropped, since `resolve_step_direction` re-reads the artists at render time and finds them disagreeing, so no convention is ever claimed that the data cannot support.

Also verified by hand against a real hypnogram figure: one series, one selector, `stepDirection: "hv"`, `[{"x": "0.0", "y": 4.0, "label": "Awake"}, ...]`, and a plain line plot still producing a single `line` layer.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules — xability/maidr#723 is merged; a published release is still pending (see Dependency status above)

## Additional Notes

`x` is emitted as a string (`"0.0"`) rather than a number. That is pre-existing `MultiLinePlot` behaviour from the categorical tick-label mapping, reproduced identically by a plain line plot on this branch's base, and is left alone here.