### PR TITLE
feat(plotly): bind a plotly step chart as a step trace, not a line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,10 @@ The `maidr/patch/` modules use `wrapt` to intercept matplotlib/seaborn plot call
 
 Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, COUNT, DODGED, HEAT, HIST, LINE, SCATTER, STACKED, STEP, SMOOTH, CANDLESTICK.
 
+Note that `maidr/plotly/` builds its MAIDR schema in Python and therefore needs its own
+handling per plot type, whereas `maidr/altair/` delegates entirely to the upstream
+Vega-Lite JS adapter — an Altair-only plot type is implemented there, not here.
+
 ### Canonical `axes` Payload
 
 Every emitted schema's `axes` object follows the canonical per-axis form:

--- a/docs/examples-altair.qmd
+++ b/docs/examples-altair.qmd
@@ -466,6 +466,69 @@ multiline_plot = (
 maidr.show(multiline_plot)  #<<
 ```
 
+### Step Plot
+
+Altair expresses a staircase through the mark's `interpolate` property, which
+Vega-Lite hands to the matching d3 curve. maidr renders Altair charts through the
+upstream Vega-Lite adapter, so a stepping `interpolate` is recognised there and
+the chart is bound as a step layer rather than a line.
+
+A **hypnogram** is the canonical case: the sleep stage is held for a stretch of
+the night and then jumps.
+
+```{python}
+#| warning: false
+#| fig-alt: Hypnogram showing sleep stage as a step chart across one night
+
+import altair as alt
+import pandas as pd
+
+import maidr  #<<
+
+# Ordinal sleep stages, deepest first, so that "up" means lighter sleep.
+STAGE_NAMES = ["N3", "N2", "N1", "REM", "Awake"]
+
+hours = [i * 0.5 for i in range(17)]
+stages = [4, 3, 2, 1, 0, 0, 1, 3, 2, 1, 0, 1, 3, 2, 1, 3, 4]
+
+df = pd.DataFrame({"hours": hours, "stage": stages})
+
+chart = (
+    alt.Chart(df)
+    .mark_line(interpolate="step-after")  #<<
+    .encode(
+        x=alt.X("hours:Q", title="Time asleep (hours)"),
+        y=alt.Y(
+            "stage:Q",
+            title="Sleep stage",
+            axis=alt.Axis(
+                values=list(range(len(STAGE_NAMES))),
+                labelExpr=(
+                    "datum.value == 0 ? 'N3' : datum.value == 1 ? 'N2' : "
+                    "datum.value == 2 ? 'N1' : datum.value == 3 ? 'REM' : 'Awake'"
+                ),
+            ),
+        ),
+    )
+    .properties(title="Hypnogram: sleep stage across one night")
+)
+
+maidr.show(chart)
+```
+
+`interpolate` decides which side of each sample the value is held on:
+
+| Altair `interpolate` | maidr `stepDirection` | Meaning |
+|----------------------|-----------------------|---------|
+| `"step-after"` | `hv` | Value holds until the next x value, then jumps |
+| `"step-before"` | `vh` | Value jumps at the current x value, then holds |
+| `"step"` | `mid` | Value jumps midway between x values |
+
+::: {.callout-note}
+`mark_area(interpolate="step-after")` binds as a step too — the fill is lost in
+the conversion, as it is for a plain area mark.
+:::
+
 ### Scatter Plot
 
 ```{python}

--- a/docs/examples-plotly.qmd
+++ b/docs/examples-plotly.qmd
@@ -399,6 +399,76 @@ fig = go.Figure(
 maidr.show(fig)  #<<
 ```
 
+### Step Plot
+
+Plotly has no step trace type. A staircase is an ordinary `Scatter` trace whose
+`line_shape` tells plotly.js to draw risers between the samples rather than
+interpolating across them, so `line_shape` is the only thing that marks the data
+as *piecewise constant*. maidr reads it and exports a step layer.
+
+A **hypnogram** is the canonical case: the sleep stage is held for a stretch of
+the night and then jumps. Drawn as a line it would claim the sleeper glided
+through every intermediate stage.
+
+```{python}
+#| warning: false
+#| fig-alt: Hypnogram showing sleep stage as a step chart across one night
+
+import plotly.graph_objects as go
+
+import maidr  #<<
+
+# Ordinal sleep stages, deepest first, so that "up" means lighter sleep.
+STAGE_NAMES = ["N3", "N2", "N1", "REM", "Awake"]
+
+hours = [i * 0.5 for i in range(17)]
+stages = [4, 3, 2, 1, 0, 0, 1, 3, 2, 1, 0, 1, 3, 2, 1, 3, 4]
+
+fig = go.Figure(
+    go.Scatter(
+        x=hours,
+        y=stages,
+        mode="lines",
+        line_shape="hv",  #<<
+        name="Night 1",
+    )
+)
+
+fig.update_layout(
+    title="Hypnogram<br>Sleep stage across one night",
+    xaxis_title="Time asleep (hours)",
+    yaxis=dict(
+        title="Sleep stage",
+        tickmode="array",
+        tickvals=list(range(len(STAGE_NAMES))),
+        ticktext=STAGE_NAMES,
+    ),
+)
+
+maidr.show(fig)
+```
+
+`line_shape` decides which side of each sample the value is held on, and maidr
+reports it so the description can say what the chart actually means:
+
+| Plotly `line_shape` | maidr `stepDirection` | Meaning |
+|---------------------|-----------------------|---------|
+| `"hv"` | `hv` | Value holds until the next x value, then jumps |
+| `"vh"` | `vh` | Value jumps at the current x value, then holds |
+| `"hvh"` | `mid` | Value jumps midway between x values |
+| `"vhv"` | *(none)* | Still a step, but no direction is claimed — see below |
+
+::: {.callout-note}
+`"vhv"` is the one shape whose horizontal segments do not sit at a sample's own
+value, so it has no maidr equivalent. The trace still binds as a step, because
+the data is piecewise constant, but no `stepDirection` is emitted rather than
+one being guessed.
+
+A maidr layer carries a single `stepDirection` for all of its series, so traces
+drawn with different shapes are exported as **separate layers**. Merging an
+`"hv"` trace with a `"vh"` one would describe one of them wrongly.
+:::
+
 ### Scatter Plot
 
 ```{python}

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -65,7 +65,7 @@ We currently support the following data visualization libraries in Python:, and 
 
 * Multi-line plot having one x (numerical) and one y (numerical) axis with multiple data series on the same axes.
 
-* Step plot having one x (numerical) and one y (numerical or ordinal) axis, for piecewise-constant values that are held over an interval and then jump — e.g. a hypnogram of sleep stage against time. Named y tick labels are announced as level names in place of the numeric level.
+* Step plot having one x (numerical) and one y (numerical or ordinal) axis, for piecewise-constant values that are held over an interval and then jump — e.g. a hypnogram of sleep stage against time. Named y tick labels are announced as level names in place of the numeric level. Recognised from matplotlib's `drawstyle="steps-*"` (including `ax.step()`), Plotly's `line_shape`, and Altair's `interpolate`.
 
 * Vertical box plot having one x (categorical) and one y (numerical) axis.
 

--- a/example/step/altair/example_altair_step.py
+++ b/example/step/altair/example_altair_step.py
@@ -1,0 +1,59 @@
+"""Hypnogram in Altair: a sleep stage held over an interval, then jumping.
+
+Altair expresses a staircase through the mark's ``interpolate`` property, which
+Vega-Lite hands to the matching d3 curve. maidr renders Altair charts through
+the upstream Vega-Lite adapter, so the step handling lives there and this file
+needs nothing maidr-specific beyond the import.
+
+``interpolate`` maps onto MAIDR's step conventions as:
+
+    "step-after"  -> hold the value, then jump at the next reading  (used here)
+    "step-before" -> jump at the reading, then hold
+    "step"        -> jump midway between readings
+"""
+
+import altair as alt
+import pandas as pd
+
+import maidr
+
+# Ordinal sleep stages, deepest first, so that "up" means lighter sleep.
+STAGE_NAMES = ["N3", "N2", "N1", "REM", "Awake"]
+
+# One reading every half hour across a night's sleep.
+hours = [i * 0.5 for i in range(17)]
+stages = [4, 3, 2, 1, 0, 0, 1, 3, 2, 1, 0, 1, 3, 2, 1, 3, 4]
+
+df = pd.DataFrame(
+    {
+        "hours": hours,
+        "stage": stages,
+        "stage_name": [STAGE_NAMES[s] for s in stages],
+    }
+)
+
+chart = (
+    alt.Chart(df)
+    # "step-after" is the hypnogram reading: the stage holds until the next
+    # reading, then jumps.
+    .mark_line(interpolate="step-after")
+    .encode(
+        x=alt.X("hours:Q", title="Time asleep (hours)"),
+        # The y values stay numeric — they drive sonification, braille and the
+        # min/max range — while the axis labels name the ordinal levels.
+        y=alt.Y(
+            "stage:Q",
+            title="Sleep stage",
+            axis=alt.Axis(
+                values=list(range(len(STAGE_NAMES))),
+                labelExpr=(
+                    "datum.value == 0 ? 'N3' : datum.value == 1 ? 'N2' : "
+                    "datum.value == 2 ? 'N1' : datum.value == 3 ? 'REM' : 'Awake'"
+                ),
+            ),
+        ),
+    )
+    .properties(title="Hypnogram: sleep stage across one night")
+)
+
+maidr.show(chart)

--- a/example/step/altair/example_altair_step.py
+++ b/example/step/altair/example_altair_step.py
@@ -28,7 +28,6 @@ df = pd.DataFrame(
     {
         "hours": hours,
         "stage": stages,
-        "stage_name": [STAGE_NAMES[s] for s in stages],
     }
 )
 

--- a/example/step/plotly/example_plotly_step.py
+++ b/example/step/plotly/example_plotly_step.py
@@ -1,0 +1,53 @@
+"""Hypnogram in Plotly: a sleep stage held over an interval, then jumping.
+
+Plotly has no step trace type. A staircase is an ordinary ``Scatter`` trace
+whose ``line_shape`` tells plotly.js to draw risers between the samples rather
+than interpolating across them, so ``line_shape`` is the only thing that marks
+the data as piecewise constant. maidr reads it and exports a step layer, which
+announces the stage names and lets a user jump transition to transition.
+
+``line_shape`` maps onto MAIDR's step conventions as:
+
+    "hv"  -> hold the value, then jump at the next reading   (used here)
+    "vh"  -> jump at the reading, then hold
+    "hvh" -> jump midway between readings
+    "vhv" -> still a step, but no MAIDR equivalent, so no direction is claimed
+"""
+
+import plotly.graph_objects as go
+
+import maidr
+
+# Ordinal sleep stages, deepest first, so that "up" means lighter sleep.
+STAGE_NAMES = ["N3", "N2", "N1", "REM", "Awake"]
+
+# One reading every half hour across a night's sleep.
+hours = [i * 0.5 for i in range(17)]
+stages = [4, 3, 2, 1, 0, 0, 1, 3, 2, 1, 0, 1, 3, 2, 1, 3, 4]
+
+fig = go.Figure(
+    go.Scatter(
+        x=hours,
+        y=stages,
+        mode="lines",
+        # "hv" is the hypnogram reading: the stage holds until the next
+        # reading, then jumps. maidr exports this as stepDirection "hv".
+        line_shape="hv",
+        name="Night 1",
+    )
+)
+
+fig.update_layout(
+    title="Hypnogram<br>Sleep stage across one night",
+    xaxis_title="Time asleep (hours)",
+    # Name the ordinal levels. The underlying y values stay numeric, which is
+    # what drives sonification, braille and the min/max range.
+    yaxis=dict(
+        title="Sleep stage",
+        tickmode="array",
+        tickvals=list(range(len(STAGE_NAMES))),
+        ticktext=STAGE_NAMES,
+    ),
+)
+
+maidr.show(fig)

--- a/maidr/plotly/line.py
+++ b/maidr/plotly/line.py
@@ -6,13 +6,53 @@ from maidr.plotly.plotly_plot import PlotlyPlot
 
 
 class PlotlyLinePlot(PlotlyPlot):
-    """Extract data from a Plotly scatter trace with mode='lines'."""
+    """
+    Extract data from a Plotly scatter trace with mode='lines'.
 
-    def __init__(self, trace: dict, layout: dict, **kwargs: str) -> None:
+    Parameters
+    ----------
+    trace : dict
+        The scatter/lines trace dict.
+    layout : dict
+        The Plotly figure layout.
+    scatter_position : int, optional
+        The trace's zero-based position among the subplot's scatter-family
+        traces. Pass this whenever the subplot holds more than this one
+        scatter trace — a step trace beside it makes that the normal case.
+    **kwargs : str
+        Axis names forwarded to the parent class.
+    """
+
+    def __init__(
+        self,
+        trace: dict,
+        layout: dict,
+        scatter_position: int | None = None,
+        **kwargs: str,
+    ) -> None:
         super().__init__(trace, layout, PlotType.LINE, **kwargs)
+        self._scatter_position = scatter_position
 
     def _get_selector(self) -> list[str]:
-        return [f"{self._subplot_css_prefix()}.trace.scatter path.js-line"]
+        """
+        Return the selector for this line's rendered path.
+
+        With a known position the selector is scoped to that one trace.
+        Without one it falls back to the unscoped subplot-wide form, which
+        assumes this is the only ``path.js-line`` on the subplot. That
+        assumption held while a line layer owned every scatter trace, but a
+        step trace renders as ``path.js-line`` too, so the unscoped form
+        would match both. ``PlotlyMaidr`` therefore always supplies a
+        position; the fallback is for direct/standalone construction.
+
+        Returns
+        -------
+        list of str
+            A single CSS selector.
+        """
+        if self._scatter_position is None:
+            return [f"{self._subplot_css_prefix()}.trace.scatter path.js-line"]
+        return [self._scatter_line_selector(self._scatter_position)]
 
     def _extract_plot_data(self) -> list[list[dict]]:
         x = self._trace.get("x", [])

--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -18,17 +18,46 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         All scatter/lines trace dicts belonging to the multi-line plot.
     layout : dict
         The Plotly figure layout.
+    scatter_positions : list of int, optional
+        Each trace's zero-based position among the subplot's scatter-family
+        traces. Required whenever these are not the leading scatter traces of
+        the subplot — which a step trace declared alongside them makes the
+        normal case. Defaults to the traces' own order, correct only for a
+        layer that owns every scatter trace on its subplot.
     """
 
-    def __init__(self, traces: list[dict], layout: dict, **kwargs: str) -> None:
+    def __init__(
+        self,
+        traces: list[dict],
+        layout: dict,
+        scatter_positions: list[int] | None = None,
+        **kwargs: str,
+    ) -> None:
         super().__init__(traces[0], layout, PlotType.LINE, **kwargs)
         self._traces = traces
+        self._scatter_positions = (
+            list(range(len(traces)))
+            if scatter_positions is None
+            else scatter_positions
+        )
 
     def _get_selector(self) -> list[str]:
-        prefix = self._subplot_css_prefix()
+        """
+        Return one selector per line, matching the rendered line paths.
+
+        Indices are subplot-relative, not layer-relative: a step trace
+        declared before these lines shifts every one of them in the
+        ``scatterlayer``, so numbering from 1 here would point each line at
+        its predecessor and collide with the step layer's own selectors.
+
+        Returns
+        -------
+        list of str
+            One CSS selector per line, in trace order.
+        """
         return [
-            f"{prefix}.scatterlayer > .trace.scatter:nth-child({i + 1}) path.js-line"
-            for i in range(len(self._traces))
+            self._scatter_line_selector(position)
+            for position in self._scatter_positions
         ]
 
     def _extract_plot_data(self) -> list[list[dict]]:

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -159,6 +159,20 @@ class PlotlyMaidr:
                 t for t in group_traces if t.get("type") == "box"
             ]
 
+            # `nth-child` counts within the subplot's scatterlayer, which holds
+            # every scatter-family trace, so any scatter trace's selector index
+            # is its position there — not its position within the MAIDR layer
+            # it lands in. The two agree only while one layer owns every
+            # scatter trace on the subplot, which splitting steps out ends.
+            scatter_family = [
+                t
+                for t in group_traces
+                if t.get("type") in ("scatter", "scattergl")
+            ]
+            position_of = {
+                id(t): index for index, t in enumerate(scatter_family)
+            }
+
             merged: set[int] = set()
 
             # Grouped / stacked bars
@@ -184,12 +198,36 @@ class PlotlyMaidr:
                 from maidr.plotly.multiline import PlotlyMultiLinePlot
 
                 plot = PlotlyMultiLinePlot(
-                    line_traces, layout, **axis_kwargs
+                    line_traces,
+                    layout,
+                    scatter_positions=[
+                        position_of[id(t)] for t in line_traces
+                    ],
+                    **axis_kwargs,
                 )
                 plot.row_index = row
                 plot.col_index = col
                 self._plots.append(plot)
                 merged.update(id(t) for t in line_traces)
+
+            # A lone line is built here rather than left to the factory below,
+            # so it too gets a position-scoped selector. The factory cannot
+            # know the trace's position among its subplot's scatter traces,
+            # and its unscoped selector would also match a step trace's path.
+            elif len(line_traces) == 1:
+                from maidr.plotly.line import PlotlyLinePlot
+
+                only_line = line_traces[0]
+                plot = PlotlyLinePlot(
+                    only_line,
+                    layout,
+                    scatter_position=position_of[id(only_line)],
+                    **axis_kwargs,
+                )
+                plot.row_index = row
+                plot.col_index = col
+                self._plots.append(plot)
+                merged.add(id(only_line))
 
             # Steps, one layer per step convention. A MAIDR layer carries a
             # single ``stepDirection`` for all of its series, so merging an
@@ -200,18 +238,6 @@ class PlotlyMaidr:
             if step_traces:
                 from maidr.plotly.step import PlotlyStepPlot
                 from maidr.plotly.step_shape import group_by_direction
-
-                # `nth-child` counts within the subplot's scatterlayer, which
-                # holds every scatter-family trace, so a step trace's selector
-                # index is its position there — not within its own layer.
-                scatter_family = [
-                    t
-                    for t in group_traces
-                    if t.get("type") in ("scatter", "scattergl")
-                ]
-                position_of = {
-                    id(t): index for index, t in enumerate(scatter_family)
-                }
 
                 for direction_group in group_by_direction(step_traces):
                     plot = PlotlyStepPlot(

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -13,6 +13,7 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.plotly_plot import PlotlyPlot
 from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
+from maidr.plotly.step_shape import is_connected_line_trace, is_step_trace
 from maidr.util.dependencies import (
     MAIDR_CSS_CDN_URL,
     MAIDR_CSS_FILENAME,
@@ -154,18 +155,12 @@ class PlotlyMaidr:
                 t for t in group_traces if t.get("type") == "bar"
             ]
             connected_traces = [
-                t
-                for t in group_traces
-                if t.get("type") in ("scatter", "scattergl")
-                and "lines" in t.get("mode", "")
-                and "markers" not in t.get("mode", "")
+                t for t in group_traces if is_connected_line_trace(t)
             ]
             # A staircase is a scatter/lines trace whose ``line.shape`` makes
             # plotly draw risers instead of interpolating, so it has to be
             # split out here: merged into the multi-line layer it would be
             # announced as an interpolated line.
-            from maidr.plotly.step_shape import is_step_trace
-
             step_traces = [t for t in connected_traces if is_step_trace(t)]
             line_traces = [t for t in connected_traces if not is_step_trace(t)]
             box_traces = [

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -140,13 +140,21 @@ class PlotlyMaidr:
             bar_traces = [
                 t for t in group_traces if t.get("type") == "bar"
             ]
-            line_traces = [
+            connected_traces = [
                 t
                 for t in group_traces
                 if t.get("type") in ("scatter", "scattergl")
                 and "lines" in t.get("mode", "")
                 and "markers" not in t.get("mode", "")
             ]
+            # A staircase is a scatter/lines trace whose ``line.shape`` makes
+            # plotly draw risers instead of interpolating, so it has to be
+            # split out here: merged into the multi-line layer it would be
+            # announced as an interpolated line.
+            from maidr.plotly.step_shape import is_step_trace
+
+            step_traces = [t for t in connected_traces if is_step_trace(t)]
+            line_traces = [t for t in connected_traces if not is_step_trace(t)]
             box_traces = [
                 t for t in group_traces if t.get("type") == "box"
             ]
@@ -182,6 +190,42 @@ class PlotlyMaidr:
                 plot.col_index = col
                 self._plots.append(plot)
                 merged.update(id(t) for t in line_traces)
+
+            # Steps, one layer per step convention. A MAIDR layer carries a
+            # single ``stepDirection`` for all of its series, so merging an
+            # ``hv`` trace with a ``vh`` one would describe one of them
+            # wrongly. Single-trace groups go through here too rather than
+            # falling to the factory below, so their selector is scoped by
+            # position among the subplot's scatter traces.
+            if step_traces:
+                from maidr.plotly.step import PlotlyStepPlot
+                from maidr.plotly.step_shape import group_by_direction
+
+                # `nth-child` counts within the subplot's scatterlayer, which
+                # holds every scatter-family trace, so a step trace's selector
+                # index is its position there — not within its own layer.
+                scatter_family = [
+                    t
+                    for t in group_traces
+                    if t.get("type") in ("scatter", "scattergl")
+                ]
+                position_of = {
+                    id(t): index for index, t in enumerate(scatter_family)
+                }
+
+                for direction_group in group_by_direction(step_traces):
+                    plot = PlotlyStepPlot(
+                        direction_group,
+                        layout,
+                        scatter_positions=[
+                            position_of[id(t)] for t in direction_group
+                        ],
+                        **axis_kwargs,
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in step_traces)
 
             # Multi-box
             if len(box_traces) > 1:

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -13,7 +13,11 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.plotly_plot import PlotlyPlot
 from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
-from maidr.plotly.step_shape import is_connected_line_trace, is_step_trace
+from maidr.plotly.step_shape import (
+    is_connected_line_trace,
+    is_scatter_family_trace,
+    is_step_trace,
+)
 from maidr.util.dependencies import (
     MAIDR_CSS_CDN_URL,
     MAIDR_CSS_FILENAME,
@@ -172,10 +176,12 @@ class PlotlyMaidr:
             # is its position there — not its position within the MAIDR layer
             # it lands in. The two agree only while one layer owns every
             # scatter trace on the subplot, which splitting steps out ends.
+            # Shares its membership test with `connected_traces` above. If the
+            # two ever disagree, a trace can be classified as a line or a step
+            # while being absent from `position_of`, and the lookup below dies
+            # with a KeyError instead of producing a wrong selector.
             scatter_family = [
-                t
-                for t in group_traces
-                if t.get("type") in ("scatter", "scattergl")
+                t for t in group_traces if is_scatter_family_trace(t)
             ]
             position_of = {
                 id(t): index for index, t in enumerate(scatter_family)

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -111,10 +111,23 @@ class PlotlyMaidr:
 
         * Multiple bar traces with ``barmode='group'`` or ``'stack'`` are
           merged into a single :class:`PlotlyGroupedBarPlot`.
-        * Multiple scatter/lines traces are merged into a single
-          :class:`PlotlyMultiLinePlot` (matching ``MultiLinePlot``).
+        * Scatter/lines traces are first split into staircases and plain
+          lines by ``line.shape``: a step merged into the line layer would be
+          announced as interpolating between samples, which is the one thing
+          piecewise-constant data does not do. The plain lines then merge into
+          a single :class:`PlotlyMultiLinePlot` (matching ``MultiLinePlot``),
+          or become one :class:`PlotlyLinePlot` when there is only one.
+        * The staircases are split again by step convention, one
+          :class:`PlotlyStepPlot` per convention, because a MAIDR layer
+          carries a single ``stepDirection`` for all of its series.
         * Multiple box traces are merged into a single
           :class:`PlotlyMultiBoxPlot` (matching ``BoxPlot``).
+
+        Every scatter-family trace is assigned a selector index from its
+        position within the subplot, not within the layer it lands in — see
+        :meth:`PlotlyPlot._scatter_line_selector`. Because of that, all
+        scatter/lines traces are built here rather than left to
+        :class:`PlotlyPlotFactory`, which cannot know those positions.
         """
         fig_dict = self._fig.to_dict()
         layout = fig_dict.get("layout", {})

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -89,6 +89,33 @@ class PlotlyPlot(ABC):
         subplot_id = f"{x_ref}{y_ref}"
         return f".subplot.{subplot_id} "
 
+    def _scatter_line_selector(self, position: int) -> str:
+        """
+        Return the selector for one scatter trace's rendered line path.
+
+        ``nth-child`` counts within the subplot's ``scatterlayer``, which
+        holds *every* scatter-family trace on the subplot. So the index has
+        to be a trace's position there, never its position within whichever
+        MAIDR layer it was grouped into. Those two agree only while one layer
+        owns every scatter trace on the subplot — which stopped being true
+        once step traces were split out into their own layers.
+
+        Parameters
+        ----------
+        position : int
+            The trace's zero-based position among the subplot's
+            scatter-family traces.
+
+        Returns
+        -------
+        str
+            A CSS selector scoped to this subplot and that one trace.
+        """
+        return (
+            f"{self._subplot_css_prefix()}.scatterlayer > "
+            f".trace.scatter:nth-child({position + 1}) path.js-line"
+        )
+
     def _get_selector(self) -> str:
         """Return a CSS selector for Plotly SVG elements."""
         return ""

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -50,6 +50,18 @@ class PlotlyPlotFactory:
         if trace_type in ("scatter", "scattergl"):
             mode = trace.get("mode", "markers")
             if "lines" in mode and "markers" not in mode:
+                # NOTE: this whole lines-mode branch is unreachable from
+                # ``PlotlyMaidr``. ``_extract_plots`` consumes every
+                # scatter/lines trace itself — steps, multi-line groups and a
+                # lone line alike — because only it knows each trace's
+                # position among its subplot's scatter traces, which the
+                # selector needs. The branch is kept for direct/standalone
+                # construction (and is exercised that way by the tests), the
+                # same role the unscoped fallback plays in
+                # ``PlotlyLinePlot._get_selector``. If the classification rule
+                # below changes, change it in ``_extract_plots`` too — these
+                # two are the only copies and nothing forces them to agree.
+                #
                 # A staircase is a scatter trace too — plotly varies
                 # ``line.shape``, not the trace type — so the shape is the only
                 # thing separating piecewise-constant data from an

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -50,6 +50,17 @@ class PlotlyPlotFactory:
         if trace_type in ("scatter", "scattergl"):
             mode = trace.get("mode", "markers")
             if "lines" in mode and "markers" not in mode:
+                # A staircase is a scatter trace too — plotly varies
+                # ``line.shape``, not the trace type — so the shape is the only
+                # thing separating piecewise-constant data from an
+                # interpolated line.
+                from maidr.plotly.step_shape import is_step_trace
+
+                if is_step_trace(trace):
+                    from maidr.plotly.step import PlotlyStepPlot
+
+                    return PlotlyStepPlot([trace], layout, **axis_kwargs)
+
                 from maidr.plotly.line import PlotlyLinePlot
 
                 return PlotlyLinePlot(trace, layout, **axis_kwargs)

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.step_shape import is_connected_line_trace, is_step_trace
 
 
 class PlotlyPlotFactory:
@@ -48,8 +49,7 @@ class PlotlyPlotFactory:
             return PlotlyBarPlot(trace, layout, **axis_kwargs)
 
         if trace_type in ("scatter", "scattergl"):
-            mode = trace.get("mode", "markers")
-            if "lines" in mode and "markers" not in mode:
+            if is_connected_line_trace(trace):
                 # NOTE: this whole lines-mode branch is unreachable from
                 # ``PlotlyMaidr``. ``_extract_plots`` consumes every
                 # scatter/lines trace itself — steps, multi-line groups and a
@@ -58,16 +58,16 @@ class PlotlyPlotFactory:
                 # selector needs. The branch is kept for direct/standalone
                 # construction (and is exercised that way by the tests), the
                 # same role the unscoped fallback plays in
-                # ``PlotlyLinePlot._get_selector``. If the classification rule
-                # below changes, change it in ``_extract_plots`` too — these
-                # two are the only copies and nothing forces them to agree.
+                # ``PlotlyLinePlot._get_selector``.
+                #
+                # The "is this a connected line" test is shared with
+                # ``_extract_plots`` through ``is_connected_line_trace`` rather
+                # than spelled out twice, so the two cannot drift apart.
                 #
                 # A staircase is a scatter trace too — plotly varies
                 # ``line.shape``, not the trace type — so the shape is the only
                 # thing separating piecewise-constant data from an
                 # interpolated line.
-                from maidr.plotly.step_shape import is_step_trace
-
                 if is_step_trace(trace):
                     from maidr.plotly.step import PlotlyStepPlot
 

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.step_shape import step_direction_of
+
+
+class PlotlyStepPlot(PlotlyPlot):
+    """
+    A Plotly staircase trace, exported as a MAIDR step layer.
+
+    Plotly has no step trace type: a step chart is a ``scatter`` trace whose
+    ``line.shape`` makes plotly.js draw risers between the samples rather than
+    interpolating across them. Read as a line, such a chart tells a blind user
+    the value passed through every intermediate level, which is exactly what
+    piecewise-constant data does not do.
+
+    One instance covers both the single- and multi-series cases, mirroring
+    ``PlotlyMultiLinePlot``: ``data`` is always a list of series. Every trace
+    handed here must share one step convention — see
+    :func:`maidr.plotly.step_shape.group_by_direction` — because a MAIDR layer
+    carries a single ``stepDirection`` for all of its series.
+
+    Parameters
+    ----------
+    traces : list of dict
+        The staircase traces forming this layer, all of one convention.
+    layout : dict
+        The Plotly figure layout.
+    scatter_positions : list of int, optional
+        Each trace's zero-based position among the subplot's scatter-family
+        traces. Required whenever this layer's traces are not the leading
+        scatter traces of the subplot — which is the normal case once steps
+        are split out by convention, or drawn alongside plain lines. Defaults
+        to the traces' own order, which is only correct for a layer that owns
+        every scatter trace on its subplot.
+    **kwargs : str
+        Axis names forwarded to the parent class.
+    """
+
+    def __init__(
+        self,
+        traces: List[dict],
+        layout: dict,
+        scatter_positions: Optional[List[int]] = None,
+        **kwargs: str,
+    ) -> None:
+        super().__init__(traces[0], layout, PlotType.STEP, **kwargs)
+        self._traces = traces
+        self._scatter_positions = (
+            list(range(len(traces)))
+            if scatter_positions is None
+            else scatter_positions
+        )
+
+    def _get_selector(self) -> List[str]:
+        """
+        Return one selector per series, matching the rendered line paths.
+
+        A staircase renders as the same ``path.js-line`` a plain line does —
+        plotly varies the path geometry, not the element — so the selectors are
+        the line ones. The single-series case is still scoped by ``nth-child``
+        rather than falling back to the unscoped ``.trace.scatter`` form, so a
+        lone step trace sitting beside other scatter traces cannot match theirs.
+
+        ``nth-child`` counts within the subplot's ``scatterlayer``, so the
+        index has to be each trace's position *there* and not its position
+        within this layer. Splitting steps by convention means a layer's
+        traces are routinely not the leading ones: an ``hv`` layer and a
+        ``vh`` layer both starting from 1 would highlight the same elements.
+
+        Returns
+        -------
+        list of str
+            One CSS selector per series, in trace order.
+        """
+        prefix = self._subplot_css_prefix()
+        return [
+            f"{prefix}.scatterlayer > .trace.scatter:nth-child({position + 1}) path.js-line"
+            for position in self._scatter_positions
+        ]
+
+    def render(self) -> dict:
+        """
+        Build the base layer schema, then add the step convention.
+
+        Returns
+        -------
+        dict
+            The MAIDR layer schema, carrying ``stepDirection`` only when the
+            traces authored a shape MAIDR has a name for. ``vhv`` reports none,
+            so such a layer binds as a step without claiming a convention.
+        """
+        schema = super().render()
+
+        direction = self._resolve_direction()
+        if direction is not None:
+            schema[MaidrKey.STEP_DIRECTION] = direction
+
+        return schema
+
+    def _resolve_direction(self) -> Optional[str]:
+        """
+        Resolve the one step convention these traces share.
+
+        Returns
+        -------
+        str or None
+            The shared direction, or None when the traces disagree or their
+            shape has no MAIDR equivalent. Disagreement should not reach here
+            — the traces are grouped by direction before construction — so the
+            check is a guard against a caller that skipped the grouping rather
+            than an expected case.
+        """
+        directions = {step_direction_of(trace) for trace in self._traces}
+        if len(directions) != 1:
+            return None
+        return directions.pop()
+
+    def _extract_plot_data(self) -> List[List[dict]]:
+        """
+        Return the samples as a list of series.
+
+        One point per **data sample**, never one per stairstep vertex: the
+        frontend derives transitions and run lengths by comparing consecutive
+        ``y`` values and reconstructs the riser geometry itself, so vertex-level
+        data would double every level and misreport both.
+
+        Returns
+        -------
+        list of list of dict
+            ``{x, y}`` per point, with ``z`` set to the trace name when it has
+            one. Empty series are dropped, matching ``PlotlyMultiLinePlot``.
+        """
+        all_series: List[List[dict]] = []
+
+        for trace in self._traces:
+            x_values = trace.get("x", [])
+            y_values = trace.get("y", [])
+            name = trace.get("name", "")
+
+            series: List[dict] = []
+            for x_value, y_value in zip(x_values, y_values):
+                point: dict = {
+                    MaidrKey.X: self._to_native(x_value),
+                    MaidrKey.Y: self._to_native(y_value),
+                }
+                if name:
+                    point[MaidrKey.Z] = name
+                series.append(point)
+
+            if series:
+                all_series.append(series)
+
+        return all_series

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -75,9 +75,8 @@ class PlotlyStepPlot(PlotlyPlot):
         list of str
             One CSS selector per series, in trace order.
         """
-        prefix = self._subplot_css_prefix()
         return [
-            f"{prefix}.scatterlayer > .trace.scatter:nth-child({position + 1}) path.js-line"
+            self._scatter_line_selector(position)
             for position in self._scatter_positions
         ]
 

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Optional
-
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot
@@ -43,9 +41,9 @@ class PlotlyStepPlot(PlotlyPlot):
 
     def __init__(
         self,
-        traces: List[dict],
+        traces: list[dict],
         layout: dict,
-        scatter_positions: Optional[List[int]] = None,
+        scatter_positions: list[int] | None = None,
         **kwargs: str,
     ) -> None:
         super().__init__(traces[0], layout, PlotType.STEP, **kwargs)
@@ -56,7 +54,7 @@ class PlotlyStepPlot(PlotlyPlot):
             else scatter_positions
         )
 
-    def _get_selector(self) -> List[str]:
+    def _get_selector(self) -> list[str]:
         """
         Return one selector per series, matching the rendered line paths.
 
@@ -102,7 +100,7 @@ class PlotlyStepPlot(PlotlyPlot):
 
         return schema
 
-    def _resolve_direction(self) -> Optional[str]:
+    def _resolve_direction(self) -> str | None:
         """
         Resolve the one step convention these traces share.
 
@@ -120,7 +118,7 @@ class PlotlyStepPlot(PlotlyPlot):
             return None
         return directions.pop()
 
-    def _extract_plot_data(self) -> List[List[dict]]:
+    def _extract_plot_data(self) -> list[list[dict]]:
         """
         Return the samples as a list of series.
 
@@ -135,14 +133,14 @@ class PlotlyStepPlot(PlotlyPlot):
             ``{x, y}`` per point, with ``z`` set to the trace name when it has
             one. Empty series are dropped, matching ``PlotlyMultiLinePlot``.
         """
-        all_series: List[List[dict]] = []
+        all_series: list[list[dict]] = []
 
         for trace in self._traces:
             x_values = trace.get("x", [])
             y_values = trace.get("y", [])
             name = trace.get("name", "")
 
-            series: List[dict] = []
+            series: list[dict] = []
             for x_value, y_value in zip(x_values, y_values):
                 point: dict = {
                     MaidrKey.X: self._to_native(x_value),

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -94,11 +94,27 @@ def is_connected_line_trace(trace: dict) -> bool:
     Returns
     -------
     bool
-        True for a scatter-family trace in a lines-only mode.
+        True for a scatter-family trace in a lines-only mode, or a staircase
+        that never authored a mode at all.
     """
     if not is_scatter_family_trace(trace):
         return False
-    mode = trace.get("mode", "markers")
+
+    mode = trace.get("mode")
+    if mode is None:
+        # ``to_dict()`` omits ``mode`` when the author never set one, and
+        # plotly's default draws lines either way — "lines+markers" under 20
+        # points, "lines" at or above. Reading an absent mode as markers-only
+        # would send a trace authored as
+        # ``add_scatter(..., line_shape="hv")`` to a scatter layer, so the
+        # chart plotly actually draws as a staircase gets announced as loose
+        # points, losing the piecewise-constant reading entirely.
+        #
+        # Only a declared stepping shape is rescued here. A mode-less trace
+        # with no ``line.shape`` keeps whatever classification it had before
+        # steps existed, so plain scatters are untouched.
+        return is_step_trace(trace)
+
     return "lines" in mode and "markers" not in mode
 
 

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -13,8 +13,6 @@ browser or exported through this package.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional
-
 #: ``line.shape`` values plotly draws as a staircase.
 #:
 #: ``linear``, ``spline`` and an absent shape are deliberately not here: they
@@ -30,14 +28,14 @@ STEP_SHAPES = frozenset({"hv", "vh", "hvh", "vhv"})
 #: ``vhv`` trace still binds as a step — the data is piecewise constant — but
 #: the direction is withheld, which is what an optional ``stepDirection``
 #: exists for.
-STEP_SHAPE_DIRECTION: Dict[str, str] = {
+STEP_SHAPE_DIRECTION: dict[str, str] = {
     "hv": "hv",
     "vh": "vh",
     "hvh": "mid",
 }
 
 
-def is_step_shape(shape: Optional[str]) -> bool:
+def is_step_shape(shape: str | None) -> bool:
     """
     Report whether a ``line.shape`` makes plotly draw a staircase.
 
@@ -54,7 +52,7 @@ def is_step_shape(shape: Optional[str]) -> bool:
     return shape is not None and shape in STEP_SHAPES
 
 
-def trace_line_shape(trace: dict) -> Optional[str]:
+def trace_line_shape(trace: dict) -> str | None:
     """
     Read ``line.shape`` off a trace, tolerating a missing or odd ``line``.
 
@@ -96,7 +94,7 @@ def is_step_trace(trace: dict) -> bool:
     return is_step_shape(trace_line_shape(trace))
 
 
-def step_direction_of(trace: dict) -> Optional[str]:
+def step_direction_of(trace: dict) -> str | None:
     """
     Resolve the MAIDR ``stepDirection`` a trace authored.
 
@@ -115,7 +113,7 @@ def step_direction_of(trace: dict) -> Optional[str]:
     return None if shape is None else STEP_SHAPE_DIRECTION.get(shape)
 
 
-def group_by_direction(traces: List[dict]) -> List[List[dict]]:
+def group_by_direction(traces: list[dict]) -> list[list[dict]]:
     """
     Split step traces into groups that share one step convention.
 
@@ -137,7 +135,7 @@ def group_by_direction(traces: List[dict]) -> List[List[dict]]:
     list of list of dict
         One inner list per distinct convention, each non-empty.
     """
-    grouped: Dict[str, List[dict]] = {}
+    grouped: dict[str, list[dict]] = {}
     for trace in traces:
         # "" keys the shapes that report no direction, keeping them together
         # instead of merging them into whichever directional group came first.

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -46,6 +46,31 @@ STEP_SHAPE_DIRECTION: dict[str, str] = {
 _CONNECTED_TRACE_TYPES = ("scatter", "scattergl")
 
 
+def is_scatter_family_trace(trace: dict) -> bool:
+    """
+    Report whether a trace belongs to the subplot's scatter layer.
+
+    This is the membership test for ``scatterlayer``, so it decides both which
+    traces can be lines or steps and which ones the ``nth-child`` selector
+    indices count over. Those two must agree: a trace classified as a line but
+    absent from the index would have no position to look up.
+
+    ``type`` defaults to ``"scatter"`` because that is plotly's own default
+    for a trace that omits it.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        True for a ``scatter`` or ``scattergl`` trace.
+    """
+    return trace.get("type", "scatter") in _CONNECTED_TRACE_TYPES
+
+
 def is_connected_line_trace(trace: dict) -> bool:
     """
     Report whether a trace draws a connected path rather than loose markers.
@@ -55,6 +80,11 @@ def is_connected_line_trace(trace: dict) -> bool:
     here so ``PlotlyMaidr._extract_plots`` and ``PlotlyPlotFactory`` share one
     definition — they classify the same traces in two places, and a rule
     duplicated by hand is one that eventually disagrees with itself.
+
+    It is deliberately built on :func:`is_scatter_family_trace` rather than
+    repeating the type test, so the scatter-family rule has exactly one home.
+    Spelling it out twice is what previously let the two tests drift apart and
+    produce a trace that was a line but had no selector position.
 
     Parameters
     ----------
@@ -66,7 +96,7 @@ def is_connected_line_trace(trace: dict) -> bool:
     bool
         True for a scatter-family trace in a lines-only mode.
     """
-    if trace.get("type", "scatter") not in _CONNECTED_TRACE_TYPES:
+    if not is_scatter_family_trace(trace):
         return False
     mode = trace.get("mode", "markers")
     return "lines" in mode and "markers" not in mode

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -1,0 +1,146 @@
+"""Recognising Plotly staircase traces and the convention they draw.
+
+Plotly has no step trace type. A step chart is an ordinary ``scatter`` trace
+whose ``line.shape`` tells plotly.js to draw risers between the samples
+instead of interpolating across them, so the shape is the only thing that
+distinguishes one from a line.
+
+The values and the direction mapping here mirror the upstream JS adapter
+(``src/adapters/plotly/extractor.ts`` in xability/maidr, added in #746) so a
+plotly figure describes itself the same way whether it is bound in the
+browser or exported through this package.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+#: ``line.shape`` values plotly draws as a staircase.
+#:
+#: ``linear``, ``spline`` and an absent shape are deliberately not here: they
+#: interpolate between samples, which is what a step chart does not do.
+STEP_SHAPES = frozenset({"hv", "vh", "hvh", "vhv"})
+
+#: Where each staircase shape jumps, in MAIDR ``stepDirection`` terms.
+#:
+#: ``vhv`` is deliberately absent rather than mapped to ``mid``. It is the one
+#: shape whose horizontal segments do not sit at a sample's own value: ``hvh``
+#: holds each sample's value and jumps midway between x values, where ``vhv``
+#: jumps at the x values themselves and holds a value between two samples. A
+#: ``vhv`` trace still binds as a step — the data is piecewise constant — but
+#: the direction is withheld, which is what an optional ``stepDirection``
+#: exists for.
+STEP_SHAPE_DIRECTION: Dict[str, str] = {
+    "hv": "hv",
+    "vh": "vh",
+    "hvh": "mid",
+}
+
+
+def is_step_shape(shape: Optional[str]) -> bool:
+    """
+    Report whether a ``line.shape`` makes plotly draw a staircase.
+
+    Parameters
+    ----------
+    shape : str or None
+        The trace's ``line.shape``, or None when it authors none.
+
+    Returns
+    -------
+    bool
+        True for every shape plotly renders as piecewise constant.
+    """
+    return shape is not None and shape in STEP_SHAPES
+
+
+def trace_line_shape(trace: dict) -> Optional[str]:
+    """
+    Read ``line.shape`` off a trace, tolerating a missing or odd ``line``.
+
+    Plotly accepts ``line`` as a dict; a trace may omit it entirely, and a
+    hand-built dict may carry something else there. Anything that is not a
+    dict with a string ``shape`` reads as "no shape authored".
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    str or None
+        The authored shape, or None.
+    """
+    line = trace.get("line")
+    if not isinstance(line, dict):
+        return None
+    shape = line.get("shape")
+    return shape if isinstance(shape, str) else None
+
+
+def is_step_trace(trace: dict) -> bool:
+    """
+    Report whether a trace is a plotly staircase.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        True when the trace's ``line.shape`` is a stepping shape.
+    """
+    return is_step_shape(trace_line_shape(trace))
+
+
+def step_direction_of(trace: dict) -> Optional[str]:
+    """
+    Resolve the MAIDR ``stepDirection`` a trace authored.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    str or None
+        One of ``"hv"``, ``"vh"``, ``"mid"``, or None when plotly's shape has
+        no MAIDR equivalent (``vhv``) or none was authored.
+    """
+    shape = trace_line_shape(trace)
+    return None if shape is None else STEP_SHAPE_DIRECTION.get(shape)
+
+
+def group_by_direction(traces: List[dict]) -> List[List[dict]]:
+    """
+    Split step traces into groups that share one step convention.
+
+    A MAIDR layer carries a single ``stepDirection`` for all of its series, so
+    merging an ``hv`` trace with a ``vh`` one would describe one of them
+    wrongly. Traces whose shape reports no direction (``vhv``) group together
+    rather than being scattered across the directional groups.
+
+    Insertion order is preserved both between and within groups, so the
+    emitted layers follow the order plotly declared the traces in.
+
+    Parameters
+    ----------
+    traces : list of dict
+        The step traces on one subplot.
+
+    Returns
+    -------
+    list of list of dict
+        One inner list per distinct convention, each non-empty.
+    """
+    grouped: Dict[str, List[dict]] = {}
+    for trace in traces:
+        # "" keys the shapes that report no direction, keeping them together
+        # instead of merging them into whichever directional group came first.
+        key = step_direction_of(trace) or ""
+        grouped.setdefault(key, []).append(trace)
+    return list(grouped.values())

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -35,6 +35,43 @@ STEP_SHAPE_DIRECTION: dict[str, str] = {
 }
 
 
+#: Plotly trace types that render as a connected path in the scatter layer.
+#:
+#: ``scattergl`` is included because the line classification has always
+#: included it. Note it draws through WebGL rather than SVG, so the
+#: ``path.js-line`` selectors built for these traces do not match anything in
+#: a ``scattergl`` figure — highlighting is silently inert there. That is
+#: pre-existing for lines and is not made worse by steps; it is called out
+#: here so the next reader does not have to rediscover it.
+_CONNECTED_TRACE_TYPES = ("scatter", "scattergl")
+
+
+def is_connected_line_trace(trace: dict) -> bool:
+    """
+    Report whether a trace draws a connected path rather than loose markers.
+
+    This is the gate in front of every line/step decision: a trace only
+    reaches that classification if plotly is joining its samples up. It lives
+    here so ``PlotlyMaidr._extract_plots`` and ``PlotlyPlotFactory`` share one
+    definition — they classify the same traces in two places, and a rule
+    duplicated by hand is one that eventually disagrees with itself.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        True for a scatter-family trace in a lines-only mode.
+    """
+    if trace.get("type", "scatter") not in _CONNECTED_TRACE_TYPES:
+        return False
+    mode = trace.get("mode", "markers")
+    return "lines" in mode and "markers" not in mode
+
+
 def is_step_shape(shape: str | None) -> bool:
     """
     Report whether a ``line.shape`` makes plotly draw a staircase.

--- a/tests/plotly/test_plotly_step.py
+++ b/tests/plotly/test_plotly_step.py
@@ -223,6 +223,50 @@ class TestStepDoesNotDisturbLines:
         assert len(by_type[PlotType.LINE][MaidrKey.DATA]) == 2
         assert len(by_type[PlotType.STEP][MaidrKey.DATA]) == 1
 
+    def test_lines_after_a_step_are_indexed_past_it(self):
+        # Splitting steps out of the multiline layer breaks the assumption
+        # that a line layer owns every scatter trace on its subplot, so the
+        # line layer must count from the step's position, not from 1. Getting
+        # this wrong made the LINE layer claim nth-child(1) — the step's own
+        # element — and shifted every line onto its predecessor.
+        fig = go.Figure()
+        fig.add_scatter(**_step_trace("hv", "step"))
+        fig.add_scatter(x=[0, 1, 2], y=[3, 2, 1], mode="lines", name="line 1")
+        fig.add_scatter(x=[0, 1, 2], y=[2, 3, 4], mode="lines", name="line 2")
+
+        by_type = {layer[MaidrKey.TYPE]: layer for layer in _layers(fig)}
+
+        assert "nth-child(1)" in by_type[PlotType.STEP][MaidrKey.SELECTOR][0]
+        assert "nth-child(2)" in by_type[PlotType.LINE][MaidrKey.SELECTOR][0]
+        assert "nth-child(3)" in by_type[PlotType.LINE][MaidrKey.SELECTOR][1]
+
+    def test_a_lone_line_beside_a_step_is_scoped_to_its_own_trace(self):
+        # A single line used to emit the unscoped `.trace.scatter
+        # path.js-line`, which was safe only while it was the subplot's one
+        # line path. A step renders as path.js-line too, so that form now
+        # matches both elements.
+        fig = go.Figure()
+        fig.add_scatter(**_step_trace("hv", "step"))
+        fig.add_scatter(x=[0, 1, 2], y=[3, 2, 1], mode="lines", name="only")
+
+        by_type = {layer[MaidrKey.TYPE]: layer for layer in _layers(fig)}
+        line_selector = by_type[PlotType.LINE][MaidrKey.SELECTOR][0]
+
+        assert "nth-child(2)" in line_selector
+        assert "nth-child(1)" in by_type[PlotType.STEP][MaidrKey.SELECTOR][0]
+
+    def test_lines_alone_still_number_from_the_first_child(self):
+        # The no-step case must be untouched: with no step carved out, the
+        # subplot-relative positions are exactly the layer-relative ones.
+        fig = go.Figure()
+        fig.add_scatter(x=[0, 1], y=[1, 2], mode="lines", name="a")
+        fig.add_scatter(x=[0, 1], y=[2, 1], mode="lines", name="b")
+
+        selectors = _layers(fig)[0][MaidrKey.SELECTOR]
+
+        assert "nth-child(1)" in selectors[0]
+        assert "nth-child(2)" in selectors[1]
+
     def test_lines_alone_still_produce_a_single_multiline_layer(self):
         fig = go.Figure()
         fig.add_scatter(x=[0, 1], y=[1, 2], mode="lines", name="a")

--- a/tests/plotly/test_plotly_step.py
+++ b/tests/plotly/test_plotly_step.py
@@ -205,6 +205,52 @@ class TestDirectionGrouping:
         assert "nth-child(3)" in vh_layer[MaidrKey.SELECTOR][0]
 
 
+class _TypelessTraceFigure:
+    """
+    A minimal figure whose trace dict omits ``type``.
+
+    ``Figure.to_dict()`` always emits ``type``, so this shape is only
+    reachable by building the dict by hand — which the internals accept and
+    which is how these classifiers get exercised directly.
+    """
+
+    def __init__(self, line_shape: str | None = None) -> None:
+        trace: dict = {"mode": "lines", "x": [0, 1, 2], "y": [1, 2, 3]}
+        if line_shape is not None:
+            trace["line"] = {"shape": line_shape}
+        self._trace = trace
+
+    def to_dict(self) -> dict:
+        return {"layout": {}, "data": [self._trace]}
+
+
+class TestClassificationAndSelectorIndexAgree:
+    """
+    Whatever counts as a line or a step must also have a selector position.
+
+    The line/step classifier and the scatter-family index are two separate
+    filters over the same traces. When they disagreed on the default for a
+    missing ``type``, a trace could be classified as a line while being absent
+    from the position map, and the selector lookup raised ``KeyError`` rather
+    than emitting a layer. They now share ``is_scatter_family_trace``.
+    """
+
+    def test_a_typeless_line_trace_still_resolves_its_position(self):
+        layers = _layers(_TypelessTraceFigure())
+
+        assert len(layers) == 1
+        assert layers[0][MaidrKey.TYPE] == PlotType.LINE
+        assert "nth-child(1)" in layers[0][MaidrKey.SELECTOR][0]
+
+    def test_a_typeless_step_trace_still_resolves_its_position(self):
+        layers = _layers(_TypelessTraceFigure(line_shape="hv"))
+
+        assert len(layers) == 1
+        assert layers[0][MaidrKey.TYPE] == PlotType.STEP
+        assert layers[0][MaidrKey.STEP_DIRECTION] == "hv"
+        assert "nth-child(1)" in layers[0][MaidrKey.SELECTOR][0]
+
+
 class TestStepDoesNotDisturbLines:
     """The regression that matters most: plain lines are untouched."""
 

--- a/tests/plotly/test_plotly_step.py
+++ b/tests/plotly/test_plotly_step.py
@@ -251,6 +251,47 @@ class TestClassificationAndSelectorIndexAgree:
         assert "nth-child(1)" in layers[0][MaidrKey.SELECTOR][0]
 
 
+class TestAModelessStaircaseStillBinds:
+    """
+    A staircase authored without ``mode`` must not fall through to scatter.
+
+    ``to_dict()`` omits ``mode`` when the author never set one, and plotly's
+    default draws lines regardless ("lines+markers" under 20 points, "lines"
+    at or above). Reading that as markers-only sent a chart plotly draws as a
+    staircase to a scatter layer — announced as loose points, with the
+    piecewise-constant reading lost. Only a declared stepping shape is
+    rescued; everything else keeps its previous classification.
+    """
+
+    def _one_layer(self, **trace_kwargs):
+        fig = go.Figure()
+        fig.add_scatter(x=list(range(6)), y=[1, 2, 3, 2, 1, 2], **trace_kwargs)
+        layers = _layers(fig)
+        assert len(layers) == 1
+        return layers[0]
+
+    def test_a_modeless_step_binds_as_step(self):
+        layer = self._one_layer(line={"shape": "hv"})
+
+        assert layer[MaidrKey.TYPE] == PlotType.STEP
+        assert layer[MaidrKey.STEP_DIRECTION] == "hv"
+
+    def test_a_modeless_trace_without_a_shape_is_untouched(self):
+        # The rescue is scoped to declared stepping shapes, so a plain
+        # mode-less scatter keeps the classification it had before steps.
+        assert self._one_layer()[MaidrKey.TYPE] == PlotType.SCATTER
+
+    def test_an_explicit_markers_mode_still_wins(self):
+        layer = self._one_layer(mode="markers", line={"shape": "hv"})
+
+        assert layer[MaidrKey.TYPE] == PlotType.SCATTER
+
+    def test_an_explicit_lines_markers_mode_is_unchanged(self):
+        layer = self._one_layer(mode="lines+markers", line={"shape": "hv"})
+
+        assert layer[MaidrKey.TYPE] == PlotType.SCATTER
+
+
 class TestStepDoesNotDisturbLines:
     """The regression that matters most: plain lines are untouched."""
 

--- a/tests/plotly/test_plotly_step.py
+++ b/tests/plotly/test_plotly_step.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import pytest
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.line import PlotlyLinePlot
+from maidr.plotly.multiline import PlotlyMultiLinePlot
+from maidr.plotly.plotly_maidr import PlotlyMaidr
+from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
+from maidr.plotly.step import PlotlyStepPlot
+from maidr.plotly.step_shape import group_by_direction, step_direction_of
+
+plotly = pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+
+def _step_trace(shape: str, name: str = "", y=None) -> dict:
+    """
+    Build a minimal plotly staircase trace dict.
+
+    Parameters
+    ----------
+    shape : str
+        The ``line.shape`` to author.
+    name : str, optional
+        Trace name, emitted as the series' ``z``.
+    y : list, optional
+        Y values; defaults to a three-point run.
+
+    Returns
+    -------
+    dict
+        A scatter/lines trace dict.
+    """
+    return {
+        "type": "scatter",
+        "mode": "lines",
+        "x": [0, 1, 2],
+        "y": [1, 2, 3] if y is None else y,
+        "line": {"shape": shape},
+        **({"name": name} if name else {}),
+    }
+
+
+def _layers(fig) -> list[dict]:
+    """
+    Render a figure through PlotlyMaidr and return its layer schemas.
+
+    Parameters
+    ----------
+    fig : plotly.graph_objects.Figure
+        The figure to export.
+
+    Returns
+    -------
+    list of dict
+        One schema per emitted layer, in emission order.
+    """
+    return [plot.schema for plot in PlotlyMaidr(fig)._plots]
+
+
+class TestStepShapeClassification:
+    """A staircase is a scatter trace; only ``line.shape`` separates it."""
+
+    @pytest.mark.parametrize("shape", ["hv", "vh", "hvh", "vhv"])
+    def test_stepping_shapes_bind_as_step(self, shape):
+        plot = PlotlyPlotFactory.create(_step_trace(shape), {})
+
+        assert isinstance(plot, PlotlyStepPlot)
+        assert plot.type == PlotType.STEP
+
+    @pytest.mark.parametrize("shape", ["linear", "spline"])
+    def test_interpolating_shapes_stay_a_line(self, shape):
+        plot = PlotlyPlotFactory.create(_step_trace(shape), {})
+
+        assert isinstance(plot, PlotlyLinePlot)
+        assert plot.type == PlotType.LINE
+
+    def test_a_trace_with_no_shape_stays_a_line(self):
+        trace = {"type": "scatter", "mode": "lines", "x": [0], "y": [1]}
+
+        assert isinstance(PlotlyPlotFactory.create(trace, {}), PlotlyLinePlot)
+
+    def test_a_non_dict_line_does_not_raise(self):
+        # Hand-built trace dicts reach this code, so `line` is not guaranteed
+        # to be the dict plotly itself would produce.
+        trace = {"type": "scatter", "mode": "lines", "x": [0], "y": [1], "line": "hv"}
+
+        assert isinstance(PlotlyPlotFactory.create(trace, {}), PlotlyLinePlot)
+
+    def test_markers_mode_is_still_a_scatter(self):
+        trace = dict(_step_trace("hv"), mode="lines+markers")
+
+        assert not isinstance(PlotlyPlotFactory.create(trace, {}), PlotlyStepPlot)
+
+
+class TestStepDirection:
+    """``stepDirection`` mirrors the upstream adapter's shape mapping."""
+
+    @pytest.mark.parametrize(
+        ("shape", "expected"),
+        [("hv", "hv"), ("vh", "vh"), ("hvh", "mid")],
+    )
+    def test_shape_maps_to_its_convention(self, shape, expected):
+        schema = PlotlyPlotFactory.create(_step_trace(shape), {}).schema
+
+        assert schema[MaidrKey.STEP_DIRECTION] == expected
+
+    def test_vhv_binds_as_step_but_claims_no_direction(self):
+        # vhv is the one shape whose horizontal segments do not sit at a
+        # sample's own value, so it has no StepDirection equivalent. The data
+        # is still piecewise constant, so it is still a step.
+        schema = PlotlyPlotFactory.create(_step_trace("vhv"), {}).schema
+
+        assert schema[MaidrKey.TYPE] == PlotType.STEP
+        assert MaidrKey.STEP_DIRECTION not in schema
+
+    def test_direction_is_withheld_when_traces_disagree(self):
+        # Guards a caller that skipped group_by_direction: better to say
+        # nothing than to describe one of the series wrongly.
+        plot = PlotlyStepPlot([_step_trace("hv"), _step_trace("vh")], {})
+
+        assert MaidrKey.STEP_DIRECTION not in plot.schema
+
+
+class TestStepPayload:
+    """The emitted layer matches the MAIDR step contract."""
+
+    def test_data_is_a_list_of_series_with_one_point_per_sample(self):
+        schema = PlotlyPlotFactory.create(_step_trace("hv", "Night 1"), {}).schema
+        data = schema[MaidrKey.DATA]
+
+        assert len(data) == 1
+        # One point per data sample, never one per stairstep vertex: the
+        # frontend rebuilds the risers itself.
+        assert len(data[0]) == 3
+        assert data[0][0] == {
+            MaidrKey.X: 0,
+            MaidrKey.Y: 1,
+            MaidrKey.Z: "Night 1",
+        }
+
+    def test_an_unnamed_trace_emits_no_z(self):
+        schema = PlotlyPlotFactory.create(_step_trace("hv"), {}).schema
+
+        assert MaidrKey.Z not in schema[MaidrKey.DATA][0][0]
+
+    def test_one_selector_per_series(self):
+        schema = PlotlyPlotFactory.create(_step_trace("hv"), {}).schema
+
+        assert len(schema[MaidrKey.SELECTOR]) == len(schema[MaidrKey.DATA])
+
+
+class TestDirectionGrouping:
+    """A layer carries one ``stepDirection``, so conventions cannot merge."""
+
+    def test_groups_split_by_convention_preserving_order(self):
+        traces = [
+            _step_trace("hv", "A"),
+            _step_trace("vh", "B"),
+            _step_trace("hv", "C"),
+        ]
+
+        groups = group_by_direction(traces)
+
+        assert [[t["name"] for t in g] for g in groups] == [["A", "C"], ["B"]]
+
+    def test_directionless_shapes_group_together(self):
+        traces = [_step_trace("vhv", "A"), _step_trace("hv", "B"), _step_trace("vhv", "C")]
+
+        groups = group_by_direction(traces)
+
+        assert [[t["name"] for t in g] for g in groups] == [["A", "C"], ["B"]]
+        assert step_direction_of(traces[0]) is None
+
+    def test_mixed_conventions_emit_one_layer_each(self):
+        fig = go.Figure()
+        fig.add_scatter(**_step_trace("hv", "A"))
+        fig.add_scatter(**_step_trace("hv", "B"))
+        fig.add_scatter(**_step_trace("vh", "C"))
+
+        layers = _layers(fig)
+
+        assert [layer[MaidrKey.TYPE] for layer in layers] == [
+            PlotType.STEP,
+            PlotType.STEP,
+        ]
+        assert [layer.get(MaidrKey.STEP_DIRECTION) for layer in layers] == ["hv", "vh"]
+        assert [len(layer[MaidrKey.DATA]) for layer in layers] == [2, 1]
+
+    def test_selectors_index_the_subplot_not_the_layer(self):
+        # `nth-child` counts within the subplot's scatterlayer. Two layers
+        # both numbering from 1 would highlight the same two elements, so the
+        # vh layer's single trace must resolve to the third child.
+        fig = go.Figure()
+        fig.add_scatter(**_step_trace("hv", "A"))
+        fig.add_scatter(**_step_trace("hv", "B"))
+        fig.add_scatter(**_step_trace("vh", "C"))
+
+        hv_layer, vh_layer = _layers(fig)
+
+        assert "nth-child(1)" in hv_layer[MaidrKey.SELECTOR][0]
+        assert "nth-child(2)" in hv_layer[MaidrKey.SELECTOR][1]
+        assert "nth-child(3)" in vh_layer[MaidrKey.SELECTOR][0]
+
+
+class TestStepDoesNotDisturbLines:
+    """The regression that matters most: plain lines are untouched."""
+
+    def test_a_step_beside_lines_leaves_the_multiline_layer_intact(self):
+        fig = go.Figure()
+        fig.add_scatter(**_step_trace("hv", "step"))
+        fig.add_scatter(x=[0, 1, 2], y=[3, 2, 1], mode="lines", name="line 1")
+        fig.add_scatter(x=[0, 1, 2], y=[2, 3, 4], mode="lines", name="line 2")
+
+        layers = _layers(fig)
+        by_type = {layer[MaidrKey.TYPE]: layer for layer in layers}
+
+        assert set(by_type) == {PlotType.LINE, PlotType.STEP}
+        # The two plain lines still merge into one multiline layer; the step
+        # is not swallowed into it.
+        assert len(by_type[PlotType.LINE][MaidrKey.DATA]) == 2
+        assert len(by_type[PlotType.STEP][MaidrKey.DATA]) == 1
+
+    def test_lines_alone_still_produce_a_single_multiline_layer(self):
+        fig = go.Figure()
+        fig.add_scatter(x=[0, 1], y=[1, 2], mode="lines", name="a")
+        fig.add_scatter(x=[0, 1], y=[2, 1], mode="lines", name="b")
+
+        plots = PlotlyMaidr(fig)._plots
+
+        assert len(plots) == 1
+        assert isinstance(plots[0], PlotlyMultiLinePlot)
+        assert plots[0].type == PlotType.LINE


### PR DESCRIPTION
## Now targets `main` directly

#299 **merged** (squashed as `72c1a8a`), so this is no longer stacked — `PlotType.STEP` and `MaidrKey.STEP_DIRECTION` are on `main`.

Because #299 was **squash**-merged, its branch commits are not ancestors of `main`, so GitHub's automatic retarget left this PR re-proposing all of #299's work on top of a `main` that already had it: **1985 additions / 29 files / 8 commits**. Rebased onto `main` (`git rebase --onto origin/main 81e7991`), dropping the redundant commits.

Current scope: **1218 additions / 19 deletions / 14 files / 7 commits** — plotly, tests and docs only.

Upstream ordering is satisfied: xability/maidr#723 (the step trace) and **#746 (the adapters)** are both merged.

## Description

Plotly has no step trace type. A staircase is an ordinary `scatter` trace whose `line.shape` makes plotly.js draw risers between the samples instead of interpolating across them — so the shape is the only thing separating piecewise-constant data from a line.

`PlotlyPlotFactory` never read it:

```python
if "lines" in mode and "markers" not in mode:
    return PlotlyLinePlot(trace, layout, **axis_kwargs)
```

So **every plotly step chart was exported as a line**, telling a blind user the value glided through each intermediate level. For a hypnogram that is the opposite of what the data says. This is the same defect #299 fixed for matplotlib, in the one path that doesn't go through matplotlib at all.

## Why Altair needed no code

`maidr/altair/` doesn't build a schema in Python — it ships the Vega-Lite spec to `maidr@latest/dist/vegalite.js` and lets the upstream adapter do the work. **#746 taught that adapter to read a stepping `interpolate`**, so Altair step charts work with zero changes here. Verified against the real spec rather than assumed:

```
mark: {"interpolate": "step-after", "type": "line"}
```

which is exactly the key `STEP_DIRECTION_BY_INTERPOLATE` maps to `hv`. The Altair example and docs added here record that path; they don't implement it.

## Changes Made

**`maidr/plotly/step_shape.py`** — the shape vocabulary, mirroring `src/adapters/plotly/extractor.ts` so a figure describes itself the same way in the browser and through this package:

| `line.shape` | `stepDirection` | Meaning |
|---|---|---|
| `hv` | `hv` | holds, then jumps at the next x |
| `vh` | `vh` | jumps at the current x, then holds |
| `hvh` | `mid` | jumps midway between x values |
| `vhv` | *(none)* | still a step; no direction claimed |

`vhv` is the one shape whose horizontal segments do not sit at a sample's own value, so it has no MAIDR equivalent. It binds as a step — the data *is* piecewise constant — but withholds the direction rather than guessing, which is what an optional `stepDirection` exists for.

**`maidr/plotly/step.py`** — `PlotlyStepPlot`, covering single- and multi-series in one class like `PlotlyMultiLinePlot`. One point per **data sample**, never one per stairstep vertex: the frontend derives transitions and run lengths from consecutive `y` values and rebuilds the risers itself.

**Steps group by convention, one layer each.** A MAIDR layer carries a single `stepDirection` for all of its series, so merging an `hv` trace with a `vh` one would describe one of them wrongly. Traces whose shape reports no direction group together rather than being scattered into whichever directional group came first.

## Four bugs found during review, each fixed and pinned

These were all caught by review rounds on this PR rather than after merge, and each regression test below was checked against the pre-fix code to confirm it actually fails there.

**1. Selector indices counted within the layer, not the subplot.** `nth-child` counts within the subplot's `scatterlayer`, and splitting steps out means a layer's traces are routinely not the leading ones. With a step declared before two plain lines:

```
PlotType.LINE  -> nth-child(1), nth-child(2)
PlotType.STEP  -> nth-child(1)
```

The LINE layer pointed at the step's own element and line 1 instead of lines 1 and 2, with `nth-child(1)` claimed twice. `PlotlyLinePlot` failed differently for the same reason: its unscoped `.trace.scatter path.js-line` matched the staircase too, since a step also renders as `path.js-line`.

The cause is worth stating: splitting steps into their own layers ended an invariant the line classes silently relied on — *a line layer owns every scatter trace on its subplot*. All three classes now build selectors through one shared `PlotlyPlot._scatter_line_selector(position)`, fed from a `position_of` map built once per subplot. A lone line is constructed in `_extract_plots` rather than by the factory, which cannot know a trace's position.

**2. The classification rule was duplicated and had already drifted.** `_extract_plots` and `PlotlyPlotFactory` each spelled out "is this a lines-only scatter trace", and they disagreed on the default for a missing `type`. Consolidated into `is_connected_line_trace()`.

**3. Consolidating (2) introduced a `KeyError`.** The new predicate defaulted a missing `type` to `"scatter"` while the `scatter_family` filter feeding `position_of` still used no default — so a trace could be classified as a line but be absent from the position map, and the lookup crashed. Fixed by extracting `is_scatter_family_trace()` and building `is_connected_line_trace()` on top of it, so the classifier and the selector index are the same test *by construction* rather than by agreement.

**4. A staircase that never authored a `mode` was dropped to scatter.** `to_dict()` omits `mode` when the author never sets one, and the classifier read absent-as-markers. So `add_scatter(..., line_shape="hv")` produced a **scatter** layer at every point count, while plotly still drew a staircase — the chart looked stepped and announced as loose points. Every example here passes `mode="lines"`, so it was invisible to anyone following the docs and silent for anyone who wasn't. Now a declared stepping shape is rescued; an explicit mode still wins, and a mode-less trace with no `line.shape` keeps its prior classification:

```
mode-less + shape hv     SCATTER -> STEP   (the defect)
mode-less, no shape      SCATTER           unchanged
mode=markers + shape     SCATTER           unchanged
mode=lines+markers       SCATTER           unchanged
mode=lines + shape       STEP              unchanged
mode=lines, no shape     LINE              unchanged
```

## Testing

`uv run pytest` — **273 passed**. `ruff check` clean on every file this PR touches. CI's own matrix runs green on Python **3.9 / 3.10 / 3.11 / 3.12**, plus lint, commit-lint, workflow lint and CodeQL, so these numbers are not local-only.

`tests/plotly/test_plotly_step.py` covers: all four shapes binding as step; `linear`/`spline`/absent staying a line; `lines+markers` staying a scatter; a non-dict `line` not raising; the direction mapping including `vhv` withholding one; grouping by convention with order preserved; subplot-relative selector indexing; the mode-less rescue and its three non-rescued neighbours; the classification/position agreement that prevents the `KeyError`; and the line-side regressions — lines after a step, a lone line beside a step, and the no-step case pinned as unchanged.

One note on why that matters here: the original `test_a_step_beside_lines_leaves_the_multiline_layer_intact` asserted only on layer *data*, which is exactly why a wrong-element selector bug sailed through CI. Every selector fix since is pinned by an assertion on the selector itself, verified to fail against the pre-fix code.

Also verified by execution: the example emits `type: step`, `stepDirection: "hv"`, 17 points, canonical `{x, y}` axes, one selector per series; the Altair example builds a spec carrying `interpolate: "step-after"`; and a bar + line + box figure emits layers in the same order as on `main`, since the step block is a no-op when no staircases are present.

## Known gaps, deliberately left

- A mode-less **plain line** (no `mode`, no `line.shape`) is still classified as `SCATTER`. This is pre-existing and affects charts beyond steps; fixing it would reclassify existing users' scatter traces, which deserves its own change. Pinned by `test_a_modeless_trace_without_a_shape_is_untouched` so the behaviour is intentional rather than incidental.
- `scattergl` is in the scatter family, but it draws through WebGL, so `path.js-line` selectors match nothing and highlighting is inert. Pre-existing for lines; documented at `_CONNECTED_TRACE_TYPES`.
- `PlotlyStepPlot`/`PlotlyMultiLinePlot` default `scatter_positions` to leading order when constructed standalone, where `PlotlyLinePlot` falls back to an unscoped selector. Both are documented and neither is reachable from `PlotlyMaidr`.
- No test covers a step beside bar/box traces, or steps across a `row`/`col` subplot grid.

## Examples and docs

- `example/step/plotly/example_plotly_step.py` and `example/step/altair/example_altair_step.py` — hypnograms, alongside the matplotlib and seaborn ones from #299.
- `docs/examples-plotly.qmd` and `docs/examples-altair.qmd` — Step Plot sections with the full shape/`interpolate` mapping tables and the `vhv` caveat.
- `docs/index.qmd` — the step bullet now names all three detection routes.
- `CLAUDE.md` — records that `maidr/plotly/` needs per-type handling in Python while `maidr/altair/` delegates upstream, so the next person doesn't look for Altair code that isn't there.