### PR TITLE
fix(plotly): resolve an absent mode the way plotly does before classifying

### DIFF
--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -8,8 +8,11 @@ class PlotlyPlotFactory:
     """
     Factory that maps Plotly trace types to PlotlyPlot subclasses.
 
-    For scatter traces, uses the ``mode`` attribute to disambiguate
-    between scatter (markers) and line (lines) plots.
+    For scatter traces, the drawing mode disambiguates loose markers from a
+    connected line. That is resolved through
+    :func:`maidr.plotly.step_shape.is_connected_line_trace` rather than read
+    off the trace, because ``Figure.to_dict()`` omits ``mode`` when the author
+    never set one — and an absent ``mode`` still draws a line.
     """
 
     @staticmethod

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -46,6 +46,72 @@ STEP_SHAPE_DIRECTION: dict[str, str] = {
 _CONNECTED_TRACE_TYPES = ("scatter", "scattergl")
 
 
+#: Point count at which plotly's default ``mode`` drops its markers.
+#:
+#: From the plotly.js ``scatter.mode`` attribute: "If there are less than 20
+#: points and the trace is not stacked, then the default is 'lines+markers'.
+#: Otherwise, 'lines'." Both halves matter — a mode-less trace is never
+#: markers-only, so reading an absent ``mode`` as markers describes a chart
+#: plotly draws as a connected line.
+_MARKER_DEFAULT_MAX_POINTS = 20
+
+
+def _trace_point_count(trace: dict) -> int:
+    """
+    Count the points a trace will actually draw.
+
+    ``x`` and ``y`` are zipped when the data is extracted, so the shorter of
+    the two is the number of points that reach the chart. A trace supplying
+    only ``y`` counts that, matching plotly generating ``x`` as ``0..n-1``.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    int
+        The number of drawn points; 0 when neither axis carries a sequence.
+    """
+    lengths = [
+        len(values)
+        for values in (trace.get("x"), trace.get("y"))
+        if values is not None and hasattr(values, "__len__")
+    ]
+    return min(lengths) if lengths else 0
+
+
+def default_mode(trace: dict) -> str:
+    """
+    Resolve the ``mode`` plotly itself applies when the author sets none.
+
+    ``Figure.to_dict()`` omits ``mode`` entirely unless it was set, so the
+    exported dict cannot be read literally — an absent ``mode`` is not "no
+    drawing mode", it is "whatever plotly's default resolves to". Reproducing
+    that default here keeps the classification tied to what is drawn rather
+    than to what happens to be spelled out in the dict.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    str
+        ``"lines+markers"`` for a short unstacked trace, ``"lines"`` otherwise.
+    """
+    # A stacked trace defaults to "lines" at any size -- plotly excludes it
+    # from the marker default explicitly.
+    if trace.get("stackgroup"):
+        return "lines"
+
+    if _trace_point_count(trace) < _MARKER_DEFAULT_MAX_POINTS:
+        return "lines+markers"
+    return "lines"
+
+
 def is_scatter_family_trace(trace: dict) -> bool:
     """
     Report whether a trace belongs to the subplot's scatter layer.
@@ -94,26 +160,27 @@ def is_connected_line_trace(trace: dict) -> bool:
     Returns
     -------
     bool
-        True for a scatter-family trace in a lines-only mode, or a staircase
-        that never authored a mode at all.
+        True for a scatter-family trace whose drawing mode joins its samples
+        up, resolving an absent ``mode`` the way plotly does.
     """
     if not is_scatter_family_trace(trace):
         return False
 
     mode = trace.get("mode")
     if mode is None:
-        # ``to_dict()`` omits ``mode`` when the author never set one, and
-        # plotly's default draws lines either way — "lines+markers" under 20
-        # points, "lines" at or above. Reading an absent mode as markers-only
-        # would send a trace authored as
-        # ``add_scatter(..., line_shape="hv")`` to a scatter layer, so the
-        # chart plotly actually draws as a staircase gets announced as loose
-        # points, losing the piecewise-constant reading entirely.
-        #
-        # Only a declared stepping shape is rescued here. A mode-less trace
-        # with no ``line.shape`` keeps whatever classification it had before
-        # steps existed, so plain scatters are untouched.
-        return is_step_trace(trace)
+        # A declared stepping shape settles it on its own: plotly draws the
+        # risers whatever the resolved mode turns out to be, so the data is
+        # piecewise constant either way. Checked before the default so a
+        # short staircase -- where the default adds markers -- still binds as
+        # a step rather than as loose points.
+        if is_step_trace(trace):
+            return True
+
+        # Otherwise stand in plotly's own default, because ``to_dict()``
+        # omits ``mode`` rather than recording it. Reading absent-as-markers
+        # described a chart plotly draws as a connected line as scattered
+        # points, losing the connectivity of the data entirely.
+        mode = default_mode(trace)
 
     return "lines" in mode and "markers" not in mode
 

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -61,8 +61,10 @@ def _trace_point_count(trace: dict) -> int:
     Count the points a trace will actually draw.
 
     ``x`` and ``y`` are zipped when the data is extracted, so the shorter of
-    the two is the number of points that reach the chart. A trace supplying
-    only ``y`` counts that, matching plotly generating ``x`` as ``0..n-1``.
+    the two is the number of points that reach the chart. Whichever axis is
+    absent is simply not counted, symmetrically: a ``y``-only trace counts
+    ``y`` — matching plotly generating ``x`` as ``0..n-1`` — and an
+    ``x``-only trace counts ``x``.
 
     Parameters
     ----------

--- a/tests/plotly/test_plotly_mode_default.py
+++ b/tests/plotly/test_plotly_mode_default.py
@@ -1,0 +1,179 @@
+"""Classifying a plotly trace that never authored a ``mode``.
+
+``Figure.to_dict()`` omits ``mode`` unless it was set, so the exported dict
+cannot be read literally: an absent ``mode`` is not "no drawing mode", it is
+"whatever plotly's default resolves to". plotly documents that default on
+``scatter.mode`` as "If there are less than 20 points and the trace is not
+stacked then the default is 'lines+markers'. Otherwise, 'lines'."
+
+Reading absent-as-markers therefore described a chart plotly draws as a
+connected line as scattered points.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_maidr import PlotlyMaidr
+from maidr.plotly.step_shape import default_mode, is_connected_line_trace
+
+plotly = pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+
+def _trace(n: int, **overrides) -> dict:
+    """
+    Build a mode-less scatter trace dict of ``n`` points.
+
+    Parameters
+    ----------
+    n : int
+        Number of points on both axes.
+    **overrides
+        Extra trace keys merged in.
+
+    Returns
+    -------
+    dict
+        A scatter trace dict with no ``mode``.
+    """
+    return {
+        "type": "scatter",
+        "x": list(range(n)),
+        "y": list(range(n)),
+        **overrides,
+    }
+
+
+def _layers(fig) -> list[dict]:
+    """
+    Render a figure through PlotlyMaidr and return its layer schemas.
+
+    Parameters
+    ----------
+    fig : plotly.graph_objects.Figure
+        The figure to export.
+
+    Returns
+    -------
+    list of dict
+        One schema per emitted layer, in emission order.
+    """
+    return [plot.schema for plot in PlotlyMaidr(fig)._plots]
+
+
+class TestPlotlysOwnDefault:
+    """``default_mode`` must reproduce the rule plotly documents."""
+
+    @pytest.mark.parametrize("n", [0, 1, 5, 19])
+    def test_a_short_trace_defaults_to_lines_and_markers(self, n):
+        assert default_mode(_trace(n)) == "lines+markers"
+
+    @pytest.mark.parametrize("n", [20, 21, 100])
+    def test_a_long_trace_defaults_to_lines(self, n):
+        assert default_mode(_trace(n)) == "lines"
+
+    def test_the_boundary_is_exclusive_at_twenty(self):
+        # "less than 20 points" -- 19 keeps markers, 20 drops them.
+        assert default_mode(_trace(19)) == "lines+markers"
+        assert default_mode(_trace(20)) == "lines"
+
+    @pytest.mark.parametrize("n", [1, 5, 19])
+    def test_a_stacked_trace_defaults_to_lines_at_any_size(self, n):
+        # plotly excludes stacked traces from the marker default explicitly.
+        assert default_mode(_trace(n, stackgroup="one")) == "lines"
+
+    def test_the_count_is_the_points_actually_drawn(self):
+        # x and y are zipped, so the shorter axis is what reaches the chart.
+        assert default_mode({"x": list(range(50)), "y": [1, 2, 3]}) == (
+            "lines+markers"
+        )
+
+    def test_a_y_only_trace_counts_its_own_length(self):
+        # plotly generates x as 0..n-1 when only y is supplied.
+        assert default_mode({"y": list(range(25))}) == "lines"
+
+    def test_a_trace_with_no_sequence_does_not_raise(self):
+        assert default_mode({}) == "lines+markers"
+        assert default_mode({"x": 3, "y": 4}) == "lines+markers"
+
+
+class TestModelessClassification:
+    """The classifier resolves the absent mode before deciding."""
+
+    def test_a_long_modeless_trace_is_a_connected_line(self):
+        assert is_connected_line_trace(_trace(25)) is True
+
+    def test_a_short_modeless_trace_is_not(self):
+        assert is_connected_line_trace(_trace(5)) is False
+
+    def test_an_explicit_mode_still_wins_over_the_default(self):
+        # A 25-point trace defaults to "lines", but an explicit markers mode
+        # is what the author asked for.
+        assert is_connected_line_trace(_trace(25, mode="markers")) is False
+        assert is_connected_line_trace(_trace(5, mode="lines")) is True
+
+    def test_a_short_modeless_staircase_is_still_connected(self):
+        # The step rescue is checked before the default, so a staircase short
+        # enough to default to markers still reads as piecewise constant.
+        assert (
+            is_connected_line_trace(_trace(5, line={"shape": "hv"})) is True
+        )
+
+    def test_a_non_scatter_trace_is_never_connected(self):
+        assert is_connected_line_trace(_trace(25, type="bar")) is False
+
+
+class TestTheExportedLayer:
+    """End to end: what a mode-less figure actually emits."""
+
+    def _types(self, n: int, **kwargs) -> list:
+        fig = go.Figure()
+        fig.add_scatter(x=list(range(n)), y=list(range(n)), **kwargs)
+        return [layer[MaidrKey.TYPE] for layer in _layers(fig)]
+
+    def test_a_modeless_line_chart_is_exported_as_a_line(self):
+        # The bug: this announced as loose points while plotly drew a line.
+        assert self._types(25) == [PlotType.LINE]
+
+    def test_a_short_modeless_chart_stays_a_scatter(self):
+        # Unchanged, and deliberately so: plotly draws markers here, and an
+        # explicit "lines+markers" is classified the same way.
+        assert self._types(6) == [PlotType.SCATTER]
+
+    def test_a_stacked_modeless_chart_is_a_line_at_any_size(self):
+        assert self._types(6, stackgroup="one") == [PlotType.LINE]
+
+    def test_the_rescued_line_gets_a_scoped_selector(self):
+        # Reclassifying is only half the job -- the layer has to carry a
+        # selector that resolves, which means a position among the subplot's
+        # scatter traces rather than the unscoped fallback.
+        fig = go.Figure()
+        fig.add_scatter(x=list(range(25)), y=list(range(25)))
+        (layer,) = _layers(fig)
+
+        assert layer[MaidrKey.TYPE] == PlotType.LINE
+        assert "nth-child(1)" in layer[MaidrKey.SELECTOR][0]
+
+    def test_a_modeless_line_after_a_step_is_indexed_past_it(self):
+        # The reclassified line now competes for scatterlayer positions with
+        # a step, which is exactly where a wrong index highlights the wrong
+        # element.
+        fig = go.Figure()
+        fig.add_scatter(
+            x=[0, 1, 2],
+            y=[1, 2, 3],
+            mode="lines",
+            line={"shape": "hv"},
+            name="step",
+        )
+        fig.add_scatter(x=list(range(25)), y=list(range(25)), name="line")
+
+        layers = _layers(fig)
+        line = next(x for x in layers if x[MaidrKey.TYPE] == PlotType.LINE)
+        step = next(x for x in layers if x[MaidrKey.TYPE] == PlotType.STEP)
+
+        assert "nth-child(1)" in step[MaidrKey.SELECTOR][0]
+        assert "nth-child(2)" in line[MaidrKey.SELECTOR][0]

--- a/tests/plotly/test_plotly_mode_default.py
+++ b/tests/plotly/test_plotly_mode_default.py
@@ -74,6 +74,13 @@ class TestTheTranscribedRuleStillMatchesUpstream:
     stacked exception and every test here would keep passing against a rule
     that no longer describes what is drawn. Reading the docstring back turns
     that silent drift into a failing build.
+
+    **If one of these fails, check for a wording change before changing any
+    code.** They match on the docstring's prose, so a purely cosmetic rewrite
+    upstream ("fewer than" for "less than") fails them without the behaviour
+    having moved at all. The question to answer first is whether the *rule*
+    changed; ``go.Figure``'s resolved ``_fullData[i].mode`` in a browser is
+    the ground truth if it is ever unclear.
     """
 
     @staticmethod
@@ -133,6 +140,38 @@ class TestPlotlysOwnDefault:
     def test_a_trace_with_no_sequence_does_not_raise(self):
         assert default_mode({}) == "lines+markers"
         assert default_mode({"x": 3, "y": 4}) == "lines+markers"
+
+
+class TestScatterglSharesTheRule:
+    """
+    ``scattergl`` is scatter-family, so the same default has to apply to it.
+
+    Its Python docstring is not evidence either way — unlike ``Scatter``'s, it
+    states no default at all, so it can neither confirm nor contradict the
+    rule. plotly.js was read instead: the threshold is one shared
+    ``PTS_LINESONLY`` constant, and both trace modules coerce with the same
+    ``n < PTS_LINESONLY ? "lines+markers" : "lines"``.
+
+    Confirmed by rendering both types in Chromium and reading back plotly's
+    own resolved ``gd._fullData[i].mode``, which agreed at every count::
+
+        n=5   scattergl lines+markers   scatter lines+markers
+        n=19  scattergl lines+markers   scatter lines+markers
+        n=20  scattergl lines           scatter lines
+        n=25  scattergl lines           scatter lines
+    """
+
+    @pytest.mark.parametrize("n", [5, 19, 20, 25])
+    def test_gl_and_svg_resolve_identically(self, n):
+        assert default_mode(_trace(n, type="scattergl")) == default_mode(
+            _trace(n)
+        )
+
+    def test_a_long_gl_trace_is_a_connected_line(self):
+        assert is_connected_line_trace(_trace(25, type="scattergl")) is True
+
+    def test_a_short_gl_trace_is_not(self):
+        assert is_connected_line_trace(_trace(5, type="scattergl")) is False
 
 
 class TestModelessClassification:

--- a/tests/plotly/test_plotly_mode_default.py
+++ b/tests/plotly/test_plotly_mode_default.py
@@ -2,7 +2,7 @@
 
 ``Figure.to_dict()`` omits ``mode`` unless it was set, so the exported dict
 cannot be read literally: an absent ``mode`` is not "no drawing mode", it is
-"whatever plotly's default resolves to". plotly documents that default on
+"whatever Plotly's default resolves to". Plotly documents that default on
 ``scatter.mode`` as "If there are less than 20 points and the trace is not
 stacked then the default is 'lines+markers'. Otherwise, 'lines'."
 
@@ -64,8 +64,43 @@ def _layers(fig) -> list[dict]:
     return [plot.schema for plot in PlotlyMaidr(fig)._plots]
 
 
+class TestTheTranscribedRuleStillMatchesUpstream:
+    """
+    Guard the one assumption the whole fix rests on.
+
+    ``default_mode`` is a hand transcription of a rule Plotly states only in
+    its generated attribute docstring — nothing in the Python package enforces
+    it, so a future Plotly release could change the boundary or drop the
+    stacked exception and every test here would keep passing against a rule
+    that no longer describes what is drawn. Reading the docstring back turns
+    that silent drift into a failing build.
+    """
+
+    @staticmethod
+    def _mode_doc() -> str:
+        return go.Scatter().__class__.mode.__doc__ or ""
+
+    def test_the_point_boundary_is_still_twenty(self):
+        from maidr.plotly.step_shape import _MARKER_DEFAULT_MAX_POINTS
+
+        doc = " ".join(self._mode_doc().split())
+
+        assert f"less than {_MARKER_DEFAULT_MAX_POINTS} points" in doc
+
+    def test_the_stacked_exception_still_exists(self):
+        doc = " ".join(self._mode_doc().split())
+
+        assert "not stacked" in doc
+
+    def test_the_two_resolved_modes_are_still_the_documented_ones(self):
+        doc = " ".join(self._mode_doc().split())
+
+        assert '"lines+markers"' in doc
+        assert '"lines"' in doc
+
+
 class TestPlotlysOwnDefault:
-    """``default_mode`` must reproduce the rule plotly documents."""
+    """``default_mode`` must reproduce the rule Plotly documents."""
 
     @pytest.mark.parametrize("n", [0, 1, 5, 19])
     def test_a_short_trace_defaults_to_lines_and_markers(self, n):

--- a/tests/plotly/test_plotly_step.py
+++ b/tests/plotly/test_plotly_step.py
@@ -259,8 +259,13 @@ class TestAModelessStaircaseStillBinds:
     default draws lines regardless ("lines+markers" under 20 points, "lines"
     at or above). Reading that as markers-only sent a chart plotly draws as a
     staircase to a scatter layer — announced as loose points, with the
-    piecewise-constant reading lost. Only a declared stepping shape is
-    rescued; everything else keeps its previous classification.
+    piecewise-constant reading lost.
+
+    A declared stepping shape is decisive on its own, checked before the mode
+    default is resolved at all: plotly draws the risers whatever the mode
+    turns out to be. Traces with no shape go on to
+    ``tests/plotly/test_plotly_mode_default.py``, which covers how an absent
+    mode resolves.
     """
 
     def _one_layer(self, **trace_kwargs):
@@ -276,9 +281,11 @@ class TestAModelessStaircaseStillBinds:
         assert layer[MaidrKey.TYPE] == PlotType.STEP
         assert layer[MaidrKey.STEP_DIRECTION] == "hv"
 
-    def test_a_modeless_trace_without_a_shape_is_untouched(self):
-        # The rescue is scoped to declared stepping shapes, so a plain
-        # mode-less scatter keeps the classification it had before steps.
+    def test_a_modeless_trace_without_a_shape_is_not_a_step(self):
+        # No shape, so nothing here claims the data is piecewise constant.
+        # This six-point trace lands on SCATTER because plotly's own default
+        # adds markers below 20 points -- not because an absent mode reads as
+        # markers-only. See test_plotly_mode_default.py for that boundary.
         assert self._one_layer()[MaidrKey.TYPE] == PlotType.SCATTER
 
     def test_an_explicit_markers_mode_still_wins(self):


### PR DESCRIPTION
## Description

A Plotly line chart written without an explicit `mode="lines"` was exported as `SCATTER`, so it announced as loose points while plotly drew a connected line. The connectivity of the data — the thing a line chart exists to show — was lost for a screen-reader user.

The cause is that `Figure.to_dict()` **omits** `mode` unless the author set one, and the classifier read that absence as markers-only:

```python
mode = trace.get("mode")
if mode is None:
    return is_step_trace(trace)   # only a declared stepping shape was rescued
```

An absent `mode` is not "no drawing mode". It is "whatever plotly's default resolves to" — and plotly's default always draws lines.

## Related Issues

Closes #308. Pre-existing behaviour, surfaced by #303.

## Changes Made

**`maidr/plotly/step_shape.py`** — a new `default_mode(trace)` reproduces the rule plotly documents on its own `scatter.mode` attribute, quoted verbatim from the installed plotly 6.7.0:

> If there are less than 20 points and the trace is not stacked then the default is "lines+markers". Otherwise, "lines".

Both halves are implemented: the `< 20` boundary, and the stacked-trace exclusion (`stackgroup` defaults to `"lines"` at any size). `_trace_point_count` counts the points actually drawn — the shorter of `x`/`y`, since they are zipped — and tolerates a `y`-only trace or a trace carrying no sequence at all.

`is_connected_line_trace` then stands that default in before applying the existing rule, instead of short-circuiting:

```python
mode = trace.get("mode")
if mode is None:
    if is_step_trace(trace):
        return True          # #303's rescue, unchanged
    mode = default_mode(trace)

return "lines" in mode and "markers" not in mode
```

## Which option this takes, and why

#308 offered three. This is **option 1 — mirror plotly's own rule** — and the reason is consistency rather than fidelity for its own sake.

Option 2 (treat every absent `mode` as `lines`) would make a mode-less six-point trace a `LINE` while an explicit `mode="lines+markers"` six-point trace stays a `SCATTER` — even though plotly draws those two **identically**. That is two classification rules for one rendered picture. Option 1 keeps one rule: resolve what plotly would draw, then classify that.

Resulting behaviour, with only the first row changed:

| trace | before | after |
|---|---|---|
| mode-less, no shape, ≥ 20 points | `SCATTER` | **`LINE`** |
| mode-less, no shape, < 20 points | `SCATTER` | `SCATTER` |
| mode-less, `stackgroup` set, any size | `SCATTER` | **`LINE`** |
| mode-less + stepping `line.shape` | `STEP` | `STEP` |
| explicit `mode="markers"` | `SCATTER` | `SCATTER` |
| explicit `mode="lines+markers"` | `SCATTER` | `SCATTER` |
| explicit `mode="lines"` | `LINE` | `LINE` |

**What this deliberately does not fix.** A short mode-less line chart is still `SCATTER`. That is not an oversight — it is the same answer plotly's own default gives, and the same answer an explicit `lines+markers` gets today. The adjacent question is whether `lines+markers` should be a `LINE` at all, since plotly does connect those points. Changing *that* reclassifies every explicit `lines+markers` trace users have today, which is a much larger behaviour change than #308 describes and wants its own argument. Happy to file it separately if you want it looked at.

The `#303` step rescue is untouched and now runs **before** the default is resolved, so a staircase short enough to default to markers still binds as a `STEP`.

## Verification

New `tests/plotly/test_plotly_mode_default.py` — 24 tests covering the default rule, the classifier, and the exported layer end to end.

Passing is not evidence on its own, so each group was checked against a deliberately broken build:

| Mutation | Tests killed |
|---|---|
| restore the pre-fix `return False` for an absent mode | 5 — the classifier, the exported line, the stacked case, both selector tests |
| `< 20` → `<= 20` | 2 — the boundary tests |
| drop the `stackgroup` exclusion | 4 — all three stacked parametrisations plus the exported layer |

Two tests go past classification to the emitted selector, because reclassifying is only half the job: a rescued line now competes for `scatterlayer` positions with a step, which is exactly where a wrong `nth-child` highlights the wrong element. Both assert on the selector string.

`tests/plotly/test_plotly_step.py` — `test_a_modeless_trace_without_a_shape_is_untouched` still passes unchanged (its trace is 6 points), but it was renamed to `..._is_not_a_step` and recommented, because the *reason* it is a `SCATTER` changed: it is now plotly's marker default, not an absent mode reading as markers. Its class docstring claimed "everything else keeps its previous classification", which is no longer true; corrected.

Full suite: **297 passed** (273 before, +24). `ruff check` clean on `maidr/plotly/` and `tests/plotly/`.

## Type of Change

- [x] Bug fix
- [x] Behaviour change — mode-less traces of ≥ 20 points, and stacked mode-less traces, now export as `LINE` instead of `SCATTER`

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added appropriate unit tests.
- [ ] I have updated the documentation — no user-facing doc describes `mode` handling; the rule is documented at `default_mode`.

## Additional Notes

**Merge-order note.** This is one of four sibling PRs closing the #303 follow-ups. It touches `maidr/plotly/step_shape.py`, which **#309 also touches** (a different region of the same file — the trace-type constants). #312 (tests only) and #311 don't conflict with it. Whichever of this and #309 merges first, the other needs a rebase; the overlap is small and adjacent rather than interleaved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_