### PR TITLE
ci: harden Claude workflows (skip Dependabot PRs, gate @claude)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Dependabot PRs are not given repository secrets even on
+    # pull_request_target, so CLAUDE_CODE_OAUTH_TOKEN resolves empty and the
+    # job fails rather than reviewing anything -- as it did on
+    # dependabot/uv/uv-a74796fa6c. Skip cleanly instead.
+    #
+    # No fork guard here, unlike maidr and r-maidr: this repo takes most of its
+    # PRs from forks, and reviewing them is the reason pull_request_target is
+    # used. See the PR description for the exposure that choice carries.
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,21 @@ on:
 
 jobs:
   claude:
+    # This repository is public and takes most of its PRs from forks, so
+    # anyone can write '@claude' anywhere. The action already refuses actors
+    # without write access on these events, so this gate does not narrow who
+    # can summon Claude -- it means a drive-by mention never starts a runner
+    # or reaches the OAuth token in the first place.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Ports what applies from the review of xability/r-maidr#50. This repo's setup differs from maidr/r-maidr, so one of the two changes is deliberately **not** ported.

## 1. Review job skips Dependabot PRs

Dependabot PRs are not given repository secrets even on `pull_request_target`, so `CLAUDE_CODE_OAUTH_TOKEN` resolves empty and the job **fails** rather than reviewing anything — observed on `dependabot/uv/uv-a74796fa6c`.

```yaml
if: github.actor != 'dependabot[bot]'
```

## 2. `@claude` gated on `author_association`

Restricted to `OWNER`/`MEMBER`/`COLLABORATOR`. This does not narrow who can summon Claude: `claude-code-action` already refuses actors without write access on those events. It means a drive-by mention never starts a runner or reaches the OAuth token.

## Deliberately NOT ported: the fork guard

maidr and r-maidr both skip fork PRs, because on the `pull_request` event a fork gets no secrets. **53 of this repo's last 100 PRs came from forks**, and reviewing them is precisely why this workflow uses `pull_request_target`. Applying the same guard here would silently drop Claude review on most of the PR traffic, so it is left off.

## Worth a separate decision: what `pull_request_target` currently exposes

Flagging this rather than changing it, since it trades review coverage against risk and that is a maintainer call.

`pull_request_target` is absent from the action's [`ENTITY_EVENT_NAMES`](https://github.com/anthropics/claude-code-action/blob/main/src/github/context.ts). `checkWritePermissions` only runs for entity contexts and `workflow_run`, so **for this workflow the action's actor gate never executes at all** — any fork author reaches the agent.

The checkout is safe on its own (no `ref:`, so it takes the base branch, and untrusted code is never executed). The exposure is the agent's input, not the code: the PR diff is attacker-controlled text, the job holds a `pull-requests: write` `GITHUB_TOKEN`, and `Bash(gh pr comment:*)` is in `--allowed-tools`. A successful prompt injection could post arbitrary comments, and `gh pr comment --body "$CLAUDE_CODE_OAUTH_TOKEN"` matches that allow-pattern — comment bodies are not subject to Actions log masking.

Options, roughly in order of effort:

1. **Accept and document** — the injection has to beat the model, and the blast radius is comment posting.
2. **Drop `gh pr comment` from `--allowed-tools`** and let the action post through its own reporting path instead of a shell command.
3. **Move to the `workflow_run` two-stage pattern** — a secretless `pull_request` job uploads the diff, a `workflow_run` job reviews it. `workflow_run` *is* permission-checked, so this needs `allowed_non_write_users: '*'` to keep reviewing forks, which the action supports for exactly this case.

Happy to implement whichever you prefer.

Both files pass `actionlint 1.7.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why `CONTRIBUTOR` is not in the allowlist

Raised in review. `CONTRIBUTOR` is someone with a merged PR but no collaborator role — so no write access, and `claude-code-action` would refuse them regardless. Leaving them out of the `if:` changes only *how* they are refused: a silent no-op instead of a visible "Actor does not have write permissions" failure. That is the intended trade for a gate whose entire purpose is to avoid starting a runner. Add `CONTRIBUTOR` to the list if a visible error is preferred over silence.