### PR TITLE
fix(bar): bind a hued seaborn bar plot as a grouped layer

### DIFF
--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -89,7 +89,7 @@ class GroupedBarPlot(
             return ""
         return title.get_text().strip()
 
-    def _extract_plot_data(self):
+    def _extract_plot_data(self) -> list[list[dict]]:
         plot = self.extract_container(self.ax, BarContainer, include_all=True)
         data = self._extract_grouped_bar_data(plot)
 
@@ -100,7 +100,7 @@ class GroupedBarPlot(
 
     def _extract_grouped_bar_data(
         self, plot: list[BarContainer] | None
-    ) -> list[dict] | None:
+    ) -> list[list[dict]] | None:
         if plot is None:
             return None
 

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -18,6 +18,50 @@ class GroupedBarPlot(
 ):
     def __init__(self, ax: Axes, plot_type: PlotType, **kwargs) -> None:
         super().__init__(ax, plot_type)
+        self._orientation = "vert"
+
+    @property
+    def _is_horizontal(self) -> bool:
+        return self._orientation == "horz"
+
+    @property
+    def _level_key(self) -> MaidrKey:
+        """
+        The axis the bar labels sit on: ``y`` for a horizontal layer
+        (``seaborn.barplot(orient="h", hue=...)``), ``x`` otherwise.
+        """
+        return MaidrKey.Y if self._is_horizontal else MaidrKey.X
+
+    @staticmethod
+    def _extract_orientation(plot: list[BarContainer] | None) -> str:
+        """
+        Read the orientation matplotlib recorded on the bar containers.
+
+        Only the first container is asked: the containers of one layer are
+        drawn by the same call, so they all run the same way.
+
+        Parameters
+        ----------
+        plot : list of BarContainer, optional
+            The containers holding the bars of this layer, one per group.
+
+        Returns
+        -------
+        str
+            ``"horz"`` for a horizontal layer, ``"vert"`` otherwise.
+        """
+        if not plot:
+            return "vert"
+
+        return "horz" if plot[0].orientation == "horizontal" else "vert"
+
+    def render(self) -> dict:
+        """Add ``orientation`` to the base schema."""
+        # Read after the super call, not before: `self._orientation` is
+        # populated by `_extract_plot_data`, which that call runs.
+        base_schema = super().render()
+        orientation = {MaidrKey.ORIENTATION: self._orientation}
+        return DictMergerMixin.merge_dict(base_schema, orientation)
 
     def _extract_axes_data(self) -> dict:
         """
@@ -60,8 +104,10 @@ class GroupedBarPlot(
         if plot is None:
             return None
 
-        x_level = self.extract_level(self.ax)
-        if x_level is None:
+        self._orientation = self._extract_orientation(plot)
+
+        level = self.extract_level(self.ax, self._level_key)
+        if not level:
             return None
 
         data = []
@@ -74,21 +120,30 @@ class GroupedBarPlot(
         hue_categories = self._extract_hue_categories_from_legend()
 
         for i, container in enumerate(plot):
-            if len(x_level) != len(container.patches):
+            if len(level) != len(container.patches):
                 return None
             container_data = []
 
             # Use hue category if available, otherwise fall back to container label
             fill_value = hue_categories[i] if i < len(hue_categories) else container.get_label()
 
-            for x, y in zip(x_level, container.patches):
-                container_data.append(
-                    {
-                        MaidrKey.X.value: x,
+            for label, patch in zip(level, container.patches):
+                # A horizontal bar's magnitude runs along x and its label sits
+                # on y, which is the layout the renderer reads for a
+                # horizontal layer. The vertical layer is the mirror of that.
+                if self._is_horizontal:
+                    point = {
+                        MaidrKey.X.value: float(patch.get_width()),
                         MaidrKey.Z.value: fill_value,
-                        MaidrKey.Y.value: float(y.get_height()),
+                        MaidrKey.Y.value: label,
                     }
-                )
+                else:
+                    point = {
+                        MaidrKey.X.value: label,
+                        MaidrKey.Z.value: fill_value,
+                        MaidrKey.Y.value: float(patch.get_height()),
+                    }
+                container_data.append(point)
             data.append(container_data)
 
         return data

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -6,22 +6,24 @@ import wrapt
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
 
-from maidr.core.enum import PlotType
+from maidr.core.enum import MaidrKey, PlotType
 from maidr.patch.common import common
+from maidr.util.mixin import LevelExtractorMixin
 
 
 def bar(
     wrapped: Callable, instance: Any, args: Tuple[Any, ...], kwargs: Dict[str, Any]
 ) -> Union[Axes, BarContainer]:
     """
-    Patch function for bar plots.
+    Patch function for `Axes.bar` and `Axes.barh`.
 
     This function patches the bar plotting functions to identify whether the
     plot should be rendered as a normal, stacked, or dodged bar plot.
-    It uses the 'bottom' keyword to identify stacked bar plots. For dodged plots,
-    it first checks for seaborn-specific indicators (hue parameter with dodge=True),
-    then uses robust detection logic that considers both width and context
-    to avoid misclassifying simple bar plots with narrow widths as dodged plots.
+    It uses the 'bottom' keyword to identify stacked bar plots. For dodged
+    plots, it uses robust detection logic that considers both width and
+    context to avoid misclassifying simple bar plots with narrow widths as
+    dodged plots. Seaborn's bar plots do not come through here — they are
+    classified from the bars they drew, in `sns_bar` below.
 
     Parameters
     ----------
@@ -34,7 +36,6 @@ def bar(
         For a dodged plot, the first argument (x positions) should be numeric.
     kwargs : dict
         Keyword arguments passed to the original function.
-        For seaborn plots, may contain 'hue' and 'dodge' parameters.
 
     Returns
     -------
@@ -43,9 +44,6 @@ def bar(
 
     Examples
     --------
-    >>> # For a seaborn dodged (grouped) bar plot:
-    >>> sns.barplot(data=df, x='category', y='value', hue='group', dodge=True)
-
     >>> # For a manual dodged (grouped) bar plot, pass numeric x positions:
     >>> x_positions = np.arange(3)
     >>> ax.bar(x_positions, heights, width, label='Group')  # Dodged bar plot.
@@ -58,27 +56,22 @@ def bar(
         if bottom is not None:
             plot_type = PlotType.STACKED
     else:
-        # Check for seaborn-specific dodged plot indicators first
-        # This handles seaborn.barplot with hue and dodge=True
-        if "hue" in kwargs and kwargs.get("dodge"):
-            plot_type = PlotType.DODGED
+        # Extract width and align parameters
+        if len(args) >= 3:
+            real_width = args[2]
         else:
-            # Extract width and align parameters
-            if len(args) >= 3:
-                real_width = args[2]
-            else:
-                real_width = kwargs.get("width", 0.8)
+            real_width = kwargs.get("width", 0.8)
 
-            align = kwargs.get("align", "center")
+        align = kwargs.get("align", "center")
 
-            # More robust dodged plot detection: consider multiple factors
-            # Only classify as DODGED if there are strong indicators of grouping
-            should_be_dodged = _should_classify_as_dodged(
-                instance, real_width, align, args, kwargs
-            )
+        # More robust dodged plot detection: consider multiple factors
+        # Only classify as DODGED if there are strong indicators of grouping
+        should_be_dodged = _should_classify_as_dodged(
+            instance, real_width, align, args, kwargs
+        )
 
-            if should_be_dodged:
-                plot_type = PlotType.DODGED
+        if should_be_dodged:
+            plot_type = PlotType.DODGED
 
     return common(plot_type, wrapped, instance, args, kwargs)
 
@@ -209,10 +202,86 @@ def _has_numeric_grouping_pattern(x_positions: Any) -> bool:
         return False
 
 
+def sns_bar(
+    wrapped: Callable, instance: Any, args: Tuple[Any, ...], kwargs: Dict[str, Any]
+) -> Union[Axes, BarContainer]:
+    """
+    Patch function for `seaborn.barplot` and `seaborn.countplot`.
+
+    Whether a hue splits the layer into groups is seaborn's decision, and it
+    is not one the arguments alone answer: `dodge` defaults to `"auto"`, and
+    a hue that repeats the category variable is drawn as a plain bar layer
+    wearing a legend. Seaborn does not forward `hue` or `dodge` to
+    `Axes.bar` either — and those inner calls are suppressed as internal
+    anyway — so the layer is classified from the bars seaborn drew.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original seaborn function.
+    instance : Any
+        Unused; seaborn's plotting functions are module level.
+    args : tuple
+        Positional arguments passed to the original function.
+    kwargs : dict
+        Keyword arguments passed to the original function.
+
+    Returns
+    -------
+    Union[Axes, BarContainer]
+        Whatever the original function returned.
+
+    Examples
+    --------
+    >>> # Grouped: one container per hue level, one bar per category.
+    >>> sns.barplot(data=df, x="day", y="tip", hue="sex")
+
+    >>> # Not grouped: the hue repeats `x`, so each container holds one bar.
+    >>> sns.barplot(data=df, x="day", y="tip", hue="day")
+    """
+    return common(_seaborn_bar_type, wrapped, instance, args, kwargs)
+
+
+def _seaborn_bar_type(ax: Axes) -> PlotType:
+    """
+    Classify a drawn seaborn bar layer as grouped or plain.
+
+    A grouped layer draws one container per hue level, each holding one bar
+    per category. Anything else — a single container, or containers that do
+    not line up with the categorical axis — is a plain bar layer. The bars
+    are counted against the same tick labels `GroupedBarPlot` pairs them
+    with, so the layer is only called grouped when it can be read as one.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes seaborn drew on.
+
+    Returns
+    -------
+    PlotType
+        `PlotType.DODGED` for a grouped layer, `PlotType.BAR` otherwise.
+    """
+    containers = [c for c in ax.containers if isinstance(c, BarContainer)]
+    if len(containers) < 2:
+        return PlotType.BAR
+
+    # The bar labels sit on y when the bars grow along x.
+    level_key = MaidrKey.Y if containers[0].orientation == "horizontal" else MaidrKey.X
+    levels = LevelExtractorMixin.extract_level(ax, level_key)
+    if not levels:
+        return PlotType.BAR
+
+    if any(len(container.patches) != len(levels) for container in containers):
+        return PlotType.BAR
+
+    return PlotType.DODGED
+
+
 # Patch matplotlib functions.
 wrapt.wrap_function_wrapper(Axes, "bar", bar)
 wrapt.wrap_function_wrapper(Axes, "barh", bar)
 
 # Patch seaborn functions.
-wrapt.wrap_function_wrapper("seaborn", "barplot", bar)
-wrapt.wrap_function_wrapper("seaborn", "countplot", bar)
+wrapt.wrap_function_wrapper("seaborn", "barplot", sns_bar)
+wrapt.wrap_function_wrapper("seaborn", "countplot", sns_bar)

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -204,7 +204,7 @@ def _has_numeric_grouping_pattern(x_positions: Any) -> bool:
 
 def sns_bar(
     wrapped: Callable, instance: Any, args: Tuple[Any, ...], kwargs: Dict[str, Any]
-) -> Union[Axes, BarContainer]:
+) -> Axes:
     """
     Patch function for `seaborn.barplot` and `seaborn.countplot`.
 
@@ -228,8 +228,8 @@ def sns_bar(
 
     Returns
     -------
-    Union[Axes, BarContainer]
-        Whatever the original function returned.
+    Axes
+        The axes seaborn drew on, which is what both functions return.
 
     Examples
     --------

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -262,6 +262,12 @@ def _seaborn_bar_type(ax: Axes) -> PlotType:
     PlotType
         `PlotType.DODGED` for a grouped layer, `PlotType.BAR` otherwise.
     """
+    # Every bar container on the axes is counted, not only the ones this call
+    # drew, so a second bar layer overlaid on the same axes is read as extra
+    # groups. That layering is already unrenderable — the first layer re-reads
+    # every container here too and raises on the count — so this does not make
+    # a working figure wrong. Scoping both to one call's own containers is the
+    # fix, and it belongs to whoever takes that on.
     containers = [c for c in ax.containers if isinstance(c, BarContainer)]
     if len(containers) < 2:
         return PlotType.BAR

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -99,6 +99,29 @@ def resolve_orientation(wrapped: Callable, args: tuple, kwargs: dict) -> str:
 
 
 def common(plot_type, wrapped, _, args, kwargs) -> Any:
+    """
+    Draw a patched plot and register the layer it produced with MAIDR.
+
+    Parameters
+    ----------
+    plot_type : PlotType or callable
+        The type to register the layer as. A callable is handed the drawn
+        Axes and returns the type, for plots whose layout is only decided
+        inside the library being patched: seaborn works out on its own
+        whether a hue splits a bar layer into groups, and does not forward
+        that decision to matplotlib.
+    wrapped : Callable
+        The original plotting function.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    Any
+        Whatever the wrapped function returned.
+    """
     # Suppress warnings not to confuse screen-reader users
     warnings.filterwarnings("ignore")
 
@@ -114,6 +137,8 @@ def common(plot_type, wrapped, _, args, kwargs) -> Any:
     # Extract the data points for MAIDR from the plot.
     ax = FigureManager.get_axes(plot)
     kwargs.pop("ax", None)
+    if callable(plot_type):
+        plot_type = plot_type(ax)
     FigureManager.create_maidr(ax, plot_type, **kwargs)
 
     return plot

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -4,7 +4,10 @@ import inspect
 import warnings
 from typing import Any, Callable
 
+from matplotlib.axes import Axes
+
 from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 
 
@@ -98,7 +101,9 @@ def resolve_orientation(wrapped: Callable, args: tuple, kwargs: dict) -> str:
     return "horz" if orientation == "horizontal" else "vert"
 
 
-def common(plot_type, wrapped, _, args, kwargs) -> Any:
+def common(
+    plot_type: PlotType | Callable[[Axes], PlotType], wrapped, _, args, kwargs
+) -> Any:
     """
     Draw a patched plot and register the layer it produced with MAIDR.
 

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -112,6 +112,9 @@ def common(plot_type, wrapped, _, args, kwargs) -> Any:
         that decision to matplotlib.
     wrapped : Callable
         The original plotting function.
+    _ : Any
+        The instance wrapt bound the patched function to, or None for a
+        module-level function. Unused here, and named for that.
     args : tuple
         Positional arguments the caller passed.
     kwargs : dict

--- a/tests/core/plot/test_seaborn_grouped_bar.py
+++ b/tests/core/plot/test_seaborn_grouped_bar.py
@@ -168,6 +168,27 @@ def test_a_hue_that_repeats_the_category_stays_a_plain_bar_layer() -> None:
     ]
 
 
+def test_hue_groups_that_do_not_cover_every_category_stay_a_plain_bar_layer() -> None:
+    """The length check, reached with two containers rather than one.
+
+    Seaborn draws no bar at all for a category and hue level that never
+    occur together, so the containers come out ragged. `GroupedBarPlot`
+    cannot read those — it pairs bars with labels by position — so the
+    classification refuses to call them grouped. The layer does not render
+    either way; what is pinned here is that the guard is what turns it back,
+    not the container count.
+    """
+    ragged = DATA[~((DATA["cat"] == "b") & (DATA["grp"] == "y"))]
+    fig, ax = plt.subplots()
+    try:
+        sns.barplot(data=ragged, x="cat", y="val", hue="grp", ax=ax)
+        # The premise: seaborn dropped the bar rather than drawing a gap.
+        assert [len(c.patches) for c in ax.containers] == [3, 2]
+        assert _layer_type(fig) is PlotType.BAR
+    finally:
+        plt.close(fig)
+
+
 def test_a_hue_with_one_level_stays_a_plain_bar_layer() -> None:
     """Nothing to group by: seaborn draws the one container it would anyway."""
     single = DATA.assign(grp="only")

--- a/tests/core/plot/test_seaborn_grouped_bar.py
+++ b/tests/core/plot/test_seaborn_grouped_bar.py
@@ -168,6 +168,24 @@ def test_a_hue_that_repeats_the_category_stays_a_plain_bar_layer() -> None:
     ]
 
 
+def test_a_hue_with_one_level_stays_a_plain_bar_layer() -> None:
+    """Nothing to group by: seaborn draws the one container it would anyway."""
+    single = DATA.assign(grp="only")
+    fig, ax = plt.subplots()
+    try:
+        sns.barplot(data=single, x="cat", y="val", hue="grp", ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert _layer_type(fig) is PlotType.BAR
+    assert schema["data"] == [
+        {"x": "a", "y": 1.5},
+        {"x": "b", "y": 3.5},
+        {"x": "c", "y": 5.5},
+    ]
+
+
 def test_a_barplot_without_a_hue_stays_a_plain_bar_layer() -> None:
     fig, ax = plt.subplots()
     try:

--- a/tests/core/plot/test_seaborn_grouped_bar.py
+++ b/tests/core/plot/test_seaborn_grouped_bar.py
@@ -1,0 +1,215 @@
+"""Tests that a hued seaborn bar plot is bound as a grouped layer.
+
+Whether a hue splits a bar layer into groups is seaborn's decision, taken
+from `dodge="auto"` and the data, and it never reaches matplotlib: seaborn
+draws through `Axes.bar` without forwarding `hue` or `dodge`. Classifying
+from the seaborn arguments therefore only caught the calls that passed
+`dodge=True` by hand; every other hued bar plot was bound as a plain bar
+layer, where the grouped bars outnumber the tick labels and extraction
+fails. These pin the classification to what seaborn actually drew, and the
+grouped layer to both orientations.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+DATA = pd.DataFrame(
+    {
+        "cat": ["a", "a", "b", "b", "c", "c"],
+        "grp": ["x", "y", "x", "y", "x", "y"],
+        "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    }
+)
+
+GROUPED = [
+    [
+        {"x": "a", "z": "x", "y": 1.0},
+        {"x": "b", "z": "x", "y": 3.0},
+        {"x": "c", "z": "x", "y": 5.0},
+    ],
+    [
+        {"x": "a", "z": "y", "y": 2.0},
+        {"x": "b", "z": "y", "y": 4.0},
+        {"x": "c", "z": "y", "y": 6.0},
+    ],
+]
+
+
+def _schema(fig) -> dict:
+    """Return the first layer's schema with plain string keys."""
+    plot = FigureManager.get_maidr(fig).plots[0]
+    return {(k.value if hasattr(k, "value") else k): v for k, v in plot.schema.items()}
+
+
+def _layer_type(fig) -> PlotType:
+    return FigureManager.get_maidr(fig).plots[0].type
+
+
+@pytest.mark.parametrize("dodge", [None, True, False])
+def test_a_hued_barplot_is_grouped_however_dodge_was_left(dodge: bool | None) -> None:
+    """The bug: only `dodge=True` was recognised, and it is not the default.
+
+    `dodge` defaults to `"auto"`, so the common call — hue and nothing else —
+    was bound as a plain bar layer and raised while extracting. `dodge=False`
+    stacks the groups on one another visually, but the data is still one
+    series per hue level, so it is read the same way.
+    """
+    fig, ax = plt.subplots()
+    try:
+        kwargs = {} if dodge is None else {"dodge": dodge}
+        sns.barplot(data=DATA, x="cat", y="val", hue="grp", ax=ax, **kwargs)
+        schema = _schema(fig)
+
+        assert _layer_type(fig) is PlotType.DODGED
+        assert schema["orientation"] == "vert"
+        assert schema["data"] == GROUPED
+    finally:
+        plt.close(fig)
+
+
+def test_a_hued_countplot_is_grouped() -> None:
+    fig, ax = plt.subplots()
+    try:
+        sns.countplot(data=DATA, x="cat", hue="grp", ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["data"] == [
+        [
+            {"x": "a", "z": "x", "y": 1.0},
+            {"x": "b", "z": "x", "y": 1.0},
+            {"x": "c", "z": "x", "y": 1.0},
+        ],
+        [
+            {"x": "a", "z": "y", "y": 1.0},
+            {"x": "b", "z": "y", "y": 1.0},
+            {"x": "c", "z": "y", "y": 1.0},
+        ],
+    ]
+
+
+def test_a_horizontal_grouped_bar_puts_the_value_on_x_and_the_label_on_y() -> None:
+    """The mirror of the vertical layout, which is what the renderer reads."""
+    fig, ax = plt.subplots()
+    try:
+        sns.barplot(data=DATA, y="cat", x="val", hue="grp", ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert schema["orientation"] == "horz"
+    assert schema["data"] == [
+        [
+            {"x": 1.0, "z": "x", "y": "a"},
+            {"x": 3.0, "z": "x", "y": "b"},
+            {"x": 5.0, "z": "x", "y": "c"},
+        ],
+        [
+            {"x": 2.0, "z": "y", "y": "a"},
+            {"x": 4.0, "z": "y", "y": "b"},
+            {"x": 6.0, "z": "y", "y": "c"},
+        ],
+    ]
+
+
+def test_a_single_category_split_by_hue_is_still_grouped() -> None:
+    """One bar per group is the edge the tick-label count has to survive.
+
+    Here each container holds a single bar, the same shape a redundant hue
+    draws — the categorical axis is what tells them apart.
+    """
+    fig, ax = plt.subplots()
+    try:
+        sns.barplot(data=DATA[DATA["cat"] == "a"], x="cat", y="val", hue="grp", ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert _layer_type(fig) is PlotType.DODGED
+    assert schema["data"] == [
+        [{"x": "a", "z": "x", "y": 1.0}],
+        [{"x": "a", "z": "y", "y": 2.0}],
+    ]
+
+
+def test_a_hue_that_repeats_the_category_stays_a_plain_bar_layer() -> None:
+    """Seaborn draws this one container per bar, and does not group it.
+
+    It is only colouring the bars it would have drawn anyway, so reading it
+    as groups would report one group per bar. The bars are counted against
+    the tick labels to tell the two apart.
+    """
+    fig, ax = plt.subplots()
+    try:
+        sns.barplot(data=DATA, x="cat", y="val", hue="cat", ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert _layer_type(fig) is PlotType.BAR
+    assert schema["data"] == [
+        {"x": "a", "y": 1.5},
+        {"x": "b", "y": 3.5},
+        {"x": "c", "y": 5.5},
+    ]
+
+
+def test_a_barplot_without_a_hue_stays_a_plain_bar_layer() -> None:
+    fig, ax = plt.subplots()
+    try:
+        sns.barplot(data=DATA, x="cat", y="val", ax=ax)
+        schema = _schema(fig)
+    finally:
+        plt.close(fig)
+
+    assert _layer_type(fig) is PlotType.BAR
+    assert schema["data"] == [
+        {"x": "a", "y": 1.5},
+        {"x": "b", "y": 3.5},
+        {"x": "c", "y": 5.5},
+    ]
+
+
+def test_a_stacked_bar_layer_reports_its_orientation() -> None:
+    """Stacked layers share the grouped extractor, so they gained the key."""
+    labels = ["a", "b", "c"]
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(labels, [1.0, 2.0, 3.0], label="lo")
+        ax.bar(labels, [4.0, 5.0, 6.0], bottom=[1.0, 2.0, 3.0], label="hi")
+        stacked = FigureManager.get_maidr(fig).plots[-1]
+        schema = {
+            (k.value if hasattr(k, "value") else k): v
+            for k, v in stacked.schema.items()
+        }
+    finally:
+        plt.close(fig)
+
+    assert stacked.type is PlotType.STACKED
+    assert schema["orientation"] == "vert"
+    assert schema["data"] == [
+        [
+            {"x": "a", "z": "lo", "y": 1.0},
+            {"x": "b", "z": "lo", "y": 2.0},
+            {"x": "c", "z": "lo", "y": 3.0},
+        ],
+        [
+            {"x": "a", "z": "hi", "y": 4.0},
+            {"x": "b", "z": "hi", "y": 5.0},
+            {"x": "c", "z": "hi", "y": 6.0},
+        ],
+    ]


### PR DESCRIPTION
# Pull Request

## Description

`sns.barplot(..., hue=...)` and `sns.countplot(..., hue=...)` fail to render unless the caller also passes `dodge=True` by hand:

```python
sns.barplot(data=df, x="cat", y="val", hue="grp")
# ExtractionError: Error extracting data for bar plot type from <class 'list'>.
```

Whether a hue splits a bar layer into groups is seaborn's decision — taken from `dodge="auto"` and the data — and it never reaches matplotlib. Seaborn draws through `Axes.bar` without forwarding `hue` or `dodge`, and those inner calls are suppressed as internal by `ContextManager` anyway, so the outermost seaborn call is what registers the layer. The classification read `"hue" in kwargs and kwargs.get("dodge")`, which is only true when `dodge=True` was passed explicitly; `dodge` defaults to `"auto"`, so the common call fell through to a plain bar layer. There the grouped bars outnumber the tick labels — six bars against three labels — and extraction fails.

The layer is now classified from the bars seaborn drew: a grouped layer is one container per hue level, each holding one bar per category. The bars are counted against the same tick labels `GroupedBarPlot` pairs them with, so a layer is only called grouped when it can be read as one.

A hue that repeats the category variable (`x="cat", hue="cat"`) draws one single-bar container per category and stays a plain bar layer, which is what it is — seaborn only coloured the bars it would have drawn anyway. That case works today and keeps working; it is what stops "has a hue" from being the test.

`GroupedBarPlot` then read every bar's height against the x tick labels, so a horizontal grouped layer would have reported bar thicknesses against the wrong axis. It now reads the magnitude off the dimension the bars grow along, the labels off the axis they sit on, and reports `orientation` in the schema — the layout `SegmentedTrace` already expects on the renderer side, and the same shape box and violin layers emit.

This is the follow-up flagged in #307; it is independent of that PR and touches none of its files.

## Related Issues

Follows up on the finding reported in #307. No issue filed.

## Changes Made

- `maidr/patch/barplot.py` — `seaborn.barplot` and `seaborn.countplot` are patched with a new `sns_bar` wrapper that classifies the layer from the drawn containers (`_seaborn_bar_type`) rather than from the seaborn arguments. `Axes.bar`/`Axes.barh` keep the existing `bar` wrapper, minus its now-unreachable `hue`/`dodge` branch — matplotlib never receives those.
- `maidr/patch/common.py` — `common()` accepts a callable `plot_type`, resolved against the drawn axes after the plot is made, for libraries that decide the layout themselves.
- `maidr/core/plot/grouped_barplot.py` — orientation support: read the level off `y` and the magnitude off `get_width()` for a horizontal layer, mirroring the vertical case, and emit `orientation` in the schema. Stacked layers share this extractor and gain the key too (`"vert"`, which is what the renderer already assumed).
- `tests/core/plot/test_seaborn_grouped_bar.py` — 10 tests: hued barplot across `dodge` unset/`True`/`False`, hued countplot, horizontal grouped layout, a single category split by hue (the edge where each container holds one bar), and three guards that a redundant hue, a single-level hue, and a plain barplot all stay `BAR`. 7 of the 10 fail on `main`; the guards pass there, as they should.

## Screenshots (if applicable)

n/a

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — 283 passed. `ruff check` reports only the seven pre-existing `F401` re-export warnings in `__init__.py` files, none in the changed files; `ruff format --diff` is clean on them.

Three behaviours deliberately left alone. All are broken on `main` too and unchanged by this PR; each was measured on both branches rather than assumed:

- **Ragged hue groups.** A missing or `NaN` category/hue combination makes seaborn drop the bar, leaving containers of unequal length. `GroupedBarPlot`'s `len(level) != len(container.patches)` check refuses those, so they fail on `main` under `dodge=True` and fail here. Fixing it means pairing bars to categories by position rather than index, plus a decision on how a gap is carried through the schema — `SegmentedTrace` already reads `NaN` as a gap, so that part is a cross-repo question. See the discussion below.
- **Manually grouped matplotlib bars** (two `ax.bar` calls with numeric offsets) still fail to extract — the classification there is a separate heuristic on numeric x positions.
- **Overlaying a second seaborn bar layer** on the same axes still fails, because the first layer re-reads every container on the axes at render time. Classification now reaches a different wrong answer for the second layer, but the figure raises at the first layer either way, so nothing observable changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017NvQqGMoq3B21znVDinNVB)_