### PR TITLE
fix(smooth): pace a smooth layer by drawn distance, not data distance

### DIFF
--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -8,7 +8,11 @@ from maidr.core.enum.plot_type import PlotType
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.util.rdp_utils import resample_curve
 from maidr.util.regression_line_utils import find_regression_line
-from maidr.util.svg_utils import data_to_svg_coords
+from maidr.util.svg_utils import (
+    data_to_svg_coords,
+    from_scaled_coords,
+    to_scaled_coords,
+)
 
 #: Default maximum number of output points per smooth curve.
 _DEFAULT_MAX_SMOOTH_POINTS = 30
@@ -49,6 +53,47 @@ class SmoothPlot(MaidrPlot):
             return [f"g[id='{self._smooth_gid}'] path"]
         return ["g[id^='maidr-'] path"]
 
+    def _thin_to_even_steps(
+        self, x_data: np.ndarray, y_data: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Thin the curve to points that step evenly across the plot.
+
+        The points are navigated and auto-played one at a time at a fixed rate,
+        so the sweep only tracks the drawn line while the steps look even on
+        screen.  Shape-based simplification gives the opposite: it collapses a
+        straight fit to its two endpoints and spends fewer steps on the flat
+        stretches of a curved one than on the bends.
+
+        Thinning happens in scale space, so a log axis paces by the distance it
+        draws rather than by raw data distance — on a linear axis the two are
+        the same thing and this costs nothing.
+
+        Parameters
+        ----------
+        x_data, y_data : np.ndarray
+            Vertices of the fitted line, in data coordinates.
+
+        Returns
+        -------
+        tuple of np.ndarray
+            The retained vertices, in data coordinates.
+        """
+        scaled = to_scaled_coords(self.ax, x_data, y_data)
+        if scaled is None:
+            # The scale cannot represent this data, leaving data coordinates as
+            # the only ordering to thin along.
+            xy = resample_curve(
+                np.column_stack([x_data, y_data]),
+                target=_DEFAULT_MAX_SMOOTH_POINTS,
+            )
+            return xy[:, 0], xy[:, 1]
+
+        xy = resample_curve(
+            np.column_stack(scaled), target=_DEFAULT_MAX_SMOOTH_POINTS
+        )
+        return from_scaled_coords(self.ax, xy[:, 0], xy[:, 1])
+
     def _extract_plot_data(self) -> list:
         """
         Extract XY data from the regression line for serialization, including SVG coordinates.
@@ -70,16 +115,7 @@ class SmoothPlot(MaidrPlot):
         xydata = np.asarray(regression_line.get_xydata())
         x_data, y_data = xydata[:, 0], xydata[:, 1]
 
-        # Thin the curve before computing SVG coordinates.  The points are
-        # navigated and auto-played one at a time at a fixed rate, so they have
-        # to stay evenly spaced along the line: shape-based simplification
-        # would collapse a straight fit to its two endpoints and stretch the
-        # flat stretches of a curved one over fewer steps than the bends.
-        xy = resample_curve(
-            np.column_stack([x_data, y_data]),
-            target=_DEFAULT_MAX_SMOOTH_POINTS,
-        )
-        x_data, y_data = xy[:, 0], xy[:, 1]
+        x_data, y_data = self._thin_to_even_steps(x_data, y_data)
 
         x_svg, y_svg = data_to_svg_coords(self.ax, x_data, y_data)
         return [

--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -95,9 +95,7 @@ class SmoothPlot(MaidrPlot):
             )
             return xy[:, 0], xy[:, 1]
 
-        xy = resample_curve(
-            np.column_stack(scaled), target=_DEFAULT_MAX_SMOOTH_POINTS
-        )
+        xy = resample_curve(np.column_stack(scaled), target=_DEFAULT_MAX_SMOOTH_POINTS)
         return from_scaled_coords(self.ax, xy[:, 0], xy[:, 1])
 
     def _extract_plot_data(self) -> list:

--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -79,6 +79,12 @@ class SmoothPlot(MaidrPlot):
         tuple of np.ndarray
             The retained vertices, in data coordinates.
         """
+        if len(x_data) <= _DEFAULT_MAX_SMOOTH_POINTS:
+            # Nothing to thin, so hand the vertices straight back.  Mapping
+            # them into scale space and out again would return them shifted by
+            # the round trip's last bit or two, for no gain.
+            return x_data, y_data
+
         scaled = to_scaled_coords(self.ax, x_data, y_data)
         if scaled is None:
             # The scale cannot represent this data, leaving data coordinates as

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -159,18 +159,17 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     curve that doubles back, or one running right to left — falls back to
     index sampling.
 
-    Spacing is even in whatever space the caller hands over.  ``SmoothPlot``
-    passes scale space rather than data space, so the evenness lands on screen
-    where the sweep is felt; see
-    :meth:`~maidr.core.plot.regplot.SmoothPlot._thin_to_even_steps`.
+    Spacing is even in whatever space the caller hands over, so a caller that
+    wants evenness on screen rather than in raw data has to convert before
+    calling and back afterwards.
 
     Interpolated points sit on the drawn line, which matters because they are
     what the highlight ring lands on.  Matplotlib renders the curve as straight
     segments between its vertices, so interpolating in scale space — an affine
     map away from the display — walks exactly that path.  That exactness is
-    the caller's to earn, though: interpolating a nonlinear axis in data space
-    instead leaves the points a fraction of a pixel off the segment, which is
-    what ``SmoothPlot`` settles for when a scale cannot represent the curve.
+    the caller's to earn, though: handing over data coordinates for a
+    nonlinear axis instead leaves the points a fraction of a pixel off the
+    segment.
 
     Parameters
     ----------

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -166,8 +166,11 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
 
     Interpolated points sit on the drawn line, which matters because they are
     what the highlight ring lands on.  Matplotlib renders the curve as straight
-    segments between its vertices, and scale space differs from the display by
-    an affine map, so the interpolation walks exactly that path.
+    segments between its vertices, so interpolating in scale space — an affine
+    map away from the display — walks exactly that path.  That exactness is
+    the caller's to earn, though: interpolating a nonlinear axis in data space
+    instead leaves the points a fraction of a pixel off the segment, which is
+    what ``SmoothPlot`` settles for when a scale cannot represent the curve.
 
     Parameters
     ----------

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -159,22 +159,15 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     curve that doubles back, or one running right to left — falls back to
     index sampling.
 
+    Spacing is even in whatever space the caller hands over.  ``SmoothPlot``
+    passes scale space rather than data space, so the evenness lands on screen
+    where the sweep is felt; see
+    :meth:`~maidr.core.plot.regplot.SmoothPlot._thin_to_even_steps`.
+
     Interpolated points sit on the drawn line, which matters because they are
     what the highlight ring lands on.  Matplotlib renders the curve as straight
-    segments between its vertices, so on a linear axis — where data and display
-    space differ by an affine map — the interpolation walks exactly that path.
-    A log axis bends each segment between the vertices, leaving a gap of about
-    a tenth of a pixel at this point count; still far under the ring's radius,
-    just not the exact landing a linear axis gives.
-
-    Known limitation: the grid is even in *data* x, which is even on screen
-    only while the axis is linear.  A log x-axis stretches the same points
-    into a roughly 100:1 spread across the plot, so auto-play sweeps the
-    picture unevenly even though the announced x values step uniformly.
-    Nothing here sets a nonlinear scale — it takes an explicit
-    ``ax.set_xscale`` — and which of the two should stay uniform is a call
-    about what the sweep represents, so this stays as-is until a caller needs
-    otherwise.
+    segments between its vertices, and scale space differs from the display by
+    an affine map, so the interpolation walks exactly that path.
 
     Parameters
     ----------

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -67,6 +67,11 @@ def to_scaled_coords(
     x_data, y_data : np.ndarray
         Data coordinates to map.
 
+    One unmappable point rejects the whole batch rather than being dropped:
+    a curve mapped point by point would mix two coordinate spaces, leaving
+    the spacing it is thinned by — and any interpolation across it —
+    meaningless.
+
     Returns
     -------
     tuple of np.ndarray, or None

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -46,6 +46,32 @@ def unique_lines_by_xy(lines: List[Line2D]) -> List[Line2D]:
     return unique_lines
 
 
+def _clip_sentinel(transform) -> Optional[float]:
+    """
+    Return the coordinate a scale parks unrepresentable values on, if it clips.
+
+    A clipping scale sends every value it cannot represent to one sentinel, so
+    it stops being injective there.  Probing with several values that only such
+    a scale would reject finds that sentinel without naming a scale or its
+    constant: a log axis collapses them onto a single coordinate, while linear,
+    symlog and asinh keep them apart and report nothing to watch for.
+
+    Parameters
+    ----------
+    transform : matplotlib.transforms.Transform
+        A scale transform, as returned by ``Axis.get_transform()``.
+
+    Returns
+    -------
+    float or None
+        The sentinel coordinate, or ``None`` for a scale that never clips.
+    """
+    probe = transform.transform(np.array([-1.0, -2.0, -4.0]))
+    if probe[0] == probe[1] == probe[2]:
+        return float(probe[0])
+    return None
+
+
 def to_scaled_coords(
     ax: Axes, x_data: np.ndarray, y_data: np.ndarray
 ) -> Optional[Tuple[np.ndarray, np.ndarray]]:
@@ -87,10 +113,19 @@ def to_scaled_coords(
     if not (np.all(np.isfinite(x_scaled)) and np.all(np.isfinite(y_scaled))):
         return None
 
-    # The check above catches only a scale that answers with infinity or NaN.
-    # A log scale clips instead, mapping an unrepresentable value to a sentinel
-    # that reads as a perfectly ordinary coordinate, so the round trip is the
-    # only thing standing between that value and a curve thinned against it.
+    # Zero is the one clipped value the round trip below cannot see: a log
+    # scale parks it on the sentinel, and inverting that underflows back to
+    # zero, so the value appears to have survived the journey intact.  Ask the
+    # scale where it parks what it rejects, and refuse anything sitting there.
+    for transform, scaled in ((x_transform, x_scaled), (y_transform, y_scaled)):
+        sentinel = _clip_sentinel(transform)
+        if sentinel is not None and np.any(scaled == sentinel):
+            return None
+
+    # The finiteness check above catches only a scale that answers with
+    # infinity or NaN.  A log scale clips instead, mapping an unrepresentable
+    # value to a coordinate that reads as perfectly ordinary, so the round trip
+    # is what stands between that value and a curve thinned against it.
     if not (
         np.allclose(
             x_transform.inverted().transform(x_scaled), x_data, rtol=1e-9, atol=0

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -62,6 +62,13 @@ def _clip_sentinel(transform) -> Optional[float]:
     finiteness check in :func:`to_scaled_coords` instead.  The two guards cover
     one mode each; neither is redundant.
 
+    This reads matplotlib's behaviour rather than a promise it makes, so a
+    future release that stops collapsing rejected values would go undetected
+    here and the sentinel would simply never be found again.  Nothing raises
+    in that case — a curve touching zero on a log axis would quietly go back
+    to being thinned against the sentinel — so a caller left wondering why
+    such a curve drifts off the canvas should suspect this probe first.
+
     Parameters
     ----------
     transform : matplotlib.transforms.Transform

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -60,17 +60,17 @@ def to_scaled_coords(
     axes' position and limits to settle.  A linear axis passes through
     unchanged; a log axis becomes its logarithm.
 
+    One unmappable point rejects the whole batch rather than being dropped:
+    a curve mapped point by point would mix two coordinate spaces, leaving
+    the spacing it is thinned by — and any interpolation across it —
+    meaningless.
+
     Parameters
     ----------
     ax : Axes
         The axes whose x and y scales apply.
     x_data, y_data : np.ndarray
         Data coordinates to map.
-
-    One unmappable point rejects the whole batch rather than being dropped:
-    a curve mapped point by point would mix two coordinate spaces, leaving
-    the spacing it is thinned by — and any interpolation across it —
-    meaningless.
 
     Returns
     -------

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -52,11 +52,13 @@ def to_scaled_coords(
     """
     Map data coordinates into the axes' scale space.
 
-    Distances there are proportional to distances on screen, because what
-    remains between scale space and the display is an affine map.  A linear
-    axis passes through unchanged; a log axis becomes its logarithm.  Working
-    in scale space rather than reading ``transData`` keeps the result
-    independent of figure layout, which is not settled during extraction.
+    What remains between scale space and the display is an affine map, so
+    ratios of distances there are the ratios on screen — which is what makes
+    reasoning about drawn distance in scale space valid at all.  Because an
+    affine map cannot change those ratios, the answer holds whatever the
+    figure layout turns out to be, so this neither needs nor waits for the
+    axes' position and limits to settle.  A linear axis passes through
+    unchanged; a log axis becomes its logarithm.
 
     Parameters
     ----------

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -50,24 +50,18 @@ def _clip_sentinel(transform) -> Optional[float]:
     """
     Return the coordinate a scale parks unrepresentable values on, if it clips.
 
-    A clipping scale sends every value it cannot represent to one sentinel, so
-    it stops being injective there.  Probing with several values that only such
-    a scale would reject finds that sentinel without naming a scale or its
-    constant: a log axis collapses them onto a single coordinate, while linear,
-    symlog and asinh keep them apart and report nothing to watch for.
+    A clipping scale sends everything it cannot represent to one coordinate,
+    so it stops being injective there; probing with values only such a scale
+    would reject finds that coordinate without naming a scale or its constant.
+    A masking scale answers with NaN, which never compares equal, so none is
+    reported for it — correctly, since it has none, and its rejected values
+    are caught by the finiteness check in :func:`to_scaled_coords` instead.
+    The two guards cover a mode each.
 
-    A scale asked to mask rather than clip answers with NaN, which never
-    compares equal, so this reports no sentinel for it.  That is the honest
-    answer — such a scale has none — and its rejected values are caught by the
-    finiteness check in :func:`to_scaled_coords` instead.  The two guards cover
-    one mode each; neither is redundant.
-
-    This reads matplotlib's behaviour rather than a promise it makes, so a
-    future release that stops collapsing rejected values would go undetected
-    here and the sentinel would simply never be found again.  Nothing raises
-    in that case — a curve touching zero on a log axis would quietly go back
-    to being thinned against the sentinel — so a caller left wondering why
-    such a curve drifts off the canvas should suspect this probe first.
+    This reads matplotlib's behaviour rather than a promise, and would fail
+    quietly: a release that stopped collapsing rejected values would leave the
+    sentinel never found, and a curve touching zero on a log axis thinned
+    against it again and drifting off the canvas.
 
     Parameters
     ----------

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from matplotlib.axes import Axes
+from matplotlib.transforms import Transform
 from matplotlib.lines import Line2D
 from typing import List, Optional, Tuple
 
@@ -46,7 +47,7 @@ def unique_lines_by_xy(lines: List[Line2D]) -> List[Line2D]:
     return unique_lines
 
 
-def _clip_sentinel(transform) -> Optional[float]:
+def _clip_sentinel(transform: Transform) -> Optional[float]:
     """
     Return the coordinate a scale parks unrepresentable values on, if it clips.
 
@@ -66,7 +67,7 @@ def _clip_sentinel(transform) -> Optional[float]:
 
     Parameters
     ----------
-    transform : matplotlib.transforms.Transform
+    transform : Transform
         A scale transform, as returned by ``Axis.get_transform()``.
 
     Returns

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -87,8 +87,10 @@ def to_scaled_coords(
     if not (np.all(np.isfinite(x_scaled)) and np.all(np.isfinite(y_scaled))):
         return None
 
-    # A clipped value maps to a sentinel rather than to infinity, so the round
-    # trip is what actually reveals whether the scale represented this data.
+    # The check above catches only a scale that answers with infinity or NaN.
+    # A log scale clips instead, mapping an unrepresentable value to a sentinel
+    # that reads as a perfectly ordinary coordinate, so the round trip is the
+    # only thing standing between that value and a curve thinned against it.
     if not (
         np.allclose(
             x_transform.inverted().transform(x_scaled), x_data, rtol=1e-9, atol=0

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -85,8 +85,12 @@ def to_scaled_coords(
     # A clipped value maps to a sentinel rather than to infinity, so the round
     # trip is what actually reveals whether the scale represented this data.
     if not (
-        np.allclose(x_transform.inverted().transform(x_scaled), x_data, rtol=1e-9)
-        and np.allclose(y_transform.inverted().transform(y_scaled), y_data, rtol=1e-9)
+        np.allclose(
+            x_transform.inverted().transform(x_scaled), x_data, rtol=1e-9, atol=0
+        )
+        and np.allclose(
+            y_transform.inverted().transform(y_scaled), y_data, rtol=1e-9, atol=0
+        )
     ):
         return None
 

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 
 def data_to_svg_coords(
@@ -44,3 +44,72 @@ def unique_lines_by_xy(lines: List[Line2D]) -> List[Line2D]:
             seen_xy.add(xy_rounded)
             unique_lines.append(line)
     return unique_lines
+
+
+def to_scaled_coords(
+    ax: Axes, x_data: np.ndarray, y_data: np.ndarray
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """
+    Map data coordinates into the axes' scale space.
+
+    Distances there are proportional to distances on screen, because what
+    remains between scale space and the display is an affine map.  A linear
+    axis passes through unchanged; a log axis becomes its logarithm.  Working
+    in scale space rather than reading ``transData`` keeps the result
+    independent of figure layout, which is not settled during extraction.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes whose x and y scales apply.
+    x_data, y_data : np.ndarray
+        Data coordinates to map.
+
+    Returns
+    -------
+    tuple of np.ndarray, or None
+        The mapped coordinates, or ``None`` when a scale cannot represent this
+        data faithfully — a log axis reaching zero or below, which matplotlib
+        clips rather than maps.  Callers should stay on data coordinates then.
+    """
+    x_transform = ax.xaxis.get_transform()
+    y_transform = ax.yaxis.get_transform()
+    x_scaled = x_transform.transform(x_data)
+    y_scaled = y_transform.transform(y_data)
+
+    if not (np.all(np.isfinite(x_scaled)) and np.all(np.isfinite(y_scaled))):
+        return None
+
+    # A clipped value maps to a sentinel rather than to infinity, so the round
+    # trip is what actually reveals whether the scale represented this data.
+    if not (
+        np.allclose(x_transform.inverted().transform(x_scaled), x_data, rtol=1e-9)
+        and np.allclose(y_transform.inverted().transform(y_scaled), y_data, rtol=1e-9)
+    ):
+        return None
+
+    return x_scaled, y_scaled
+
+
+def from_scaled_coords(
+    ax: Axes, x_scaled: np.ndarray, y_scaled: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Invert :func:`to_scaled_coords`, returning data coordinates.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes whose x and y scales apply.
+    x_scaled, y_scaled : np.ndarray
+        Coordinates in the axes' scale space.
+
+    Returns
+    -------
+    tuple of np.ndarray
+        The same points in data coordinates.
+    """
+    return (
+        ax.xaxis.get_transform().inverted().transform(x_scaled),
+        ax.yaxis.get_transform().inverted().transform(y_scaled),
+    )

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -53,10 +53,11 @@ def _clip_sentinel(transform) -> Optional[float]:
     A clipping scale sends everything it cannot represent to one coordinate,
     so it stops being injective there; probing with values only such a scale
     would reject finds that coordinate without naming a scale or its constant.
-    A masking scale answers with NaN, which never compares equal, so none is
-    reported for it — correctly, since it has none, and its rejected values
-    are caught by the finiteness check in :func:`to_scaled_coords` instead.
-    The two guards cover a mode each.
+    The probe looks downward only, since a lower bound is the one a scale
+    parks values below; a scale rejecting on an upper bound, as logit does at
+    1, answers with infinity rather than a sentinel.  That and a masking
+    scale's NaN both fall to the finiteness check in :func:`to_scaled_coords`,
+    which is why the guards there cover a mode each.
 
     This reads matplotlib's behaviour rather than a promise, and would fail
     quietly: a release that stopped collapsing rejected values would leave the

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -56,6 +56,12 @@ def _clip_sentinel(transform) -> Optional[float]:
     constant: a log axis collapses them onto a single coordinate, while linear,
     symlog and asinh keep them apart and report nothing to watch for.
 
+    A scale asked to mask rather than clip answers with NaN, which never
+    compares equal, so this reports no sentinel for it.  That is the honest
+    answer — such a scale has none — and its rejected values are caught by the
+    finiteness check in :func:`to_scaled_coords` instead.  The two guards cover
+    one mode each; neither is redundant.
+
     Parameters
     ----------
     transform : matplotlib.transforms.Transform

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -162,8 +162,12 @@ def test_straight_regression_line_keeps_the_full_point_budget(regplot_figure):
 
 @pytest.mark.parametrize(
     "figure_fixture",
-    ["regplot_figure", "histplot_kde_figure", "lowess_regplot_figure",
-     "log_x_regplot_figure"],
+    [
+        "regplot_figure",
+        "histplot_kde_figure",
+        "lowess_regplot_figure",
+        "log_x_regplot_figure",
+    ],
     ids=["reg", "kde", "lowess", "log"],
 )
 def test_smooth_points_are_evenly_spaced(figure_fixture, request):
@@ -178,8 +182,12 @@ def test_smooth_points_are_evenly_spaced(figure_fixture, request):
 
 @pytest.mark.parametrize(
     "figure_fixture",
-    ["regplot_figure", "histplot_kde_figure", "lowess_regplot_figure",
-     "log_x_regplot_figure"],
+    [
+        "regplot_figure",
+        "histplot_kde_figure",
+        "lowess_regplot_figure",
+        "log_x_regplot_figure",
+    ],
     ids=["reg", "kde", "lowess", "log"],
 )
 def test_smooth_points_span_the_whole_line(figure_fixture, request):
@@ -257,6 +265,35 @@ def test_curve_within_budget_is_passed_through_untouched():
         emitted = _x_values(_smooth_points(fig))
 
         assert np.array_equal(emitted, source[:, 0])
+    finally:
+        plt.close(fig)
+
+
+def test_filled_kde_boundary_is_thinned_by_index():
+    """A filled KDE registers its polygon outline, which has no x ordering.
+
+    ``sns.kdeplot(fill=True)`` hands ``SmoothPlot`` the boundary of a
+    ``PolyCollection`` — a closed loop that runs out along the curve and back
+    along the baseline — so x doubles back and the even-x path cannot apply.
+    Thinning has to fall through to vertex index and still produce a usable
+    trace rather than mangling the outline.
+    """
+    rng = np.random.default_rng(11)
+    data = rng.normal(0, 1, 400)
+
+    fig, ax = plt.subplots()
+    sns.kdeplot(data, fill=True, ax=ax)
+    try:
+        plots = [
+            p for p in FigureManager.get_maidr(fig).plots if p.type is PlotType.SMOOTH
+        ]
+        assert len(plots) == 1
+        assert plots[0]._is_polycollection, "fixture must exercise the poly path"
+
+        x = _x_values(plots[0].schema["data"][0])
+
+        assert not np.all(np.diff(x) > 0), "a closed outline must double back"
+        assert len(x) == _DEFAULT_MAX_SMOOTH_POINTS
     finally:
         plt.close(fig)
 

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -46,6 +46,11 @@ def _source_line(fig) -> np.ndarray:
     return np.asarray(line.get_xydata())
 
 
+def _svg_x_values(points: list[dict]) -> np.ndarray:
+    """Pull the on-screen x coordinates out of a smooth layer's point list."""
+    return np.array([float(p["svg_x"]) for p in points])
+
+
 def _x_values(points: list[dict]) -> np.ndarray:
     """Pull the x coordinates out of a smooth layer's point list."""
     return np.array([float(p[MaidrKey.X]) for p in points])
@@ -102,6 +107,37 @@ def test_lowess_fit_source_curve_really_is_clustered(lowess_regplot_figure):
     assert gaps.max() / gaps.min() > 50
 
 
+@pytest.fixture
+def log_x_regplot_figure():
+    """A regplot on a log x-axis, where data distance stops matching the screen."""
+    rng = np.random.default_rng(1)
+    x = np.geomspace(1, 1000, 60)
+    y = np.log10(x) * 3 + rng.normal(0, 0.2, 60)
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    sns.regplot(x=x, y=y, ax=ax, ci=None)
+    ax.set_xscale("log")
+    yield fig
+    plt.close(fig)
+
+
+def test_log_axis_paces_by_the_screen_not_the_data(log_x_regplot_figure):
+    """Auto-play advances a constant distance across the plot, as drawn.
+
+    The sweep is meant to track what a sighted reader sees moving left to
+    right, so a log axis has to pace by drawn distance. Uniform data steps
+    would bunch almost the whole curve into the last part of the plot.
+    """
+    points = _smooth_points(log_x_regplot_figure)
+    screen_gaps = np.abs(np.diff(_svg_x_values(points)))
+    data_gaps = np.diff(_x_values(points))
+
+    assert screen_gaps.max() / screen_gaps.min() < 2.0
+    # And confirm this genuinely cost the data-space evenness, so the test
+    # cannot pass by the two spacings happening to agree.
+    assert data_gaps.max() / data_gaps.min() > 50
+
+
 def test_straight_regression_line_is_not_collapsed_to_its_endpoints(regplot_figure):
     """A linear fit must stay navigable, not shrink to a start and an end."""
     points = _smooth_points(regplot_figure)
@@ -125,23 +161,25 @@ def test_straight_regression_line_keeps_the_full_point_budget(regplot_figure):
 
 @pytest.mark.parametrize(
     "figure_fixture",
-    ["regplot_figure", "histplot_kde_figure", "lowess_regplot_figure"],
-    ids=["reg", "kde", "lowess"],
+    ["regplot_figure", "histplot_kde_figure", "lowess_regplot_figure",
+     "log_x_regplot_figure"],
+    ids=["reg", "kde", "lowess", "log"],
 )
 def test_smooth_points_are_evenly_spaced(figure_fixture, request):
-    """Steps along x stay uniform so auto-play paces the trend correctly."""
+    """Steps stay uniform on screen so auto-play paces the trend correctly."""
     fig = request.getfixturevalue(figure_fixture)
-    x = _x_values(_smooth_points(fig))
-    gaps = np.diff(x)
+    points = _smooth_points(fig)
+    gaps = np.abs(np.diff(_svg_x_values(points)))
 
-    assert np.all(gaps > 0), "x must stay monotonically increasing"
-    assert gaps.max() / gaps.min() < 2.0, f"uneven steps along x: {gaps}"
+    assert np.all(np.diff(_x_values(points)) > 0), "x must stay increasing"
+    assert gaps.max() / gaps.min() < 2.0, f"uneven steps across the plot: {gaps}"
 
 
 @pytest.mark.parametrize(
     "figure_fixture",
-    ["regplot_figure", "histplot_kde_figure", "lowess_regplot_figure"],
-    ids=["reg", "kde", "lowess"],
+    ["regplot_figure", "histplot_kde_figure", "lowess_regplot_figure",
+     "log_x_regplot_figure"],
+    ids=["reg", "kde", "lowess", "log"],
 )
 def test_smooth_points_span_the_whole_line(figure_fixture, request):
     """Thinning keeps both endpoints, so the trace covers the fitted range."""

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -424,6 +424,34 @@ def test_a_representable_zero_is_not_rejected(scale):
         plt.close(fig)
 
 
+def test_a_masking_scale_is_caught_by_the_finiteness_guard():
+    """The guard table claims this path; nothing was holding it to that.
+
+    A scale asked to mask rather than clip is the one case the sentinel probe
+    reports nothing for, so the finiteness check has to carry it. That rests
+    on matplotlib handing back a plain array of NaN and infinity rather than a
+    masked one — on a masked array the reduction would count masked entries as
+    vacuously true and wave the curve through.
+    """
+    fig, ax = plt.subplots()
+    ax.set_xscale("log", nonpositive="mask")
+    try:
+        transform = ax.xaxis.get_transform()
+        scaled = transform.transform(np.array([-1.0, 0.0, 1.0, 10.0]))
+
+        assert not np.ma.is_masked(scaled), "a masked array would break the guard"
+        assert isinstance(np.all(np.isfinite(scaled)), (bool, np.bool_))
+        assert not np.all(np.isfinite(scaled))
+        assert _clip_sentinel(transform) is None, "masking parks nothing"
+
+        x = np.array([-1.0, 1.0, 10.0])
+        y = np.array([1.0, 2.0, 3.0])
+
+        assert to_scaled_coords(ax, x, y) is None
+    finally:
+        plt.close(fig)
+
+
 def test_curve_within_budget_is_passed_through_untouched():
     """A short fit keeps its exact vertices, not a scale round trip's rounding.
 

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -218,24 +218,54 @@ def log_y_crossing_zero_figure():
     plt.close(fig)
 
 
-def test_unmappable_scale_is_detected(log_y_crossing_zero_figure):
-    """Guards the fixture: the fallback test means nothing if the scale maps."""
-    ax = FigureManager.get_axes(log_y_crossing_zero_figure)[0]
-    source = _source_line(log_y_crossing_zero_figure)
+@pytest.fixture
+def log_x_crossing_zero_figure():
+    """The same unmappable case on the other axis.
 
-    assert source[:, 1].min() < 0, "fitted line must reach below zero"
+    ``to_scaled_coords`` checks x and y separately, so covering only one axis
+    would leave the other resting on an assumption of symmetry.
+    """
+    rng = np.random.default_rng(4)
+    x = np.linspace(-3, 12, 60)
+    y = 2 * x + rng.normal(0, 1.5, 60)
+
+    fig, ax = plt.subplots()
+    sns.regplot(x=x, y=y, ax=ax, ci=None)
+    ax.set_xscale("log")
+    yield fig
+    plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    "figure_fixture",
+    ["log_y_crossing_zero_figure", "log_x_crossing_zero_figure"],
+    ids=["log_y", "log_x"],
+)
+def test_unmappable_scale_is_detected(figure_fixture, request):
+    """Guards the fixtures: the fallback tests mean nothing if the scale maps."""
+    fig = request.getfixturevalue(figure_fixture)
+    ax = FigureManager.get_axes(fig)[0]
+    source = _source_line(fig)
+
+    assert source.min(axis=0).min() < 0, "the fit must reach below zero"
     assert to_scaled_coords(ax, source[:, 0], source[:, 1]) is None
 
 
-def test_unmappable_scale_still_thins_the_curve(log_y_crossing_zero_figure):
+@pytest.mark.parametrize(
+    "figure_fixture",
+    ["log_y_crossing_zero_figure", "log_x_crossing_zero_figure"],
+    ids=["log_y", "log_x"],
+)
+def test_unmappable_scale_still_thins_the_curve(figure_fixture, request):
     """Falling back to data space must still yield a usable trace.
 
     Screen-even pacing is out of reach when the scale cannot represent the
     line, but degrading to data-space spacing has to stay graceful — a full
     budget of points spanning the fit, not a collapse or a crash.
     """
-    source_x = _source_line(log_y_crossing_zero_figure)[:, 0]
-    x = _x_values(_smooth_points(log_y_crossing_zero_figure))
+    fig = request.getfixturevalue(figure_fixture)
+    source_x = _source_line(fig)[:, 0]
+    x = _x_values(_smooth_points(fig))
     gaps = np.diff(x)
 
     assert len(x) == _DEFAULT_MAX_SMOOTH_POINTS

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -24,6 +24,7 @@ from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.core.plot.regplot import _DEFAULT_MAX_SMOOTH_POINTS  # noqa: E402
 from maidr.util.rdp_utils import resample_curve  # noqa: E402
 from maidr.util.regression_line_utils import find_regression_line  # noqa: E402
+from maidr.util.svg_utils import to_scaled_coords  # noqa: E402
 
 
 def _smooth_points(fig) -> list[dict]:
@@ -189,6 +190,75 @@ def test_smooth_points_span_the_whole_line(figure_fixture, request):
 
     assert x[0] == pytest.approx(source_x[0])
     assert x[-1] == pytest.approx(source_x[-1])
+
+
+@pytest.fixture
+def log_y_crossing_zero_figure():
+    """A log y-axis whose fitted line dips below zero, which no log can map.
+
+    Matplotlib clips such a value to a sentinel rather than refusing it, so
+    this is the case ``to_scaled_coords`` has to catch by round-tripping.
+    """
+    rng = np.random.default_rng(3)
+    x = np.linspace(1, 10, 60)
+    y = np.linspace(-5, 20, 60) + rng.normal(0, 1, 60)
+
+    fig, ax = plt.subplots()
+    sns.regplot(x=x, y=y, ax=ax, ci=None)
+    ax.set_yscale("log")
+    yield fig
+    plt.close(fig)
+
+
+def test_unmappable_scale_is_detected(log_y_crossing_zero_figure):
+    """Guards the fixture: the fallback test means nothing if the scale maps."""
+    ax = FigureManager.get_axes(log_y_crossing_zero_figure)[0]
+    source = _source_line(log_y_crossing_zero_figure)
+
+    assert source[:, 1].min() < 0, "fitted line must reach below zero"
+    assert to_scaled_coords(ax, source[:, 0], source[:, 1]) is None
+
+
+def test_unmappable_scale_still_thins_the_curve(log_y_crossing_zero_figure):
+    """Falling back to data space must still yield a usable trace.
+
+    Screen-even pacing is out of reach when the scale cannot represent the
+    line, but degrading to data-space spacing has to stay graceful — a full
+    budget of points spanning the fit, not a collapse or a crash.
+    """
+    source_x = _source_line(log_y_crossing_zero_figure)[:, 0]
+    x = _x_values(_smooth_points(log_y_crossing_zero_figure))
+    gaps = np.diff(x)
+
+    assert len(x) == _DEFAULT_MAX_SMOOTH_POINTS
+    assert x[0] == pytest.approx(source_x[0])
+    assert x[-1] == pytest.approx(source_x[-1])
+    assert gaps.max() / gaps.min() < 2.0
+
+
+def test_curve_within_budget_is_passed_through_untouched():
+    """A short fit keeps its exact vertices, not a scale round trip's rounding.
+
+    ``lowess`` over few points returns a fit shorter than the budget, so there
+    is nothing to thin — and mapping it through a log scale and back would
+    shift the values by the round trip's last bits for no gain.
+    """
+    rng = np.random.default_rng(5)
+    x = np.sort(rng.uniform(1, 100, 12))
+    y = np.log10(x) * 4 + rng.normal(0, 0.3, 12)
+
+    fig, ax = plt.subplots()
+    sns.regplot(x=x, y=y, ax=ax, ci=None, lowess=True)
+    ax.set_xscale("log")
+    try:
+        source = _source_line(fig)
+        assert len(source) <= _DEFAULT_MAX_SMOOTH_POINTS, "fit must be under budget"
+
+        emitted = _x_values(_smooth_points(fig))
+
+        assert np.array_equal(emitted, source[:, 0])
+    finally:
+        plt.close(fig)
 
 
 def test_resample_curve_keeps_a_straight_line_at_full_budget():

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -328,6 +328,40 @@ def test_filled_kde_boundary_is_thinned_by_index():
         plt.close(fig)
 
 
+def test_filled_kde_on_a_log_axis_falls_back_twice():
+    """Both fallbacks compose: an unmappable scale, then a curve with no order.
+
+    A filled KDE's support runs past its data, into x values a log axis cannot
+    map, so the scale falls back to data space — and the outline is a closed
+    loop, so thinning falls back again to vertex index. Each is covered alone;
+    this pins that stacking them still yields a full, usable trace.
+    """
+    rng = np.random.default_rng(21)
+    data = rng.lognormal(3.0, 0.45, 500)
+
+    fig, ax = plt.subplots()
+    sns.kdeplot(data, fill=True, ax=ax)
+    ax.set_xscale("log")
+    try:
+        plots = [
+            p for p in FigureManager.get_maidr(fig).plots if p.type is PlotType.SMOOTH
+        ]
+        assert len(plots) == 1
+        points = plots[0].schema["data"][0]
+        source = np.asarray(plots[0]._elements[0].get_xydata())
+
+        assert plots[0]._is_polycollection, "fixture must exercise the poly path"
+        assert source[:, 0].min() <= 0, "support must reach where a log cannot map"
+        assert to_scaled_coords(ax, source[:, 0], source[:, 1]) is None
+
+        x = _x_values(points)
+
+        assert not np.all(np.diff(x) > 0), "a closed outline must double back"
+        assert len(x) == _DEFAULT_MAX_SMOOTH_POINTS
+    finally:
+        plt.close(fig)
+
+
 def test_resample_curve_keeps_a_straight_line_at_full_budget():
     """Collinear points carry no shape, so only the spacing can guide us."""
     points = np.column_stack([np.linspace(0, 1, 100), np.linspace(0, 2, 100)])

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -24,7 +24,7 @@ from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.core.plot.regplot import _DEFAULT_MAX_SMOOTH_POINTS  # noqa: E402
 from maidr.util.rdp_utils import resample_curve  # noqa: E402
 from maidr.util.regression_line_utils import find_regression_line  # noqa: E402
-from maidr.util.svg_utils import to_scaled_coords  # noqa: E402
+from maidr.util.svg_utils import _clip_sentinel, to_scaled_coords  # noqa: E402
 
 
 def _smooth_points(fig) -> list[dict]:
@@ -366,6 +366,33 @@ def test_filled_kde_doubles_back_inside_scale_space():
 
         assert not np.all(np.diff(x) > 0), "a closed outline must double back"
         assert len(x) == _DEFAULT_MAX_SMOOTH_POINTS
+    finally:
+        plt.close(fig)
+
+
+def test_a_scale_rejecting_on_an_upper_bound_is_caught():
+    """The sentinel probe looks downward; infinity is what covers the other end.
+
+    ``logit`` rejects at both 0 and 1, and signals with infinity rather than
+    parking values on a sentinel, so the probe finds nothing for it. The round
+    trip cannot see it either — inverting infinity returns 1.0 unchanged. The
+    finiteness check is what stands there.
+    """
+    fig, ax = plt.subplots()
+    ax.set_xscale("logit")
+    try:
+        transform = ax.xaxis.get_transform()
+        x = np.array([0.2, 0.5, 0.9, 1.0])
+        y = np.array([1.0, 2.0, 3.0, 4.0])
+        scaled = transform.transform(x)
+
+        assert _clip_sentinel(transform) is None, "logit parks nothing on a sentinel"
+        assert not np.isfinite(scaled).all(), "it signals with infinity instead"
+        # The trap this guards: the round trip alone reports the value intact.
+        round_tripped = transform.inverted().transform(scaled)
+        assert np.allclose(round_tripped, x, rtol=1e-9, atol=0)
+
+        assert to_scaled_coords(ax, x, y) is None
     finally:
         plt.close(fig)
 

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -306,6 +306,36 @@ def test_unmappable_scale_still_thins_the_curve(figure_fixture, request):
     assert gaps.max() / gaps.min() < 2.0
 
 
+def test_a_fit_touching_zero_on_a_log_axis_is_not_mapped():
+    """Exactly zero is the clipped value a round trip alone cannot see.
+
+    A log scale parks it on a sentinel, and inverting that underflows back to
+    zero, so the value looks like it survived the journey. Thinning against
+    the sentinel then drags almost the whole curve off the canvas. ``x``
+    starting at zero is an ordinary fixture, so this is reachable rather than
+    exotic.
+    """
+    rng = np.random.default_rng(2)
+    x = np.linspace(0, 10, 50)
+    y = 2 * x + 1 + rng.normal(0, 1.5, 50)
+
+    fig, ax = plt.subplots()
+    sns.regplot(x=x, y=y, ax=ax, ci=None)
+    ax.set_xscale("log")
+    try:
+        source = _source_line(fig)
+        assert source[0, 0] == 0.0, "the fit must land on zero exactly"
+        assert to_scaled_coords(ax, source[:, 0], source[:, 1]) is None
+
+        points = _smooth_points(fig)
+        off_canvas = int((_svg_x_values(points) < 0).sum())
+
+        # Only the zero itself, which no log axis can place, may fall outside.
+        assert off_canvas <= 1, f"{off_canvas} of {len(points)} points off canvas"
+    finally:
+        plt.close(fig)
+
+
 def test_curve_within_budget_is_passed_through_untouched():
     """A short fit keeps its exact vertices, not a scale round trip's rounding.
 

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -336,6 +336,40 @@ def test_a_fit_touching_zero_on_a_log_axis_is_not_mapped():
         plt.close(fig)
 
 
+def test_filled_kde_doubles_back_inside_scale_space():
+    """The index fallback also has to work on scale-space coordinates.
+
+    Data far enough from zero keeps a filled KDE's whole outline positive, so
+    a log axis maps it and thinning stays on the scale-space path — where the
+    closed loop still has to fall back to vertex index. The other outline
+    tests either take both fallbacks or neither, leaving this one unpinned.
+    """
+    rng = np.random.default_rng(5)
+    data = rng.normal(1000, 5, 500)
+
+    fig, ax = plt.subplots()
+    sns.kdeplot(data, fill=True, ax=ax)
+    ax.set_xscale("log")
+    try:
+        plots = [
+            p for p in FigureManager.get_maidr(fig).plots if p.type is PlotType.SMOOTH
+        ]
+        assert len(plots) == 1
+        points = plots[0].schema["data"][0]
+        source = np.asarray(plots[0]._elements[0].get_xydata())
+
+        assert plots[0]._is_polycollection, "fixture must exercise the poly path"
+        assert source[:, 0].min() > 0, "outline must stay mappable on a log axis"
+        assert to_scaled_coords(ax, source[:, 0], source[:, 1]) is not None
+
+        x = _x_values(points)
+
+        assert not np.all(np.diff(x) > 0), "a closed outline must double back"
+        assert len(x) == _DEFAULT_MAX_SMOOTH_POINTS
+    finally:
+        plt.close(fig)
+
+
 def test_curve_within_budget_is_passed_through_untouched():
     """A short fit keeps its exact vertices, not a scale round trip's rounding.
 

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -24,7 +24,11 @@ from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.core.plot.regplot import _DEFAULT_MAX_SMOOTH_POINTS  # noqa: E402
 from maidr.util.rdp_utils import resample_curve  # noqa: E402
 from maidr.util.regression_line_utils import find_regression_line  # noqa: E402
-from maidr.util.svg_utils import _clip_sentinel, to_scaled_coords  # noqa: E402
+from maidr.util.svg_utils import (  # noqa: E402
+    _clip_sentinel,
+    from_scaled_coords,
+    to_scaled_coords,
+)
 
 
 def _smooth_points(fig) -> list[dict]:
@@ -393,6 +397,29 @@ def test_a_scale_rejecting_on_an_upper_bound_is_caught():
         assert np.allclose(round_tripped, x, rtol=1e-9, atol=0)
 
         assert to_scaled_coords(ax, x, y) is None
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize("scale", ["linear", "symlog", "asinh"])
+def test_a_representable_zero_is_not_rejected(scale):
+    """Zero must map where it is legal, not be swept up with the clipped kind.
+
+    The round trip compares on relative tolerance alone, so a value of zero
+    has to come back as exactly zero to pass. That holds on the scales where
+    zero is representable, and rejecting it would drop the whole curve to the
+    fallback for no reason.
+    """
+    x = np.array([-10.0, -1.0, 0.0, 1.0, 10.0])
+    y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+    fig, ax = plt.subplots()
+    ax.set_xscale(scale)
+    try:
+        scaled = to_scaled_coords(ax, x, y)
+
+        assert scaled is not None, f"{scale} represents zero and must map it"
+        assert from_scaled_coords(ax, *scaled)[0][2] == 0.0
     finally:
         plt.close(fig)
 

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -139,6 +139,38 @@ def test_log_axis_paces_by_the_screen_not_the_data(log_x_regplot_figure):
     assert data_gaps.max() / data_gaps.min() > 50
 
 
+@pytest.mark.parametrize("scale", ["symlog", "asinh"])
+def test_any_nonlinear_scale_paces_by_the_screen(scale):
+    """Pacing follows whatever scale the axis carries, not log in particular.
+
+    The thinning reads ``axis.get_transform()`` rather than testing for a log
+    axis, so scales that are linear near zero and compress further out should
+    work the same way. These also map values a log axis cannot, which keeps
+    them on the scale-space path rather than the fallback.
+    """
+    rng = np.random.default_rng(9)
+    x = np.concatenate([-np.geomspace(1000, 1, 30), np.geomspace(1, 1000, 30)])
+    y = np.sign(x) * np.log10(np.abs(x) + 1) * 2 + rng.normal(0, 0.2, 60)
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    sns.regplot(x=x, y=y, ax=ax, ci=None)
+    ax.set_xscale(scale)
+    try:
+        source = _source_line(fig)
+        assert to_scaled_coords(ax, source[:, 0], source[:, 1]) is not None
+
+        points = _smooth_points(fig)
+        screen_gaps = np.abs(np.diff(_svg_x_values(points)))
+        data_gaps = np.diff(_x_values(points))
+
+        assert screen_gaps.max() / screen_gaps.min() < 2.0
+        # Spanning several decades either side of zero, so data-space steps
+        # diverge wildly — the test would be empty if they happened to agree.
+        assert data_gaps.max() / data_gaps.min() > 50
+    finally:
+        plt.close(fig)
+
+
 def test_straight_regression_line_is_not_collapsed_to_its_endpoints(regplot_figure):
     """A linear fit must stay navigable, not shrink to a start and an end."""
     points = _smooth_points(regplot_figure)


### PR DESCRIPTION
## Description

Follow-up to #319, split out of it so that PR stayed scoped to the reported bug. #319 has since merged, and this is rebased onto `main`.

#319 made a `smooth` layer's points evenly spaced **along x**. That is evenly spaced **on screen** only while the axis is linear. A log x-axis stretches the same points into a roughly **102:1** spread across the plot, so auto-play sweeps the picture unevenly even though the announced x values step uniformly — the pacing problem #319 fixes, reappearing for a non-default axis scale.

A `smooth` trace is meant to let a blind reader follow the same trend a sighted reader sees moving left to right, so drawn distance is what has to stay even. This PR makes that the behaviour.

## Related Issues

Follows #318 / #319.

## Changes Made

- `maidr/util/svg_utils.py` — added `to_scaled_coords()` / `from_scaled_coords()`, mapping between data coordinates and the axes' scale space. What remains between scale space and the display is an affine map, so ratios of distances there are the ratios on screen; because an affine map cannot change those ratios, the answer holds under any figure layout. `to_scaled_coords` returns `None` when a scale cannot represent the data, guarded three ways — see below.
- `maidr/core/plot/regplot.py` — `SmoothPlot._thin_to_even_steps()` thins in scale space and maps back. It returns the vertices untouched when the curve already fits the budget, since the scale round trip is not bit-exact and would otherwise shift a short fit off the drawn line. It thins in data space when the scale cannot represent the line.
- `maidr/util/rdp_utils.py` — `resample_curve`'s docstring drops the log-axis limitation #319 documented, now that the caller resolves it, and no longer reaches into a specific caller's internals.
- `tests/core/plot/test_smooth_sampling.py` — grown from 15 tests to **37**.

### Three guards, one failure mode each

A scale can refuse data in more than one way, and no single check catches them all:

| guard | catches | pinned by |
|---|---|---|
| finiteness | a scale answering with `inf`/`NaN` — `nonpositive='mask'`, and `logit` at its upper bound | `test_a_masking_scale_is_caught_by_the_finiteness_guard`, `test_a_scale_rejecting_on_an_upper_bound_is_caught` |
| `_clip_sentinel` probe | a clipping scale's sentinel, which reads as an ordinary coordinate | `test_a_fit_touching_zero_on_a_log_axis_is_not_mapped` |
| round trip (`rtol=1e-9, atol=0`) | a value that maps somewhere it cannot come back from | `test_unmappable_scale_is_detected` |

None of the three is redundant, and two of them catch cases the round trip actively reports as fine: a log scale's sentinel inverts back to zero, and `logit`'s infinity inverts back to `1.0`.

`atol=0` is deliberate: numpy's default `atol=1e-8` swamps the relative tolerance near zero, and a value mangled from `1e-12` to `5e-12` compared as faithful under it. It does not cost a legitimate zero, which round-trips exactly on every scale that represents one (`test_a_representable_zero_is_not_rejected`).

The sentinel probe is scale-agnostic — it looks for the coordinate several unrepresentable inputs collapse onto, rather than naming log or its constant, so `symlog` and `asinh` (where zero is representable) are left alone.

## Verification

Spacing spread (max step ÷ min step) across the smooth layer:

| axis | on-screen, before | on-screen, after |
|---|---|---|
| linear | 1.00× | 1.00× |
| log | **101.78×** | **1.00×** |
| `symlog` | — | **1.00×** |
| `asinh` | — | **1.00×** |

**The linear path is provably untouched.** A linear axis's scale transform is the exact identity, verified by round trip. Hashing the full emitted point list for the default `regplot` and the `histplot(kde=True)` fixture before and after gives the same digest, `87bc3065…` both ways.

**It also removes a second log-axis defect.** Interpolating in scale space lands on the chord matplotlib actually renders:

| axis | on-the-line deviation, before | after |
|---|---|---|
| linear | 1.1e-13 px | 1.1e-13 px |
| log | 0.107 px | **1.1e-13 px** |

**A fit touching exactly zero was dragging the trace off the canvas.** Raised in review as a low-severity edge case; measuring it showed otherwise. `x = np.linspace(0, 10, 50)` is an ordinary fixture, and seaborn evaluates the fit from `x.min()`, so `grid[0]` is `0.0` exactly. A log scale parks it on the sentinel and inverting underflows back to zero, so it round-tripped intact and passed as mappable:

```
to_scaled_coords -> MAPPED (slipped through)
  scale-space x[0] = -1000.0   vs x[1] = -0.996
  points off-canvas (svg_x < 0): 29 of 30
```

**29 of 30 navigable points landed outside the plot.** With the sentinel probe, that drops to 1 — the zero itself, which no log axis can place.

**The trade, stated plainly.** On a log axis the announced x values now step unevenly (788× spread) in exchange for an even sweep. That is the intended direction, decided by the maintainer, and `test_log_axis_paces_by_the_screen_not_the_data` asserts both directions so it cannot pass by the two spacings coinciding.

**Round-trip drift is why the budget guard exists.** A log axis round-trips `uniform(0.001, 5000)` with up to **4.99e-16** relative drift, so a below-budget curve would come out fractionally off the line it used to pass through untouched.

**Edge paths covered.** A log y-axis whose fit dips below zero exercises the unmappable-scale fallback, on both axes, with guard tests confirming `to_scaled_coords` really does return `None` there. `sns.kdeplot(fill=True)` registers a `PolyCollection` outline — a closed loop out along the curve and back along the baseline — the only shipped caller whose x doubles back. On a log axis it reaches **both** fallbacks at once, since a KDE's support runs past its data into values a log cannot map; data far enough from zero keeps the outline mappable, so the index fallback also runs inside scale space.

### Tests are not vacuous

Each behaviour was re-run against the code it replaced: the `lowess` case fails against index sampling, the passthrough test fails without the budget guard, and the zero-touching test fails without the sentinel probe.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass — `uv run pytest` green at **423 passed**. `ruff check` and `ruff format --diff` clean on the changed files.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable — no docs change needed; the example pages regenerate from the same source.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Scope is py-maidr only, as with #319.

The follow-up this PR's notes used to describe — `rdp_utils.py` hosting `resample_curve`, which has nothing to do with Ramer–Douglas–Peucker — is now open as **#321**, stacked on this branch. It moves the function out rather than renaming the module, because r-maidr's `R/rdp_utils.R` holds the RDP trio and nothing else, so renaming would have widened the gap between the two ports instead of closing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHKWpgDYkw6aPtTYn33osp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHKWpgDYkw6aPtTYn33osp)_