### PR TITLE
ci: release weekly like upstream maidr, and keep chore out of the changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,18 @@
 name: Test & Release
 
 on:
-  workflow_dispatch:
+  # Release on a weekly cadence rather than on every push to ``main``, matching
+  # the upstream ``xability/maidr`` repo.  Upstream releases Mondays at 15:00
+  # UTC; we run an hour later so the ``maidr`` npm package that the bundle step
+  # below pulls from the registry is the release upstream just published, not
+  # the previous week's.
+  #
+  # 16:00 UTC = 10 AM CST (winter) / 11 AM CDT (summer).  GitHub Actions cron
+  # runs in UTC and does not observe DST.
+  schedule:
+    - cron: '0 16 * * 1'
 
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -56,24 +63,19 @@ jobs:
           args: "check --diff"
           version: "0.3.4"
 
-  commit-lint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Lint commit messages
-        uses: wagoid/commitlint-github-action@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failOnWarnings: 'false'
-          commitDepth: 1
+  # NOTE: there is deliberately no ``commit-lint`` job here.  On a scheduled run
+  # there is no push or pull-request payload to derive a commit range from --
+  # ``wagoid/commitlint-github-action`` only supports ``push``,
+  # ``pull_request``, and ``merge_group`` -- so gating the release on it would
+  # risk blocking every release on undefined behaviour.  Commit messages are
+  # already linted before they reach ``main`` by the ``commit-lint`` job in
+  # ``ci.yml``, which runs on every pull request and branch push.
 
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    concurrency: push
-    needs: [test, lint, commit-lint]
+    concurrency: release
+    needs: [test, lint]
     if: github.repository == 'xability/py-maidr'
     environment:
       name: pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,12 +137,24 @@ match = "(main|master)"
 prerelease_token = "rc"
 prerelease = false
 
-[tool.semantic_release.changelog.default_templates]
-template_dir = "templates"
-changelog_file = "CHANGELOG.md"
+[tool.semantic_release.changelog]
+# ``exclude_commit_patterns`` belongs to *this* table, not to
+# ``changelog.default_templates``.  python-semantic-release parses its config
+# with pydantic, which silently drops unknown keys, so while this list lived
+# under ``default_templates`` it was never applied and every commit type landed
+# in the changelog.
+#
+# The pattern is an allowlist expressed as a negative lookahead: a commit is
+# excluded unless its subject starts with one of the listed types.  ``chore`` is
+# deliberately absent -- the release-time ``chore: update bundled maidr.js to
+# vX.Y.Z`` commits and dependency bumps are housekeeping, and they were crowding
+# out the entries a reader of the release notes actually cares about.
 exclude_commit_patterns = [
-  "^(?!feat: |feat\\(.*\\): |fix: |fix\\(.*\\): |docs: |docs\\(.*\\): |perf: |perf\\(.*\\): |refactor: |refactor\\(.*\\): |test: |test\\(.*\\): |build: |build\\(.*\\): |chore: |chore\\(.*\\): |ci: |ci\\(.*\\): |style: |style\\(.*\\): ).*"
+  "^(?!feat: |feat\\(.*\\): |fix: |fix\\(.*\\): |docs: |docs\\(.*\\): |perf: |perf\\(.*\\): |refactor: |refactor\\(.*\\): |test: |test\\(.*\\): |build: |build\\(.*\\): |ci: |ci\\(.*\\): |style: |style\\(.*\\): ).*"
 ]
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.changelog.environment]
 block_start_string = "{%"


### PR DESCRIPTION
## Summary

Two related changes to how py-maidr cuts releases.

**1. `chore` commits no longer land in `CHANGELOG.md`** — and the exclusion list works at all now.

`exclude_commit_patterns` was declared under `[tool.semantic_release.changelog.default_templates]`, but python-semantic-release reads it from `[tool.semantic_release.changelog]`. PSR's config models are pydantic `BaseModel`s, which silently ignore unknown keys, so the list was **never applied**. Loading the config with the pinned 9.21.0 confirms it:

```
$ python -c "...RawConfig.model_validate(raw)..."
exclude_commit_patterns = ()      # before this PR
```

That is why the v1.19.0 notes are seven `chore: update bundled maidr.js to …` lines wrapped around three entries anyone actually reads. This PR moves the key to the table PSR reads and drops `chore` from the allowlist. Verified against the loaded pattern:

| Commit | Result |
| --- | --- |
| `feat: …`, `fix: …`, `perf(render): …`, `docs: …`, `ci: …`, `refactor: …` | included |
| `chore: update bundled maidr.js to v3.73.0` | **excluded** |
| `chore(deps): bump numpy` | **excluded** |
| `Revert "…"`, `Merge pull request …` | **excluded** |

`chore` stays in `allowed_tags`, so those commits still parse — they just get no changelog line. And since `chore` is in neither `minor_tags` nor `patch_tags` it never bumps a version, so it can't hit PSR's "keep an excluded commit if it caused the bump" carve-out.

**2. Releases run on a weekly cron instead of on every push to `main`**, matching upstream `xability/maidr`.

The cron is 16:00 UTC Monday — an hour *after* upstream's 15:00 UTC slot, not at the same instant. The bundle step resolves `maidr` from the npm registry's `latest` tag at release time, so firing together would race upstream's own build-and-publish and ship the previous week's `maidr.js`.

## Things worth a second opinion

- **`main` now has no CI on push.** `ci.yml` is `branches-ignore: main`, so main's tests were riding on `release.yml`'s push trigger. Main is now verified only at the weekly release. This matches upstream maidr, whose `ci.yml` runs on `pull_request` only — but if you'd rather not, dropping `branches-ignore` from `ci.yml` restores it.
- **The bundled maidr.js version disappears from the release notes.** It stays in `maidr/static/VERSION` and in git history, but you can no longer read "this release ships maidr.js v3.73.0" from the changelog. If that's worth keeping, retyping just the bundle commit to `build:` would surface it — `build` is still in the allowlist.
- **`commit-lint` is dropped from the release workflow.** `wagoid/commitlint-github-action` documents `push`, `pull_request`, and `merge_group` only, and a scheduled run has no payload to derive a commit range from; gating releases on undefined behaviour risks blocking them outright. The identical job in `ci.yml` already lints every PR and branch push.
- **A fix merged Tuesday now waits until the following Monday.** That's the intent of matching upstream's cadence, but it is a real change in turnaround. `workflow_dispatch` is still there for anything urgent.

## Test plan

- [x] `pyproject.toml` parses; PSR 9.21.0 loads one exclusion pattern (was zero)
- [x] Pattern verified against the 11 commit-subject samples above
- [x] `release.yml` parses; triggers `[schedule, workflow_dispatch]`, jobs `[test, lint, release]`, `release.needs = [test, lint]`
- [x] `commitlint --from=origin/main --to=HEAD` — 0 problems, 0 warnings
- [ ] First scheduled run — the real check on the cron and on a changelog with no `chore` entries

Existing `chore` entries in `CHANGELOG.md` are untouched; PSR's `mode` is the default `init`, so this takes effect from the next release forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
