### PR TITLE
feat(bar): support horizontal bar and histogram layers

### DIFF
--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -59,12 +59,11 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
     def _extract_plot_data(self) -> list:
         plot = self.extract_container(self.ax, BarContainer, include_all=True)
         self._orientation = self._extract_orientation(plot)
+        levels = self.extract_level(self.ax, self._level_key)
 
-        data = self._extract_bar_container_data(plot)
+        data = self._extract_bar_container_data(plot, levels)
         if data is None:
             raise ExtractionError(self.type, plot)
-
-        levels = self.extract_level(self.ax, self._level_key)
 
         # A horizontal bar's magnitude runs along x and its label sits on y,
         # which is the layout the renderer reads for a horizontal layer. The
@@ -78,8 +77,26 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         return [{"x": x, "y": y} for x, y in combined_data]
 
     def _extract_bar_container_data(
-        self, plot: list[BarContainer] | None
+        self, plot: list[BarContainer] | None, levels: list[str] | None
     ) -> list | None:
+        """
+        Read one magnitude per bar, in the containers' own order.
+
+        Parameters
+        ----------
+        plot : list of BarContainer, optional
+            The containers holding the bars of this layer.
+        levels : list of str, optional
+            The bar labels read off the categorical axis. Used only to check
+            that the axis has one label per bar; an axis with no tick labels
+            at all places no constraint.
+
+        Returns
+        -------
+        list, optional
+            One magnitude per bar, or None when the bars and the labels do
+            not line up.
+        """
         if plot is None:
             return None
 
@@ -88,11 +105,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         # So, extract data correspondingly based on the level.
         # Flatten all the `list[BarContainer]` to `list[Patch]`.
         plot = [patch for container in plot for patch in container.patches]
-        level = self.extract_level(self.ax, self._level_key)
-        if len(level) == 0:  # type: ignore
-            level = ["" for _ in range(len(plot))]  # type: ignore
-
-        if len(plot) != len(level):
+        if levels and len(plot) != len(levels):
             return None
 
         self._elements.extend(plot)

--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -35,6 +35,10 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         """
         Read the orientation matplotlib recorded on the bar container.
 
+        Only the first container is asked: every container on one Axes is
+        drawn by the same call, so a layer runs one way or the other, never
+        both. A mixed-orientation layer would need this to say so per bar.
+
         Parameters
         ----------
         plot : list of BarContainer, optional
@@ -89,7 +93,9 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         levels : list of str, optional
             The bar labels read off the categorical axis. Used only to check
             that the axis has one label per bar; an axis with no tick labels
-            at all places no constraint.
+            at all is not checked here — the caller pairs the magnitudes with
+            the labels, so it ends up raising `ExtractionError` on an empty
+            list regardless.
 
         Returns
         -------

--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
 
-from maidr.core.enum import PlotType
+from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
 from maidr.util.mixin import (
@@ -16,27 +16,66 @@ from maidr.util.mixin import (
 class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMergerMixin):
     def __init__(self, ax: Axes) -> None:
         super().__init__(ax, PlotType.BAR)
+        self._orientation = "vert"
+
+    @property
+    def _is_horizontal(self) -> bool:
+        return self._orientation == "horz"
+
+    @property
+    def _level_key(self) -> MaidrKey:
+        """
+        The axis the bar labels sit on: ``y`` for a horizontal bar plot
+        (``Axes.barh``, ``seaborn.barplot(orient="h")``), ``x`` otherwise.
+        """
+        return MaidrKey.Y if self._is_horizontal else MaidrKey.X
+
+    @staticmethod
+    def _extract_orientation(plot: list[BarContainer] | None) -> str:
+        """
+        Read the orientation matplotlib recorded on the bar container.
+
+        Parameters
+        ----------
+        plot : list of BarContainer, optional
+            The containers holding the bars of this layer.
+
+        Returns
+        -------
+        str
+            ``"horz"`` for a horizontal bar plot, ``"vert"`` otherwise.
+        """
+        if not plot:
+            return "vert"
+
+        return "horz" if plot[0].orientation == "horizontal" else "vert"
+
+    def render(self) -> dict:
+        """Add ``orientation`` to the base schema."""
+        base_schema = super().render()
+        bar_orientation = {MaidrKey.ORIENTATION: self._orientation}
+        return DictMergerMixin.merge_dict(base_schema, bar_orientation)
 
     def _extract_plot_data(self) -> list:
         plot = self.extract_container(self.ax, BarContainer, include_all=True)
+        self._orientation = self._extract_orientation(plot)
+
         data = self._extract_bar_container_data(plot)
-        levels = self.extract_level(self.ax)
-        formatted_data = []
-        combined_data = list(
-            zip(levels, data)
-            if plot[0].orientation == "vertical"
-            else zip(data, levels)  # type: ignore
-        )
-        if combined_data:  # type: ignore
-            for x, y in combined_data:  # type: ignore
-                formatted_data.append({"x": x, "y": y})
-            return formatted_data
-        if len(formatted_data) == 0:
-            raise ExtractionError(self.type, plot)
         if data is None:
             raise ExtractionError(self.type, plot)
 
-        return data
+        levels = self.extract_level(self.ax, self._level_key)
+
+        # A horizontal bar's magnitude runs along x and its label sits on y,
+        # which is the layout the renderer reads for a horizontal layer. The
+        # vertical layer is the mirror of that.
+        combined_data = list(
+            zip(data, levels) if self._is_horizontal else zip(levels, data)  # type: ignore
+        )
+        if not combined_data:
+            raise ExtractionError(self.type, plot)
+
+        return [{"x": x, "y": y} for x, y in combined_data]
 
     def _extract_bar_container_data(
         self, plot: list[BarContainer] | None
@@ -49,7 +88,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         # So, extract data correspondingly based on the level.
         # Flatten all the `list[BarContainer]` to `list[Patch]`.
         plot = [patch for container in plot for patch in container.patches]
-        level = self.extract_level(self.ax)
+        level = self.extract_level(self.ax, self._level_key)
         if len(level) == 0:  # type: ignore
             level = ["" for _ in range(len(plot))]  # type: ignore
 
@@ -57,5 +96,10 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
             return None
 
         self._elements.extend(plot)
+
+        # A bar's magnitude is the dimension it grows along: the width of a
+        # horizontal bar, the height of a vertical one.
+        if self._is_horizontal:
+            return [float(patch.get_width()) for patch in plot]
 
         return [float(patch.get_height()) for patch in plot]

--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -56,6 +56,8 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
 
     def render(self) -> dict:
         """Add ``orientation`` to the base schema."""
+        # Read after the super call, not before: `self._orientation` is
+        # populated by `_extract_plot_data`, which that call runs.
         base_schema = super().render()
         bar_orientation = {MaidrKey.ORIENTATION: self._orientation}
         return DictMergerMixin.merge_dict(base_schema, bar_orientation)
@@ -72,9 +74,11 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         # A horizontal bar's magnitude runs along x and its label sits on y,
         # which is the layout the renderer reads for a horizontal layer. The
         # vertical layer is the mirror of that.
-        combined_data = list(
-            zip(data, levels) if self._is_horizontal else zip(levels, data)  # type: ignore
-        )
+        if self._is_horizontal:
+            combined_data = list(zip(data, levels))  # type: ignore
+        else:
+            combined_data = list(zip(levels, data))  # type: ignore
+
         if not combined_data:
             raise ExtractionError(self.type, plot)
 

--- a/maidr/core/plot/histogram.py
+++ b/maidr/core/plot/histogram.py
@@ -6,15 +6,44 @@ from matplotlib.container import BarContainer
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
-from maidr.util.mixin import ContainerExtractorMixin
+from maidr.util.mixin import ContainerExtractorMixin, DictMergerMixin
 
 
-class HistPlot(MaidrPlot, ContainerExtractorMixin):
+class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
     def __init__(self, ax: Axes) -> None:
         super().__init__(ax, PlotType.HIST)
+        self._orientation = "vert"
+
+    @staticmethod
+    def _extract_orientation(plot: BarContainer | None) -> str:
+        """
+        Read the orientation matplotlib recorded on the bar container.
+
+        Parameters
+        ----------
+        plot : BarContainer, optional
+            The container holding the histogram bars.
+
+        Returns
+        -------
+        str
+            ``"horz"`` for ``hist(orientation="horizontal")``, ``"vert"``
+            otherwise.
+        """
+        if plot is None:
+            return "vert"
+
+        return "horz" if plot.orientation == "horizontal" else "vert"
+
+    def render(self) -> dict:
+        """Add ``orientation`` to the base schema."""
+        base_schema = super().render()
+        hist_orientation = {MaidrKey.ORIENTATION: self._orientation}
+        return DictMergerMixin.merge_dict(base_schema, hist_orientation)
 
     def _extract_plot_data(self) -> list[dict]:
         plot = self.extract_container(self.ax, BarContainer)
+        self._orientation = self._extract_orientation(plot)
         data = self._extract_bar_container_data(plot)
 
         if data is None:
@@ -30,18 +59,39 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin):
 
         data = []
         for patch in plot.patches:
-            y = float(patch.get_height())
-            x = float(patch.get_x())
-            width = float(patch.get_width())
+            # A horizontal histogram runs its bins up the y axis and its
+            # counts along x, so the bin edges come off the patch's y and
+            # height and the count off its width. The vertical case is the
+            # mirror of that.
+            if self._orientation == "horz":
+                count = float(patch.get_width())
+                bin_start = float(patch.get_y())
+                bin_size = float(patch.get_height())
+
+                data.append(
+                    {
+                        MaidrKey.X.value: count,
+                        MaidrKey.Y.value: bin_start + bin_size / 2,
+                        MaidrKey.Y_MIN.value: bin_start,
+                        MaidrKey.Y_MAX.value: bin_start + bin_size,
+                        MaidrKey.X_MIN.value: 0,
+                        MaidrKey.X_MAX.value: count,
+                    }
+                )
+                continue
+
+            count = float(patch.get_height())
+            bin_start = float(patch.get_x())
+            bin_size = float(patch.get_width())
 
             data.append(
                 {
-                    MaidrKey.Y.value: y,
-                    MaidrKey.X.value: x + width / 2,
-                    MaidrKey.X_MIN.value: x,
-                    MaidrKey.X_MAX.value: x + width,
+                    MaidrKey.Y.value: count,
+                    MaidrKey.X.value: bin_start + bin_size / 2,
+                    MaidrKey.X_MIN.value: bin_start,
+                    MaidrKey.X_MAX.value: bin_start + bin_size,
                     MaidrKey.Y_MIN.value: 0,
-                    MaidrKey.Y_MAX.value: y,
+                    MaidrKey.Y_MAX.value: count,
                 }
             )
 

--- a/maidr/core/plot/histogram.py
+++ b/maidr/core/plot/histogram.py
@@ -37,6 +37,8 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
 
     def render(self) -> dict:
         """Add ``orientation`` to the base schema."""
+        # Read after the super call, not before: `self._orientation` is
+        # populated by `_extract_plot_data`, which that call runs.
         base_schema = super().render()
         hist_orientation = {MaidrKey.ORIENTATION: self._orientation}
         return DictMergerMixin.merge_dict(base_schema, hist_orientation)

--- a/tests/core/plot/test_bar_orientation.py
+++ b/tests/core/plot/test_bar_orientation.py
@@ -15,10 +15,12 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
 import seaborn as sns  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.exception import ExtractionError  # noqa: E402
 
 
 LABELS = ["a", "b", "c"]
@@ -132,6 +134,27 @@ def test_horizontal_histogram_bins_run_along_y() -> None:
     assert first["y"] == (first["yMin"] + first["yMax"]) / 2
     assert first["xMin"] == 0
     assert first["xMax"] == first["x"]
+
+
+def test_a_label_count_mismatch_raises_extraction_error() -> None:
+    """The failure this reordering fixed: an `ExtractionError`, not a `TypeError`.
+
+    Three bars against two tick labels is the shape that made
+    `_extract_bar_container_data` return None. The magnitudes and the labels
+    are zipped straight after, so before the None was checked first this
+    surfaced as `TypeError: 'NoneType' object is not iterable`.
+    """
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(LABELS, VALUES)
+        ax.set_xticks([0, 1])
+        ax.set_xticklabels(LABELS[:2])
+        plot = FigureManager.get_maidr(fig).plots[0]
+
+        with pytest.raises(ExtractionError):
+            plot._extract_plot_data()
+    finally:
+        plt.close(fig)
 
 
 def test_seaborn_horizontal_histplot() -> None:

--- a/tests/core/plot/test_bar_orientation.py
+++ b/tests/core/plot/test_bar_orientation.py
@@ -132,3 +132,27 @@ def test_horizontal_histogram_bins_run_along_y() -> None:
     assert first["y"] == (first["yMin"] + first["yMax"]) / 2
     assert first["xMin"] == 0
     assert first["xMax"] == first["x"]
+
+
+def test_seaborn_horizontal_histplot() -> None:
+    """`sns.histplot(y=...)` reaches the same extractor as `hist()`.
+
+    Seaborn asks for a horizontal histogram by binning `y` rather than by an
+    `orientation` argument, so this is a distinct entry point into the code
+    the matplotlib tests above cover.
+    """
+    fig, ax = plt.subplots()
+    try:
+        sns.histplot(y=SAMPLES, bins=3, ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["orientation"] == "horz"
+    counts = [bin_["x"] for bin_ in schema["data"]]
+    assert counts == [1.0, 2.0, 3.0]
+    first = schema["data"][0]
+    assert first["yMin"] == 1.0
+    assert first["y"] == (first["yMin"] + first["yMax"]) / 2
+    assert first["xMin"] == 0
+    assert first["xMax"] == first["x"]

--- a/tests/core/plot/test_bar_orientation.py
+++ b/tests/core/plot/test_bar_orientation.py
@@ -136,19 +136,26 @@ def test_horizontal_histogram_bins_run_along_y() -> None:
     assert first["xMax"] == first["x"]
 
 
-def test_a_label_count_mismatch_raises_extraction_error() -> None:
+@pytest.mark.parametrize("horizontal", [False, True])
+def test_a_label_count_mismatch_raises_extraction_error(horizontal: bool) -> None:
     """The failure this reordering fixed: an `ExtractionError`, not a `TypeError`.
 
     Three bars against two tick labels is the shape that made
     `_extract_bar_container_data` return None. The magnitudes and the labels
     are zipped straight after, so before the None was checked first this
-    surfaced as `TypeError: 'NoneType' object is not iterable`.
+    surfaced as `TypeError: 'NoneType' object is not iterable`. Both
+    orientations are driven because each zips its own way round.
     """
     fig, ax = plt.subplots()
     try:
-        ax.bar(LABELS, VALUES)
-        ax.set_xticks([0, 1])
-        ax.set_xticklabels(LABELS[:2])
+        if horizontal:
+            ax.barh(LABELS, VALUES)
+            ax.set_yticks([0, 1])
+            ax.set_yticklabels(LABELS[:2])
+        else:
+            ax.bar(LABELS, VALUES)
+            ax.set_xticks([0, 1])
+            ax.set_xticklabels(LABELS[:2])
         plot = FigureManager.get_maidr(fig).plots[0]
 
         with pytest.raises(ExtractionError):

--- a/tests/core/plot/test_bar_orientation.py
+++ b/tests/core/plot/test_bar_orientation.py
@@ -164,6 +164,28 @@ def test_a_label_count_mismatch_raises_extraction_error(horizontal: bool) -> Non
         plt.close(fig)
 
 
+def test_an_axis_with_no_tick_labels_raises_extraction_error() -> None:
+    """Unchanged by the refactor, and pinned here because it looks changed.
+
+    The old `_extract_bar_container_data` swapped an empty level list for a
+    list of empty strings, which reads like it emitted a blank label per bar.
+    It did not: the substitution was local to that method and existed only to
+    let its own length check pass, while the caller went on to zip against
+    the real, still-empty list. Both before and after, a bar axis stripped of
+    its tick labels raises rather than emitting blank labels.
+    """
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(LABELS, VALUES)
+        ax.set_xticks([])
+        plot = FigureManager.get_maidr(fig).plots[0]
+
+        with pytest.raises(ExtractionError):
+            plot._extract_plot_data()
+    finally:
+        plt.close(fig)
+
+
 def test_seaborn_horizontal_histplot() -> None:
     """`sns.histplot(y=...)` reaches the same extractor as `hist()`.
 

--- a/tests/core/plot/test_bar_orientation.py
+++ b/tests/core/plot/test_bar_orientation.py
@@ -1,0 +1,134 @@
+"""Tests that bar and histogram layers support both orientations.
+
+A horizontal bar layer reaches the renderer as ``{"x": value, "y": label}``
+with ``orientation: "horz"``, the mirror of the vertical layout, so the
+magnitude is read off the axis it actually grows along. Before this was
+handled, ``Axes.barh`` and ``seaborn.barplot(orient="h")`` raised
+``TypeError`` while extracting, and a horizontal histogram emitted bin edges
+as counts.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+LABELS = ["a", "b", "c"]
+VALUES = [1.0, 2.0, 3.0]
+SAMPLES = [1, 2, 2, 3, 3, 3]
+
+
+def _schema(fig) -> dict:
+    """Return the first layer's schema with plain string keys."""
+    plot = FigureManager.get_maidr(fig).plots[0]
+    return {(k.value if hasattr(k, "value") else k): v for k, v in plot.schema.items()}
+
+
+def test_vertical_bar_keeps_labels_on_x() -> None:
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(LABELS, VALUES)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["orientation"] == "vert"
+    assert schema["data"] == [
+        {"x": "a", "y": 1.0},
+        {"x": "b", "y": 2.0},
+        {"x": "c", "y": 3.0},
+    ]
+
+
+def test_horizontal_bar_puts_the_value_on_x_and_the_label_on_y() -> None:
+    fig, ax = plt.subplots()
+    try:
+        ax.barh(LABELS, VALUES)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["orientation"] == "horz"
+    assert schema["data"] == [
+        {"x": 1.0, "y": "a"},
+        {"x": 2.0, "y": "b"},
+        {"x": 3.0, "y": "c"},
+    ]
+
+
+def test_seaborn_horizontal_barplot() -> None:
+    fig, ax = plt.subplots()
+    try:
+        sns.barplot(x=VALUES, y=LABELS, orient="h", ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["orientation"] == "horz"
+    assert schema["data"] == [
+        {"x": 1.0, "y": "a"},
+        {"x": 2.0, "y": "b"},
+        {"x": 3.0, "y": "c"},
+    ]
+
+
+def test_seaborn_horizontal_countplot() -> None:
+    """A count plot is registered as a bar layer, so it orients the same way."""
+    fig, ax = plt.subplots()
+    try:
+        sns.countplot(y=["a", "b", "b", "c", "c", "c"], ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["orientation"] == "horz"
+    assert schema["data"] == [
+        {"x": 1.0, "y": "a"},
+        {"x": 2.0, "y": "b"},
+        {"x": 3.0, "y": "c"},
+    ]
+
+
+def test_vertical_histogram_bins_run_along_x() -> None:
+    fig, ax = plt.subplots()
+    try:
+        ax.hist(SAMPLES, bins=3)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["orientation"] == "vert"
+    counts = [bin_["y"] for bin_ in schema["data"]]
+    assert counts == [1.0, 2.0, 3.0]
+    first = schema["data"][0]
+    assert first["xMin"] == 1.0
+    assert first["x"] == (first["xMin"] + first["xMax"]) / 2
+    assert first["yMin"] == 0
+    assert first["yMax"] == first["y"]
+
+
+def test_horizontal_histogram_bins_run_along_y() -> None:
+    fig, ax = plt.subplots()
+    try:
+        ax.hist(SAMPLES, bins=3, orientation="horizontal")
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["orientation"] == "horz"
+    # The counts are the same numbers as the vertical case, read off x.
+    counts = [bin_["x"] for bin_ in schema["data"]]
+    assert counts == [1.0, 2.0, 3.0]
+    first = schema["data"][0]
+    assert first["yMin"] == 1.0
+    assert first["y"] == (first["yMin"] + first["yMax"]) / 2
+    assert first["xMin"] == 0
+    assert first["xMax"] == first["x"]


### PR DESCRIPTION
## Description

Horizontal bar plots have no working path today. Every one of these raises while extracting:

```python
ax.barh(["a", "b", "c"], [1, 2, 3])
sns.barplot(x=[1, 2, 3], y=["a", "b", "c"], orient="h")
sns.countplot(y=["a", "b", "b", "c", "c", "c"])
# TypeError: 'NoneType' object is not iterable
```

The bar labels were always read off the **x** axis, so for a horizontal layer the level count never matched the patch count, `_extract_bar_container_data` returned `None`, and the `zip` that followed it crashed on the `None`.

A horizontal histogram did not crash but was just as wrong — a bar's magnitude was always taken from `patch.get_height()`, which for a horizontal bar is the bin thickness, not the count:

```
ax.hist([1, 2, 2, 3, 3, 3], bins=3, orientation="horizontal")

before: {"y": 0.2, "x": 0.5, "xMin": 0.0, "xMax": 1.0, ...}   # bin size as the count
after:  {"x": 1.0, "y": 1.33, "yMin": 1.0, "yMax": 1.67, "xMin": 0, "xMax": 1.0}
```

This is the follow-up flagged in #301, which fixed the same class of bug for box and violin layers.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Tagged `feat` rather than `fix` because horizontal bar layers become usable rather than merely correct — though it presents as a crash.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description

See above — `Axes.barh`, `seaborn.barplot(orient="h")` and `seaborn.countplot(y=...)` crashed while extracting, and a horizontal histogram emitted bin edges where its counts belong.

## Related Issues

Follow-up to #301, which noted this gap in its description.

## Changes Made

- **`maidr/core/plot/barplot.py`** — read the orientation matplotlib already records on the `BarContainer` and extract along it: labels off the y axis and the magnitude from `patch.get_width()` when the layer is horizontal. The emitted point is the mirror of the vertical one, `{"x": value, "y": label}`, which is the layout the renderer reads for a horizontal bar trace. `orientation` now reaches the schema, so the renderer navigates and announces the layer as horizontal instead of falling back to vertical. The `None` guard moved ahead of the `zip`, so an extraction that genuinely fails raises `ExtractionError` rather than a `TypeError` from inside the zip.
- **`maidr/core/plot/histogram.py`** — same treatment: for a horizontal histogram the bin edges come off the patch's `y`/`height` and the count off its `width`, emitted as `yMin`/`yMax` with the count on `x`. Also emits `orientation`.
- **`tests/core/plot/test_bar_orientation.py`** (new) — both orientations for `ax.bar`/`ax.barh`, `seaborn.barplot(orient="h")`, `seaborn.countplot(y=...)`, and `ax.hist` with and without `orientation="horizontal"`, asserting the exact emitted payload and that the counts are the same numbers in both orientations.

Vertical payloads are unchanged, which the vertical tests pin.

`GroupedBarPlot` (dodged/stacked) and `MplfinanceBarPlot` do not inherit from `BarPlot`, so they are untouched; horizontal grouped bars remain unsupported.

## Screenshots (if applicable)

n/a

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` passes (247 tests). `ruff check` and `ruff format` are clean on every changed file; the repository's pre-existing `F401` errors in `__init__.py` files are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NvQqGMoq3B21znVDinNVB)_