### PR TITLE
fix(plotly): stop claiming a highlight for canvas-painted traces

### DIFF
--- a/maidr/plotly/line.py
+++ b/maidr/plotly/line.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.step_shape import renders_through_webgl
 
 
 class PlotlyLinePlot(PlotlyPlot):
@@ -45,11 +46,18 @@ class PlotlyLinePlot(PlotlyPlot):
         would match both. ``PlotlyMaidr`` therefore always supplies a
         position; the fallback is for direct/standalone construction.
 
+        A ``scattergl`` line gets none, on either path: it is painted to a
+        canvas, so there is no path to address.
+
         Returns
         -------
         list of str
-            A single CSS selector.
+            A single CSS selector, or empty for a WebGL trace.
         """
+        # Guarded once, ahead of both paths: neither an unscoped nor a
+        # position-scoped selector can address a canvas.
+        if renders_through_webgl(self._trace):
+            return []
         if self._scatter_position is None:
             return [f"{self._subplot_css_prefix()}.trace.scatter path.js-line"]
         return [self._scatter_line_selector(self._scatter_position)]

--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -59,9 +59,7 @@ class PlotlyMultiLinePlot(PlotlyPlot):
             One CSS selector per line, in trace order; empty for a WebGL
             layer.
         """
-        return self._scatter_line_selectors(
-            self._traces, self._scatter_positions
-        )
+        return self._scatter_line_selectors(self._traces, self._scatter_positions)
 
     def _extract_plot_data(self) -> list[list[dict]]:
         """Return multi-line data as a list-of-lists.

--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -50,15 +50,18 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         ``scatterlayer``, so numbering from 1 here would point each line at
         its predecessor and collide with the step layer's own selectors.
 
+        A ``scattergl`` layer gets none: it is painted to a canvas, so there
+        is no path to address.
+
         Returns
         -------
         list of str
-            One CSS selector per line, in trace order.
+            One CSS selector per line, in trace order; empty for a WebGL
+            layer.
         """
-        return [
-            self._scatter_line_selector(position)
-            for position in self._scatter_positions
-        ]
+        return self._scatter_line_selectors(
+            self._traces, self._scatter_positions
+        )
 
     def _extract_plot_data(self) -> list[list[dict]]:
         """Return multi-line data as a list-of-lists.

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -122,7 +122,12 @@ class PlotlyMaidr:
           selector list is all-or-nothing, so a mixed layer could only claim a
           highlight for every series or for none. The groups are built in
           first-seen order, so the emitted layers still follow plotly's own
-          trace order.
+          trace order. Grouping is coarse rather than interleaved: traces
+          alternating ``svg, gl, svg`` emit ``[svg, svg]`` then ``[gl]``,
+          because both SVG traces belong to one merged layer. That is
+          inherent to merging at all, and matches how
+          :func:`~maidr.plotly.step_shape.group_by_direction` already behaves
+          for alternating step conventions.
         * Within a renderer they are split into staircases and plain lines by
           ``line.shape``: a step merged into the line layer would be
           announced as interpolating between samples, which is the one thing

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -17,6 +17,7 @@ from maidr.plotly.step_shape import (
     is_connected_line_trace,
     is_scatter_family_trace,
     is_step_trace,
+    renders_through_webgl,
 )
 from maidr.util.dependencies import (
     MAIDR_CSS_CDN_URL,
@@ -161,31 +162,39 @@ class PlotlyMaidr:
             connected_traces = [
                 t for t in group_traces if is_connected_line_trace(t)
             ]
-            # A staircase is a scatter/lines trace whose ``line.shape`` makes
-            # plotly draw risers instead of interpolating, so it has to be
-            # split out here: merged into the multi-line layer it would be
-            # announced as an interpolated line.
-            step_traces = [t for t in connected_traces if is_step_trace(t)]
-            line_traces = [t for t in connected_traces if not is_step_trace(t)]
             box_traces = [
                 t for t in group_traces if t.get("type") == "box"
             ]
 
-            # `nth-child` counts within the subplot's scatterlayer, which holds
-            # every scatter-family trace, so any scatter trace's selector index
-            # is its position there — not its position within the MAIDR layer
-            # it lands in. The two agree only while one layer owns every
-            # scatter trace on the subplot, which splitting steps out ends.
-            # Shares its membership test with `connected_traces` above. If the
-            # two ever disagree, a trace can be classified as a line or a step
-            # while being absent from `position_of`, and the lookup below dies
-            # with a KeyError instead of producing a wrong selector.
+            # `nth-child` counts within the subplot's SVG `scatterlayer`, so a
+            # scatter trace's selector index is its position *there* — not its
+            # position within the MAIDR layer it lands in. The two agree only
+            # while one layer owns every scatter trace on the subplot, which
+            # splitting steps out ends.
+            #
+            # A `scattergl` trace is painted into a shared `<canvas>` and never
+            # appears in the `scatterlayer` at all. Verified in a browser
+            # rather than assumed: with a gl trace declared before an svg one,
+            # the `scatterlayer` holds exactly one child and it is the svg
+            # trace, at `nth-child(1)`; `nth-child(2)` matches nothing.
+            # Counting gl traces here therefore pushed every svg sibling one
+            # position along, onto a selector that matched nothing — so a
+            # single gl trace silently broke its neighbours' highlighting too.
             scatter_family = [
-                t for t in group_traces if is_scatter_family_trace(t)
+                t
+                for t in group_traces
+                if is_scatter_family_trace(t) and not renders_through_webgl(t)
             ]
             position_of = {
                 id(t): index for index, t in enumerate(scatter_family)
             }
+
+            # Looked up below with `.get(..., 0)` rather than by subscript,
+            # because this map deliberately no longer covers every trace the
+            # classifiers accept: a gl trace is still a line or a step, it
+            # just has no scatterlayer position. Its layer emits no selectors
+            # at all (see `PlotlyPlot._scatter_line_selectors`), so the
+            # fallback is never rendered — it only keeps the lists aligned.
 
             merged: set[int] = set()
 
@@ -207,65 +216,97 @@ class PlotlyMaidr:
                 self._plots.append(plot)
                 merged.update(id(t) for t in bar_traces)
 
-            # Multi-line
-            if len(line_traces) > 1:
-                from maidr.plotly.multiline import PlotlyMultiLinePlot
+            # Lines and steps are grouped within one renderer, never across
+            # two. A layer's selector list is positional and all-or-nothing
+            # (see `PlotlyPlot._scatter_line_selectors`), so a layer holding
+            # both a canvas trace and an SVG one could only describe every
+            # series or none of them. Merging them meant a single `scattergl`
+            # line took the highlight away from every ordinary line beside it.
+            # Splitting first keeps each layer homogeneous: the SVG traces
+            # keep working selectors, and the WebGL ones honestly claim none.
+            svg_connected = [
+                t for t in connected_traces if not renders_through_webgl(t)
+            ]
+            gl_connected = [
+                t for t in connected_traces if renders_through_webgl(t)
+            ]
 
-                plot = PlotlyMultiLinePlot(
-                    line_traces,
-                    layout,
-                    scatter_positions=[
-                        position_of[id(t)] for t in line_traces
-                    ],
-                    **axis_kwargs,
-                )
-                plot.row_index = row
-                plot.col_index = col
-                self._plots.append(plot)
-                merged.update(id(t) for t in line_traces)
+            for renderer_traces in (svg_connected, gl_connected):
+                if not renderer_traces:
+                    continue
 
-            # A lone line is built here rather than left to the factory below,
-            # so it too gets a position-scoped selector. The factory cannot
-            # know the trace's position among its subplot's scatter traces,
-            # and its unscoped selector would also match a step trace's path.
-            elif len(line_traces) == 1:
-                from maidr.plotly.line import PlotlyLinePlot
+                # A staircase is a scatter/lines trace whose ``line.shape``
+                # makes plotly draw risers instead of interpolating, so it has
+                # to be split out here: merged into the multi-line layer it
+                # would be announced as an interpolated line.
+                step_traces = [
+                    t for t in renderer_traces if is_step_trace(t)
+                ]
+                line_traces = [
+                    t for t in renderer_traces if not is_step_trace(t)
+                ]
 
-                only_line = line_traces[0]
-                plot = PlotlyLinePlot(
-                    only_line,
-                    layout,
-                    scatter_position=position_of[id(only_line)],
-                    **axis_kwargs,
-                )
-                plot.row_index = row
-                plot.col_index = col
-                self._plots.append(plot)
-                merged.add(id(only_line))
+                # Multi-line
+                if len(line_traces) > 1:
+                    from maidr.plotly.multiline import PlotlyMultiLinePlot
 
-            # Steps, one layer per step convention. A MAIDR layer carries a
-            # single ``stepDirection`` for all of its series, so merging an
-            # ``hv`` trace with a ``vh`` one would describe one of them
-            # wrongly. Single-trace groups go through here too rather than
-            # falling to the factory below, so their selector is scoped by
-            # position among the subplot's scatter traces.
-            if step_traces:
-                from maidr.plotly.step import PlotlyStepPlot
-                from maidr.plotly.step_shape import group_by_direction
-
-                for direction_group in group_by_direction(step_traces):
-                    plot = PlotlyStepPlot(
-                        direction_group,
+                    plot = PlotlyMultiLinePlot(
+                        line_traces,
                         layout,
                         scatter_positions=[
-                            position_of[id(t)] for t in direction_group
+                            position_of.get(id(t), 0) for t in line_traces
                         ],
                         **axis_kwargs,
                     )
                     plot.row_index = row
                     plot.col_index = col
                     self._plots.append(plot)
-                merged.update(id(t) for t in step_traces)
+                    merged.update(id(t) for t in line_traces)
+
+                # A lone line is built here rather than left to the factory
+                # below, so it too gets a position-scoped selector. The factory
+                # cannot know the trace's position among its subplot's scatter
+                # traces, and its unscoped selector would also match a step
+                # trace's path.
+                elif len(line_traces) == 1:
+                    from maidr.plotly.line import PlotlyLinePlot
+
+                    only_line = line_traces[0]
+                    plot = PlotlyLinePlot(
+                        only_line,
+                        layout,
+                        scatter_position=position_of.get(id(only_line), 0),
+                        **axis_kwargs,
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                    merged.add(id(only_line))
+
+                # Steps, one layer per step convention. A MAIDR layer carries a
+                # single ``stepDirection`` for all of its series, so merging an
+                # ``hv`` trace with a ``vh`` one would describe one of them
+                # wrongly. Single-trace groups go through here too rather than
+                # falling to the factory below, so their selector is scoped by
+                # position among the subplot's scatter traces.
+                if step_traces:
+                    from maidr.plotly.step import PlotlyStepPlot
+                    from maidr.plotly.step_shape import group_by_direction
+
+                    for direction_group in group_by_direction(step_traces):
+                        plot = PlotlyStepPlot(
+                            direction_group,
+                            layout,
+                            scatter_positions=[
+                                position_of.get(id(t), 0)
+                                for t in direction_group
+                            ],
+                            **axis_kwargs,
+                        )
+                        plot.row_index = row
+                        plot.col_index = col
+                        self._plots.append(plot)
+                    merged.update(id(t) for t in step_traces)
 
             # Multi-box
             if len(box_traces) > 1:

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -117,8 +117,14 @@ class PlotlyMaidr:
 
         * Multiple bar traces with ``barmode='group'`` or ``'stack'`` are
           merged into a single :class:`PlotlyGroupedBarPlot`.
-        * Scatter/lines traces are first split into staircases and plain
-          lines by ``line.shape``: a step merged into the line layer would be
+        * Scatter/lines traces are split by *renderer* first — SVG traces
+          apart from canvas-painted ``scattergl`` ones — because a layer's
+          selector list is all-or-nothing, so a mixed layer could only claim a
+          highlight for every series or for none. The groups are built in
+          first-seen order, so the emitted layers still follow plotly's own
+          trace order.
+        * Within a renderer they are split into staircases and plain lines by
+          ``line.shape``: a step merged into the line layer would be
           announced as interpolating between samples, which is the one thing
           piecewise-constant data does not do. The plain lines then merge into
           a single :class:`PlotlyMultiLinePlot` (matching ``MultiLinePlot``),
@@ -224,17 +230,20 @@ class PlotlyMaidr:
             # line took the highlight away from every ordinary line beside it.
             # Splitting first keeps each layer homogeneous: the SVG traces
             # keep working selectors, and the WebGL ones honestly claim none.
-            svg_connected = [
-                t for t in connected_traces if not renders_through_webgl(t)
-            ]
-            gl_connected = [
-                t for t in connected_traces if renders_through_webgl(t)
-            ]
+            #
+            # Grouped in first-seen order rather than SVG-then-WebGL, so the
+            # emitted layers still follow the order plotly declared the traces
+            # in — the same property `group_by_direction` preserves. A fixed
+            # order would reorder the layers of any figure that declares a gl
+            # trace before its svg ones, pulling MAIDR's navigation order out
+            # of step with plotly's own trace and legend order.
+            renderer_groups: dict[bool, list[dict]] = {}
+            for trace in connected_traces:
+                renderer_groups.setdefault(
+                    renders_through_webgl(trace), []
+                ).append(trace)
 
-            for renderer_traces in (svg_connected, gl_connected):
-                if not renderer_traces:
-                    continue
-
+            for renderer_traces in renderer_groups.values():
                 # A staircase is a scatter/lines trace whose ``line.shape``
                 # makes plotly draw risers instead of interpolating, so it has
                 # to be split out here: merged into the multi-line layer it

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.step_shape import renders_through_webgl
 
 
 class PlotlyPlot(ABC):
@@ -115,6 +116,40 @@ class PlotlyPlot(ABC):
             f"{self._subplot_css_prefix()}.scatterlayer > "
             f".trace.scatter:nth-child({position + 1}) path.js-line"
         )
+
+    def _scatter_line_selectors(
+        self, traces: list[dict], positions: list[int]
+    ) -> list[str]:
+        """
+        Return one line selector per trace, or none when they are not SVG.
+
+        A WebGL trace has no element to address, so a selector built for it
+        would resolve to zero elements and the highlight would simply not
+        appear — with nothing in the output to say why. Emitting no selector
+        at all says the same thing honestly: this layer has no highlightable
+        geometry, while its audio, braille and text are unaffected.
+
+        The choice is all-or-nothing per layer rather than per trace, because
+        the emitted list is positional — the frontend pairs selector *i* with
+        series *i*. Dropping one entry from the middle would slide every later
+        series onto the wrong element, which is worse than no highlight.
+
+        Parameters
+        ----------
+        traces : list of dict
+            The traces this layer covers, in series order.
+        positions : list of int
+            Each trace's zero-based position among the subplot's
+            scatter-family traces, in the same order.
+
+        Returns
+        -------
+        list of str
+            One selector per series, or an empty list for a WebGL layer.
+        """
+        if any(renders_through_webgl(trace) for trace in traces):
+            return []
+        return [self._scatter_line_selector(position) for position in positions]
 
     def _get_selector(self) -> str:
         """Return a CSS selector for Plotly SVG elements."""

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -147,9 +147,15 @@ class PlotlyPlot(ABC):
         list of str
             One selector per series, or an empty list for a WebGL layer.
         """
+        # `any`, not `all`: the renderer split upstream already guarantees a
+        # homogeneous layer, so the two agree today. If that invariant ever
+        # breaks, `any` fails closed -- no highlight -- while `all` would emit
+        # a full set of selectors for a layer that is partly canvas, putting
+        # every series after the gl trace on the wrong element.
         if any(renders_through_webgl(trace) for trace in traces):
             return []
         return [self._scatter_line_selector(position) for position in positions]
+
     @staticmethod
     def _validate_scatter_positions(positions: list[int], trace_count: int) -> None:
         """

--- a/maidr/plotly/scatter.py
+++ b/maidr/plotly/scatter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.step_shape import renders_through_webgl
 
 
 class PlotlyScatterPlot(PlotlyPlot):
@@ -12,6 +13,21 @@ class PlotlyScatterPlot(PlotlyPlot):
         super().__init__(trace, layout, PlotType.SCATTER, **kwargs)
 
     def _get_selector(self) -> str:
+        """
+        Return the selector matching this trace's rendered marker elements.
+
+        A ``scattergl`` trace gets none. Its markers are painted into the
+        subplot's shared ``<canvas>``, so there is no ``.point`` element to
+        match — and a selector that resolves to nothing is a highlight that
+        silently never appears.
+
+        Returns
+        -------
+        str
+            A CSS selector, or an empty string for a WebGL trace.
+        """
+        if renders_through_webgl(self._trace):
+            return ""
         return f"{self._subplot_css_prefix()}.trace.scatter .point"
 
     def _extract_axes_data(self) -> dict:

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -70,15 +70,18 @@ class PlotlyStepPlot(PlotlyPlot):
         traces are routinely not the leading ones: an ``hv`` layer and a
         ``vh`` layer both starting from 1 would highlight the same elements.
 
+        A ``scattergl`` staircase gets none: it is painted to a canvas, so
+        there is no path to address.
+
         Returns
         -------
         list of str
-            One CSS selector per series, in trace order.
+            One CSS selector per series, in trace order; empty for a WebGL
+            layer.
         """
-        return [
-            self._scatter_line_selector(position)
-            for position in self._scatter_positions
-        ]
+        return self._scatter_line_selectors(
+            self._traces, self._scatter_positions
+        )
 
     def render(self) -> dict:
         """

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -79,9 +79,7 @@ class PlotlyStepPlot(PlotlyPlot):
             One CSS selector per series, in trace order; empty for a WebGL
             layer.
         """
-        return self._scatter_line_selectors(
-            self._traces, self._scatter_positions
-        )
+        return self._scatter_line_selectors(self._traces, self._scatter_positions)
 
     def render(self) -> dict:
         """

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -37,13 +37,47 @@ STEP_SHAPE_DIRECTION: dict[str, str] = {
 
 #: Plotly trace types that render as a connected path in the scatter layer.
 #:
-#: ``scattergl`` is included because the line classification has always
-#: included it. Note it draws through WebGL rather than SVG, so the
-#: ``path.js-line`` selectors built for these traces do not match anything in
-#: a ``scattergl`` figure — highlighting is silently inert there. That is
-#: pre-existing for lines and is not made worse by steps; it is called out
-#: here so the next reader does not have to rediscover it.
+#: ``scattergl`` is included because it is a scatter trace in every respect
+#: that matters to classification — same ``mode``, same ``line.shape``, same
+#: data. It differs only in how it is painted, which
+#: :func:`renders_through_webgl` handles separately.
 _CONNECTED_TRACE_TYPES = ("scatter", "scattergl")
+
+
+#: Plotly trace types painted onto a ``<canvas>`` through WebGL, not as SVG.
+#:
+#: These have no per-trace DOM element, so no CSS selector can address their
+#: geometry — see :func:`renders_through_webgl` for what follows from that.
+_WEBGL_TRACE_TYPES = ("scattergl",)
+
+
+def renders_through_webgl(trace: dict) -> bool:
+    """
+    Report whether a trace is painted to a canvas rather than to SVG.
+
+    A WebGL trace has no element to select: plotly draws every ``scattergl``
+    trace on the subplot into one shared ``<canvas>``, so there is no
+    ``path.js-line`` and no ``.point`` to match. Emitting the SVG selectors
+    anyway produced layers whose highlight silently resolved to zero elements
+    — correct audio, braille and text, no visible highlight, no warning.
+
+    Upstream leaves no room for a canvas selector either. ``maidr``'s
+    highlight service rejects a non-``SVGElement`` outright, and canvas-backed
+    libraries are served instead by the ``onNavigate`` callback, which
+    ``src/type/grammar.ts`` documents as "not serializable as JSON" — so it is
+    unreachable from an exported figure by construction, not merely unused.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        True when the trace renders through WebGL.
+    """
+    return trace.get("type", "scatter") in _WEBGL_TRACE_TYPES
 
 
 def is_scatter_family_trace(trace: dict) -> bool:

--- a/tests/plotly/test_plotly_scattergl.py
+++ b/tests/plotly/test_plotly_scattergl.py
@@ -213,6 +213,27 @@ class TestAGlTraceDoesNotDisplaceItsSvgNeighbours:
         assert MaidrKey.SELECTOR not in gl_layer
         assert "nth-child(1)" in svg_layer[MaidrKey.SELECTOR][0]
 
+    def test_layers_follow_the_order_the_traces_were_declared_in(self):
+        # Renderer groups are built in first-seen order, not svg-then-gl, so a
+        # figure declaring its gl trace first keeps that ordering. Grouping in
+        # a fixed order would pull MAIDR's navigation order out of step with
+        # plotly's own trace and legend order.
+        gl_first = go.Figure()
+        gl_first.add_scattergl(x=[0, 1], y=[1, 2], mode="lines", name="gl")
+        gl_first.add_scatter(x=[0, 1], y=[2, 1], mode="lines", name="svg")
+
+        svg_first = go.Figure()
+        svg_first.add_scatter(x=[0, 1], y=[2, 1], mode="lines", name="svg")
+        svg_first.add_scattergl(x=[0, 1], y=[1, 2], mode="lines", name="gl")
+
+        def names(fig):
+            return [
+                layer[MaidrKey.DATA][0][0][MaidrKey.Z] for layer in _layers(fig)
+            ]
+
+        assert names(gl_first) == ["gl", "svg"]
+        assert names(svg_first) == ["svg", "gl"]
+
     def test_gl_lines_do_not_merge_into_the_svg_multiline_layer(self):
         # Two SVG lines still merge with each other; the gl line becomes its
         # own layer rather than joining them.

--- a/tests/plotly/test_plotly_scattergl.py
+++ b/tests/plotly/test_plotly_scattergl.py
@@ -116,6 +116,38 @@ class TestAWebglLayerClaimsNoHighlight:
         assert MaidrKey.SELECTOR not in layer
 
 
+class TestTheStandaloneFallbackIsGuardedToo:
+    """
+    ``PlotlyLinePlot``'s unscoped fallback must not resurrect a selector.
+
+    That branch exists for direct construction without a position, which
+    ``PlotlyMaidr`` never takes. The WebGL guard sits ahead of *both* paths,
+    so a gl trace built that way is silent too — the one combination the
+    layer-level guard does not cover on its own.
+    """
+
+    def test_a_gl_line_built_without_a_position_still_emits_nothing(self):
+        from maidr.plotly.line import PlotlyLinePlot
+
+        plot = PlotlyLinePlot(
+            {"type": "scattergl", "mode": "lines", "x": [0, 1], "y": [1, 2]}, {}
+        )
+
+        assert plot._get_selector() == []
+        assert MaidrKey.SELECTOR not in plot.schema
+
+    def test_an_svg_line_built_without_a_position_still_gets_the_fallback(self):
+        from maidr.plotly.line import PlotlyLinePlot
+
+        plot = PlotlyLinePlot(
+            {"type": "scatter", "mode": "lines", "x": [0, 1], "y": [1, 2]}, {}
+        )
+
+        (selector,) = plot._get_selector()
+
+        assert selector.endswith(".trace.scatter path.js-line")
+
+
 class TestSvgTracesAreUnaffected:
     """The pre-existing SVG behaviour is untouched."""
 
@@ -233,6 +265,42 @@ class TestAGlTraceDoesNotDisplaceItsSvgNeighbours:
 
         assert names(gl_first) == ["gl", "svg"]
         assert names(svg_first) == ["svg", "gl"]
+
+    def test_alternating_traces_group_coarsely_and_that_is_expected(self):
+        # `svg, gl, svg` emits [svg, svg] then [gl] -- the gl trace does not
+        # keep its middle position, because both svg traces belong to one
+        # merged layer. That is inherent to merging at all, not a defect of
+        # first-seen ordering, and `group_by_direction` already behaves the
+        # same way for alternating step conventions. Pinned so the limitation
+        # is explicit rather than discovered.
+        fig = go.Figure()
+        fig.add_scatter(x=[0, 1], y=[1, 2], mode="lines", name="svg a")
+        fig.add_scattergl(x=[0, 1], y=[2, 1], mode="lines", name="gl")
+        fig.add_scatter(x=[0, 1], y=[1, 3], mode="lines", name="svg b")
+
+        layers = _layers(fig)
+        series_names = [
+            [series[0][MaidrKey.Z] for series in layer[MaidrKey.DATA]]
+            for layer in layers
+        ]
+
+        assert series_names == [["svg a", "svg b"], ["gl"]]
+        assert MaidrKey.SELECTOR in layers[0]
+        assert MaidrKey.SELECTOR not in layers[1]
+
+    def test_the_svg_pair_still_numbers_from_the_first_svg_child(self):
+        # The consequence that actually matters: the gl trace sits between
+        # them in declaration order but occupies no scatterlayer position, so
+        # the two svg lines are children 1 and 2, not 1 and 3.
+        fig = go.Figure()
+        fig.add_scatter(x=[0, 1], y=[1, 2], mode="lines", name="svg a")
+        fig.add_scattergl(x=[0, 1], y=[2, 1], mode="lines", name="gl")
+        fig.add_scatter(x=[0, 1], y=[1, 3], mode="lines", name="svg b")
+
+        svg_layer = _layers(fig)[0]
+
+        assert "nth-child(1)" in svg_layer[MaidrKey.SELECTOR][0]
+        assert "nth-child(2)" in svg_layer[MaidrKey.SELECTOR][1]
 
     def test_gl_lines_do_not_merge_into_the_svg_multiline_layer(self):
         # Two SVG lines still merge with each other; the gl line becomes its

--- a/tests/plotly/test_plotly_scattergl.py
+++ b/tests/plotly/test_plotly_scattergl.py
@@ -1,0 +1,230 @@
+"""WebGL traces have no element to highlight, and must not claim one.
+
+A ``scattergl`` trace is painted into a shared ``<canvas>`` rather than drawn
+as SVG. It was still given ``path.js-line`` / ``.point`` selectors, which
+resolved to zero elements: correct audio, braille and text, no visible
+highlight, and nothing in the output to say why.
+
+The DOM facts asserted here were confirmed by rendering plotly's own bundle in
+Chromium. With a ``scattergl`` trace declared before a ``scatter`` one, the
+subplot's ``scatterlayer`` holds exactly **one** child — the SVG trace — so
+``nth-child(1)`` matches the SVG line and ``nth-child(2)`` matches nothing.
+That is why a gl trace must not occupy a position in the index either: doing
+so pushed every SVG sibling one place along, onto a selector matching nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_maidr import PlotlyMaidr
+from maidr.plotly.step_shape import renders_through_webgl
+
+plotly = pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+
+def _layers(fig) -> list[dict]:
+    """
+    Render a figure through PlotlyMaidr and return its layer schemas.
+
+    Parameters
+    ----------
+    fig : plotly.graph_objects.Figure
+        The figure to export.
+
+    Returns
+    -------
+    list of dict
+        One schema per emitted layer, in emission order.
+    """
+    return [plot.schema for plot in PlotlyMaidr(fig)._plots]
+
+
+class TestTheWebglPredicate:
+    """Only the canvas-painted trace types report True."""
+
+    def test_scattergl_renders_through_webgl(self):
+        assert renders_through_webgl({"type": "scattergl"}) is True
+
+    @pytest.mark.parametrize("trace_type", ["scatter", "bar", "box", "heatmap"])
+    def test_svg_types_do_not(self, trace_type):
+        assert renders_through_webgl({"type": trace_type}) is False
+
+    def test_a_missing_type_reads_as_svg_scatter(self):
+        # plotly's own default for an absent type is "scatter".
+        assert renders_through_webgl({}) is False
+
+
+class TestAWebglLayerClaimsNoHighlight:
+    """The layer still carries data; it just does not promise a highlight."""
+
+    def test_a_gl_line_emits_no_selector(self):
+        fig = go.Figure()
+        fig.add_scattergl(x=[0, 1, 2], y=[1, 2, 3], mode="lines")
+
+        (layer,) = _layers(fig)
+
+        assert layer[MaidrKey.TYPE] == PlotType.LINE
+        assert MaidrKey.SELECTOR not in layer
+
+    def test_a_gl_line_still_carries_its_data(self):
+        # The point of dropping the selector is that the other three
+        # modalities keep working -- this would be a regression, not a fix,
+        # if the layer came out empty.
+        fig = go.Figure()
+        fig.add_scattergl(x=[0, 1, 2], y=[1, 2, 3], mode="lines")
+
+        (layer,) = _layers(fig)
+
+        assert len(layer[MaidrKey.DATA][0]) == 3
+
+    def test_a_gl_step_emits_no_selector_but_keeps_its_direction(self):
+        fig = go.Figure()
+        fig.add_scattergl(
+            x=[0, 1, 2], y=[1, 2, 3], mode="lines", line={"shape": "hv"}
+        )
+
+        (layer,) = _layers(fig)
+
+        assert layer[MaidrKey.TYPE] == PlotType.STEP
+        assert layer[MaidrKey.STEP_DIRECTION] == "hv"
+        assert MaidrKey.SELECTOR not in layer
+
+    def test_a_gl_scatter_emits_no_selector(self):
+        # `.point` is as unmatched as `path.js-line` -- markers are painted to
+        # the same canvas.
+        fig = go.Figure()
+        fig.add_scattergl(x=[0, 1, 2], y=[1, 2, 3], mode="markers")
+
+        (layer,) = _layers(fig)
+
+        assert layer[MaidrKey.TYPE] == PlotType.SCATTER
+        assert MaidrKey.SELECTOR not in layer
+
+    def test_a_gl_multiline_emits_no_selectors(self):
+        fig = go.Figure()
+        fig.add_scattergl(x=[0, 1], y=[1, 2], mode="lines", name="a")
+        fig.add_scattergl(x=[0, 1], y=[2, 1], mode="lines", name="b")
+
+        (layer,) = _layers(fig)
+
+        assert layer[MaidrKey.TYPE] == PlotType.LINE
+        assert len(layer[MaidrKey.DATA]) == 2
+        assert MaidrKey.SELECTOR not in layer
+
+
+class TestSvgTracesAreUnaffected:
+    """The pre-existing SVG behaviour is untouched."""
+
+    def test_an_svg_line_still_gets_its_selector(self):
+        fig = go.Figure()
+        fig.add_scatter(x=[0, 1, 2], y=[1, 2, 3], mode="lines")
+
+        (layer,) = _layers(fig)
+
+        assert "nth-child(1)" in layer[MaidrKey.SELECTOR][0]
+
+    def test_an_svg_scatter_still_gets_its_selector(self):
+        fig = go.Figure()
+        fig.add_scatter(x=[0, 1, 2], y=[1, 2, 3], mode="markers")
+
+        (layer,) = _layers(fig)
+
+        assert layer[MaidrKey.SELECTOR].endswith(".point")
+
+
+class TestAGlTraceDoesNotDisplaceItsSvgNeighbours:
+    """
+    The second half of the defect: a gl trace broke everyone else's highlight.
+
+    Because a gl trace never enters the ``scatterlayer``, counting it in the
+    position index shifted every SVG sibling one place along -- so declaring
+    one ``scattergl`` trace silently disabled highlighting for the ordinary
+    SVG traces beside it.
+    """
+
+    def test_an_svg_line_after_a_gl_line_is_still_the_first_child(self):
+        fig = go.Figure()
+        fig.add_scattergl(x=[0, 1, 2], y=[1, 2, 3], mode="lines", name="gl")
+        fig.add_scatter(x=[0, 1, 2], y=[3, 2, 1], mode="lines", name="svg")
+
+        layers = _layers(fig)
+        svg = [x for x in layers if MaidrKey.SELECTOR in x]
+
+        assert len(svg) == 1
+        assert "nth-child(1)" in svg[0][MaidrKey.SELECTOR][0]
+
+    def test_two_svg_lines_after_a_gl_line_number_from_one(self):
+        fig = go.Figure()
+        fig.add_scattergl(x=[0, 1], y=[1, 2], mode="lines", name="gl")
+        fig.add_scatter(x=[0, 1], y=[2, 1], mode="lines", name="svg a")
+        fig.add_scatter(x=[0, 1], y=[1, 3], mode="lines", name="svg b")
+
+        layers = _layers(fig)
+        multiline = next(
+            x
+            for x in layers
+            if MaidrKey.SELECTOR in x and len(x[MaidrKey.SELECTOR]) == 2
+        )
+
+        assert "nth-child(1)" in multiline[MaidrKey.SELECTOR][0]
+        assert "nth-child(2)" in multiline[MaidrKey.SELECTOR][1]
+
+    def test_steps_of_one_convention_still_split_across_renderers(self):
+        # Both steps share the `hv` convention, so grouping by convention
+        # alone would merge them -- and the merged layer, holding a gl trace,
+        # could then only claim a highlight for both or for neither. Splitting
+        # by renderer first keeps the SVG step's highlight working.
+        fig = go.Figure()
+        fig.add_scattergl(
+            x=[0, 1], y=[1, 2], mode="lines", line={"shape": "hv"}, name="gl"
+        )
+        fig.add_scatter(
+            x=[0, 1], y=[2, 1], mode="lines", line={"shape": "hv"}, name="svg"
+        )
+
+        layers = _layers(fig)
+
+        assert len(layers) == 2
+        assert [x[MaidrKey.STEP_DIRECTION] for x in layers] == ["hv", "hv"]
+
+        with_selector = [x for x in layers if MaidrKey.SELECTOR in x]
+        assert len(with_selector) == 1
+        assert "nth-child(1)" in with_selector[0][MaidrKey.SELECTOR][0]
+
+    def test_a_gl_and_an_svg_step_of_different_conventions_split_cleanly(self):
+        # Convention splitting still applies within a renderer, so this is
+        # two layers for two reasons at once.
+        fig = go.Figure()
+        fig.add_scattergl(
+            x=[0, 1], y=[1, 2], mode="lines", line={"shape": "hv"}, name="gl"
+        )
+        fig.add_scatter(
+            x=[0, 1], y=[2, 1], mode="lines", line={"shape": "vh"}, name="svg"
+        )
+
+        layers = _layers(fig)
+        gl_layer = next(x for x in layers if x[MaidrKey.STEP_DIRECTION] == "hv")
+        svg_layer = next(x for x in layers if x[MaidrKey.STEP_DIRECTION] == "vh")
+
+        assert MaidrKey.SELECTOR not in gl_layer
+        assert "nth-child(1)" in svg_layer[MaidrKey.SELECTOR][0]
+
+    def test_gl_lines_do_not_merge_into_the_svg_multiline_layer(self):
+        # Two SVG lines still merge with each other; the gl line becomes its
+        # own layer rather than joining them.
+        fig = go.Figure()
+        fig.add_scattergl(x=[0, 1], y=[1, 2], mode="lines", name="gl")
+        fig.add_scatter(x=[0, 1], y=[2, 1], mode="lines", name="svg a")
+        fig.add_scatter(x=[0, 1], y=[1, 3], mode="lines", name="svg b")
+
+        layers = _layers(fig)
+        svg_layer = next(x for x in layers if MaidrKey.SELECTOR in x)
+        gl_layer = next(x for x in layers if MaidrKey.SELECTOR not in x)
+
+        assert len(layers) == 2
+        assert len(svg_layer[MaidrKey.DATA]) == 2
+        assert len(gl_layer[MaidrKey.DATA]) == 1


### PR DESCRIPTION
## Description

A `scattergl` trace is painted into a shared `<canvas>`, not drawn as SVG — but it was still given `path.js-line` / `.point` selectors. Those resolved to **zero elements**: the layer sonified, brailled and described correctly, and the highlight simply never appeared, with nothing in the output to say why.

WebGL layers now emit **no selector at all**, which says the same thing honestly: this layer has no highlightable geometry, and the other three modalities are unaffected.

## Related Issues

Closes #309. Pre-existing behaviour, documented but not fixed by #303.

## Which option this takes, and why

#309 offered three, and asked that option 1 (find the WebGL geometry and select it) be checked against the JS side before choosing. It was, and it is closed off:

- `src/service/highlight.ts` builds a highlight by cloning the target element, and rejects a non-`SVGElement` outright — `createHighlightElement` throws `TypeError`.
- Canvas-backed libraries are served by a different mechanism entirely: the `onNavigate` callback. `src/type/grammar.ts` documents it as *"not serializable as JSON; it is only available when constructing MAIDR data programmatically"* — so it is unreachable from an exported figure **by construction**, not merely unused.

So option 1 isn't a matter of effort; a serialized schema has no way to express it. This is **option 2 — emit no selectors**.

## The second half of the defect, found in a browser

Rendering plotly's own bundle in Chromium (self-contained, `include_plotlyjs=True`) to check the DOM turned up something the issue didn't cover. **A `scattergl` trace never enters the SVG `scatterlayer` at all.** With one gl trace declared before one svg trace:

```
scatterlayer children:  ['trace scatter tracec98aaf']   <- one child, the SVG trace
path.js-line count:     1
canvas count:           3
nth-child(1) ->  M0,26.2L1064,497.8     (the svg line)
nth-child(2) ->  NO MATCH
```

`position_of` counted gl traces into the index, so that svg line was assigned position 1 → `nth-child(2)` → **matched nothing**. A single `scattergl` trace silently disabled highlighting for the ordinary SVG traces beside it. That is the same bug as the one reported, landing on the neighbours, so it is fixed here rather than filed separately.

## Changes Made

**`maidr/plotly/step_shape.py`** — `renders_through_webgl(trace)`, alongside the existing trace-type vocabulary. The `_CONNECTED_TRACE_TYPES` comment that merely *described* this problem is replaced by the predicate that handles it.

**`maidr/plotly/plotly_plot.py`** — `_scatter_line_selectors(traces, positions)`, the shared guard. All-or-nothing per layer, deliberately: the emitted list is positional — the frontend pairs selector *i* with series *i* — so dropping one entry from the middle would slide every later series onto the wrong element, which is worse than no highlight. The check is `any`, not `all`, so it fails closed if the homogeneity invariant upstream ever breaks.

**`maidr/plotly/plotly_maidr.py`** — two changes:
1. `position_of` numbers **each renderer from its own zero**. An SVG trace keeps its real `scatterlayer` index; a gl trace gets an index that is never rendered but is still well-formed. Lookups stay direct `position_of[id(t)]`, which preserves the `KeyError` guard from #303 — a trace classified as a line but missing from the index fails loudly rather than silently landing on position 0.
2. lines and steps group **within one renderer, never across two**. Since a layer's selector list is all-or-nothing, a mixed layer could only claim a highlight for every series or none — so merging a gl line with svg lines would have taken the highlight away from the svg ones. Splitting first keeps each layer homogeneous. This mirrors the existing reason steps split by convention: a layer carries one `stepDirection`, and now one renderer. Groups are built in first-seen order so the emitted layers follow plotly's own trace order.

**`maidr/plotly/{line,multiline,step,scatter}.py`** — routed through the guard. `scatter.py` is included because `.point` is as unmatched as `path.js-line`; markers go to the same canvas.

## Verification

`tests/plotly/test_plotly_scattergl.py` — 23 tests. Full suite **365 passed**. `ruff check --diff` clean under the version CI pins (0.3.4).

The end-to-end check that matters, run in Chromium against the actual emitted schema:

| | selector emitted | elements matched |
|---|---|---|
| before | `…:nth-child(2) path.js-line` | **0** |
| after | `…:nth-child(1) path.js-line` | **1** — the svg line |

One test deliberately pins that a gl line's layer still carries its full data, since dropping the selector would be a regression rather than a fix if the layer came out empty.

## Merge resolution against #312 / #313 / #315

Those three landed first. Resolving this branch against them turned up two things worth recording:

**`line.py` was a semantic conflict, not a textual one.** #315 removed the `scatter_position is None` fallback and made the parameter required; this branch added a WebGL guard ahead of both paths. Taking either side wholesale drops one of the two fixes — "theirs" resurrects a dead fallback that contradicts the required parameter, "ours" deletes the WebGL guard and re-breaks #309. The resolution keeps the guard and the required position.

**Combining the two produced a bug neither had alone.** This branch originally excluded gl traces from the index and padded them with a placeholder `0`; #315 added a uniqueness check on that same list. Two `scattergl` traces on one subplot therefore both got position `0`, and the figure raised `ValueError` instead of exporting. Fixed at the source — per-renderer numbering, described above — rather than by loosening the validator, and covered by two regression tests.

Two tests that pinned the removed fallback now construct with a position instead.

## Type of Change

- [x] Bug fix
- [x] Behaviour change — a figure mixing `scattergl` and `scatter` connected traces now emits one layer per renderer instead of one merged layer

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added appropriate unit tests.
- [ ] I have updated the documentation — no user-facing doc describes selector generation.