### PR TITLE
fix(patch): read box and violin orientation the way matplotlib does

### DIFF
--- a/maidr/patch/boxplot.py
+++ b/maidr/patch/boxplot.py
@@ -6,36 +6,7 @@ from matplotlib.axes import Axes
 from maidr.core.context_manager import BoxplotContextManager, ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-
-
-def _resolve_bxp_orientation(kwargs: dict) -> str:
-    """
-    Resolve the MAIDR orientation of a ``Axes.bxp`` call.
-
-    Matplotlib 3.10 introduced ``orientation`` and pending-deprecated ``vert``,
-    and ``Axes.boxplot`` forwards *both* to ``Axes.bxp`` — passing ``vert=None``
-    whenever the caller did not set it. Reading ``vert`` alone therefore reads
-    every default (vertical) box plot as horizontal, which flips the announced
-    orientation and makes the extractor read box statistics off the wrong axis.
-
-    Mirror what ``Axes.bxp`` itself does: an explicitly set ``vert`` wins while
-    it is still supported, and ``orientation`` decides otherwise.
-
-    Parameters
-    ----------
-    kwargs : dict
-        Keyword arguments the caller passed to ``Axes.bxp``.
-
-    Returns
-    -------
-    str
-        ``"horz"`` for a horizontal box plot, ``"vert"`` otherwise.
-    """
-    vert = kwargs.get("vert")
-    if vert is not None:
-        return "vert" if vert else "horz"
-
-    return "horz" if kwargs.get("orientation") == "horizontal" else "vert"
+from maidr.patch.common import resolve_orientation
 
 
 @wrapt.patch_function_wrapper(Axes, "bxp")
@@ -52,7 +23,7 @@ def mpl_box(wrapped, _, args, kwargs) -> dict:
         plot = wrapped(*args, **kwargs)
 
     # Set the orientation of the boxplot
-    orientation = _resolve_bxp_orientation(kwargs)
+    orientation = resolve_orientation(wrapped, args, kwargs)
 
     # Extract the boxplot data points for MAIDR from the plot.
     ax = FigureManager.get_axes(plot)

--- a/maidr/patch/boxplot.py
+++ b/maidr/patch/boxplot.py
@@ -12,8 +12,8 @@ def _resolve_bxp_orientation(kwargs: dict) -> str:
     """
     Resolve the MAIDR orientation of a ``Axes.bxp`` call.
 
-    Matplotlib 3.9 deprecated ``vert`` in favour of ``orientation``, and
-    ``Axes.boxplot`` forwards *both* to ``Axes.bxp`` — passing ``vert=None``
+    Matplotlib 3.10 introduced ``orientation`` and pending-deprecated ``vert``,
+    and ``Axes.boxplot`` forwards *both* to ``Axes.bxp`` — passing ``vert=None``
     whenever the caller did not set it. Reading ``vert`` alone therefore reads
     every default (vertical) box plot as horizontal, which flips the announced
     orientation and makes the extractor read box statistics off the wrong axis.

--- a/maidr/patch/boxplot.py
+++ b/maidr/patch/boxplot.py
@@ -8,6 +8,36 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 
 
+def _resolve_bxp_orientation(kwargs: dict) -> str:
+    """
+    Resolve the MAIDR orientation of a ``Axes.bxp`` call.
+
+    Matplotlib 3.9 deprecated ``vert`` in favour of ``orientation``, and
+    ``Axes.boxplot`` forwards *both* to ``Axes.bxp`` — passing ``vert=None``
+    whenever the caller did not set it. Reading ``vert`` alone therefore reads
+    every default (vertical) box plot as horizontal, which flips the announced
+    orientation and makes the extractor read box statistics off the wrong axis.
+
+    Mirror what ``Axes.bxp`` itself does: an explicitly set ``vert`` wins while
+    it is still supported, and ``orientation`` decides otherwise.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Keyword arguments the caller passed to ``Axes.bxp``.
+
+    Returns
+    -------
+    str
+        ``"horz"`` for a horizontal box plot, ``"vert"`` otherwise.
+    """
+    vert = kwargs.get("vert")
+    if vert is not None:
+        return "vert" if vert else "horz"
+
+    return "horz" if kwargs.get("orientation") == "horizontal" else "vert"
+
+
 @wrapt.patch_function_wrapper(Axes, "bxp")
 def mpl_box(wrapped, _, args, kwargs) -> dict:
     # Don't proceed if the call is made internally by the patched function.
@@ -22,10 +52,7 @@ def mpl_box(wrapped, _, args, kwargs) -> dict:
         plot = wrapped(*args, **kwargs)
 
     # Set the orientation of the boxplot
-    if not kwargs.get("vert", True):
-        orientation = "horz"
-    else:
-        orientation = "vert"
+    orientation = _resolve_bxp_orientation(kwargs)
 
     # Extract the boxplot data points for MAIDR from the plot.
     ax = FigureManager.get_axes(plot)

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -1,10 +1,86 @@
 from __future__ import annotations
 
+import inspect
 import warnings
-from typing import Any
+from typing import Any, Callable
 
 from maidr.core.context_manager import ContextManager
 from maidr.core.figure_manager import FigureManager
+
+
+def _argument(name: str, wrapped: Callable, args: tuple, kwargs: dict) -> Any:
+    """
+    Read one argument of a patched call, whether it was passed by name or by
+    position.
+
+    Parameters
+    ----------
+    name : str
+        Name of the parameter to read.
+    wrapped : Callable
+        The wrapped matplotlib function, used for its parameter order. It is
+        the bound method, so ``self`` is not among its parameters.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    Any
+        The argument's value, or None when the caller did not pass it or the
+        installed matplotlib has no such parameter.
+    """
+    if name in kwargs:
+        return kwargs[name]
+
+    try:
+        parameters = list(inspect.signature(wrapped).parameters)
+    except (TypeError, ValueError):
+        return None
+
+    if name not in parameters:
+        return None
+
+    index = parameters.index(name)
+    return args[index] if index < len(args) else None
+
+
+def resolve_orientation(wrapped: Callable, args: tuple, kwargs: dict) -> str:
+    """
+    Resolve the MAIDR orientation of a matplotlib call that takes ``vert``.
+
+    Matplotlib 3.10 introduced ``orientation`` and pending-deprecated ``vert``
+    on ``Axes.boxplot``, ``Axes.bxp`` and ``Axes.violinplot``. Reading ``vert``
+    alone misses ``orientation="horizontal"``, and — because ``Axes.boxplot``
+    forwards ``vert=None`` to ``Axes.bxp`` whenever the caller omits it —
+    defaulting an absent ``vert`` to False reads every vertical plot as
+    horizontal.
+
+    Mirror what matplotlib itself does: an explicitly set ``vert`` wins while
+    it is still supported, and ``orientation`` decides otherwise.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The wrapped matplotlib function, used to read arguments the caller
+        passed positionally.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    str
+        ``"horz"`` for a horizontal plot, ``"vert"`` otherwise.
+    """
+    vert = _argument("vert", wrapped, args, kwargs)
+    if vert is not None:
+        return "vert" if vert else "horz"
+
+    orientation = _argument("orientation", wrapped, args, kwargs)
+    return "horz" if orientation == "horizontal" else "vert"
 
 
 def common(plot_type, wrapped, _, args, kwargs) -> Any:

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -35,14 +35,29 @@ def _argument(name: str, wrapped: Callable, args: tuple, kwargs: dict) -> Any:
         return kwargs[name]
 
     try:
-        parameters = list(inspect.signature(wrapped).parameters)
+        parameters = inspect.signature(wrapped).parameters
     except (TypeError, ValueError):
         return None
 
-    if name not in parameters:
+    # Declared order is the binding order: matplotlib's `vert` and
+    # `orientation` are declared keyword-only, yet the deprecation shim they
+    # sit behind still accepts them positionally and assigns them in that
+    # order, so the kind cannot be filtered on. A variadic parameter is the one
+    # thing that breaks the correspondence — past it an index means nothing —
+    # so stop there and let the keyword lookup above be the only answer.
+    positional: list[str] = []
+    for parameter_name, parameter in parameters.items():
+        if parameter.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            break
+        positional.append(parameter_name)
+
+    if name not in positional:
         return None
 
-    index = parameters.index(name)
+    index = positional.index(name)
     return args[index] if index < len(args) else None
 
 

--- a/maidr/patch/violinplot.py
+++ b/maidr/patch/violinplot.py
@@ -23,6 +23,7 @@ from maidr.core.enum import PlotType
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.violinplot import ViolinDataExtractor
+from maidr.patch.common import resolve_orientation
 from maidr.util.mixin.extractor_mixin import LevelExtractorMixin
 
 
@@ -85,7 +86,7 @@ def mpl_violinplot(wrapped: Callable, instance: Axes, args: tuple, kwargs: dict)
         plot = wrapped(*args, **kwargs)
 
     plot_ax: Axes = instance
-    orientation = "vert" if kwargs.get("vert", True) else "horz"
+    orientation = resolve_orientation(wrapped, args, kwargs)
 
     violin_options = {
         "showMean": bool(kwargs.get("showmeans", False)),

--- a/tests/core/plot/test_boxplot_orientation.py
+++ b/tests/core/plot/test_boxplot_orientation.py
@@ -15,6 +15,7 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
+import packaging.version as version  # noqa: E402
 import pytest  # noqa: E402
 import seaborn as sns  # noqa: E402
 
@@ -24,6 +25,16 @@ from maidr.patch.boxplot import _resolve_bxp_orientation  # noqa: E402
 
 
 DATA = [[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]]
+
+# `orientation` arrived in matplotlib 3.9; older releases only accept `vert`.
+# The resolver's handling of the keyword is covered version-independently by
+# ``test_resolve_bxp_orientation``.
+_HAS_ORIENTATION_KWARG = version.parse(matplotlib.__version__) >= version.parse("3.9")
+
+_needs_orientation_kwarg = pytest.mark.skipif(
+    not _HAS_ORIENTATION_KWARG,
+    reason="matplotlib < 3.9 has no `orientation` parameter",
+)
 
 
 def _schema(fig) -> dict:
@@ -38,8 +49,12 @@ def _schema(fig) -> dict:
         ({}, "vert"),
         ({"vert": True}, "vert"),
         ({"vert": False}, "horz"),
-        ({"orientation": "vertical"}, "vert"),
-        ({"orientation": "horizontal"}, "horz"),
+        pytest.param(
+            {"orientation": "vertical"}, "vert", marks=_needs_orientation_kwarg
+        ),
+        pytest.param(
+            {"orientation": "horizontal"}, "horz", marks=_needs_orientation_kwarg
+        ),
     ],
 )
 def test_matplotlib_boxplot_orientation(kwargs: dict, expected: str) -> None:

--- a/tests/core/plot/test_boxplot_orientation.py
+++ b/tests/core/plot/test_boxplot_orientation.py
@@ -23,7 +23,7 @@ from matplotlib.axes import Axes  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.figure_manager import FigureManager  # noqa: E402
-from maidr.patch.boxplot import _resolve_bxp_orientation  # noqa: E402
+from maidr.patch.common import resolve_orientation  # noqa: E402
 
 
 DATA = [[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]]
@@ -112,11 +112,44 @@ def test_seaborn_boxplot_orientation(orient: str | None, expected: str) -> None:
         # An explicitly set `vert` still wins while matplotlib supports it.
         ({"vert": False, "orientation": "vertical"}, "horz"),
         ({"vert": True, "orientation": "horizontal"}, "vert"),
-        # Pre-3.9 matplotlib passes `vert` alone.
+        # Older matplotlib passes `vert` alone.
         ({"vert": True}, "vert"),
         ({"vert": False}, "horz"),
         ({}, "vert"),
     ],
 )
-def test_resolve_bxp_orientation(kwargs: dict, expected: str) -> None:
-    assert _resolve_bxp_orientation(kwargs) == expected
+def test_resolve_orientation_from_keywords(kwargs: dict, expected: str) -> None:
+    fig, ax = plt.subplots()
+    try:
+        assert resolve_orientation(ax.bxp, (), kwargs) == expected
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        # Axes.bxp(bxpstats, positions, widths, vert, ...)
+        (([], None, None, False), "horz"),
+        (([], None, None, True), "vert"),
+        (([], None, None), "vert"),
+    ],
+)
+def test_resolve_orientation_from_positional_arguments(
+    args: tuple, expected: str
+) -> None:
+    """`Axes.bxp` is public, so a caller can pass `vert` positionally."""
+    fig, ax = plt.subplots()
+    try:
+        assert resolve_orientation(ax.bxp, args, {}) == expected
+    finally:
+        plt.close(fig)
+
+
+def test_resolve_orientation_ignores_parameters_matplotlib_lacks() -> None:
+    """A function without either parameter resolves to the vertical default."""
+
+    def no_orientation(dataset, positions=None):  # pragma: no cover - shape only
+        raise AssertionError("never called")
+
+    assert resolve_orientation(no_orientation, ([],), {}) == "vert"

--- a/tests/core/plot/test_boxplot_orientation.py
+++ b/tests/core/plot/test_boxplot_orientation.py
@@ -1,0 +1,104 @@
+"""Tests that box plots report the orientation they were actually drawn with.
+
+The orientation reaches the MAIDR JSON as ``orientation`` and drives two
+user-visible things: the announced plot type ("vertical box" / "horizontal
+box") and which axis the extractor reads the Tukey statistics off. Matplotlib
+3.9 deprecated ``vert`` in favour of ``orientation`` and ``Axes.boxplot``
+forwards both to ``Axes.bxp``, so the detection has to read them the way
+matplotlib itself does.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.patch.boxplot import _resolve_bxp_orientation  # noqa: E402
+
+
+DATA = [[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]]
+
+
+def _schema(fig) -> dict:
+    """Return the first layer's schema with plain string keys."""
+    plot = FigureManager.get_maidr(fig)._plots[0]
+    return {(k.value if hasattr(k, "value") else k): v for k, v in plot.schema.items()}
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({}, "vert"),
+        ({"vert": True}, "vert"),
+        ({"vert": False}, "horz"),
+        ({"orientation": "vertical"}, "vert"),
+        ({"orientation": "horizontal"}, "horz"),
+    ],
+)
+def test_matplotlib_boxplot_orientation(kwargs: dict, expected: str) -> None:
+    fig, ax = plt.subplots()
+    try:
+        ax.boxplot(DATA, **kwargs)
+        assert _schema(fig)["orientation"] == expected
+    finally:
+        plt.close(fig)
+
+
+def test_matplotlib_vertical_boxplot_reads_statistics_off_the_y_axis() -> None:
+    """A vertical box plot read as horizontal yields positions, not values."""
+    fig, ax = plt.subplots()
+    try:
+        ax.boxplot(DATA)
+        first_box = _schema(fig)["data"][0]
+    finally:
+        plt.close(fig)
+
+    assert first_box["min"] == 1.0
+    assert first_box["q1"] == 2.0
+    assert first_box["q2"] == 3.0
+    assert first_box["q3"] == 4.0
+    assert first_box["max"] == 4.0
+    assert first_box["upperOutliers"] == [9.0]
+
+
+@pytest.mark.parametrize(
+    ("orient", "expected"),
+    [(None, "vert"), ("h", "horz")],
+)
+def test_seaborn_boxplot_orientation(orient: str | None, expected: str) -> None:
+    fig, ax = plt.subplots()
+    try:
+        if orient is None:
+            sns.boxplot(data=DATA, ax=ax)
+        else:
+            sns.boxplot(data=DATA, orient=orient, ax=ax)
+        assert _schema(fig)["orientation"] == expected
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        # `Axes.boxplot` forwards `vert=None` whenever the caller omits it, so
+        # an absent `vert` must not be read as horizontal.
+        ({"vert": None, "orientation": "vertical"}, "vert"),
+        ({"vert": None, "orientation": "horizontal"}, "horz"),
+        # An explicitly set `vert` still wins while matplotlib supports it.
+        ({"vert": False, "orientation": "vertical"}, "horz"),
+        ({"vert": True, "orientation": "horizontal"}, "vert"),
+        # Pre-3.9 matplotlib passes `vert` alone.
+        ({"vert": True}, "vert"),
+        ({"vert": False}, "horz"),
+        ({}, "vert"),
+    ],
+)
+def test_resolve_bxp_orientation(kwargs: dict, expected: str) -> None:
+    assert _resolve_bxp_orientation(kwargs) == expected

--- a/tests/core/plot/test_boxplot_orientation.py
+++ b/tests/core/plot/test_boxplot_orientation.py
@@ -2,22 +2,24 @@
 
 The orientation reaches the MAIDR JSON as ``orientation`` and drives two
 user-visible things: the announced plot type ("vertical box" / "horizontal
-box") and which axis the extractor reads the Tukey statistics off. Matplotlib
-3.9 deprecated ``vert`` in favour of ``orientation`` and ``Axes.boxplot``
+box") and which axis the extractor reads the Tukey statistics off. Recent
+matplotlib deprecated ``vert`` in favour of ``orientation`` and ``Axes.boxplot``
 forwards both to ``Axes.bxp``, so the detection has to read them the way
 matplotlib itself does.
 """
 
 from __future__ import annotations
 
+import inspect
+
 import matplotlib
 
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
-import packaging.version as version  # noqa: E402
 import pytest  # noqa: E402
 import seaborn as sns  # noqa: E402
+from matplotlib.axes import Axes  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.figure_manager import FigureManager  # noqa: E402
@@ -26,14 +28,15 @@ from maidr.patch.boxplot import _resolve_bxp_orientation  # noqa: E402
 
 DATA = [[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]]
 
-# `orientation` arrived in matplotlib 3.9; older releases only accept `vert`.
-# The resolver's handling of the keyword is covered version-independently by
-# ``test_resolve_bxp_orientation``.
-_HAS_ORIENTATION_KWARG = version.parse(matplotlib.__version__) >= version.parse("3.9")
+# Older matplotlib releases accept only `vert`, and the supported Python range
+# spans both. Ask the installed signature rather than hardcoding the release
+# that introduced `orientation`. The resolver's handling of the keyword is
+# covered on every version by ``test_resolve_bxp_orientation``.
+_HAS_ORIENTATION_KWARG = "orientation" in inspect.signature(Axes.boxplot).parameters
 
 _needs_orientation_kwarg = pytest.mark.skipif(
     not _HAS_ORIENTATION_KWARG,
-    reason="matplotlib < 3.9 has no `orientation` parameter",
+    reason="this matplotlib has no `orientation` parameter on Axes.boxplot",
 )
 
 

--- a/tests/core/plot/test_boxplot_orientation.py
+++ b/tests/core/plot/test_boxplot_orientation.py
@@ -153,3 +153,13 @@ def test_resolve_orientation_ignores_parameters_matplotlib_lacks() -> None:
         raise AssertionError("never called")
 
     assert resolve_orientation(no_orientation, ([],), {}) == "vert"
+
+
+def test_resolve_orientation_does_not_index_past_a_variadic_parameter() -> None:
+    """A `*args` ahead of the parameter makes a positional index meaningless."""
+
+    def variadic(dataset, *extra, vert=None):  # pragma: no cover - shape only
+        raise AssertionError("never called")
+
+    assert resolve_orientation(variadic, ([], False), {}) == "vert"
+    assert resolve_orientation(variadic, ([],), {"vert": False}) == "horz"

--- a/tests/core/plot/test_boxplot_orientation.py
+++ b/tests/core/plot/test_boxplot_orientation.py
@@ -42,7 +42,7 @@ _needs_orientation_kwarg = pytest.mark.skipif(
 
 def _schema(fig) -> dict:
     """Return the first layer's schema with plain string keys."""
-    plot = FigureManager.get_maidr(fig)._plots[0]
+    plot = FigureManager.get_maidr(fig).plots[0]
     return {(k.value if hasattr(k, "value") else k): v for k, v in plot.schema.items()}
 
 
@@ -65,6 +65,20 @@ def test_matplotlib_boxplot_orientation(kwargs: dict, expected: str) -> None:
     try:
         ax.boxplot(DATA, **kwargs)
         assert _schema(fig)["orientation"] == expected
+    finally:
+        plt.close(fig)
+
+
+def test_matplotlib_boxplot_orientation_passed_positionally() -> None:
+    """`ax.boxplot(x, notch, sym, vert)` still binds `vert` by position."""
+    fig, ax = plt.subplots()
+    try:
+        try:
+            ax.boxplot(DATA, None, None, False)
+        except TypeError:
+            # Matplotlib says these become keyword-only in 3.12.
+            pytest.skip("this matplotlib no longer accepts `vert` positionally")
+        assert _schema(fig)["orientation"] == "horz"
     finally:
         plt.close(fig)
 

--- a/tests/core/plot/test_boxplot_orientation.py
+++ b/tests/core/plot/test_boxplot_orientation.py
@@ -31,7 +31,7 @@ DATA = [[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]]
 # Older matplotlib releases accept only `vert`, and the supported Python range
 # spans both. Ask the installed signature rather than hardcoding the release
 # that introduced `orientation`. The resolver's handling of the keyword is
-# covered on every version by ``test_resolve_bxp_orientation``.
+# covered on every version by ``test_resolve_orientation_from_keywords``.
 _HAS_ORIENTATION_KWARG = "orientation" in inspect.signature(Axes.boxplot).parameters
 
 _needs_orientation_kwarg = pytest.mark.skipif(

--- a/tests/core/plot/test_violinplot_orientation.py
+++ b/tests/core/plot/test_violinplot_orientation.py
@@ -1,0 +1,87 @@
+"""Tests that violin plots report the orientation they were actually drawn with.
+
+``Axes.violinplot`` took the same ``vert`` → ``orientation`` migration as
+``Axes.boxplot``, and both of a violin's layers (``violin_box`` and
+``violin_kde``) carry the resolved orientation into the MAIDR JSON, where it
+decides the announced plot type and which axis the data is read along.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+from matplotlib.axes import Axes  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+DATA = [[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]]
+
+_needs_orientation_kwarg = pytest.mark.skipif(
+    "orientation" not in inspect.signature(Axes.violinplot).parameters,
+    reason="this matplotlib has no `orientation` parameter on Axes.violinplot",
+)
+
+
+def _orientations(fig) -> list[str]:
+    """Return the orientation of every layer registered for the figure."""
+    return [
+        {(k.value if hasattr(k, "value") else k): v for k, v in plot.schema.items()}[
+            "orientation"
+        ]
+        for plot in FigureManager.get_maidr(fig).plots
+    ]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({}, "vert"),
+        ({"vert": True}, "vert"),
+        ({"vert": False}, "horz"),
+        pytest.param(
+            {"orientation": "vertical"}, "vert", marks=_needs_orientation_kwarg
+        ),
+        pytest.param(
+            {"orientation": "horizontal"}, "horz", marks=_needs_orientation_kwarg
+        ),
+    ],
+)
+def test_matplotlib_violinplot_orientation(kwargs: dict, expected: str) -> None:
+    """Both layers of the violin agree on the orientation it was drawn with."""
+    fig, ax = plt.subplots()
+    try:
+        ax.violinplot(DATA, **kwargs)
+        orientations = _orientations(fig)
+    finally:
+        plt.close(fig)
+
+    assert orientations, "violinplot registered no layers"
+    assert orientations == [expected] * len(orientations)
+
+
+@pytest.mark.parametrize(
+    ("orient", "expected"),
+    [(None, "vert"), ("h", "horz")],
+)
+def test_seaborn_violinplot_orientation(orient: str | None, expected: str) -> None:
+    fig, ax = plt.subplots()
+    try:
+        if orient is None:
+            sns.violinplot(data=DATA, ax=ax)
+        else:
+            sns.violinplot(data=DATA, orient=orient, ax=ax)
+        orientations = _orientations(fig)
+    finally:
+        plt.close(fig)
+
+    assert orientations, "violinplot registered no layers"
+    assert orientations == [expected] * len(orientations)

--- a/tests/core/plot/test_violinplot_orientation.py
+++ b/tests/core/plot/test_violinplot_orientation.py
@@ -68,6 +68,27 @@ def test_matplotlib_violinplot_orientation(kwargs: dict, expected: str) -> None:
     assert orientations == [expected] * len(orientations)
 
 
+def test_matplotlib_violinplot_orientation_passed_positionally() -> None:
+    """`ax.violinplot(dataset, positions, vert)` still binds `vert` by position.
+
+    Unlike `Axes.boxplot`, this patch wraps the call the user made, so the
+    positional argument reaches it verbatim.
+    """
+    fig, ax = plt.subplots()
+    try:
+        try:
+            ax.violinplot(DATA, None, False)
+        except TypeError:
+            # Matplotlib says these become keyword-only in 3.12.
+            pytest.skip("this matplotlib no longer accepts `vert` positionally")
+        orientations = _orientations(fig)
+    finally:
+        plt.close(fig)
+
+    assert orientations, "violinplot registered no layers"
+    assert orientations == ["horz"] * len(orientations)
+
+
 @pytest.mark.parametrize(
     ("orient", "expected"),
     [(None, "vert"), ("h", "horz")],


### PR DESCRIPTION
## Description

Every **vertical** matplotlib box plot has been emitting `"orientation": "horz"`, which flips the announced plot type ("horizontal box") and — worse — makes `BoxPlotExtractor` read the whiskers, caps and medians off the x axis, so the layer reports box *positions* in place of its Tukey statistics.

Reproduction on matplotlib 3.10 with `ax.boxplot([[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]])`:

```
before: orientation=horz   min 1.9625, q1 2.0, q2 1.925, q3 2.0, max 1.9625
after:  orientation=vert   min 1.0,    q1 2.0, q2 3.0,   q3 4.0, max 4.0, upperOutliers [9.0]
```

Root cause: matplotlib 3.10 introduced `orientation` and pending-deprecated `vert`, and `Axes.boxplot` forwards **both** to `Axes.bxp` — passing `vert=None` whenever the caller omits it. The patch read `not kwargs.get("vert", True)`, and `not None` is `True`, so an absent `vert` was read as horizontal. Seaborn was unaffected: it goes through `BoxplotContextManager` and reads `orient` instead.

Two sibling cases came out of review and are fixed here too, since they are the same `vert`/`orientation` rule read in a different place:

- **`mpl_violinplot`** had the mirror-image bug — it read only `vert`, defaulting an absent one to `True`, so `ax.violinplot(data, orientation="horizontal")` (the form matplotlib now recommends) was registered as vertical and read along the wrong axis. `Axes.violinplot` took the same migration as `Axes.boxplot`.
- **Positional arguments** were not inspected at all. `Axes.bxp` and `Axes.violinplot` are public, so `ax.bxp(stats, None, None, False)` — `vert` passed positionally — resolved to vertical.

```
before: violinplot(orientation='horizontal') -> ['vert', 'vert']    bxp(stats, None, None, False) -> ['vert']
after:  violinplot(orientation='horizontal') -> ['horz', 'horz']    bxp(stats, None, None, False) -> ['horz']
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description

See above — matplotlib box and violin plots reported the wrong orientation, and with it the wrong statistics axis.

## Related Issues

None filed — reported directly, alongside the observation that violin layers announce their orientation while box plots did not (or announced the wrong one).

## Changes Made

- **`maidr/patch/common.py`** — new `resolve_orientation(wrapped, args, kwargs)` resolves the orientation the way matplotlib itself does: an explicitly set `vert` wins while it is still supported, and `orientation` decides otherwise. It reads either argument whether it was passed by name or by position, taking the positions from the wrapped function's own signature so a matplotlib that lacks one of the parameters resolves through the other.
- **`maidr/patch/boxplot.py`** — `mpl_box` calls it in place of the inline `vert` check.
- **`maidr/patch/violinplot.py`** — `mpl_violinplot` calls it in place of `"vert" if kwargs.get("vert", True) else "horz"`.
- **`tests/core/plot/test_boxplot_orientation.py`** (new) — emitted orientation for `ax.boxplot()` with no kwargs, `vert=True/False` and `orientation="vertical"/"horizontal"`; the same for `sns.boxplot` with and without `orient="h"`; a regression test asserting the vertical five-number summary is the data's, not the box positions'; and resolver cases for keyword, positional and absent-parameter shapes.
- **`tests/core/plot/test_violinplot_orientation.py`** (new) — the same matrix for `ax.violinplot` and `sns.violinplot`, asserting both registered layers (`violin_box` and `violin_kde`) agree.

The `orientation=` cases are skipped when the installed `Axes.boxplot` / `Axes.violinplot` has no such parameter — asked of `inspect.signature` rather than hardcoded to a release — so the Python 3.9 job, which resolves matplotlib 3.9.x, stays green.

## Screenshots (if applicable)

n/a

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` passes (204 tests). `ruff check` reports the same 7 pre-existing `F401` errors as on `main` and none from these files; `ruff format` is clean on every changed file.

Not addressed here, found while checking the other oriented plot types: `plt.barh` raises `TypeError: 'NoneType' object is not iterable` in `BarPlot._extract_plot_data`, because the levels are always read off the x axis and the bar values always from `patch.get_height()`. Horizontal bar plots therefore have no working path today; making them work (and emitting `orientation` for them) is a separate change from this one.

Companion change in the renderer: xability/maidr#747 — every trace type that has an orientation now announces it, defaulting to vertical when the JSON declares none.