### PR TITLE
refactor(plotly): require a selector position instead of guessing one

### DIFF
--- a/maidr/plotly/line.py
+++ b/maidr/plotly/line.py
@@ -42,7 +42,7 @@ class PlotlyLinePlot(PlotlyPlot):
     ) -> None:
         # Routed through the list validator so the non-negative rule has
         # one home rather than a scalar copy that can drift from it.
-        self._validate_scatter_positions([scatter_position], 1)
+        PlotlyPlot._validate_scatter_positions([scatter_position], 1)
 
         super().__init__(trace, layout, PlotType.LINE, **kwargs)
         self._scatter_position = scatter_position

--- a/maidr/plotly/line.py
+++ b/maidr/plotly/line.py
@@ -15,19 +15,29 @@ class PlotlyLinePlot(PlotlyPlot):
         The scatter/lines trace dict.
     layout : dict
         The Plotly figure layout.
-    scatter_position : int, optional
+    scatter_position : int
         The trace's zero-based position among the subplot's scatter-family
-        traces. Pass this whenever the subplot holds more than this one
-        scatter trace — a step trace beside it makes that the normal case.
+        traces. Required: it is the only thing that makes this layer's
+        selector address *this* trace rather than whichever one happens to
+        sit first. See the class note below on why it has no default.
     **kwargs : str
         Axis names forwarded to the parent class.
+
+    Notes
+    -----
+    ``scatter_position`` deliberately has no default. It previously fell back
+    to an unscoped ``.trace.scatter path.js-line``, which over-matched — a
+    step trace renders as ``path.js-line`` too, so the fallback selected it
+    as well. A caller that cannot supply a real position has to say so at the
+    call site now, rather than silently getting a selector that is wrong in a
+    way nothing reports.
     """
 
     def __init__(
         self,
         trace: dict,
         layout: dict,
-        scatter_position: int | None = None,
+        scatter_position: int,
         **kwargs: str,
     ) -> None:
         super().__init__(trace, layout, PlotType.LINE, **kwargs)
@@ -37,21 +47,12 @@ class PlotlyLinePlot(PlotlyPlot):
         """
         Return the selector for this line's rendered path.
 
-        With a known position the selector is scoped to that one trace.
-        Without one it falls back to the unscoped subplot-wide form, which
-        assumes this is the only ``path.js-line`` on the subplot. That
-        assumption held while a line layer owned every scatter trace, but a
-        step trace renders as ``path.js-line`` too, so the unscoped form
-        would match both. ``PlotlyMaidr`` therefore always supplies a
-        position; the fallback is for direct/standalone construction.
-
         Returns
         -------
         list of str
-            A single CSS selector.
+            A single CSS selector, scoped to this trace's position among the
+            subplot's scatter traces.
         """
-        if self._scatter_position is None:
-            return [f"{self._subplot_css_prefix()}.trace.scatter path.js-line"]
         return [self._scatter_line_selector(self._scatter_position)]
 
     def _extract_plot_data(self) -> list[list[dict]]:

--- a/maidr/plotly/line.py
+++ b/maidr/plotly/line.py
@@ -40,6 +40,10 @@ class PlotlyLinePlot(PlotlyPlot):
         scatter_position: int,
         **kwargs: str,
     ) -> None:
+        # Routed through the list validator so the non-negative rule has
+        # one home rather than a scalar copy that can drift from it.
+        self._validate_scatter_positions([scatter_position], 1)
+
         super().__init__(trace, layout, PlotType.LINE, **kwargs)
         self._scatter_position = scatter_position
 

--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -21,6 +21,8 @@ class PlotlyMultiLinePlot(PlotlyPlot):
     scatter_positions : list of int
         Each trace's zero-based position among the subplot's scatter-family
         traces, in trace order. Required: see the note below.
+    **kwargs : str
+        Axis names forwarded to the parent class.
 
     Notes
     -----
@@ -41,6 +43,10 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         scatter_positions: list[int],
         **kwargs: str,
     ) -> None:
+        if not traces:
+            raise ValueError("a multi-line layer needs at least one trace")
+        self._validate_scatter_positions(scatter_positions, len(traces))
+
         super().__init__(traces[0], layout, PlotType.LINE, **kwargs)
         self._traces = traces
         self._scatter_positions = scatter_positions

--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -45,7 +45,7 @@ class PlotlyMultiLinePlot(PlotlyPlot):
     ) -> None:
         if not traces:
             raise ValueError("a multi-line layer needs at least one trace")
-        self._validate_scatter_positions(scatter_positions, len(traces))
+        PlotlyPlot._validate_scatter_positions(scatter_positions, len(traces))
 
         super().__init__(traces[0], layout, PlotType.LINE, **kwargs)
         # Copied, not aliased: a caller mutating its list afterwards would

--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -18,28 +18,32 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         All scatter/lines trace dicts belonging to the multi-line plot.
     layout : dict
         The Plotly figure layout.
-    scatter_positions : list of int, optional
+    scatter_positions : list of int
         Each trace's zero-based position among the subplot's scatter-family
-        traces. Required whenever these are not the leading scatter traces of
-        the subplot — which a step trace declared alongside them makes the
-        normal case. Defaults to the traces' own order, correct only for a
-        layer that owns every scatter trace on its subplot.
+        traces, in trace order. Required: see the note below.
+
+    Notes
+    -----
+    ``scatter_positions`` deliberately has no default. It previously fell back
+    to the traces' own order, ``list(range(len(traces)))``, which is right
+    only for a layer that owns every scatter trace on its subplot — an
+    invariant that ended when steps were split into their own layers. For any
+    other layer that default emitted ``nth-child(1), nth-child(2), …``
+    pointing at whichever elements happened to occupy those positions: no
+    error, nothing visibly wrong in the output, and the wrong element
+    highlighted. A missing position is now a ``TypeError`` at the call site.
     """
 
     def __init__(
         self,
         traces: list[dict],
         layout: dict,
-        scatter_positions: list[int] | None = None,
+        scatter_positions: list[int],
         **kwargs: str,
     ) -> None:
         super().__init__(traces[0], layout, PlotType.LINE, **kwargs)
         self._traces = traces
-        self._scatter_positions = (
-            list(range(len(traces)))
-            if scatter_positions is None
-            else scatter_positions
-        )
+        self._scatter_positions = scatter_positions
 
     def _get_selector(self) -> list[str]:
         """

--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -48,8 +48,11 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         self._validate_scatter_positions(scatter_positions, len(traces))
 
         super().__init__(traces[0], layout, PlotType.LINE, **kwargs)
-        self._traces = traces
-        self._scatter_positions = scatter_positions
+        # Copied, not aliased: a caller mutating its list afterwards would
+        # silently change this layer's selectors on the next render -- the
+        # same wrong-element failure the required parameter exists to end.
+        self._traces = list(traces)
+        self._scatter_positions = list(scatter_positions)
 
     def _get_selector(self) -> list[str]:
         """

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -130,6 +130,13 @@ class PlotlyPlot(ABC):
         element. None of those raise on their own; they highlight the wrong
         geometry, which is the outcome this whole parameter exists to prevent.
 
+        The guard is not exhaustive, and cannot be: a position beyond the
+        subplot's actual scatter-trace count is well-formed by every rule
+        here, so ``scatter_position=99`` on a two-trace subplot constructs
+        happily and simply matches nothing at render time. Only
+        ``PlotlyMaidr._extract_plots`` knows that total, so an upper bound
+        would have to live there rather than in this class.
+
         Parameters
         ----------
         positions : list of int

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -117,9 +117,7 @@ class PlotlyPlot(ABC):
         )
 
     @staticmethod
-    def _validate_scatter_positions(
-        positions: list[int], trace_count: int
-    ) -> None:
+    def _validate_scatter_positions(positions: list[int], trace_count: int) -> None:
         """
         Reject a position list that cannot describe these traces.
 
@@ -151,13 +149,9 @@ class PlotlyPlot(ABC):
                 f"{trace_count} trace(s), got {len(positions)}: {positions}"
             )
         if any(position < 0 for position in positions):
-            raise ValueError(
-                f"scatter positions must be >= 0, got {positions}"
-            )
+            raise ValueError(f"scatter positions must be >= 0, got {positions}")
         if len(set(positions)) != len(positions):
-            raise ValueError(
-                f"scatter positions must be unique, got {positions}"
-            )
+            raise ValueError(f"scatter positions must be unique, got {positions}")
 
     def _get_selector(self) -> str:
         """Return a CSS selector for Plotly SVG elements."""

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -116,6 +116,49 @@ class PlotlyPlot(ABC):
             f".trace.scatter:nth-child({position + 1}) path.js-line"
         )
 
+    @staticmethod
+    def _validate_scatter_positions(
+        positions: list[int], trace_count: int
+    ) -> None:
+        """
+        Reject a position list that cannot describe these traces.
+
+        Requiring positions closes the hole where a caller supplied none. It
+        leaves a second one with the same failure mode: a list that is simply
+        wrong. The emitted selector list is positional — the frontend pairs
+        selector *i* with series *i* — so a length mismatch slides every later
+        series onto another element, a negative index builds ``nth-child(0)``
+        or lower and matches nothing, and a repeat points two series at one
+        element. None of those raise on their own; they highlight the wrong
+        geometry, which is the outcome this whole parameter exists to prevent.
+
+        Parameters
+        ----------
+        positions : list of int
+            Zero-based positions among the subplot's scatter-family traces.
+        trace_count : int
+            How many traces this layer covers.
+
+        Raises
+        ------
+        ValueError
+            If the length disagrees with ``trace_count``, or any position is
+            negative or repeated.
+        """
+        if len(positions) != trace_count:
+            raise ValueError(
+                f"expected {trace_count} scatter position(s) to match "
+                f"{trace_count} trace(s), got {len(positions)}: {positions}"
+            )
+        if any(position < 0 for position in positions):
+            raise ValueError(
+                f"scatter positions must be >= 0, got {positions}"
+            )
+        if len(set(positions)) != len(positions):
+            raise ValueError(
+                f"scatter positions must be unique, got {positions}"
+            )
+
     def _get_selector(self) -> str:
         """Return a CSS selector for Plotly SVG elements."""
         return ""

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -144,9 +144,10 @@ class PlotlyPlot(ABC):
             negative or repeated.
         """
         if len(positions) != trace_count:
+            plural = "" if trace_count == 1 else "s"
             raise ValueError(
-                f"expected {trace_count} scatter position(s) to match "
-                f"{trace_count} trace(s), got {len(positions)}: {positions}"
+                f"expected {trace_count} scatter position{plural} to match "
+                f"{trace_count} trace{plural}, got {len(positions)}: {positions}"
             )
         if any(position < 0 for position in positions):
             raise ValueError(f"scatter positions must be >= 0, got {positions}")

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -146,16 +146,35 @@ class PlotlyPlot(ABC):
 
         Raises
         ------
+        TypeError
+            If ``positions`` is not a list/tuple, or any entry is not an int.
         ValueError
             If the length disagrees with ``trace_count``, or any position is
             negative or repeated.
         """
+        # Type-checked before anything else, because the value most likely to
+        # arrive here wrongly is ``None`` -- it was this parameter's default
+        # until it became required, so a caller migrating off that default is
+        # exactly who passes it explicitly. Left unchecked it surfaced as
+        # "object of type 'NoneType' has no len()" or "'<' not supported
+        # between instances of 'NoneType' and 'int'", neither of which names
+        # the argument at fault.
+        if not isinstance(positions, (list, tuple)):
+            raise TypeError(
+                f"scatter positions must be a list of int, got {positions!r}"
+            )
+
         if len(positions) != trace_count:
             plural = "" if trace_count == 1 else "s"
             raise ValueError(
                 f"expected {trace_count} scatter position{plural} to match "
                 f"{trace_count} trace{plural}, got {len(positions)}: {positions}"
             )
+        if any(not isinstance(position, int) for position in positions):
+            raise TypeError(
+                f"scatter positions must all be int, got {positions!r}"
+            )
+
         if any(position < 0 for position in positions):
             raise ValueError(f"scatter positions must be >= 0, got {positions}")
         if len(set(positions)) != len(positions):

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -73,6 +73,15 @@ class PlotlyPlotFactory:
                 # trace" — is the only assumption available, and it belongs
                 # here, visible, rather than hidden inside the three classes
                 # where every other caller would inherit it silently.
+                #
+                # What it costs when the assumption is wrong: a direct caller
+                # handing this factory one trace out of a multi-trace figure
+                # used to get an unscoped selector that over-matched — wrong,
+                # but visibly so. It now gets a confidently wrong one bound to
+                # position 0. That is the failure mode this parameter exists
+                # to remove, surviving in the single place that cannot know
+                # better; `PlotlyMaidr` never reaches here precisely because
+                # it does know, and passes real positions.
                 if is_step_trace(trace):
                     from maidr.plotly.step import PlotlyStepPlot
 

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -56,9 +56,7 @@ class PlotlyPlotFactory:
                 # lone line alike — because only it knows each trace's
                 # position among its subplot's scatter traces, which the
                 # selector needs. The branch is kept for direct/standalone
-                # construction (and is exercised that way by the tests), the
-                # same role the unscoped fallback plays in
-                # ``PlotlyLinePlot._get_selector``.
+                # construction, and is exercised that way by the tests.
                 #
                 # The "is this a connected line" test is shared with
                 # ``_extract_plots`` through ``is_connected_line_trace`` rather
@@ -68,14 +66,25 @@ class PlotlyPlotFactory:
                 # ``line.shape``, not the trace type — so the shape is the only
                 # thing separating piecewise-constant data from an
                 # interpolated line.
+                #
+                # Position 0 is passed explicitly rather than left to a
+                # default. This factory sees one trace with no idea what else
+                # is on its subplot, so 0 — "assume it is the only scatter
+                # trace" — is the only assumption available, and it belongs
+                # here, visible, rather than hidden inside the three classes
+                # where every other caller would inherit it silently.
                 if is_step_trace(trace):
                     from maidr.plotly.step import PlotlyStepPlot
 
-                    return PlotlyStepPlot([trace], layout, **axis_kwargs)
+                    return PlotlyStepPlot(
+                        [trace], layout, scatter_positions=[0], **axis_kwargs
+                    )
 
                 from maidr.plotly.line import PlotlyLinePlot
 
-                return PlotlyLinePlot(trace, layout, **axis_kwargs)
+                return PlotlyLinePlot(
+                    trace, layout, scatter_position=0, **axis_kwargs
+                )
 
             from maidr.plotly.scatter import PlotlyScatterPlot
 

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -91,9 +91,7 @@ class PlotlyPlotFactory:
 
                 from maidr.plotly.line import PlotlyLinePlot
 
-                return PlotlyLinePlot(
-                    trace, layout, scatter_position=0, **axis_kwargs
-                )
+                return PlotlyLinePlot(trace, layout, scatter_position=0, **axis_kwargs)
 
             from maidr.plotly.scatter import PlotlyScatterPlot
 

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -56,8 +56,11 @@ class PlotlyStepPlot(PlotlyPlot):
         self._validate_scatter_positions(scatter_positions, len(traces))
 
         super().__init__(traces[0], layout, PlotType.STEP, **kwargs)
-        self._traces = traces
-        self._scatter_positions = scatter_positions
+        # Copied, not aliased: a caller mutating its list afterwards would
+        # silently change this layer's selectors on the next render -- the
+        # same wrong-element failure the required parameter exists to end.
+        self._traces = list(traces)
+        self._scatter_positions = list(scatter_positions)
 
     def _get_selector(self) -> list[str]:
         """

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -51,6 +51,10 @@ class PlotlyStepPlot(PlotlyPlot):
         scatter_positions: list[int],
         **kwargs: str,
     ) -> None:
+        if not traces:
+            raise ValueError("a step layer needs at least one trace")
+        self._validate_scatter_positions(scatter_positions, len(traces))
+
         super().__init__(traces[0], layout, PlotType.STEP, **kwargs)
         self._traces = traces
         self._scatter_positions = scatter_positions

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -53,7 +53,7 @@ class PlotlyStepPlot(PlotlyPlot):
     ) -> None:
         if not traces:
             raise ValueError("a step layer needs at least one trace")
-        self._validate_scatter_positions(scatter_positions, len(traces))
+        PlotlyPlot._validate_scatter_positions(scatter_positions, len(traces))
 
         super().__init__(traces[0], layout, PlotType.STEP, **kwargs)
         # Copied, not aliased: a caller mutating its list afterwards would

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -28,31 +28,32 @@ class PlotlyStepPlot(PlotlyPlot):
         The staircase traces forming this layer, all of one convention.
     layout : dict
         The Plotly figure layout.
-    scatter_positions : list of int, optional
+    scatter_positions : list of int
         Each trace's zero-based position among the subplot's scatter-family
-        traces. Required whenever this layer's traces are not the leading
-        scatter traces of the subplot — which is the normal case once steps
-        are split out by convention, or drawn alongside plain lines. Defaults
-        to the traces' own order, which is only correct for a layer that owns
-        every scatter trace on its subplot.
+        traces, in trace order. Required: see the note below.
     **kwargs : str
         Axis names forwarded to the parent class.
+
+    Notes
+    -----
+    ``scatter_positions`` deliberately has no default. It previously fell back
+    to the traces' own order, which is right only for a layer that owns every
+    scatter trace on its subplot — and splitting steps by convention makes a
+    step layer routinely *not* the leading one. An ``hv`` layer and a ``vh``
+    layer both numbering from 1 would highlight the same elements, silently.
+    A missing position is now a ``TypeError`` at the call site.
     """
 
     def __init__(
         self,
         traces: list[dict],
         layout: dict,
-        scatter_positions: list[int] | None = None,
+        scatter_positions: list[int],
         **kwargs: str,
     ) -> None:
         super().__init__(traces[0], layout, PlotType.STEP, **kwargs)
         self._traces = traces
-        self._scatter_positions = (
-            list(range(len(traces)))
-            if scatter_positions is None
-            else scatter_positions
-        )
+        self._scatter_positions = scatter_positions
 
     def _get_selector(self) -> list[str]:
         """

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -134,7 +134,7 @@ class TestPlotlyLinePlot:
             "y": [10, 20, 15],
             "name": "Series A",
         }
-        plot = PlotlyLinePlot(trace, {})
+        plot = PlotlyLinePlot(trace, {}, scatter_position=0)
         data = plot._extract_plot_data()
 
         # Line data is wrapped in an outer list
@@ -146,7 +146,7 @@ class TestPlotlyLinePlot:
 
     def test_no_name_omits_z(self):
         trace = {"type": "scatter", "mode": "lines", "x": [1], "y": [2]}
-        plot = PlotlyLinePlot(trace, {})
+        plot = PlotlyLinePlot(trace, {}, scatter_position=0)
         data = plot._extract_plot_data()
 
         assert MaidrKey.Z not in data[0][0]
@@ -324,7 +324,7 @@ class TestPlotlyMultiLinePlot:
             {"type": "scatter", "mode": "lines", "x": [1, 2], "y": [10, 20], "name": "A"},
             {"type": "scatter", "mode": "lines", "x": [1, 2], "y": [5, 15], "name": "B"},
         ]
-        plot = PlotlyMultiLinePlot(traces, {})
+        plot = PlotlyMultiLinePlot(traces, {}, scatter_positions=[0, 1])
         data = plot._extract_plot_data()
 
         assert len(data) == 2
@@ -338,7 +338,7 @@ class TestPlotlyMultiLinePlot:
             {"type": "scatter", "mode": "lines", "x": [1], "y": [2], "name": "L1"},
             {"type": "scatter", "mode": "lines", "x": [1], "y": [3], "name": "L2"},
         ]
-        plot = PlotlyMultiLinePlot(traces, {})
+        plot = PlotlyMultiLinePlot(traces, {}, scatter_positions=[0, 1])
         schema = plot.schema
 
         assert schema[MaidrKey.TYPE] == PlotType.LINE

--- a/tests/plotly/test_plotly_selector_positions.py
+++ b/tests/plotly/test_plotly_selector_positions.py
@@ -1,0 +1,171 @@
+"""The three line-family classes require a selector position.
+
+They previously disagreed about what to do when nobody supplied one, and the
+two fallbacks failed in different ways. ``PlotlyLinePlot`` fell back to an
+unscoped ``.trace.scatter path.js-line``, which over-matched — a step trace
+renders as ``path.js-line`` too. ``PlotlyStepPlot`` and
+``PlotlyMultiLinePlot`` fell back to leading order, which is *silently* wrong:
+constructed for traces that are not the subplot's first scatter children, it
+emitted ``nth-child(1), nth-child(2), …`` pointing at whichever elements
+happened to sit there, with no error and nothing visibly amiss.
+
+Both fallbacks are gone. A caller that cannot supply a real position now has
+to say so at the call site.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.plotly.line import PlotlyLinePlot
+from maidr.plotly.multiline import PlotlyMultiLinePlot
+from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
+from maidr.plotly.step import PlotlyStepPlot
+
+plotly = pytest.importorskip("plotly")
+
+
+def _line(name: str = "") -> dict:
+    """
+    Build a minimal plotly line trace dict.
+
+    Parameters
+    ----------
+    name : str, optional
+        Trace name.
+
+    Returns
+    -------
+    dict
+        A scatter/lines trace dict.
+    """
+    return {
+        "type": "scatter",
+        "mode": "lines",
+        "x": [0, 1, 2],
+        "y": [1, 2, 3],
+        **({"name": name} if name else {}),
+    }
+
+
+def _step(shape: str = "hv") -> dict:
+    """
+    Build a minimal plotly staircase trace dict.
+
+    Parameters
+    ----------
+    shape : str, optional
+        The ``line.shape`` to author.
+
+    Returns
+    -------
+    dict
+        A scatter/lines trace dict carrying a stepping shape.
+    """
+    return dict(_line(), line={"shape": shape})
+
+
+class TestAPositionIsRequired:
+    """Omitting one is a TypeError, not a silently wrong default."""
+
+    def test_line_requires_a_position(self):
+        with pytest.raises(TypeError):
+            PlotlyLinePlot(_line(), {})
+
+    def test_multiline_requires_positions(self):
+        with pytest.raises(TypeError):
+            PlotlyMultiLinePlot([_line("a"), _line("b")], {})
+
+    def test_step_requires_positions(self):
+        with pytest.raises(TypeError):
+            PlotlyStepPlot([_step()], {})
+
+
+class TestTheFallbacksAreGone:
+    """Neither old default can be reached any more."""
+
+    def test_a_line_never_emits_the_unscoped_selector(self):
+        # The old fallback. It matched every `path.js-line` on the subplot,
+        # including any step trace's.
+        plot = PlotlyLinePlot(_line(), {}, scatter_position=3)
+        (selector,) = plot.schema[MaidrKey.SELECTOR]
+
+        assert "nth-child(4)" in selector
+        assert selector != ".subplot.xy .trace.scatter path.js-line"
+
+    def test_a_step_layer_honours_positions_past_the_leading_ones(self):
+        # Under the old leading-order default this emitted nth-child(1) and
+        # (2) regardless -- the silent failure the issue describes.
+        plot = PlotlyStepPlot(
+            [_step(), _step()], {}, scatter_positions=[2, 4]
+        )
+        first, second = plot.schema[MaidrKey.SELECTOR]
+
+        assert "nth-child(3)" in first
+        assert "nth-child(5)" in second
+
+    def test_a_multiline_layer_honours_positions_past_the_leading_ones(self):
+        plot = PlotlyMultiLinePlot(
+            [_line("a"), _line("b")], {}, scatter_positions=[1, 3]
+        )
+        first, second = plot.schema[MaidrKey.SELECTOR]
+
+        assert "nth-child(2)" in first
+        assert "nth-child(4)" in second
+
+
+class TestTheFactoryStatesItsAssumption:
+    """
+    The one caller that cannot know a position now says so out loud.
+
+    ``PlotlyPlotFactory`` sees a single trace with no idea what else is on its
+    subplot, so position 0 is the only assumption available. Passing it
+    explicitly keeps that assumption at the one call site that has to make it,
+    instead of in a default every other caller would inherit silently.
+    """
+
+    def test_a_factory_built_line_is_scoped_to_the_first_child(self):
+        plot = PlotlyPlotFactory.create(_line(), {})
+        (selector,) = plot.schema[MaidrKey.SELECTOR]
+
+        assert "nth-child(1)" in selector
+        assert ".scatterlayer" in selector
+
+    def test_a_factory_built_step_is_scoped_to_the_first_child(self):
+        plot = PlotlyPlotFactory.create(_step(), {})
+        (selector,) = plot.schema[MaidrKey.SELECTOR]
+
+        assert "nth-child(1)" in selector
+
+    def test_a_factory_built_line_still_carries_its_data(self):
+        # The constructor signature changed; the layer must not have.
+        plot = PlotlyPlotFactory.create(_line("Series A"), {})
+        data = plot.schema[MaidrKey.DATA]
+
+        assert len(data) == 1
+        assert len(data[0]) == 3
+        assert data[0][0][MaidrKey.Z] == "Series A"
+
+
+class TestPlotlyMaidrStillSuppliesRealPositions:
+    """The production path was already correct and must stay that way."""
+
+    def test_a_step_and_two_lines_each_get_their_own_index(self):
+        import plotly.graph_objects as go
+
+        from maidr.core.enum.plot_type import PlotType
+        from maidr.plotly.plotly_maidr import PlotlyMaidr
+
+        fig = go.Figure()
+        fig.add_scatter(**_step(), name="step")
+        fig.add_scatter(**_line("line 1"))
+        fig.add_scatter(**_line("line 2"))
+
+        layers = [plot.schema for plot in PlotlyMaidr(fig)._plots]
+        lines = next(x for x in layers if x[MaidrKey.TYPE] == PlotType.LINE)
+        step = next(x for x in layers if x[MaidrKey.TYPE] == PlotType.STEP)
+
+        assert "nth-child(1)" in step[MaidrKey.SELECTOR][0]
+        assert "nth-child(2)" in lines[MaidrKey.SELECTOR][0]
+        assert "nth-child(3)" in lines[MaidrKey.SELECTOR][1]

--- a/tests/plotly/test_plotly_selector_positions.py
+++ b/tests/plotly/test_plotly_selector_positions.py
@@ -123,6 +123,33 @@ class TestAPositionListMustDescribeItsTraces:
         with pytest.raises(ValueError, match="at least one trace"):
             cls([], {}, scatter_positions=[])
 
+    @pytest.mark.parametrize(
+        "cls", [PlotlyStepPlot, PlotlyMultiLinePlot], ids=["step", "multiline"]
+    )
+    def test_mutating_the_caller_s_list_afterwards_changes_nothing(self, cls):
+        # Stored by value, not aliased. A validated list that the caller then
+        # mutates would otherwise slip past validation and reach render() --
+        # the wrong-element failure, arrived at after the guard rather than
+        # around it.
+        positions = [2, 4]
+        plot = cls([_step(), _step()], {}, scatter_positions=positions)
+
+        positions[0] = 99
+        positions.append(7)
+
+        first, second = plot.schema[MaidrKey.SELECTOR]
+
+        assert "nth-child(3)" in first
+        assert "nth-child(5)" in second
+
+    def test_mutating_the_caller_s_trace_list_afterwards_changes_nothing(self):
+        traces = [_step(), _step()]
+        plot = PlotlyStepPlot(traces, {}, scatter_positions=[0, 1])
+
+        traces.append(_step())
+
+        assert len(plot.schema[MaidrKey.DATA]) == 2
+
     def test_a_valid_out_of_order_list_is_accepted(self):
         # Positions need not be sorted or contiguous -- only well-formed.
         plot = PlotlyStepPlot([_step(), _step()], {}, scatter_positions=[5, 1])

--- a/tests/plotly/test_plotly_selector_positions.py
+++ b/tests/plotly/test_plotly_selector_positions.py
@@ -150,6 +150,26 @@ class TestAPositionListMustDescribeItsTraces:
 
         assert len(plot.schema[MaidrKey.DATA]) == 2
 
+    def test_an_explicit_none_names_the_argument_at_fault(self):
+        # `None` was this parameter's default until it became required, so a
+        # caller migrating off that default is exactly who passes it
+        # explicitly -- and used to get "object of type 'NoneType' has no
+        # len()", which names nothing.
+        with pytest.raises(TypeError, match="must be a list of int"):
+            PlotlyStepPlot([_step()], {}, scatter_positions=None)
+
+    def test_an_explicit_none_position_on_a_lone_line_does_too(self):
+        # Reached the `< 0` comparison and raised "'<' not supported between
+        # instances of 'NoneType' and 'int'".
+        with pytest.raises(TypeError, match="must all be int"):
+            PlotlyLinePlot(_line(), {}, scatter_position=None)
+
+    def test_a_non_int_entry_is_rejected(self):
+        with pytest.raises(TypeError, match="must all be int"):
+            PlotlyMultiLinePlot(
+                [_line("a"), _line("b")], {}, scatter_positions=[0, "1"]
+            )
+
     def test_a_valid_out_of_order_list_is_accepted(self):
         # Positions need not be sorted or contiguous -- only well-formed.
         plot = PlotlyStepPlot([_step(), _step()], {}, scatter_positions=[5, 1])

--- a/tests/plotly/test_plotly_selector_positions.py
+++ b/tests/plotly/test_plotly_selector_positions.py
@@ -82,6 +82,56 @@ class TestAPositionIsRequired:
             PlotlyStepPlot([_step()], {})
 
 
+class TestAPositionListMustDescribeItsTraces:
+    """
+    Requiring positions closes one hole; a wrong list is the other.
+
+    The emitted selector list is positional, so a length mismatch slides every
+    later series onto another element, a negative index builds
+    ``nth-child(0)`` and matches nothing, and a repeat points two series at
+    one element. None of those raise on their own — they highlight the wrong
+    geometry, which is exactly what requiring positions was meant to end.
+    """
+
+    def test_too_few_positions_is_rejected(self):
+        with pytest.raises(ValueError, match="expected 2 scatter position"):
+            PlotlyStepPlot([_step(), _step()], {}, scatter_positions=[0])
+
+    def test_too_many_positions_is_rejected(self):
+        with pytest.raises(ValueError, match="expected 1 scatter position"):
+            PlotlyMultiLinePlot([_line("a")], {}, scatter_positions=[0, 1])
+
+    def test_a_negative_position_is_rejected(self):
+        with pytest.raises(ValueError, match="must be >= 0"):
+            PlotlyStepPlot([_step()], {}, scatter_positions=[-1])
+
+    def test_a_negative_position_is_rejected_for_a_lone_line(self):
+        with pytest.raises(ValueError, match="must be >= 0"):
+            PlotlyLinePlot(_line(), {}, scatter_position=-1)
+
+    def test_duplicate_positions_are_rejected(self):
+        with pytest.raises(ValueError, match="must be unique"):
+            PlotlyMultiLinePlot(
+                [_line("a"), _line("b")], {}, scatter_positions=[2, 2]
+            )
+
+    @pytest.mark.parametrize(
+        "cls", [PlotlyStepPlot, PlotlyMultiLinePlot], ids=["step", "multiline"]
+    )
+    def test_an_empty_trace_list_is_rejected(self, cls):
+        # Would otherwise die on `traces[0]` inside the parent constructor.
+        with pytest.raises(ValueError, match="at least one trace"):
+            cls([], {}, scatter_positions=[])
+
+    def test_a_valid_out_of_order_list_is_accepted(self):
+        # Positions need not be sorted or contiguous -- only well-formed.
+        plot = PlotlyStepPlot([_step(), _step()], {}, scatter_positions=[5, 1])
+        first, second = plot.schema[MaidrKey.SELECTOR]
+
+        assert "nth-child(6)" in first
+        assert "nth-child(2)" in second
+
+
 class TestTheFallbacksAreGone:
     """Neither old default can be reached any more."""
 
@@ -97,9 +147,7 @@ class TestTheFallbacksAreGone:
     def test_a_step_layer_honours_positions_past_the_leading_ones(self):
         # Under the old leading-order default this emitted nth-child(1) and
         # (2) regardless -- the silent failure the issue describes.
-        plot = PlotlyStepPlot(
-            [_step(), _step()], {}, scatter_positions=[2, 4]
-        )
+        plot = PlotlyStepPlot([_step(), _step()], {}, scatter_positions=[2, 4])
         first, second = plot.schema[MaidrKey.SELECTOR]
 
         assert "nth-child(3)" in first

--- a/tests/plotly/test_plotly_step.py
+++ b/tests/plotly/test_plotly_step.py
@@ -119,7 +119,9 @@ class TestStepDirection:
     def test_direction_is_withheld_when_traces_disagree(self):
         # Guards a caller that skipped group_by_direction: better to say
         # nothing than to describe one of the series wrongly.
-        plot = PlotlyStepPlot([_step_trace("hv"), _step_trace("vh")], {})
+        plot = PlotlyStepPlot(
+            [_step_trace("hv"), _step_trace("vh")], {}, scatter_positions=[0, 1]
+        )
 
         assert MaidrKey.STEP_DIRECTION not in plot.schema
 


### PR DESCRIPTION
## Description

The three Plotly line-family classes disagreed about what to do when nobody told them where their traces sit in the subplot, and the two fallbacks failed in different ways.

`PlotlyLinePlot` fell back to an **unscoped** selector:

```python
if self._scatter_position is None:
    return [f"{self._subplot_css_prefix()}.trace.scatter path.js-line"]
```

That over-matches — a step trace renders as `path.js-line` too, so the fallback selected it as well. At least over-matching is visible.

`PlotlyStepPlot` and `PlotlyMultiLinePlot` fell back to **leading order**:

```python
self._scatter_positions = (
    list(range(len(traces))) if scatter_positions is None else scatter_positions
)
```

That one is silent. Constructed for traces that are not the subplot's first scatter children, it emits `nth-child(1), nth-child(2), …` pointing at whichever elements happen to occupy those positions — no error, nothing visibly wrong in the output, and the wrong element highlighted.

## Related Issues

Closes #311. Follow-up to #303. Surfaced #316 (see below).

## Changes Made

Both fallbacks are removed; `scatter_position` / `scatter_positions` are now **required**. A missing position is a `TypeError` at the call site instead of a wrong element at runtime — the right trade for something whose failure mode is "highlights someone else's geometry".

Each class carries a `Notes` section recording *which* wrong default it used to have — these differ per class (unscoped for `PlotlyLinePlot`, leading-order for the other two), so the reasoning survives the diff rather than only living here.

**`PlotlyPlotFactory` is the one caller that genuinely cannot know a position.** It sees a single trace with no idea what else is on its subplot, so `0` is the only assumption available, and it now passes that explicitly rather than inheriting a hidden default. The comment there also records what the assumption costs when wrong — see "Residual risk" below.

**Validation** (`PlotlyPlot._validate_scatter_positions`), added during review: requiring a position closes the hole where a caller supplies *none*, but leaves the one where a caller supplies a **wrong** list, which fails identically silently. The validator checks, in order: container type → length → entry type → non-negativity → uniqueness. `TypeError` for shape problems, `ValueError` for content. Its docstring also states what it *cannot* check (see below).

**Lists are stored by value**, not aliased — a caller mutating its list after construction would otherwise silently change the layer's selectors on the next `render()`: validated input slipping past the guard by being edited after it ran.

## Verification

New `tests/plotly/test_plotly_selector_positions.py` — **22 test functions, 24 collected items**. Full suite **273 → 297 passed**. `ruff check --diff` clean under the version CI pins (0.3.4).

Covers: omission raises `TypeError` on all three classes; malformed lists (wrong length, negative, duplicate, empty, non-int, explicit `None`) raise with a message naming the argument; neither old fallback is reachable (a line built at position 3 emits `nth-child(4)` and is explicitly *not* the old unscoped string; a step layer given `[2, 4]` emits `nth-child(3)`/`(5)` where leading order would have emitted `(1)`/`(2)`); mutating the caller's list after construction changes nothing; the factory's stated position-0 assumption; and the production path still assigns a step and two lines `nth-child(1)`, `(2)`, `(3)`.

The copy and `None` tests were both checked against the un-fixed code and fail there, so they pin the behaviour rather than merely exercising it.

**`PlotlyMaidr._extract_plots` already supplied positions unconditionally**, so no production path changes behaviour — confirmed by the existing 273 tests passing unmodified except at the five direct-construction sites #311 predicted (`test_plotly_plots.py` ×4, `test_plotly_step.py` ×1).

## What this does *not* guard, deliberately

- **No upper bound.** A position beyond the subplot's actual scatter-trace count is well-formed by every rule here, so `scatter_position=99` on a two-trace subplot constructs happily and matches nothing at render. Only `_extract_plots` knows that total, so an upper bound would have to live there. Stated in the validator's docstring so the guard isn't read as exhaustive.
- **No cross-layer duplicate detection.** Two independently-constructed layers can still claim the same position. That needs a shared registry, which is a lot of machinery for a hazard the production path already precludes by centralising assignment.
- **Residual risk in the factory.** A direct caller handing it one trace out of a multi-trace figure used to get an unscoped selector that over-matched — wrong, but visibly. It now gets a confidently wrong one bound to position 0. That is the failure mode this parameter removes elsewhere, surviving in the single place that cannot know better. Documented at the call site.
- **The scalar error message stays list-shaped.** `PlotlyLinePlot(scatter_position=-1)` reports `got [-1]`. Threading a noun through the validator to fix the wording would put back the second code path that routing the scalar case through the list validator exists to avoid, and drift between two copies of the rule is a worse problem than an awkward message on an internal API.

## Type of Change

- [x] Refactor — no behaviour change on any path reachable from `PlotlyMaidr`
- [x] Breaking change for direct construction of `PlotlyLinePlot` / `PlotlyStepPlot` / `PlotlyMultiLinePlot`

On that second box: these are internal classes under `maidr/plotly/`, not exported from `maidr/__init__.py`, and the only in-repo callers are `_extract_plots`, the factory, and tests. Flagged rather than waved away, since anyone constructing them directly will get a `TypeError` — the intended outcome, but it shouldn't be a surprise.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added appropriate unit tests.
- [ ] I have updated the documentation — not applicable; internal classes with no user-facing docs.

## Additional Notes

**Spun out as an issue rather than fixed here: #316.** Reviewing this PR surfaced that `_extract_plot_data` drops a trace whose series comes out empty while `_get_selector` always emits one selector per trace, so an empty series desynchronises the two lists and every later series inherits its predecessor's selector. Same wrong-highlight failure, reached by a different route. Fixing it changes what `_extract_plot_data` emits, which would cost this PR its "no production path changes behaviour" property, so it is filed separately with the options laid out.

**Merge-order note.** The last of four sibling PRs closing the #303 follow-ups (#312, #313, #314). This one and **#314** both touch `line.py`, `multiline.py` and `step.py` — #314 changes what `_get_selector` returns, this one changes the constructors, so the overlap is real but in different methods. #313 and #312 don't conflict.

Suggested order to minimise rebasing: **#312 → #313 → this → #314**, since #314's `_get_selector` bodies are the most rewritten and are easiest to rebase last.