### PR TITLE
refactor(smooth): move resample_curve out of the RDP module

### DIFF
--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -6,7 +6,7 @@ from maidr.exception.extraction_error import ExtractionError
 import numpy as np
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.enum.maidr_key import MaidrKey
-from maidr.util.rdp_utils import resample_curve
+from maidr.util.resample_utils import resample_curve
 from maidr.util.regression_line_utils import find_regression_line
 from maidr.util.svg_utils import (
     data_to_svg_coords,

--- a/maidr/util/rdp_utils.py
+++ b/maidr/util/rdp_utils.py
@@ -1,15 +1,16 @@
-"""Curve thinning utilities.
+"""Ramer-Douglas-Peucker curve simplification utilities.
 
-These helpers reduce the number of points on a curve to keep the MAIDR JSON
-payload compact.  Two strategies live here because the two callers want
-different things:
+These helpers reduce the number of points on a curve while preserving its
+*shape*, dropping vertices that already sit close to the chord between their
+neighbours.  :class:`~maidr.core.plot.violin_kde_plot.ViolinKdePlot` uses them
+to pick the levels that outline a violin.
 
-- :func:`simplify_curve` runs Ramer-Douglas-Peucker, which preserves *shape*
-  and is used by :class:`~maidr.core.plot.violin_kde_plot.ViolinKdePlot` to
-  pick the levels that outline a violin.
-- :func:`resample_curve` keeps the vertices evenly spaced and is used by
-  :class:`~maidr.core.plot.regplot.SmoothPlot`, whose points are navigated and
-  sonified one at a time, so *spacing* matters more than shape.
+Shape is the wrong objective for a curve that is navigated and sonified one
+point at a time, where the steps have to stay evenly spaced instead; see
+:func:`~maidr.util.resample_utils.resample_curve` for that.
+
+This module mirrors r-maidr's ``R/rdp_utils.R``, so a change to either
+belongs in both.
 """
 
 from __future__ import annotations
@@ -139,68 +140,3 @@ def simplify_curve(
             break
 
     return best_mask
-
-
-def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
-    """
-    Thin a 2-D curve down to *target* evenly spaced vertices.
-
-    Unlike :func:`simplify_curve`, this keeps the retained vertices spread
-    evenly along the curve rather than clustering them where the curve bends.
-    A straight line therefore survives as *target* points instead of
-    collapsing to its two endpoints, and a curved line keeps a steady step
-    size.  The first and last vertices are always kept.
-
-    Spacing is measured along x whenever x increases monotonically, which
-    covers every curve seaborn fits.  Sampling by vertex index instead would
-    only be even in x when the source grid already was — true of a plain
-    ``regplot`` fit or a KDE, but not of a ``lowess=True`` fit, which lands on
-    the observed x values and inherits their clustering.  Anything else — a
-    curve that doubles back, or one running right to left — falls back to
-    index sampling.
-
-    Spacing is even in whatever space the caller hands over, so a caller that
-    wants evenness on screen rather than in raw data has to convert before
-    calling and back afterwards.
-
-    Interpolated points sit on the drawn line, which matters because they are
-    what the highlight ring lands on.  Matplotlib renders the curve as straight
-    segments between its vertices, so interpolating in scale space — an affine
-    map away from the display — walks exactly that path.  That exactness is
-    the caller's to earn, though: handing over data coordinates for a
-    nonlinear axis instead leaves the points a fraction of a pixel off the
-    segment.
-
-    Parameters
-    ----------
-    points : np.ndarray, shape (N, 2)
-        Ordered (x, y) points.
-    target : int
-        Desired number of retained points.  Values below 2 are raised to 2,
-        since the endpoints alone already describe a segment.
-
-    Returns
-    -------
-    np.ndarray, shape (M, 2)
-        The resampled points, where ``M == min(N, max(target, 2))``.  A curve
-        that already fits the budget comes back as *points* itself, not a
-        copy, so callers that intend to mutate the result should copy it.
-    """
-    n = len(points)
-    count = max(int(target), 2)
-    if n <= count:
-        return points
-
-    x, y = points[:, 0], points[:, 1]
-    if np.all(np.diff(x) > 0):
-        grid = np.linspace(x[0], x[-1], count)
-        return np.column_stack([grid, np.interp(grid, x, y)])
-
-    # Left-to-right is the only order worth special-casing, since it is the one
-    # every fit produces; a decreasing or self-crossing curve falls through to
-    # even spacing by vertex index rather than growing a case for each shape.
-    # ``n > count >= 2`` puts the step ``(n - 1) / (count - 1)`` strictly above
-    # 1, so rounding can never land two samples on the same vertex: the result
-    # always holds exactly ``count`` distinct points.
-    idx = np.rint(np.linspace(0, n - 1, count)).astype(int)
-    return points[idx]

--- a/maidr/util/resample_utils.py
+++ b/maidr/util/resample_utils.py
@@ -1,14 +1,10 @@
 """Even curve resampling.
 
-Thins a curve by spreading the points it keeps evenly, rather than by where
-the curve bends.  :class:`~maidr.core.plot.regplot.SmoothPlot` needs that: its
-points are navigated and auto-played one at a time at a fixed rate, so the
-spacing between them is what a reader hears, and
-:func:`~maidr.util.rdp_utils.simplify_curve` would collapse a straight fit to
-its two endpoints.
-
-r-maidr has no counterpart, since its smooth processor emits every vertex the
-plot was built with.
+Kept apart from :mod:`maidr.util.rdp_utils` because the two thin a curve
+towards different ends, and only that one mirrors r-maidr's ``R/rdp_utils.R``.
+:class:`~maidr.core.plot.regplot.SmoothPlot` is the caller here; r-maidr has
+no counterpart, since its smooth processor emits every vertex the plot was
+built with.
 """
 
 from __future__ import annotations
@@ -20,11 +16,12 @@ def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
     """
     Thin a 2-D curve down to *target* evenly spaced vertices.
 
-    Unlike :func:`simplify_curve`, this keeps the retained vertices spread
-    evenly along the curve rather than clustering them where the curve bends.
-    A straight line therefore survives as *target* points instead of
-    collapsing to its two endpoints, and a curved line keeps a steady step
-    size.  The first and last vertices are always kept.
+    Unlike :func:`~maidr.util.rdp_utils.simplify_curve`, this keeps the
+    retained vertices spread evenly along the curve rather than clustering
+    them where the curve bends.  A straight line therefore survives as
+    *target* points instead of collapsing to its two endpoints, and a curved
+    line keeps a steady step size.  The first and last vertices are always
+    kept.
 
     Spacing is measured along x whenever x increases monotonically, which
     covers every curve seaborn fits.  Sampling by vertex index instead would

--- a/maidr/util/resample_utils.py
+++ b/maidr/util/resample_utils.py
@@ -1,0 +1,81 @@
+"""Even curve resampling.
+
+Thins a curve by spreading the points it keeps evenly, rather than by where
+the curve bends.  :class:`~maidr.core.plot.regplot.SmoothPlot` needs that: its
+points are navigated and auto-played one at a time at a fixed rate, so the
+spacing between them is what a reader hears, and
+:func:`~maidr.util.rdp_utils.simplify_curve` would collapse a straight fit to
+its two endpoints.
+
+r-maidr has no counterpart, since its smooth processor emits every vertex the
+plot was built with.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def resample_curve(points: np.ndarray, target: int) -> np.ndarray:
+    """
+    Thin a 2-D curve down to *target* evenly spaced vertices.
+
+    Unlike :func:`simplify_curve`, this keeps the retained vertices spread
+    evenly along the curve rather than clustering them where the curve bends.
+    A straight line therefore survives as *target* points instead of
+    collapsing to its two endpoints, and a curved line keeps a steady step
+    size.  The first and last vertices are always kept.
+
+    Spacing is measured along x whenever x increases monotonically, which
+    covers every curve seaborn fits.  Sampling by vertex index instead would
+    only be even in x when the source grid already was — true of a plain
+    ``regplot`` fit or a KDE, but not of a ``lowess=True`` fit, which lands on
+    the observed x values and inherits their clustering.  Anything else — a
+    curve that doubles back, or one running right to left — falls back to
+    index sampling.
+
+    Spacing is even in whatever space the caller hands over, so a caller that
+    wants evenness on screen rather than in raw data has to convert before
+    calling and back afterwards.
+
+    Interpolated points sit on the drawn line, which matters because they are
+    what the highlight ring lands on.  Matplotlib renders the curve as straight
+    segments between its vertices, so interpolating in scale space — an affine
+    map away from the display — walks exactly that path.  That exactness is
+    the caller's to earn, though: handing over data coordinates for a
+    nonlinear axis instead leaves the points a fraction of a pixel off the
+    segment.
+
+    Parameters
+    ----------
+    points : np.ndarray, shape (N, 2)
+        Ordered (x, y) points.
+    target : int
+        Desired number of retained points.  Values below 2 are raised to 2,
+        since the endpoints alone already describe a segment.
+
+    Returns
+    -------
+    np.ndarray, shape (M, 2)
+        The resampled points, where ``M == min(N, max(target, 2))``.  A curve
+        that already fits the budget comes back as *points* itself, not a
+        copy, so callers that intend to mutate the result should copy it.
+    """
+    n = len(points)
+    count = max(int(target), 2)
+    if n <= count:
+        return points
+
+    x, y = points[:, 0], points[:, 1]
+    if np.all(np.diff(x) > 0):
+        grid = np.linspace(x[0], x[-1], count)
+        return np.column_stack([grid, np.interp(grid, x, y)])
+
+    # Left-to-right is the only order worth special-casing, since it is the one
+    # every fit produces; a decreasing or self-crossing curve falls through to
+    # even spacing by vertex index rather than growing a case for each shape.
+    # ``n > count >= 2`` puts the step ``(n - 1) / (count - 1)`` strictly above
+    # 1, so rounding can never land two samples on the same vertex: the result
+    # always holds exactly ``count`` distinct points.
+    idx = np.rint(np.linspace(0, n - 1, count)).astype(int)
+    return points[idx]

--- a/tests/core/plot/test_smooth_sampling.py
+++ b/tests/core/plot/test_smooth_sampling.py
@@ -22,7 +22,7 @@ from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.core.plot.regplot import _DEFAULT_MAX_SMOOTH_POINTS  # noqa: E402
-from maidr.util.rdp_utils import resample_curve  # noqa: E402
+from maidr.util.resample_utils import resample_curve  # noqa: E402
 from maidr.util.regression_line_utils import find_regression_line  # noqa: E402
 from maidr.util.svg_utils import (  # noqa: E402
     _clip_sentinel,


### PR DESCRIPTION
## Description

Follow-up raised repeatedly in review of #319 / #320: `maidr/util/rdp_utils.py` hosted `resample_curve`, which has nothing to do with Ramer–Douglas–Peucker.

#320 has merged, so this is rebased onto `main` and retargeted.

## Not the rename that was suggested, and why

Review proposed renaming the module to something like `curve_thinning.py`. Checking the r-maidr side first showed that would make things worse rather than better:

| | `perpendicular_distance` | `rdp` | `simplify_curve` | `resample_curve` |
|---|---|---|---|---|
| py-maidr `maidr/util/rdp_utils.py` | ✓ | ✓ | ✓ | ✓ ← the odd one |
| r-maidr `R/rdp_utils.R` | ✓ | ✓ | ✓ | — |

r-maidr's file holds the RDP trio and nothing else, and its header says it was ported from py-maidr's. So the module isn't mis-named for having grown a broader purpose — it's mis-named because **one function that isn't RDP was added to an RDP module**, by #319. Renaming would have kept that function where it doesn't belong *and* dropped the name the R port still uses, widening the gap between two files meant to stay in step.

Moving the odd function out restores the correspondence instead: `rdp_utils.py` is once again exactly what its name and its mirror say.

## Changes Made

- `maidr/util/resample_utils.py` — new. Holds `resample_curve`, moved verbatim. Its docstring records that r-maidr has no counterpart, since that side's smooth processor emits every vertex the plot was built with.
- `maidr/util/rdp_utils.py` — back to the RDP trio. Module docstring describes shape preservation and its one caller, points at `resample_curve` for the objective it doesn't serve, and notes the file mirrors `R/rdp_utils.R` so a change to either belongs in both.
- `maidr/core/plot/regplot.py`, `tests/core/plot/test_smooth_sampling.py` — import updated.

No behaviour change: `resample_curve`'s body is moved unchanged, and `simplify_curve`'s only caller (`ViolinKdePlot`) is untouched.

### One defect the move introduced, and fixed

`resample_curve`'s docstring opened with `` :func:`simplify_curve` `` — unqualified, which resolved while the two functions shared a module and stopped the moment they didn't. Sphinx doesn't error on that; it renders as inert text, so a "pure move" hides it. Now fully qualified. The new module docstring also restated the shape-versus-spacing contrast that the function docstring already draws a few lines below, so that's left to the function and the module says only what's true of the module.

## Verification

`uv run pytest` green at **423 passed** — the same count as before the move, since nothing about behaviour changed. `ruff check` and `ruff format --diff` clean on all four files.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor — no behaviour change

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable — no user-facing docs reference these module paths.
- [ ] I have added appropriate unit tests, if applicable — none needed; the existing suite covers both functions and pins that the move changed nothing.

## Additional Notes

Both modules are internal (`maidr/util/`), so no public import path changes.

Worth a maintainer's eye: this leaves `rdp_utils.py` and `R/rdp_utils.R` matched again, which only matters if keeping those two ports aligned is still intended. If the R side ever gains an equivalent of `resample_curve`, it would land as `R/resample_utils.R` under this arrangement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHKWpgDYkw6aPtTYn33osp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHKWpgDYkw6aPtTYn33osp)_