### PR TITLE
Revert "ci: let the Claude action post under its own identity again"

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,12 +40,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # No github_token on purpose. The input is "optional if using GitHub
-          # App", and supplying it makes the action post as github-actions[bot]
-          # instead of claude[bot] -- which is what every review here has been
-          # attributed to since f22e3187. The Claude app is installed on this
-          # repo (it posted as claude[bot] on #273), so leaving this out lets
-          # the action use its own app token and its own identity again.
+          # Required. Without it the action tries to exchange the workflow's
+          # OIDC token for a Claude app token, and that exchange returns
+          # "401 Unauthorized - Invalid OIDC token" on this repo -- which is
+          # what f22e3187 was working around, and what #302 reintroduced by
+          # removing this line. The cost is that reviews post as
+          # github-actions[bot] rather than claude[bot]; see #305.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,11 +45,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # No github_token on purpose -- see the note in
-          # claude-code-review.yml. Supplying it costs the claude[bot] identity,
-          # and here it also could not have worked: this job grants only
-          # `issues: read` / `pull-requests: read`, so GITHUB_TOKEN cannot post
-          # the reply an @claude mention asks for.
+          # Required -- see the note in claude-code-review.yml: the OIDC to
+          # app-token exchange fails on this repo, so the action cannot obtain
+          # a token of its own.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
Reverts #302. **Please merge this promptly** — Claude review is failing on every PR right now.

## What broke

#302 removed `github_token` from both Claude workflows so the action would post as `claude[bot]` instead of `github-actions[bot]`. Without that input the action tries to exchange the workflow's OIDC token for a Claude app token, and on this repo the exchange is rejected:

```
Exchanging OIDC token for app token...
Attempt 1 of 3...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
Attempt 2 of 3...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
Attempt 3 of 3...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
Action failed with error: Invalid OIDC token
```

Timeline:

| time (UTC) | event |
|---|---|
| 18:55 | #302's own review run — **success** |
| 18:59 | #302 merged |
| 19:44 | first review after the merge — **failure** |
| 19:51 | **failure** |

Every run before the merge passed; both runs after it failed the same way. `claude.yml` is affected too — it lost the same input.

## Why #302's own green check meant nothing

`claude-code-review.yml` runs on `pull_request_target`, which takes the workflow file **from the base branch**. The run on #302 at 18:55 therefore exercised `main`'s version — the one that still had `github_token`. #302 said this could not be validated before merging; it was right, and the merge was the test.

## Why the reasoning was wrong

#302 argued the bypass might be stale because `f22e3187` ("ci: add github_token to bypass OIDC in claude review workflow") recorded no error and no run link. That is an argument about the *evidence*, not about the *condition*. The absence of a written-down error is not evidence the error is gone, and treating it as such is what caused this.

The Claude app being installed and having posted as `claude[bot]` on #273 was also weaker support than it looked: it shows the app exists on the repo, not that this workflow can obtain a token for it via OIDC.

## What this restores

The `github_token` input in both workflows, with comments that now name the actual failure instead of a guess — so the next person who notices the `github-actions[bot]` attribution finds the reason before removing the line again.

Reviews go back to posting as `github-actions[bot]`. That is the cost, and it is much smaller than reviews not running.

## Follow-up

#305 tracks the OIDC exchange itself. Fixing that is the only route to `claude[bot]` here, and it needs to be diagnosed on a branch where the workflow actually runs — not inferred from a PR that cannot exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)