### PR TITLE
ci: let the Claude action post under its own identity again

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # No github_token on purpose. The input is "optional if using GitHub
+          # App", and supplying it makes the action post as github-actions[bot]
+          # instead of claude[bot] -- which is what every review here has been
+          # attributed to since f22e3187. The Claude app is installed on this
+          # repo (it posted as claude[bot] on #273), so leaving this out lets
+          # the action use its own app token and its own identity again.
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,7 +45,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # No github_token on purpose -- see the note in
+          # claude-code-review.yml. Supplying it costs the claude[bot] identity,
+          # and here it also could not have worked: this job grants only
+          # `issues: read` / `pull-requests: read`, so GITHUB_TOKEN cannot post
+          # the reply an @claude mention asks for.
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## What

Removes one input from both Claude workflows:

```yaml
github_token: ${{ secrets.GITHUB_TOKEN }}
```

## Why

Every Claude review here is attributed to **github-actions[bot]**; on `maidr` and `r-maidr` the same action posts as **claude[bot]**. That single input is the whole difference — the workflows are otherwise the same shape.

The action's own `action.yml` says so:

```yaml
github_token:
  description: "GitHub token with repo and pull request permissions (optional if using GitHub App)"
# and among the outputs:
github_token:
  description: "The GitHub token used by the action (Claude App token if available)"
```

Supplied, it overrides the app token, so the action speaks as the workflow instead of as itself.

## Where it came from

```
2026-03-04  5b38610c  ci: install claude github app (#273)
2026-03-05  a35b5925  ci: update claude review to pull_request_target with write permissions
2026-03-05  f22e3187  ci: add github_token to bypass OIDC in claude review workflow
```

The bypass landed the day after the app was installed and the day the review moved to `pull_request_target`. The commit records only its title — no error, no run link — so what OIDC failure it addressed is not recoverable from the history. The app is installed and working: it posted as `claude[bot]` on #273 on 2026-03-04.

Worth noting separately: in `claude.yml` the input could not have been doing its job at all. That job grants `issues: read` and `pull-requests: read`, so `GITHUB_TOKEN` has no permission to post the reply an `@claude` mention exists to produce.

## This cannot be verified before merging

`claude-code-review.yml` runs on `pull_request_target`, and `claude.yml` on `issue_comment` — **both take the workflow file from the base branch**, so this PR will be reviewed by the current `main` version, not by the version it proposes. There is no way to exercise the change from a PR.

So the honest sequence is: merge, watch the next PR, and revert if the job fails. It is one line in each file.

If the OIDC problem does resurface, the failure will be at the action's auth step rather than silent.

## One thing to decide, not fixed here

Removing the input changes which token the action holds. `GITHUB_TOKEN` is bounded by this workflow's `permissions:` block; the Claude app token is bounded by what the app was granted at install, which the workflow file does not control. On `claude-code-review.yml` that matters more than usual, because it runs on `pull_request_target` against fork branches — the exposure the file's own comment already flags.

Two consequences worth a maintainer's call:

- `pull-requests: write` in `claude-code-review.yml` exists so `GITHUB_TOKEN` could post. With the app token it no longer needs to be there, and narrowing it to `read` would shrink what a prompt injection could reach through `GITHUB_TOKEN`. Left alone here to keep this diff to one concern, and because it would need to go back if this change is reverted.
- If the wider app-token scope is not wanted on a `pull_request_target` workflow, the alternative is `maidr`'s shape: plain `pull_request` with a fork guard. That trades away fork-PR reviews, which the comment in this file says is the reason `pull_request_target` was chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
