### PR TITLE
fix(smooth): keep a regression line navigable point by point

### DIFF
--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -6,7 +6,7 @@ from maidr.exception.extraction_error import ExtractionError
 import numpy as np
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.enum.maidr_key import MaidrKey
-from maidr.util.rdp_utils import simplify_curve
+from maidr.util.rdp_utils import resample_curve
 from maidr.util.regression_line_utils import find_regression_line
 from maidr.util.svg_utils import data_to_svg_coords
 
@@ -70,14 +70,16 @@ class SmoothPlot(MaidrPlot):
         xydata = np.asarray(regression_line.get_xydata())
         x_data, y_data = xydata[:, 0], xydata[:, 1]
 
-        # Simplify the curve with RDP before computing SVG coordinates.
-        if len(x_data) > _DEFAULT_MAX_SMOOTH_POINTS:
-            mask = simplify_curve(
-                np.column_stack([x_data, y_data]),
-                target=_DEFAULT_MAX_SMOOTH_POINTS,
-            )
-            x_data = x_data[mask]
-            y_data = y_data[mask]
+        # Thin the curve before computing SVG coordinates.  The points are
+        # navigated and auto-played one at a time at a fixed rate, so they have
+        # to stay evenly spaced along the line: shape-based simplification
+        # would collapse a straight fit to its two endpoints and stretch the
+        # flat stretches of a curved one over fewer steps than the bends.
+        xy = resample_curve(
+            np.column_stack([x_data, y_data]),
+            target=_DEFAULT_MAX_SMOOTH_POINTS,
+        )
+        x_data, y_data = xy[:, 0], xy[:, 1]
 
         x_svg, y_svg = data_to_svg_coords(self.ax, x_data, y_data)
         return [

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -155,8 +155,9 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     covers every curve seaborn fits.  Sampling by vertex index instead would
     only be even in x when the source grid already was — true of a plain
     ``regplot`` fit or a KDE, but not of a ``lowess=True`` fit, which lands on
-    the observed x values and inherits their clustering.  Curves that double
-    back carry no usable x ordering, so those fall back to index sampling.
+    the observed x values and inherits their clustering.  Anything else — a
+    curve that doubles back, or one running right to left — falls back to
+    index sampling.
 
     Interpolated points sit exactly on the drawn line: matplotlib renders the
     curve as straight segments between its vertices, which is the same path
@@ -187,7 +188,9 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
         grid = np.linspace(x[0], x[-1], count)
         return np.column_stack([grid, np.interp(grid, x, y)])
 
-    # No usable x ordering, so fall back to even spacing by vertex index.
+    # Left-to-right is the only order worth special-casing, since it is the one
+    # every fit produces; a decreasing or self-crossing curve falls through to
+    # even spacing by vertex index rather than growing a case for each shape.
     # ``n > count >= 2`` puts the step ``(n - 1) / (count - 1)`` strictly above
     # 1, so rounding can never land two samples on the same vertex: the result
     # always holds exactly ``count`` distinct points.

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -159,9 +159,13 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     curve that doubles back, or one running right to left — falls back to
     index sampling.
 
-    Interpolated points sit exactly on the drawn line: matplotlib renders the
-    curve as straight segments between its vertices, which is the same path
-    the interpolation walks.
+    Interpolated points sit on the drawn line, which matters because they are
+    what the highlight ring lands on.  Matplotlib renders the curve as straight
+    segments between its vertices, so on a linear axis — where data and display
+    space differ by an affine map — the interpolation walks exactly that path.
+    A log axis bends each segment between the vertices, leaving a gap of about
+    a tenth of a pixel at this point count; still far under the ring's radius,
+    just not the exact landing a linear axis gives.
 
     Parameters
     ----------

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -167,7 +167,9 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     Returns
     -------
     np.ndarray, shape (M, 2)
-        The retained points, where ``M == min(N, max(target, 2))``.
+        The retained points, where ``M == min(N, max(target, 2))``.  A curve
+        that already fits the budget comes back as *points* itself, not a
+        copy, so callers that intend to mutate the result should copy it.
     """
     n = len(points)
     count = max(int(target), 2)

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -151,10 +151,16 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     collapsing to its two endpoints, and a curved line keeps a steady step
     size.  The first and last vertices are always kept.
 
-    Sampling is by vertex index, so the result is evenly spaced *in x* only
-    when the input is too — which holds for the curves matplotlib and seaborn
-    evaluate on a uniform grid.  A curve sampled unevenly would need
-    arc-length interpolation instead.
+    Spacing is measured along x whenever x increases monotonically, which
+    covers every curve seaborn fits.  Sampling by vertex index instead would
+    only be even in x when the source grid already was — true of a plain
+    ``regplot`` fit or a KDE, but not of a ``lowess=True`` fit, which lands on
+    the observed x values and inherits their clustering.  Curves that double
+    back carry no usable x ordering, so those fall back to index sampling.
+
+    Interpolated points sit exactly on the drawn line: matplotlib renders the
+    curve as straight segments between its vertices, which is the same path
+    the interpolation walks.
 
     Parameters
     ----------
@@ -167,7 +173,7 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     Returns
     -------
     np.ndarray, shape (M, 2)
-        The retained points, where ``M == min(N, max(target, 2))``.  A curve
+        The resampled points, where ``M == min(N, max(target, 2))``.  A curve
         that already fits the budget comes back as *points* itself, not a
         copy, so callers that intend to mutate the result should copy it.
     """
@@ -176,6 +182,12 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     if n <= count:
         return points
 
+    x, y = points[:, 0], points[:, 1]
+    if np.all(np.diff(x) > 0):
+        grid = np.linspace(x[0], x[-1], count)
+        return np.column_stack([grid, np.interp(grid, x, y)])
+
+    # No usable x ordering, so fall back to even spacing by vertex index.
     # ``n > count >= 2`` puts the step ``(n - 1) / (count - 1)`` strictly above
     # 1, so rounding can never land two samples on the same vertex: the result
     # always holds exactly ``count`` distinct points.

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -1,9 +1,15 @@
-"""Ramer-Douglas-Peucker curve simplification utilities.
+"""Curve thinning utilities.
 
-These helpers reduce the number of points on a curve while preserving its
-shape.  They are used by :class:`~maidr.core.plot.violin_kde_plot.ViolinKdePlot`
-and :class:`~maidr.core.plot.regplot.SmoothPlot` to keep the MAIDR JSON
-payload compact.
+These helpers reduce the number of points on a curve to keep the MAIDR JSON
+payload compact.  Two strategies live here because the two callers want
+different things:
+
+- :func:`simplify_curve` runs Ramer-Douglas-Peucker, which preserves *shape*
+  and is used by :class:`~maidr.core.plot.violin_kde_plot.ViolinKdePlot` to
+  pick the levels that outline a violin.
+- :func:`resample_curve` keeps the vertices evenly spaced and is used by
+  :class:`~maidr.core.plot.regplot.SmoothPlot`, whose points are navigated and
+  sonified one at a time, so *spacing* matters more than shape.
 """
 
 from __future__ import annotations
@@ -133,3 +139,34 @@ def simplify_curve(
             break
 
     return best_mask
+
+
+def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
+    """
+    Thin a 2-D curve down to *target* evenly spaced vertices.
+
+    Unlike :func:`simplify_curve`, this keeps the retained vertices spread
+    evenly along the curve rather than clustering them where the curve bends.
+    A straight line therefore survives as *target* points instead of
+    collapsing to its two endpoints, and a curved line keeps a steady step
+    size.  The first and last vertices are always kept.
+
+    Parameters
+    ----------
+    points : np.ndarray, shape (N, 2)
+        Ordered (x, y) points.
+    target : int
+        Desired maximum number of retained points.
+
+    Returns
+    -------
+    np.ndarray, shape (M, 2)
+        The retained points, where ``M <= max(target, 2)``.
+    """
+    n = len(points)
+    if n <= target:
+        return points
+
+    count = max(int(target), 2)
+    idx = np.unique(np.rint(np.linspace(0, n - 1, count)).astype(int))
+    return points[idx]

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -151,22 +151,31 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     collapsing to its two endpoints, and a curved line keeps a steady step
     size.  The first and last vertices are always kept.
 
+    Sampling is by vertex index, so the result is evenly spaced *in x* only
+    when the input is too — which holds for the curves matplotlib and seaborn
+    evaluate on a uniform grid.  A curve sampled unevenly would need
+    arc-length interpolation instead.
+
     Parameters
     ----------
     points : np.ndarray, shape (N, 2)
         Ordered (x, y) points.
     target : int
-        Desired maximum number of retained points.
+        Desired number of retained points.  Values below 2 are raised to 2,
+        since the endpoints alone already describe a segment.
 
     Returns
     -------
     np.ndarray, shape (M, 2)
-        The retained points, where ``M <= max(target, 2)``.
+        The retained points, where ``M == min(N, max(target, 2))``.
     """
     n = len(points)
-    if n <= target:
+    count = max(int(target), 2)
+    if n <= count:
         return points
 
-    count = max(int(target), 2)
-    idx = np.unique(np.rint(np.linspace(0, n - 1, count)).astype(int))
+    # ``n > count >= 2`` puts the step ``(n - 1) / (count - 1)`` strictly above
+    # 1, so rounding can never land two samples on the same vertex: the result
+    # always holds exactly ``count`` distinct points.
+    idx = np.rint(np.linspace(0, n - 1, count)).astype(int)
     return points[idx]

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -167,6 +167,15 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     a tenth of a pixel at this point count; still far under the ring's radius,
     just not the exact landing a linear axis gives.
 
+    Known limitation: the grid is even in *data* x, which is even on screen
+    only while the axis is linear.  A log x-axis stretches the same points
+    into a roughly 100:1 spread across the plot, so auto-play sweeps the
+    picture unevenly even though the announced x values step uniformly.
+    Nothing here sets a nonlinear scale — it takes an explicit
+    ``ax.set_xscale`` — and which of the two should stay uniform is a call
+    about what the sweep represents, so this stays as-is until a caller needs
+    otherwise.
+
     Parameters
     ----------
     points : np.ndarray, shape (N, 2)

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -166,12 +166,17 @@ def test_resample_curve_keeps_a_straight_line_at_full_budget():
 
 
 def test_resample_curve_returns_short_curves_untouched():
-    """Nothing to thin when the curve already fits in the budget."""
+    """Nothing to thin when the curve already fits in the budget.
+
+    Identity, not just equality: the docstring promises the input array back
+    rather than a copy, so a refactor that quietly started copying would be a
+    contract change even though every value still matched.
+    """
     points = np.column_stack([np.arange(5.0), np.arange(5.0) ** 2])
 
     kept = resample_curve(points, target=30)
 
-    assert np.array_equal(kept, points)
+    assert kept is points
 
 
 @pytest.mark.parametrize("n,target", [(100, 30), (31, 30), (61, 30), (7, 5)])

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -158,6 +158,35 @@ def test_resample_curve_returns_exactly_the_requested_count(n, target):
     assert len(kept) == target
 
 
+def test_resample_curve_evens_out_a_clustered_source_curve():
+    """A lowess fit lands on the observed x values and inherits their gaps.
+
+    Sampling such a curve by vertex index would carry the clustering straight
+    through into the emitted points, which is what auto-play pacing feels.
+    """
+    x = np.concatenate([np.linspace(0, 1, 90), np.linspace(2, 10, 10)])
+    points = np.column_stack([x, x**2])
+    source_gaps = np.diff(x)
+    assert source_gaps.max() / source_gaps.min() > 50, "fixture must be clustered"
+
+    kept = resample_curve(points, target=30)
+
+    gaps = np.diff(kept[:, 0])
+    assert gaps.max() / gaps.min() < 2.0, f"clustering survived: {gaps}"
+
+
+def test_resample_curve_falls_back_to_index_sampling_when_x_doubles_back():
+    """A curve with no usable x ordering still gets thinned, just by index."""
+    t = np.linspace(0, 2 * np.pi, 100)
+    points = np.column_stack([np.cos(t), np.sin(t)])
+
+    kept = resample_curve(points, target=30)
+
+    assert len(kept) == 30
+    assert np.array_equal(kept[0], points[0])
+    assert np.array_equal(kept[-1], points[-1])
+
+
 def test_resample_curve_keeps_both_endpoints():
     """The first and last vertices anchor the navigable range."""
     points = np.column_stack([np.linspace(0, 7, 61), np.sin(np.linspace(0, 7, 61))])

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -23,6 +23,7 @@ from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.core.plot.regplot import _DEFAULT_MAX_SMOOTH_POINTS  # noqa: E402
 from maidr.util.rdp_utils import resample_curve  # noqa: E402
+from maidr.util.regression_line_utils import find_regression_line  # noqa: E402
 
 
 def _smooth_points(fig) -> list[dict]:
@@ -31,6 +32,18 @@ def _smooth_points(fig) -> list[dict]:
     smooth = [p for p in plots if p.type is PlotType.SMOOTH]
     assert len(smooth) == 1, f"expected one smooth layer, got {len(smooth)}"
     return smooth[0].schema["data"][0]
+
+
+def _source_line(fig) -> np.ndarray:
+    """Return the vertices of the line the extractor actually reads.
+
+    Resolved through ``find_regression_line`` — the same lookup
+    ``SmoothPlot`` uses — so a test's idea of the source curve cannot drift
+    from the extractor's if seaborn ever adds another ``Line2D`` to the axes.
+    """
+    line = find_regression_line(FigureManager.get_axes(fig)[0])
+    assert line is not None, "no regression line found on the axes"
+    return np.asarray(line.get_xydata())
 
 
 def _x_values(points: list[dict]) -> np.ndarray:
@@ -77,8 +90,7 @@ def test_straight_regression_line_keeps_the_full_point_budget(regplot_figure):
     so the assertion tracks ``resample_curve``'s contract instead of whichever
     grid size seaborn happens to evaluate the fit on.
     """
-    source = FigureManager.get_axes(regplot_figure)[0].get_lines()[-1]
-    expected = min(_DEFAULT_MAX_SMOOTH_POINTS, len(source.get_xydata()))
+    expected = min(_DEFAULT_MAX_SMOOTH_POINTS, len(_source_line(regplot_figure)))
 
     points = _smooth_points(regplot_figure)
 
@@ -104,8 +116,7 @@ def test_smooth_points_are_evenly_spaced(figure_fixture, request):
 def test_smooth_points_span_the_whole_line(figure_fixture, request):
     """Thinning keeps both endpoints, so the trace covers the fitted range."""
     fig = request.getfixturevalue(figure_fixture)
-    line = FigureManager.get_axes(fig)[0].get_lines()[-1]
-    source_x = np.asarray(line.get_xydata())[:, 0]
+    source_x = _source_line(fig)[:, 0]
     x = _x_values(_smooth_points(fig))
 
     assert x[0] == pytest.approx(source_x[0])

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -21,6 +21,7 @@ import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.core.plot.regplot import _DEFAULT_MAX_SMOOTH_POINTS  # noqa: E402
 from maidr.util.rdp_utils import resample_curve  # noqa: E402
 
 
@@ -69,10 +70,18 @@ def test_straight_regression_line_is_not_collapsed_to_its_endpoints(regplot_figu
 
 
 def test_straight_regression_line_keeps_the_full_point_budget(regplot_figure):
-    """A 100-vertex seaborn fit is thinned to the 30-point budget, not below."""
+    """A fit longer than the budget is thinned to it exactly, not below.
+
+    The expected count is derived from the fitted line rather than hard-coded,
+    so the assertion tracks ``resample_curve``'s contract instead of whichever
+    grid size seaborn happens to evaluate the fit on.
+    """
+    source = FigureManager.get_axes(regplot_figure)[0].get_lines()[-1]
+    expected = min(_DEFAULT_MAX_SMOOTH_POINTS, len(source.get_xydata()))
+
     points = _smooth_points(regplot_figure)
 
-    assert len(points) == 30
+    assert len(points) == expected
 
 
 @pytest.mark.parametrize(
@@ -121,6 +130,20 @@ def test_resample_curve_returns_short_curves_untouched():
     kept = resample_curve(points, target=30)
 
     assert np.array_equal(kept, points)
+
+
+@pytest.mark.parametrize("n,target", [(100, 30), (31, 30), (61, 30), (7, 5)])
+def test_resample_curve_returns_exactly_the_requested_count(n, target):
+    """Rounding never collapses two samples onto one vertex.
+
+    The step between samples stays above 1 whenever the curve is longer than
+    the target, which is what makes the count exact even at awkward ratios.
+    """
+    points = np.column_stack([np.linspace(0, 1, n), np.linspace(0, 1, n) ** 2])
+
+    kept = resample_curve(points, target=target)
+
+    assert len(kept) == target
 
 
 def test_resample_curve_keeps_both_endpoints():

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -27,7 +27,8 @@ from maidr.util.rdp_utils import resample_curve  # noqa: E402
 
 def _smooth_points(fig) -> list[dict]:
     """Return the point list of the figure's single smooth layer."""
-    smooth = [p for p in FigureManager.get_maidr(fig).plots if p.type is PlotType.SMOOTH]
+    plots = FigureManager.get_maidr(fig).plots
+    smooth = [p for p in plots if p.type is PlotType.SMOOTH]
     assert len(smooth) == 1, f"expected one smooth layer, got {len(smooth)}"
     return smooth[0].schema["data"][0]
 

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -76,6 +76,32 @@ def histplot_kde_figure():
     plt.close(fig)
 
 
+@pytest.fixture
+def lowess_regplot_figure():
+    """A lowess fit over clustered x, the case a uniform grid does not cover.
+
+    ``statsmodels``'s lowess returns y-hat at the *observed* x values, so a
+    skewed sample hands the extractor a curve whose own vertices bunch up at
+    one end — unlike a plain fit or a KDE, which seaborn evaluates on a
+    ``linspace`` grid.
+    """
+    rng = np.random.default_rng(0)
+    x = np.sort(rng.exponential(2.0, 80))
+    y = 2 * x + rng.normal(0, 1.5, 80)
+
+    fig, ax = plt.subplots()
+    sns.regplot(x=x, y=y, ax=ax, ci=None, lowess=True)
+    yield fig
+    plt.close(fig)
+
+
+def test_lowess_fit_source_curve_really_is_clustered(lowess_regplot_figure):
+    """Guards the fixture: without clustered input the next test proves nothing."""
+    gaps = np.diff(_source_line(lowess_regplot_figure)[:, 0])
+
+    assert gaps.max() / gaps.min() > 50
+
+
 def test_straight_regression_line_is_not_collapsed_to_its_endpoints(regplot_figure):
     """A linear fit must stay navigable, not shrink to a start and an end."""
     points = _smooth_points(regplot_figure)
@@ -98,7 +124,9 @@ def test_straight_regression_line_keeps_the_full_point_budget(regplot_figure):
 
 
 @pytest.mark.parametrize(
-    "figure_fixture", ["regplot_figure", "histplot_kde_figure"], ids=["reg", "kde"]
+    "figure_fixture",
+    ["regplot_figure", "histplot_kde_figure", "lowess_regplot_figure"],
+    ids=["reg", "kde", "lowess"],
 )
 def test_smooth_points_are_evenly_spaced(figure_fixture, request):
     """Steps along x stay uniform so auto-play paces the trend correctly."""
@@ -111,7 +139,9 @@ def test_smooth_points_are_evenly_spaced(figure_fixture, request):
 
 
 @pytest.mark.parametrize(
-    "figure_fixture", ["regplot_figure", "histplot_kde_figure"], ids=["reg", "kde"]
+    "figure_fixture",
+    ["regplot_figure", "histplot_kde_figure", "lowess_regplot_figure"],
+    ids=["reg", "kde", "lowess"],
 )
 def test_smooth_points_span_the_whole_line(figure_fixture, request):
     """Thinning keeps both endpoints, so the trace covers the fitted range."""

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -1,0 +1,133 @@
+"""Tests that a smooth layer keeps evenly spaced, navigable points.
+
+A smooth trace is navigated and auto-played one point at a time at a fixed
+rate, so the emitted points have to stay spread along the line.  Shape-based
+simplification does the opposite: it collapses a straight fit to its two
+endpoints and clusters the survivors of a curved fit around the bends.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.util.rdp_utils import resample_curve  # noqa: E402
+
+
+def _smooth_points(fig) -> list[dict]:
+    """Return the point list of the figure's single smooth layer."""
+    smooth = [p for p in FigureManager.get_maidr(fig).plots if p.type is PlotType.SMOOTH]
+    assert len(smooth) == 1, f"expected one smooth layer, got {len(smooth)}"
+    return smooth[0].schema["data"][0]
+
+
+def _x_values(points: list[dict]) -> np.ndarray:
+    """Pull the x coordinates out of a smooth layer's point list."""
+    return np.array([float(p[MaidrKey.X]) for p in points])
+
+
+@pytest.fixture
+def regplot_figure():
+    """A seaborn regplot whose fitted line is perfectly straight."""
+    rng = np.random.default_rng(42)
+    x = np.linspace(0, 10, 50)
+    y = 2 * x + 1 + rng.normal(0, 1.5, 50)
+
+    fig, ax = plt.subplots()
+    sns.regplot(x=x, y=y, ax=ax)
+    yield fig
+    plt.close(fig)
+
+
+@pytest.fixture
+def histplot_kde_figure():
+    """A seaborn histogram with an overlaid — and genuinely curved — KDE."""
+    rng = np.random.default_rng(7)
+    data = np.concatenate([rng.normal(-2, 0.5, 300), rng.normal(2, 0.8, 300)])
+
+    fig, ax = plt.subplots()
+    sns.histplot(data, kde=True, ax=ax)
+    yield fig
+    plt.close(fig)
+
+
+def test_straight_regression_line_is_not_collapsed_to_its_endpoints(regplot_figure):
+    """A linear fit must stay navigable, not shrink to a start and an end."""
+    points = _smooth_points(regplot_figure)
+
+    assert len(points) > 2
+
+
+def test_straight_regression_line_keeps_the_full_point_budget(regplot_figure):
+    """A 100-vertex seaborn fit is thinned to the 30-point budget, not below."""
+    points = _smooth_points(regplot_figure)
+
+    assert len(points) == 30
+
+
+@pytest.mark.parametrize(
+    "figure_fixture", ["regplot_figure", "histplot_kde_figure"], ids=["reg", "kde"]
+)
+def test_smooth_points_are_evenly_spaced(figure_fixture, request):
+    """Steps along x stay uniform so auto-play paces the trend correctly."""
+    fig = request.getfixturevalue(figure_fixture)
+    x = _x_values(_smooth_points(fig))
+    gaps = np.diff(x)
+
+    assert np.all(gaps > 0), "x must stay monotonically increasing"
+    assert gaps.max() / gaps.min() < 2.0, f"uneven steps along x: {gaps}"
+
+
+@pytest.mark.parametrize(
+    "figure_fixture", ["regplot_figure", "histplot_kde_figure"], ids=["reg", "kde"]
+)
+def test_smooth_points_span_the_whole_line(figure_fixture, request):
+    """Thinning keeps both endpoints, so the trace covers the fitted range."""
+    fig = request.getfixturevalue(figure_fixture)
+    line = FigureManager.get_axes(fig)[0].get_lines()[-1]
+    source_x = np.asarray(line.get_xydata())[:, 0]
+    x = _x_values(_smooth_points(fig))
+
+    assert x[0] == pytest.approx(source_x[0])
+    assert x[-1] == pytest.approx(source_x[-1])
+
+
+def test_resample_curve_keeps_a_straight_line_at_full_budget():
+    """Collinear points carry no shape, so only the spacing can guide us."""
+    points = np.column_stack([np.linspace(0, 1, 100), np.linspace(0, 2, 100)])
+
+    kept = resample_curve(points, target=30)
+
+    assert len(kept) == 30
+
+    gaps = np.diff(kept[:, 0])
+    assert gaps.max() / gaps.min() < 2.0
+
+
+def test_resample_curve_returns_short_curves_untouched():
+    """Nothing to thin when the curve already fits in the budget."""
+    points = np.column_stack([np.arange(5.0), np.arange(5.0) ** 2])
+
+    kept = resample_curve(points, target=30)
+
+    assert np.array_equal(kept, points)
+
+
+def test_resample_curve_keeps_both_endpoints():
+    """The first and last vertices anchor the navigable range."""
+    points = np.column_stack([np.linspace(0, 7, 61), np.sin(np.linspace(0, 7, 61))])
+
+    kept = resample_curve(points, target=10)
+
+    assert np.array_equal(kept[0], points[0])
+    assert np.array_equal(kept[-1], points[-1])


### PR DESCRIPTION
## Description

The `smooth` layer of a `sns.regplot` collapsed to **two** navigable points. Pressing <kbd>Page Up</kbd> onto the fitted-line layer on the [Regression Plots example](https://py.maidr.ai/examples.html#regression-plots) landed on the start of the line, and a single <kbd>→</kbd> jumped to the end and reported "No more data to display". Auto-play was one jump. The KDE curve overlaid on a histogram is the same trace type and navigates with 30 points, so the two overlays behaved inconsistently.

`SmoothPlot._extract_plot_data()` thinned the fitted line with Ramer–Douglas–Peucker via `simplify_curve()`. RDP preserves *shape*, dropping vertices that lie on the chord between their neighbours. A seaborn regplot fit is a straight line sampled on a 100-point grid, so every interior vertex is exactly collinear, every perpendicular distance is `0`, and `dists[max_rel] > epsilon` never fires — not even at `epsilon = 0`. The line reduced to its two endpoints.

Shape preservation is the wrong objective for this trace. A `smooth` layer is navigated and auto-played one vertex at a time at a fixed rate (`SmoothTrace` maps vertex index to time and `y` to frequency), so the vertices need to be *evenly spaced along x* for the sonified sweep to track the visual trend. The same thinning warped the KDE curve as well, clustering its 30 vertices around the bends until the step along x varied by 16.6× (a visible skip from 1.8 straight to 2.3), racing through flat stretches and crawling through curves.

## Related Issues

Fixes #318

## Scope

This PR is deliberately limited to the reported bug. It contains two things:

1. **RDP → even resampling** — the fix for #318.
2. **Even by vertex index → even along x** — because step 1 alone made `sns.regplot(..., lowess=True)` on a skewed sample *worse* than what it replaced (**319×** step spread versus RDP's 87×). A regression this PR introduced, so it is fixed here rather than deferred.

Screen-space pacing — which matters once an axis is log-scaled, where even-along-x stops being even-on-screen — was split out to **#320** so this PR stays close to the bug it fixes. `resample_curve`'s docstring records that limitation until #320 lands.

## Changes Made

- `maidr/util/rdp_utils.py` — added `resample_curve()`, which thins a polyline to points evenly spaced along x, always keeping the first and last. It places samples on an even x grid and interpolates y whenever x increases monotonically, and falls back to even-by-vertex-index for a curve that decreases or doubles back. Module docstring explains why two thinning strategies now coexist.
- `maidr/core/plot/regplot.py` — `SmoothPlot._extract_plot_data()` calls `resample_curve()` instead of `simplify_curve()`, with a comment on why spacing beats shape here.
- `tests/core/plot/test_smooth_sampling.py` — new. End-to-end fixtures for a linear `regplot`, `histplot(kde=True)`, and a clustered-x `lowess` fit, plus unit coverage of `resample_curve`.

`ViolinKdePlot`'s use of `simplify_curve()` is untouched — outlining a violin genuinely wants shape preservation, and it remains that function's only caller.

## Verification

Browser-driven with Playwright, activating the figure and pressing <kbd>Page Up</kbd> then <kbd>→</kbd> repeatedly.

**Regression plot, layer 2 — before**

```
Layer 2 of 2: smooth plot at X values is 0.0, Y values is 1.13
X values is 10.0, Y values is 19.97
No more data to display
```

**Regression plot, layer 2 — after**

```
Layer 2 of 2: smooth plot at X values is 0.0, Y values is 1.10
X values is 0.3, Y values is 1.68
X values is 0.7, Y values is 2.45
X values is 1.0, Y values is 3.03
… (30 points, evenly spaced)
```

**Histogram + KDE, layer 2 — before** (note the skip from 1.8 to 2.3)

```
1.2 → 1.3 → 1.4 → 1.5 → 1.6 → 1.7 → 1.8 → 2.3 → 2.5 → 2.7 → 2.8 → 2.9
```

**Histogram + KDE, layer 2 — after**

```
1.2 → 1.4 → 1.6 → 1.8 → 2.0 → 2.2 → 2.4 → 2.6 → 2.8 → 3.0 → 3.2 → 3.4
```

Spacing spread (max x-step ÷ min x-step) across the smooth layer:

| fit | before (RDP) | after |
|---|---|---|
| `regplot` (order=1) | 2 points only | 1.00× |
| `regplot(order=2)` | — | 1.00× |
| `regplot(lowess=True)`, skewed x | 86.7× | 1.00× |
| `histplot(kde=True)` | 16.6× | 1.00× |

### Nothing changes for sighted users

The emitted `svg_x`/`svg_y` feed `SmoothTraceSvgXY`'s highlight overlay, so this was checked rather than assumed. Comparing old and new extraction with `ci=None` — seaborn's bootstrap CI band otherwise makes any two runs differ by ~1 px regardless of this change, a confound that has to be removed first:

- The fitted line's SVG `d` attribute is **byte-identical**, 100 vertices in both. `_extract_plot_data` only reads `Line2D.get_xydata()`; hashed the vertex array before and after extraction to confirm.
- Rendered screenshots of the un-activated chart: **0 differing pixels** out of 490,000.
- Mid-navigation screenshots differ by 323 pixels — the highlight dot at a different point along the line, which is the fix.
- The overlay circles stay hidden: 31 exist after activation (30 points + the highlight clone) versus 3 before, but exactly **1 is visible** in both.

Interpolated points land on the drawn line to **7e-12 px** on a linear axis. A log axis leaves ~0.107 px, sub-pixel and addressed by #320.

### Tests are not vacuous

Each behaviour was re-run against the code it replaced: 3 tests fail against the pre-fix RDP extractor, and the `lowess` end-to-end case plus the clustered-curve unit test fail against index sampling.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass — `uv run pytest` green at **404 passed**, and `ruff check` clean on the changed files. The pre-existing `ruff` errors elsewhere in `maidr/`, and the one 98-char signature in `rdp_utils.py` that this branch never touches, are left alone.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable — no docs change needed; the example pages regenerate from the same source.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Scope is py-maidr only. The `maidr` JS side consumes the points as given and needs no change, and r-maidr is unaffected — `Ggplot2SmoothLayerProcessor` emits every built vertex and its only `simplify_curve()` caller is the violin processor.

Earlier revisions of this branch also carried the screen-pacing work; that history now lives on `claude/smooth-screen-pacing-vqse7v` and is reviewed in #320, so review comments on this PR referring to `to_scaled_coords` or `_thin_to_even_steps` belong there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHKWpgDYkw6aPtTYn33osp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHKWpgDYkw6aPtTYn33osp)_