### PR TITLE
feat(pie): support matplotlib, seaborn and plotly pie charts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The `maidr/patch/` modules use `wrapt` to intercept matplotlib/seaborn plot call
 
 ### Supported Plot Types
 
-Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, COUNT, DODGED, HEAT, HIST, LINE, SCATTER, STACKED, STEP, SMOOTH, CANDLESTICK.
+Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, COUNT, DODGED, HEAT, HIST, LINE, PIE, SCATTER, STACKED, STEP, SMOOTH, CANDLESTICK, VIOLIN_KDE, VIOLIN_BOX.
 
 Note that `maidr/plotly/` builds its MAIDR schema in Python and therefore needs its own
 handling per plot type, whereas `maidr/altair/` delegates entirely to the upstream

--- a/docs/examples-plotly.qmd
+++ b/docs/examples-plotly.qmd
@@ -139,6 +139,69 @@ fig = go.Figure(
 maidr.show(fig)  #<<
 ```
 
+### Pie Chart
+
+A pie is one flat row of slices, so navigation runs left and right across them
+and there is no second dimension to move through. Each slice is announced by
+its label, its value, and the share of the whole that value works out to. The
+percentage is derived from the values at render time rather than authored, so
+it can never disagree with the numbers it is derived from.
+
+Plotly draws a pie's wedges largest first — `sort` defaults to true — so the
+order of the `values` array is not the order of the slices. maidr reproduces
+that ordering, because the slice a user hears has to be the slice that
+highlights. Pass `sort=False` to keep the authored order in both.
+
+```{python}
+#| warning: false
+#| fig-alt: Pie chart showing the share of tips recorded on each day of the week
+
+import plotly.graph_objects as go
+import seaborn as sns
+
+import maidr  #<<
+
+# Load the tips dataset
+tips = sns.load_dataset("tips")
+
+# Count the tips recorded on each day of the week
+day_counts = tips["day"].value_counts()
+
+fig = go.Figure(
+    go.Pie( #<<
+        labels=day_counts.index.tolist(),
+        values=day_counts.values.tolist(),
+        # Keep the authored order rather than letting plotly re-sort it.
+        sort=False,
+    )
+)
+
+fig.update_layout(
+    title="Share of Tips by Day",
+    # Name the two dimensions of a slice, so it is read out as
+    # "Day: Sat, Number of tips: 87" rather than "Label: Sat, Value: 87".
+    xaxis=dict(title="Day"), #<<
+    yaxis=dict(title="Number of tips"), #<<
+)
+
+maidr.show(fig)  #<<
+```
+
+A donut is the same chart with `hole` set: it changes the wedge geometry and
+leaves the data behind it untouched, so it is emitted as a pie layer too.
+
+::: {.callout-note}
+Plotly names neither axis of a pie, so the layout's `xaxis`/`yaxis` titles are
+what tell maidr how to announce a slice; without them it falls back to "Label"
+and "Value".
+
+Plotly builds its own slice list before drawing, and maidr follows it exactly
+so that data index *k* and highlighted wedge *k* stay the same slice: entries
+plotly does not read as numbers draw no wedge, repeated labels merge into one
+wedge holding their sum, and a label listed in `layout.hiddenlabels` is
+dropped along with its wedge.
+:::
+
 ### Histogram
 
 ```{python}

--- a/docs/examples-plotly.qmd
+++ b/docs/examples-plotly.qmd
@@ -192,8 +192,14 @@ leaves the data behind it untouched, so it is emitted as a pie layer too.
 
 ::: {.callout-note}
 Plotly names neither axis of a pie, so the layout's `xaxis`/`yaxis` titles are
-what tell maidr how to announce a slice; without them it falls back to "Label"
-and "Value".
+what tell maidr how to announce a slice; without them it falls back to
+"Category" and "Value", the same pair the matplotlib side uses.
+
+Those titles are only borrowed when the figure holds nothing but pies. A
+cartesian trace that declares no axis pair of its own shares the same default
+`xaxis`/`yaxis`, and those titles describe *its* axes — so in a mixed figure
+the pie keeps the generic pair rather than announcing a bar's axis names
+against its slices.
 
 Plotly builds its own slice list before drawing, and maidr follows it exactly
 so that data index *k* and highlighted wedge *k* stay the same slice: entries

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -255,7 +255,9 @@ the slice values measure. Leave them unset and maidr falls back to "Category"
 and "Value", which at least read as English where "X" and "Y" would not.
 
 Negative sizes are rejected — matplotlib refuses to draw a wedge with no area,
-and so does maidr. Drawing options that only move the wedges around
+so `ax.pie()` raises before maidr sees the call at all; maidr repeats the check
+for anyone building a `PiePlot` directly. Drawing options that only move the
+wedges around
 (`startangle`, `counterclock`, `explode`, `shadow`) leave the slice order
 alone, so the data stays index-aligned with what is on screen.
 :::

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -43,7 +43,7 @@ maidr.set_backend(use_maidr=True)    # plt.show() renders accessible maidr outpu
 
 #### Unsupported Plot Types
 
-For plot types not yet supported by maidr (e.g. pie charts, contour plots, 3D plots), `plt.show()` will automatically fall back to displaying a static image and emit a warning. No code changes are needed — your plots will always be visible.
+For plot types not yet supported by maidr (e.g. contour plots, 3D plots), `plt.show()` will automatically fall back to displaying a static image and emit a warning. No code changes are needed — your plots will always be visible.
 
 ### Bar Plots
 
@@ -199,6 +199,66 @@ ax.yaxis.set_major_formatter("{x:.0f}")
 # Display the plot
 plt.show() #<<
 ```
+
+### Pie Chart
+
+A pie is one flat row of slices, so navigation runs left and right across them
+and there is no second dimension to move through. Each slice is announced by
+its label, its value, and the share of the whole that value works out to. The
+percentage is derived from the values at render time rather than authored, so
+it can never disagree with the numbers it is derived from.
+
+`ax.pie()` normalises what it is given — it draws `x / sum(x)`, and each wedge
+keeps only its angles — so the counts below survive as counts because maidr
+reads them off the call rather than off the drawn wedges.
+
+```{python}
+#| warning: false
+#| fig-alt: Pie chart showing the share of tips recorded on each day of the week
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+import maidr #<<
+
+# Load the tips dataset
+tips = sns.load_dataset("tips")
+
+# Count the tips recorded on each day of the week
+day_counts = tips["day"].value_counts()
+
+fig, ax = plt.subplots(figsize=(8, 8))
+
+# autopct draws the percentages onto the chart for sighted readers; maidr
+# derives its own from the values, so the two cannot drift apart.
+ax.pie( #<<
+    list(day_counts.values),
+    labels=list(day_counts.index),
+    autopct="%1.1f%%",
+    startangle=90,
+)
+
+ax.set_title("Share of Tips by Day")
+
+# Name the two dimensions of a slice, so it is read out as
+# "Day: Sat, Number of tips: 87" rather than "X: Sat, Y: 87".
+ax.set_xlabel("Day") #<<
+ax.set_ylabel("Number of tips") #<<
+
+plt.show() #<<
+```
+
+::: {.callout-note}
+A pie has no x or y scale, so its two axis labels name the *dimensions* of a
+slice instead: `xlabel` says what the slice labels mean and `ylabel` says what
+the slice values measure. Leave them unset and maidr falls back to "Category"
+and "Value", which at least read as English where "X" and "Y" would not.
+
+Negative sizes are rejected — matplotlib refuses to draw a wedge with no area,
+and so does maidr. Drawing options that only move the wedges around
+(`startangle`, `counterclock`, `explode`, `shadow`) leave the slice order
+alone, so the data stays index-aligned with what is on screen.
+:::
 
 ### Histogram
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > py-maidr is a Python library that makes matplotlib, seaborn, and plotly data visualizations accessible to blind and low-vision users through sonification, braille, text, and AI-powered conversational modalities. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
 
-maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, box, violin, heatmap, scatter, smooth/regression, candlestick, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
+maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, pie, box, violin, heatmap, scatter, smooth/regression, candlestick, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
 
 ## Docs
 - [Documentation Home](https://py.maidr.ai/): Installation, quick start, and overview

--- a/example/pie/matplotlib/example_mpl_pie_plot.py
+++ b/example/pie/matplotlib/example_mpl_pie_plot.py
@@ -1,0 +1,45 @@
+"""Pie chart: parts of one whole, read out as slices.
+
+A pie is one flat row of slices, so navigation runs left and right across
+them and there is no second dimension to move through. Each slice is
+announced by its label, its value, and the share of the whole that value
+works out to — the percentage is derived from the values at render time
+rather than authored, so it can never disagree with them.
+
+``Axes.pie`` normalises what it is given: it draws ``x / sum(x)`` and each
+wedge keeps only its angles, so the counts below survive as counts only
+because maidr reads them off the call. Set ``xlabel`` and ``ylabel`` to name
+what a slice *is* and what it *measures*; otherwise a slice is announced with
+the generic "Category" and "Value".
+"""
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+import maidr  # noqa: F401
+
+# Load dataset
+tips = sns.load_dataset("tips")
+
+# Count the tips recorded on each day of the week.
+day_counts = tips["day"].value_counts()
+
+fig, ax = plt.subplots(figsize=(8, 8))
+
+# autopct draws the percentages onto the chart for sighted readers; maidr
+# derives its own from the values, so the two cannot drift apart.
+ax.pie(
+    list(day_counts.values),
+    labels=list(day_counts.index),
+    autopct="%1.1f%%",
+    startangle=90,
+)
+
+ax.set_title("Share of Tips by Day")
+
+# Name the two dimensions of a slice, so it is read out as
+# "Day: Sat, Number of tips: 87" rather than "X: Sat, Y: 87".
+ax.set_xlabel("Day")
+ax.set_ylabel("Number of tips")
+
+plt.show()

--- a/example/pie/plotly/example_plotly_pie_plot.py
+++ b/example/pie/plotly/example_plotly_pie_plot.py
@@ -1,0 +1,42 @@
+"""Pie chart in Plotly: parts of one whole, read out as slices.
+
+Plotly draws a pie's wedges largest first — ``sort`` defaults to true — so the
+order of the ``values`` array is not the order of the slices. maidr reproduces
+that ordering, because the slice a user hears has to be the slice that
+highlights. Pass ``sort=False`` to keep the authored order in both.
+
+Plotly names neither axis of a pie, so ``xaxis``/``yaxis`` titles in the layout
+are what tell maidr how to announce a slice; without them it falls back to the
+generic "Label" and "Value". A donut is the same chart with ``hole`` set.
+"""
+
+import plotly.graph_objects as go
+import seaborn as sns
+
+import maidr
+
+# Load dataset
+tips = sns.load_dataset("tips")
+
+# Count the tips recorded on each day of the week.
+day_counts = tips["day"].value_counts()
+
+fig = go.Figure(
+    go.Pie(
+        labels=day_counts.index.tolist(),
+        values=day_counts.values.tolist(),
+        # Keep the authored order, so the slices read in the order
+        # `value_counts()` produced rather than being re-sorted by plotly.
+        sort=False,
+    )
+)
+
+fig.update_layout(
+    title="Share of Tips by Day",
+    # Name the two dimensions of a slice, so it is read out as
+    # "Day: Sat, Number of tips: 87" rather than "Label: Sat, Value: 87".
+    xaxis=dict(title="Day"),
+    yaxis=dict(title="Number of tips"),
+)
+
+maidr.show(fig)

--- a/example/pie/plotly/example_plotly_pie_plot.py
+++ b/example/pie/plotly/example_plotly_pie_plot.py
@@ -7,7 +7,8 @@ highlights. Pass ``sort=False`` to keep the authored order in both.
 
 Plotly names neither axis of a pie, so ``xaxis``/``yaxis`` titles in the layout
 are what tell maidr how to announce a slice; without them it falls back to the
-generic "Label" and "Value". A donut is the same chart with ``hole`` set.
+generic "Category" and "Value" — the same pair the matplotlib pie falls back
+to. A donut is the same chart with ``hole`` set.
 """
 
 import plotly.graph_objects as go

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -11,6 +11,7 @@ class PlotType(str, Enum):
     HEAT = "heat"
     HIST = "hist"
     LINE = "line"
+    PIE = "pie"
     SCATTER = "point"
     STACKED = "stacked_bar"
     STEP = "step"

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -53,6 +53,7 @@ class FigureManager:
         PlotType.BOX: 1,
         PlotType.HEAT: 1,
         PlotType.COUNT: 1,
+        PlotType.PIE: 1,
         PlotType.SMOOTH: 1,
         PlotType.CANDLESTICK: 1,
         PlotType.VIOLIN_KDE: 1,

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -9,6 +9,7 @@ from maidr.core.plot.heatmap import HeatPlot
 from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
 from maidr.core.plot.maidr_plot import MaidrPlot
+from maidr.core.plot.pieplot import PiePlot
 from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.regplot import SmoothPlot
 from maidr.core.plot.stepplot import StepPlot
@@ -64,6 +65,8 @@ class MaidrPlotFactory:
                 return MultiLinePlot(single_ax, **kwargs)
         elif PlotType.STEP == plot_type:
             return StepPlot(single_ax, **kwargs)
+        elif PlotType.PIE == plot_type:
+            return PiePlot(single_ax, **kwargs)
         elif PlotType.SCATTER == plot_type:
             return ScatterPlot(single_ax)
         elif PlotType.DODGED == plot_type or PlotType.STACKED == plot_type:

--- a/maidr/core/plot/pieplot.py
+++ b/maidr/core/plot/pieplot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import warnings
+import logging
 from typing import Any
 
 from matplotlib.axes import Axes
@@ -9,6 +9,8 @@ from matplotlib.patches import Wedge
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
+
+_logger = logging.getLogger(__name__)
 
 
 class PiePlot(MaidrPlot):
@@ -73,9 +75,40 @@ class PiePlot(MaidrPlot):
         }
 
     def _extract_plot_data(self) -> list:
+        """
+        Read this layer's slices as a flat row of ``{x, y}`` points.
+
+        An empty pie is emitted as an empty layer rather than raised on.
+        ``ax.pie([])`` is a legal call that draws no wedges, and the figure is
+        already registered by the time this runs — raising here takes the
+        whole figure down, so a working bar drawn beside the empty pie would
+        die with it. This is the rule
+        :meth:`maidr.plotly.pie.PlotlyPiePlot._slices` already follows for the
+        same reason: an empty layer reaches the wire intact.
+
+        A *failed* extraction is still an error. The patch hands over the
+        wedges the call drew, so an empty list from it means matplotlib drew
+        none. Without that list this falls back to scanning the axes, and
+        finding no wedges there means the layer was built for a pie that
+        cannot be found — nothing to describe and no evidence it was ever
+        empty by intent.
+
+        Returns
+        -------
+        list of dict
+            One ``{"x": label, "y": value}`` point per slice, in slice order.
+
+        Raises
+        ------
+        ExtractionError
+            If no wedges could be found on an axes that was not handed its
+            own wedge list.
+        """
         wedges = self._extract_wedges()
         if not wedges:
-            raise ExtractionError(self.type, self.ax)
+            if self._wedges is None:
+                raise ExtractionError(self.type, self.ax)
+            return []
 
         values = self._extract_values(wedges)
         labels = self._extract_labels(wedges)
@@ -155,12 +188,19 @@ class PiePlot(MaidrPlot):
         # to pass unnoticed -- 0.3 where the caller wrote 30. Say so, so a
         # future bug that decouples the two is visible rather than quietly
         # rescaling every announcement.
+        #
+        # This is logged rather than warned because a warning cannot be heard
+        # from here: `maidr.patch.pieplot.pie` calls
+        # `warnings.filterwarnings("ignore")` on every `Axes.pie`, so by the
+        # time `render()` reaches this line the process has a persistent
+        # catch-all "ignore" filter in front of it. `logging` is the channel
+        # that patch does not close, and the one `maidr.backend` already uses.
         if values is not None:
-            warnings.warn(
-                f"maidr: pie has {len(values)} values for {len(wedges)} wedges; "
-                "reporting each slice's share of the whole instead of the "
-                "magnitudes passed.",
-                stacklevel=2,
+            _logger.warning(
+                "maidr: pie has %d values for %d wedges; reporting each "
+                "slice's share of the whole instead of the magnitudes passed.",
+                len(values),
+                len(wedges),
             )
 
         # `theta2 - theta1` is the slice's share of the 360 degree whole. A

--- a/maidr/core/plot/pieplot.py
+++ b/maidr/core/plot/pieplot.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from typing import Any
+
+from matplotlib.axes import Axes
+from matplotlib.patches import Wedge
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot import MaidrPlot
+from maidr.exception import ExtractionError
+
+
+class PiePlot(MaidrPlot):
+    """
+    A MAIDR layer for a matplotlib pie chart.
+
+    A pie is one flat row of slices: N labels paired with N magnitudes, in the
+    order ``Axes.pie`` drew them. The percentage a slice covers is derived from
+    those magnitudes by the renderer, so it is deliberately absent here — a
+    percentage emitted alongside the values it is supposedly derived from is a
+    second source of truth that can disagree with the first.
+
+    Parameters
+    ----------
+    ax : Axes
+        The ``matplotlib.axes.Axes`` the pie was drawn on.
+    **kwargs
+        ``values`` and ``labels``, as the patch on ``Axes.pie`` read them off
+        the original call, and ``wedges``, the slices that call drew. All
+        three are optional; see the ``_extract_*`` methods for what happens
+        without them.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        self._values = kwargs.pop("values", None)
+        self._labels = kwargs.pop("labels", None)
+        self._wedges = kwargs.pop("wedges", None)
+        super().__init__(ax, PlotType.PIE)
+
+    def _extract_axes_data(self) -> dict:
+        """
+        Extract the plot's axes data as canonical per-axis ``AxisConfig``
+        objects.
+
+        A pie has no x or y scale, so the two axes name the *dimensions* of a
+        slice rather than a position: ``x`` says what the slice labels mean and
+        ``y`` says what the slice magnitudes measure. An author who set
+        ``xlabel``/``ylabel`` on the axes has already named them; otherwise the
+        generic "X"/"Y" of the base class would be read out against every slice
+        ("X: Apples"), so a pie names them after what they hold instead.
+
+        Returns
+        -------
+        dict
+            ``{"x": {"label": ...}, "y": {"label": ...}}``.
+        """
+        x_label = self.ax.get_xlabel()
+        if not x_label:
+            x_label = self.extract_shared_xlabel(self.ax)
+        if not x_label:
+            x_label = "Category"
+
+        y_label = self.ax.get_ylabel()
+        if not y_label:
+            y_label = self.extract_shared_ylabel(self.ax)
+        if not y_label:
+            y_label = "Value"
+
+        return {
+            MaidrKey.X: self._axis_config(label=x_label),
+            MaidrKey.Y: self._axis_config(label=y_label),
+        }
+
+    def _extract_plot_data(self) -> list:
+        wedges = self._extract_wedges()
+        if not wedges:
+            raise ExtractionError(self.type, self.ax)
+
+        values = self._extract_values(wedges)
+        labels = self._extract_labels(wedges)
+
+        self._elements.extend(wedges)
+
+        return [
+            {MaidrKey.X: label, MaidrKey.Y: value}
+            for label, value in zip(labels, values)
+        ]
+
+    def _extract_wedges(self) -> list[Wedge]:
+        """
+        Read the slices of this layer, in the order they were drawn.
+
+        The wedges ``Axes.pie`` returned are used when the patch handed them
+        over, because they are this call's own: a nested pie draws two rings
+        on one axes, and a layer that read the axes instead would see both
+        rings' wedges and pair the wrong ones with its values.
+
+        Falling back to the axes, ``Axes.pie`` adds one ``Wedge`` per slice
+        in slice order, so the patch order is the data order the renderer
+        indexes by. ``shadow=True`` interleaves a ``Shadow`` patch behind
+        each slice; those are not wedges and are dropped either way, which
+        keeps the wedges contiguous and index-aligned with the data.
+
+        Returns
+        -------
+        list of Wedge
+            One wedge per slice, in slice order.
+        """
+        patches = self.ax.patches if self._wedges is None else self._wedges
+        return [patch for patch in patches if isinstance(patch, Wedge)]
+
+    def _extract_values(self, wedges: list[Wedge]) -> list[float]:
+        """
+        Read one magnitude per slice, in slice order.
+
+        A ``Wedge`` carries only its start and end angle, and ``Axes.pie``
+        normalises its input — it plots ``x / sum(x)`` whenever the sum
+        exceeds 1 — so the angles no longer hold the magnitudes the caller
+        passed. ``ax.pie([30, 50, 20])`` draws wedges spanning 108/180/72
+        degrees, and reading those back reports the fractions 0.3/0.5/0.2 for
+        a plot of counts. The patch sees the call before matplotlib rewrites
+        it, so the caller's own numbers are used whenever it supplied them.
+
+        The angular fallback covers the case where they were not: the plot
+        is then only recoverable as fractions of the whole, which is what
+        matplotlib itself kept.
+
+        Parameters
+        ----------
+        wedges : list of Wedge
+            The slices of this layer, in slice order.
+
+        Returns
+        -------
+        list of float
+            One magnitude per slice.
+
+        Raises
+        ------
+        ValueError
+            If any magnitude is negative. A negative slice has no area to
+            draw, and matplotlib rejects one for the same reason.
+        """
+        values = self._as_floats(self._values)
+
+        if values is None or len(values) != len(wedges):
+            # `theta2 - theta1` is the slice's share of the 360 degree whole.
+            values = [
+                (float(wedge.theta2) - float(wedge.theta1)) / 360.0 for wedge in wedges
+            ]
+
+        if any(value < 0 for value in values):
+            raise ValueError("Wedge sizes 'x' must be non negative values")
+
+        return values
+
+    def _extract_labels(self, wedges: list[Wedge]) -> list[Any]:
+        """
+        Read one label per slice, in slice order.
+
+        Parameters
+        ----------
+        wedges : list of Wedge
+            The slices of this layer, in slice order.
+
+        Returns
+        -------
+        list
+            The ``labels`` argument of the original call where it was given,
+            the labels matplotlib set on the wedges themselves where it was
+            not, and the slice's position as a last resort — an unlabelled
+            pie is still navigable when each slice can be named.
+        """
+        if self._labels is not None and len(self._labels) == len(wedges):
+            return [self._as_label(label) for label in self._labels]
+
+        labels = [str(wedge.get_label()) for wedge in wedges]
+        return [label or str(index) for index, label in enumerate(labels)]
+
+    @staticmethod
+    def _as_label(label: Any) -> Any:
+        """
+        Coerce one slice label to something the schema can carry.
+
+        A label is a string or a number on the wire, and the schema is JSON,
+        so the numpy scalar a pandas column hands over has to be unwrapped to
+        the Python value inside it — ``json.dumps`` refuses it otherwise, and
+        the whole figure fails to render over one label. Anything else is
+        named by its text, which is what a slice label is for.
+
+        Parameters
+        ----------
+        label : Any
+            One entry of the ``labels`` argument of the original call.
+
+        Returns
+        -------
+        Any
+            The label as a string or a number.
+        """
+        if isinstance(label, str):
+            return label
+
+        value = label.item() if hasattr(label, "item") else label
+        if isinstance(value, (str, int, float)) and not isinstance(value, bool):
+            return value
+
+        return str(label)
+
+    @staticmethod
+    def _as_floats(values: Any) -> list[float] | None:
+        """
+        Coerce the caller's wedge sizes to plain floats.
+
+        ``Axes.pie`` takes any 1-D array-like — a list, a numpy array, a
+        pandas Series — and the schema is JSON, so whatever came in is read
+        as a sequence of floats or not read at all.
+
+        Parameters
+        ----------
+        values : Any
+            The ``x`` argument of the original call, or None.
+
+        Returns
+        -------
+        list of float, optional
+            The magnitudes, or None when they are not a sequence of numbers.
+        """
+        # A string is iterable and its characters are not magnitudes; an
+        # unresolved `data=` column name arrives as exactly that.
+        if values is None or isinstance(values, (str, bytes)):
+            return None
+
+        try:
+            return [float(value) for value in values]
+        except (TypeError, ValueError):
+            return None

--- a/maidr/core/plot/pieplot.py
+++ b/maidr/core/plot/pieplot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 from matplotlib.axes import Axes
@@ -148,6 +149,19 @@ class PiePlot(MaidrPlot):
             if any(value < 0 for value in values):
                 raise ValueError("Wedge sizes 'x' must be non negative values")
             return values
+
+        # Reaching here through the patch would mean the wedges and the call's
+        # own `x` had come apart, and the fractions below are plausible enough
+        # to pass unnoticed -- 0.3 where the caller wrote 30. Say so, so a
+        # future bug that decouples the two is visible rather than quietly
+        # rescaling every announcement.
+        if values is not None:
+            warnings.warn(
+                f"maidr: pie has {len(values)} values for {len(wedges)} wedges; "
+                "reporting each slice's share of the whole instead of the "
+                "magnitudes passed.",
+                stacklevel=2,
+            )
 
         # `theta2 - theta1` is the slice's share of the 360 degree whole. A
         # wedge matplotlib drew has already passed its own non-negative check,

--- a/maidr/core/plot/pieplot.py
+++ b/maidr/core/plot/pieplot.py
@@ -138,21 +138,21 @@ class PiePlot(MaidrPlot):
         Raises
         ------
         ValueError
-            If any magnitude is negative. A negative slice has no area to
-            draw, and matplotlib rejects one for the same reason.
+            If any magnitude the caller passed is negative. A negative slice
+            has no area to draw, and matplotlib rejects one for the same
+            reason.
         """
         values = self._as_floats(self._values)
 
-        if values is None or len(values) != len(wedges):
-            # `theta2 - theta1` is the slice's share of the 360 degree whole.
-            values = [
-                (float(wedge.theta2) - float(wedge.theta1)) / 360.0 for wedge in wedges
-            ]
+        if values is not None and len(values) == len(wedges):
+            if any(value < 0 for value in values):
+                raise ValueError("Wedge sizes 'x' must be non negative values")
+            return values
 
-        if any(value < 0 for value in values):
-            raise ValueError("Wedge sizes 'x' must be non negative values")
-
-        return values
+        # `theta2 - theta1` is the slice's share of the 360 degree whole. A
+        # wedge matplotlib drew has already passed its own non-negative check,
+        # so this branch has nothing left to reject.
+        return [(float(wedge.theta2) - float(wedge.theta1)) / 360.0 for wedge in wedges]
 
     def _extract_labels(self, wedges: list[Wedge]) -> list[Any]:
         """

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -7,6 +7,7 @@ from . import (  # noqa: F401
     highlight,
     histogram,
     lineplot,
+    pieplot,
     scatterplot,
     regplot,
     kdeplot,

--- a/maidr/patch/pieplot.py
+++ b/maidr/patch/pieplot.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable
 
 import wrapt
 from matplotlib.axes import Axes
@@ -13,7 +13,7 @@ from maidr.patch.common import _argument
 
 
 def pie(
-    wrapped: Callable, instance: Axes, args: Tuple[Any, ...], kwargs: Dict[str, Any]
+    wrapped: Callable, instance: Axes, args: tuple, kwargs: dict
 ) -> tuple:
     """
     Patch function for `Axes.pie`.

--- a/maidr/patch/pieplot.py
+++ b/maidr/patch/pieplot.py
@@ -48,7 +48,14 @@ def pie(
         `(wedges, texts)`, or `(wedges, texts, autotexts)` when the caller
         passed `autopct` — whichever the original function returned.
     """
-    # Suppress warnings not to confuse screen-reader users
+    # Suppress warnings not to confuse screen-reader users.
+    #
+    # This is a process-wide, persistent catch-all, which is broader than this
+    # call needs -- but it is exactly what `maidr.patch.common.common` does on
+    # every other patched plot type, and a pie that filtered differently would
+    # make matplotlib's warnings appear or disappear depending on which plot
+    # type the user happened to draw. Parity is kept deliberately; narrowing
+    # it is a change to make in `common` for all plot types at once.
     warnings.filterwarnings("ignore")
 
     # Don't proceed if the call is made internally by the patched function.

--- a/maidr/patch/pieplot.py
+++ b/maidr/patch/pieplot.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import warnings
+from typing import Any, Callable, Dict, Tuple
+
+import wrapt
+from matplotlib.axes import Axes
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import _argument
+
+
+def pie(
+    wrapped: Callable, instance: Axes, args: Tuple[Any, ...], kwargs: Dict[str, Any]
+) -> tuple:
+    """
+    Patch function for `Axes.pie`.
+
+    The slice magnitudes are read off the call rather than off the wedges it
+    drew: `Axes.pie` plots `x / sum(x)` whenever the sum exceeds 1, and a
+    `Wedge` keeps only its angles, so by the time the plot exists the caller's
+    own numbers are gone. Reading them here is what lets `ax.pie([30, 50, 20])`
+    report 30/50/20 instead of 0.3/0.5/0.2. `labels` travels the same way, for
+    the same reason in reverse: matplotlib copies it onto the wedges, but only
+    when the caller passed it.
+
+    `maidr.patch.common.common` is not used here. It hands the wrapped
+    function's return value to `FigureManager.get_axes`, and `Axes.pie` returns
+    a tuple of artist lists rather than an artist; and its `kwargs` are the
+    call's own, so there is nowhere in it to put what is extracted here.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original function to be wrapped.
+    instance : Axes
+        The axes `Axes.pie` was called on, and the one it drew the wedges on.
+    args : tuple
+        Positional arguments passed to the original function.
+    kwargs : dict
+        Keyword arguments passed to the original function.
+
+    Returns
+    -------
+    tuple
+        `(wedges, texts)`, or `(wedges, texts, autotexts)` when the caller
+        passed `autopct` — whichever the original function returned.
+    """
+    # Suppress warnings not to confuse screen-reader users
+    warnings.filterwarnings("ignore")
+
+    # Don't proceed if the call is made internally by the patched function.
+    if ContextManager.is_internal_context():
+        return wrapped(*args, **kwargs)
+
+    # Set the internal context to avoid cyclic processing.
+    with ContextManager.set_internal_context():
+        plot = wrapped(*args, **kwargs)
+
+    data = _argument("data", wrapped, args, kwargs)
+    values = _resolve(_argument("x", wrapped, args, kwargs), data)
+    labels = _resolve(_argument("labels", wrapped, args, kwargs), data)
+
+    # `plot[0]` is the wedge list in both return shapes. Handing it over keeps
+    # a nested pie's two rings apart: each layer then describes the slices its
+    # own call drew rather than every wedge sitting on the axes.
+    FigureManager.create_maidr(
+        instance, PlotType.PIE, values=values, labels=labels, wedges=plot[0]
+    )
+
+    return plot
+
+
+def _resolve(value: Any, data: Any) -> Any:
+    """
+    Resolve an argument that names a column of the call's ``data``.
+
+    `Axes.pie` sits behind matplotlib's `_preprocess_data`, so
+    ``ax.pie("sales", labels="fruit", data=df)`` is a valid call in which both
+    arguments are column names. The patch wraps the outside of that decorator
+    and therefore sees the names, not the columns; this looks them up the way
+    matplotlib does.
+
+    Parameters
+    ----------
+    value : Any
+        The argument as the caller passed it.
+    data : Any
+        The call's ``data`` argument, or None when it had none.
+
+    Returns
+    -------
+    Any
+        The indexed value, or the argument unchanged when it does not name
+        anything in ``data``.
+    """
+    if data is None or not isinstance(value, str):
+        return value
+
+    try:
+        return data[value]
+    except Exception:
+        # Matplotlib treats an unresolvable name as a plain value too, and a
+        # pie that renders must not fail to be described.
+        return value
+
+
+# Patch matplotlib function.
+wrapt.wrap_function_wrapper(Axes, "pie", pie)

--- a/maidr/patch/pieplot.py
+++ b/maidr/patch/pieplot.py
@@ -101,9 +101,12 @@ def _resolve(value: Any, data: Any) -> Any:
 
     try:
         return data[value]
-    except Exception:
+    except (KeyError, IndexError, TypeError):
         # Matplotlib treats an unresolvable name as a plain value too, and a
-        # pie that renders must not fail to be described.
+        # pie that renders must not fail to be described. Only the three ways
+        # an indexable object says "not this key" are caught -- a wider net
+        # would swallow a genuinely broken ``data`` and leave nothing to
+        # debug from.
         return value
 
 

--- a/maidr/patch/pieplot.py
+++ b/maidr/patch/pieplot.py
@@ -12,9 +12,7 @@ from maidr.core.figure_manager import FigureManager
 from maidr.patch.common import _argument
 
 
-def pie(
-    wrapped: Callable, instance: Axes, args: tuple, kwargs: dict
-) -> tuple:
+def pie(wrapped: Callable, instance: Axes, args: tuple, kwargs: dict) -> tuple:
     """
     Patch function for `Axes.pie`.
 

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -167,19 +167,17 @@ class PlotlyPiePlot(PlotlyPlot):
         if self._trace.get("sort", True):
             wedges.sort(key=lambda wedge: wedge[1], reverse=True)
 
-        # Both sides of this comparison must go through the same normalisation.
-        # A null label reaches ``wedges`` as ``"null"``, so a raw ``None`` in
-        # ``hiddenlabels`` -- which is what an author writing the label they
-        # passed would naturally use -- has to become ``"null"`` too, or it
-        # matches nothing and the wedge stays visible.
-        #
-        # An empty entry is deliberately left alone rather than given an index:
-        # a hidden label carries no position to substitute, and the empty label
-        # it would name has already become that entry's own index. Plotly
-        # itself cannot match one either, so leaving it unmatched is faithful.
+        # Plotly matches `hiddenlabels` with `indexOf` against the *stringified*
+        # label -- `i.indexOf(p) !== -1`, where `p` has already become "null",
+        # an index, or `String(label)`. `indexOf` is strict equality, so only a
+        # string entry can ever match: `[null].indexOf("null")` is -1, and so is
+        # `[5].indexOf("5")`. A non-string entry therefore hides nothing there,
+        # and must hide nothing here -- dropping a wedge plotly still draws
+        # would shift every later slice onto the wrong element.
         hidden = {
-            _wedge_label(self._to_native(label), None)
+            label
             for label in _as_list(self._layout.get("hiddenlabels"))
+            if isinstance(label, str)
         }
         return [(label, value) for label, value in wedges if label not in hidden]
 
@@ -205,7 +203,7 @@ class PlotlyPiePlot(PlotlyPlot):
         }
 
 
-def _wedge_label(label: Any, index: int | None) -> str:
+def _wedge_label(label: Any, index: int) -> str:
     """
     Name a wedge the way plotly names it.
 
@@ -214,17 +212,12 @@ def _wedge_label(label: Any, index: int | None) -> str:
     of nulls merges into a single wedge there -- and so has to merge here too,
     or every slice after the second lands on the wrong element.
 
-    Shared with the ``hiddenlabels`` lookup so both sides of that comparison
-    agree; see the call site for why an empty entry has no index to take.
-
     Parameters
     ----------
     label : Any
         The label as the author wrote it, already converted to a Python scalar.
-    index : int, optional
-        The entry's position, substituted for an empty label. ``None`` when the
-        label has no position -- a ``hiddenlabels`` entry -- in which case an
-        empty label is left empty.
+    index : int
+        The entry's position, substituted for an empty label.
 
     Returns
     -------
@@ -233,7 +226,7 @@ def _wedge_label(label: Any, index: int | None) -> str:
     """
     if label is None:
         return "null"
-    if label == "" and index is not None:
+    if label == "":
         return str(index)
     return str(label)
 

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, domain_interval
 
 
 class PlotlyPiePlot(PlotlyPlot):
@@ -31,6 +31,14 @@ class PlotlyPiePlot(PlotlyPlot):
         what makes the selector address *this* pie. The default describes the
         single-pie figure; :class:`~maidr.plotly.plotly_maidr.PlotlyMaidr`
         passes real positions.
+    borrows_axis_titles : bool, default=True
+        Whether this pie may name its two dimensions from the layout's axis
+        titles. A pie draws no axes, so those titles are only its own when no
+        cartesian trace shares them — see :meth:`_extract_axes_data` for why
+        borrowing another trace's is worse than the generic fallback. The
+        default describes the pie-only figure;
+        :class:`~maidr.plotly.plotly_maidr.PlotlyMaidr` passes False when a
+        cartesian trace shares the pie's default axis pair.
     **kwargs : str
         Axis names forwarded to the parent class.
     """
@@ -73,6 +81,33 @@ class PlotlyPiePlot(PlotlyPlot):
             f".pielayer > .trace:nth-child({self._pie_position + 1}) "
             f"> .slice > path.surface"
         )
+
+    def _title_anchor(self) -> tuple[float, float]:
+        """
+        Return the point a ``subplot_titles`` annotation for this pie sits at.
+
+        The base class reads the rectangle off ``layout.xaxis``/``yaxis``,
+        which a pie does not have: every pie in a figure shares the *default*
+        axis names, so every one of them would read the default domain
+        ``[0, 1]``, put its anchor at the middle of the figure, and match none
+        of the titles ``make_subplots`` centred over the actual columns. A pie
+        is placed by its own ``domain`` rectangle instead — the same one
+        :meth:`~maidr.plotly.plotly_maidr.PlotlyMaidr._trace_domain_start`
+        reads to give it a grid cell — so that is what it is anchored by.
+
+        Only the anchor is overridden; matching a title to it stays in the
+        base class, so a pie and a bar agree on what counts as a match.
+
+        Returns
+        -------
+        tuple of (float, float)
+            The ``(x_mid, y_top)`` of this pie's rectangle, as fractions of
+            the figure.
+        """
+        domain = self._trace.get("domain")
+        x_start, x_end = domain_interval(domain, "x")
+        _, y_top = domain_interval(domain, "y")
+        return (x_start + x_end) / 2, y_top
 
     def _extract_plot_data(self) -> list[dict]:
         """Return one flat ``{x: label, y: value}`` point per drawn wedge."""

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import base64
+import math
+from typing import Any
+
+import numpy as np
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot
+
+
+class PlotlyPiePlot(PlotlyPlot):
+    """
+    Extract data from a Plotly pie trace.
+
+    A donut needs nothing of its own here: ``hole`` cuts the middle out of the
+    wedges and leaves the data behind them untouched, so it is still a pie.
+
+    Parameters
+    ----------
+    trace : dict
+        The pie trace dict.
+    layout : dict
+        The Plotly figure layout.
+    pie_position : int, default=0
+        The trace's zero-based position among the figure's pie traces. Plotly
+        draws every pie into one figure-level ``pielayer`` rather than into a
+        subplot, so this — not an axis pair, which a pie does not have — is
+        what makes the selector address *this* pie. The default describes the
+        single-pie figure; :class:`~maidr.plotly.plotly_maidr.PlotlyMaidr`
+        passes real positions.
+    **kwargs : str
+        Axis names forwarded to the parent class.
+    """
+
+    def __init__(
+        self,
+        trace: dict,
+        layout: dict,
+        *,
+        pie_position: int = 0,
+        **kwargs: str,
+    ) -> None:
+        # A negative position builds ``nth-child(0)`` or lower, which matches
+        # nothing and reports nothing -- the highlight simply never appears.
+        if pie_position < 0:
+            raise ValueError(f"pie position must be >= 0, got {pie_position}")
+
+        super().__init__(trace, layout, PlotType.PIE, **kwargs)
+        self._pie_position = pie_position
+
+    def _get_selector(self) -> str:
+        """
+        Return the selector matching this pie's wedges, in slice order.
+
+        This is the one plot type here that cannot scope itself with
+        :meth:`_subplot_css_prefix`: pies are drawn into a figure-level
+        ``g.pielayer``, so their wedges are never inside a ``.subplot.xy``
+        group and a prefixed selector would match nothing. The pie's position
+        among that layer's trace groups takes its place.
+
+        Returns
+        -------
+        str
+            A CSS selector resolving to one ``path.surface`` per slice, in the
+            same order as the emitted data.
+        """
+        return (
+            f".pielayer > .trace:nth-child({self._pie_position + 1}) "
+            f"> .slice > path.surface"
+        )
+
+    def _extract_plot_data(self) -> list[dict]:
+        """Return one flat ``{x: label, y: value}`` point per drawn wedge."""
+        return [
+            {MaidrKey.X: label, MaidrKey.Y: value}
+            for label, value in self._slices()
+        ]
+
+    def _slices(self) -> list[tuple[str, float]]:
+        """
+        Reproduce the wedges plotly draws, in the order it draws them.
+
+        Plotly does not draw one wedge per ``values`` entry in the order
+        given; ``pie/calc.js`` builds its own slice list first. The emitted
+        data has to follow that list exactly, because the selector is
+        positional — one element per slice — so the first divergence lands
+        every later slice on another wedge. The rules it applies, in order:
+
+        * a value plotly does not read as a number is skipped, drawing no
+          wedge at all;
+        * repeated labels merge into one wedge holding their sum, kept at the
+          label's first position;
+        * an empty label becomes the entry's own index, while a null one
+          stringifies to ``null`` as plotly's does, so a pair of them merges
+          into one wedge in both;
+        * a wedge whose merged total is negative is dropped;
+        * with ``sort`` — plotly's *default* — the wedges are then ordered by
+          value, largest first, which is why data order is not slice order;
+        * a label named in ``layout.hiddenlabels`` keeps its place in that
+          ordering but has its wedge removed, so it must not be emitted
+          either.
+
+        A pie with no positive value left to draw is marked invisible by
+        plotly and renders nothing, so it yields no slices here.
+
+        Returns
+        -------
+        list of (str, float)
+            One ``(label, value)`` pair per drawn wedge, in slice order.
+        """
+        raw_labels = self._trace.get("labels")
+        raw_values = self._trace.get("values")
+        labels = _as_list(raw_labels)
+        values = _as_list(raw_values)
+
+        # Each array bounds the other, and an array the author never supplied
+        # bounds nothing -- an empty one still bounds the pie down to nothing.
+        has_labels = raw_labels is not None
+        has_values = raw_values is not None
+        lengths = [len(labels)] if has_labels else []
+        if has_values:
+            lengths.append(len(values))
+        length = min(lengths) if lengths else 0
+        if not length:
+            return []
+
+        numbers = [_as_number(value) for value in values[:length]]
+        if has_values and not any(n is not None and n > 0 for n in numbers):
+            return []
+
+        # Without a ``values`` array plotly weighs every entry equally and the
+        # pie reports label counts; without a ``labels`` array it names the
+        # wedges off ``label0``/``dlabel``, whose defaults number them 0, 1, 2.
+        label0 = self._trace.get("label0", 0)
+        dlabel = self._trace.get("dlabel", 1)
+
+        wedges: list[list[Any]] = []
+        position_of: dict[str, int] = {}
+        for index in range(length):
+            value = numbers[index] if has_values else 1
+            if value is None:
+                continue
+
+            label = (
+                self._to_native(labels[index])
+                if has_labels
+                else label0 + index * dlabel
+            )
+            # An empty label is the only one plotly replaces. A null one it
+            # simply stringifies, which is why two of them merge into a single
+            # "null" wedge there -- and so have to merge here too, or every
+            # slice after the second lands on the wrong element.
+            if label is None:
+                label = "null"
+            elif label == "":
+                label = index
+            label = str(label)
+
+            position = position_of.get(label)
+            if position is None:
+                position_of[label] = len(wedges)
+                wedges.append([label, value])
+            else:
+                wedges[position][1] += value
+
+        wedges = [wedge for wedge in wedges if wedge[1] >= 0]
+        if self._trace.get("sort", True):
+            wedges.sort(key=lambda wedge: wedge[1], reverse=True)
+
+        hidden = {str(label) for label in _as_list(self._layout.get("hiddenlabels"))}
+        return [(label, value) for label, value in wedges if label not in hidden]
+
+    def _extract_axes_data(self) -> dict:
+        """Extract the two axis labels a pie carries.
+
+        A pie draws no axes, but the wire format still names what its slice
+        labels *are* on ``x`` and what their values *measure* on ``y`` — MAIDR
+        announces a slice as those two names paired with the point. Plotly
+        names neither, so an author who wants them says so through the
+        layout's axis titles; otherwise the generic pair stands in, which at
+        least reads as English where ``X`` and ``Y`` would not.
+        """
+        return {
+            MaidrKey.X: self._axis_config(
+                label=_axis_title(self._layout.get(self._xaxis_name, {}), "Label")
+            ),
+            MaidrKey.Y: self._axis_config(
+                label=_axis_title(self._layout.get(self._yaxis_name, {}), "Value")
+            ),
+        }
+
+
+def _as_list(value: Any) -> list:
+    """
+    Return a plotly data array as a plain list.
+
+    ``Figure.to_dict()`` hands back the arrays the author supplied, plus one
+    shape they never wrote: a numeric numpy array is exported as the
+    ``{"dtype": ..., "bdata": ...}`` base64 spec plotly.js consumes, which is
+    what ``plotly.express`` produces for every numeric column. Decoding it
+    here keeps ``px.pie`` on the same path as a hand-built ``go.Pie``, where
+    iterating the dict would otherwise walk its two keys. Anything that will
+    not decode comes back empty rather than as something worse.
+
+    Parameters
+    ----------
+    value : Any
+        A plotly data array, a typed-array spec, or None.
+
+    Returns
+    -------
+    list
+        The array's entries, or an empty list.
+    """
+    if value is None:
+        return []
+
+    if isinstance(value, dict):
+        dtype = value.get("dtype")
+        bdata = value.get("bdata")
+        if dtype is None or bdata is None:
+            return []
+        try:
+            return np.frombuffer(base64.b64decode(bdata), dtype=dtype).tolist()
+        except (TypeError, ValueError):
+            return []
+
+    # A string is iterable, so without this it would decompose into one
+    # single-character entry per letter instead of being rejected.
+    if isinstance(value, str):
+        return []
+
+    try:
+        return list(value)
+    except TypeError:
+        return []
+
+
+def _as_number(value: Any) -> float | None:
+    """
+    Return ``value`` as a number when plotly would read it as one.
+
+    Plotly's numeric gate accepts finite numbers and the strings that parse as
+    them, and skips everything else — a skipped entry draws no wedge, which is
+    why this returns None rather than a stand-in. Booleans are numbers to
+    Python but not to that gate, so they are rejected here too.
+
+    Parameters
+    ----------
+    value : Any
+        A single entry of the trace's ``values`` array.
+
+    Returns
+    -------
+    float or None
+        The number plotly would use, or None when it would skip the entry.
+    """
+    number = PlotlyPlot._to_native(value)
+
+    if isinstance(number, bool):
+        return None
+    if isinstance(number, (int, float)):
+        return number if math.isfinite(number) else None
+    if isinstance(number, str):
+        try:
+            parsed = float(number)
+        except ValueError:
+            return None
+        return parsed if math.isfinite(parsed) else None
+    return None
+
+
+def _axis_title(axis: dict, default: str) -> str:
+    """Return a plotly axis dict's title text, or ``default`` when unset."""
+    title = axis.get("title", "")
+    if isinstance(title, dict):
+        title = title.get("text", "")
+    return str(title) if title else default

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -181,11 +181,13 @@ class PlotlyPiePlot(PlotlyPlot):
         announces a slice as those two names paired with the point. Plotly
         names neither, so an author who wants them says so through the
         layout's axis titles; otherwise the generic pair stands in, which at
-        least reads as English where ``X`` and ``Y`` would not.
+        least reads as English where ``X`` and ``Y`` would not. It is the same
+        pair :class:`~maidr.core.plot.pieplot.PiePlot` falls back to, because
+        an unlabelled pie is announced by its plot type, not by its library.
         """
         return {
             MaidrKey.X: self._axis_config(
-                label=_axis_title(self._layout.get(self._xaxis_name, {}), "Label")
+                label=_axis_title(self._layout.get(self._xaxis_name, {}), "Category")
             ),
             MaidrKey.Y: self._axis_config(
                 label=_axis_title(self._layout.get(self._yaxis_name, {}), "Value")

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -135,6 +135,10 @@ class PlotlyPiePlot(PlotlyPlot):
             return []
 
         numbers = [_as_number(value) for value in values[:length]]
+        # Plotly marks a pie with nothing positive to draw invisible, so it
+        # renders no wedges at all. This is a short circuit, not a rule of its
+        # own: the merge and filter steps below reach the same empty answer,
+        # since merging can only sum values that were already non-positive.
         if has_values and not any(n is not None and n > 0 for n in numbers):
             return []
 

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -106,6 +106,11 @@ class PlotlyPiePlot(PlotlyPlot):
         A pie with no positive value left to draw is marked invisible by
         plotly and renders nothing, so it yields no slices here.
 
+        These rules are mirrored rather than called, so they can drift if
+        plotly changes them. Verified against plotly.py 6.7.0; the tests pin
+        one rule each, so a drift surfaces as a named failure rather than as
+        silently shifted slices.
+
         Returns
         -------
         list of (str, float)
@@ -149,15 +154,7 @@ class PlotlyPiePlot(PlotlyPlot):
                 if has_labels
                 else label0 + index * dlabel
             )
-            # An empty label is the only one plotly replaces. A null one it
-            # simply stringifies, which is why two of them merge into a single
-            # "null" wedge there -- and so have to merge here too, or every
-            # slice after the second lands on the wrong element.
-            if label is None:
-                label = "null"
-            elif label == "":
-                label = index
-            label = str(label)
+            label = _wedge_label(label, index)
 
             position = position_of.get(label)
             if position is None:
@@ -170,7 +167,20 @@ class PlotlyPiePlot(PlotlyPlot):
         if self._trace.get("sort", True):
             wedges.sort(key=lambda wedge: wedge[1], reverse=True)
 
-        hidden = {str(label) for label in _as_list(self._layout.get("hiddenlabels"))}
+        # Both sides of this comparison must go through the same normalisation.
+        # A null label reaches ``wedges`` as ``"null"``, so a raw ``None`` in
+        # ``hiddenlabels`` -- which is what an author writing the label they
+        # passed would naturally use -- has to become ``"null"`` too, or it
+        # matches nothing and the wedge stays visible.
+        #
+        # An empty entry is deliberately left alone rather than given an index:
+        # a hidden label carries no position to substitute, and the empty label
+        # it would name has already become that entry's own index. Plotly
+        # itself cannot match one either, so leaving it unmatched is faithful.
+        hidden = {
+            _wedge_label(self._to_native(label), None)
+            for label in _as_list(self._layout.get("hiddenlabels"))
+        }
         return [(label, value) for label, value in wedges if label not in hidden]
 
     def _extract_axes_data(self) -> dict:
@@ -193,6 +203,39 @@ class PlotlyPiePlot(PlotlyPlot):
                 label=_axis_title(self._layout.get(self._yaxis_name, {}), "Value")
             ),
         }
+
+
+def _wedge_label(label: Any, index: int | None) -> str:
+    """
+    Name a wedge the way plotly names it.
+
+    Plotly replaces exactly one label: an empty one becomes the entry's own
+    index. A null one it simply stringifies to ``null``, which is why a pair
+    of nulls merges into a single wedge there -- and so has to merge here too,
+    or every slice after the second lands on the wrong element.
+
+    Shared with the ``hiddenlabels`` lookup so both sides of that comparison
+    agree; see the call site for why an empty entry has no index to take.
+
+    Parameters
+    ----------
+    label : Any
+        The label as the author wrote it, already converted to a Python scalar.
+    index : int, optional
+        The entry's position, substituted for an empty label. ``None`` when the
+        label has no position -- a ``hiddenlabels`` entry -- in which case an
+        empty label is left empty.
+
+    Returns
+    -------
+    str
+        The wedge's name.
+    """
+    if label is None:
+        return "null"
+    if label == "" and index is not None:
+        return str(index)
+    return str(label)
 
 
 def _as_list(value: Any) -> list:

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -41,6 +41,7 @@ class PlotlyPiePlot(PlotlyPlot):
         layout: dict,
         *,
         pie_position: int = 0,
+        borrows_axis_titles: bool = True,
         **kwargs: str,
     ) -> None:
         # A negative position builds ``nth-child(0)`` or lower, which matches
@@ -50,6 +51,7 @@ class PlotlyPiePlot(PlotlyPlot):
 
         super().__init__(trace, layout, PlotType.PIE, **kwargs)
         self._pie_position = pie_position
+        self._borrows_axis_titles = borrows_axis_titles
 
     def _get_selector(self) -> str:
         """
@@ -192,14 +194,22 @@ class PlotlyPiePlot(PlotlyPlot):
         least reads as English where ``X`` and ``Y`` would not. It is the same
         pair :class:`~maidr.core.plot.pieplot.PiePlot` falls back to, because
         an unlabelled pie is announced by its plot type, not by its library.
+
+        Those titles are only borrowed when the pie has them to itself. A
+        cartesian trace with no explicit axis pair shares the same default
+        ``xaxis``/``yaxis``, and their titles describe *its* axes — a bar's
+        "Month" read against a pie's slice labels is worse than the generic
+        pair, because it is confidently wrong rather than merely vague.
         """
+        if self._borrows_axis_titles:
+            x_axis = self._layout.get(self._xaxis_name, {})
+            y_axis = self._layout.get(self._yaxis_name, {})
+        else:
+            x_axis, y_axis = {}, {}
+
         return {
-            MaidrKey.X: self._axis_config(
-                label=_axis_title(self._layout.get(self._xaxis_name, {}), "Category")
-            ),
-            MaidrKey.Y: self._axis_config(
-                label=_axis_title(self._layout.get(self._yaxis_name, {}), "Value")
-            ),
+            MaidrKey.X: self._axis_config(label=_axis_title(x_axis, "Category")),
+            MaidrKey.Y: self._axis_config(label=_axis_title(y_axis, "Value")),
         }
 
 

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -435,11 +435,20 @@ class PlotlyMaidr:
             if pie_traces:
                 from maidr.plotly.pie import PlotlyPiePlot
 
+                # A pie has no axes of its own, so it names its dimensions from
+                # ``layout.xaxis``/``yaxis`` when nothing else has claimed them.
+                # A cartesian trace with no explicit axis pair shares this same
+                # default group, and those titles describe *its* axes -- letting
+                # the pie borrow them would announce a bar's "Month" against a
+                # pie's slice labels.
+                pie_owns_axes = len(pie_traces) == len(group_traces)
+
                 for position, pie_trace in enumerate(pie_traces):
                     plot = PlotlyPiePlot(
                         pie_trace,
                         layout,
                         pie_position=position,
+                        borrows_axis_titles=pie_owns_axes,
                         **axis_kwargs,
                     )
                     plot.row_index, plot.col_index = self._grid_position(

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -43,6 +43,43 @@ from maidr.util.iframe_utils import wrap_in_iframe_plotly
 #: Add a type here when maidr learns to render it, not before.
 _PLACED_BY_DOMAIN = frozenset({"pie"})
 
+#: Every trace type plotly places by a ``domain`` rectangle rather than by a
+#: cartesian axis pair. These share the default ``("x", "y")`` trace group with
+#: each other simply because none of them names an axis -- not because any of
+#: them has a claim on ``layout.xaxis``/``yaxis``. Used to decide whether a pie
+#: may take those titles for its own dimension names; see ``_extract_plots``.
+_DOMAIN_TRACE_TYPES = frozenset(
+    {
+        "pie",
+        "funnelarea",
+        "sunburst",
+        "treemap",
+        "icicle",
+        "indicator",
+        "table",
+        "sankey",
+        "parcats",
+        "parcoords",
+    }
+)
+
+
+def _is_domain_trace(trace: dict) -> bool:
+    """Report whether plotly places this trace by a domain rather than an axis.
+
+    Parameters
+    ----------
+    trace : dict
+        One trace of the figure.
+
+    Returns
+    -------
+    bool
+        True when the trace carries no cartesian axis pair. A trace with no
+        ``type`` at all is a ``scatter``, which is cartesian.
+    """
+    return trace.get("type") in _DOMAIN_TRACE_TYPES
+
 
 class PlotlyMaidr:
     """
@@ -459,7 +496,15 @@ class PlotlyMaidr:
                 # default group, and those titles describe *its* axes -- letting
                 # the pie borrow them would announce a bar's "Month" against a
                 # pie's slice labels.
-                pie_owns_axes = len(pie_traces) == len(group_traces)
+                #
+                # Only a *cartesian* trace claims them. The other domain traces
+                # land in this group for the same reason a pie does -- they
+                # carry no axis pair either -- so a pie beside a `go.Sunburst`
+                # still owns the titles, and falling back to the generic pair
+                # there would lose a label the author did write.
+                pie_owns_axes = all(
+                    _is_domain_trace(trace) for trace in group_traces
+                )
 
                 for position, pie_trace in enumerate(pie_traces):
                     plot = PlotlyPiePlot(

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, cast
 from htmltools import HTML, HTMLDocument, Tag, tags
 
 from maidr.core.enum.maidr_key import MaidrKey
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, domain_interval
 from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
 from maidr.plotly.step_shape import (
     is_connected_line_trace,
@@ -29,6 +29,19 @@ from maidr.util.dependencies import (
 )
 from maidr.util.environment import Environment
 from maidr.util.iframe_utils import wrap_in_iframe_plotly
+
+
+#: Trace types placed by their own ``domain`` rectangle that maidr renders as
+#: a layer. Plotly has other domain traces -- ``table``, ``sunburst``,
+#: ``treemap``, ``indicator`` -- and maidr draws no layer for any of them, so
+#: their rectangles are deliberately not folded into the figure's row and
+#: column universe by :meth:`PlotlyMaidr._subplot_domain_starts`. Folding them
+#: in would move the cartesian subplots sitting beside them: a bar to the right
+#: of a ``go.Table`` in a 1x2 grid would go from column 0, the only column
+#: maidr has anything to put in, to column 1 behind an empty cell.
+#:
+#: Add a type here when maidr learns to render it, not before.
+_PLACED_BY_DOMAIN = frozenset({"pie"})
 
 
 class PlotlyMaidr:
@@ -82,6 +95,12 @@ class PlotlyMaidr:
         together: a figure mixing a pie with a cartesian subplot has to order
         their columns against each other, not each against its own kind.
 
+        Only the domain traces maidr renders are collected -- see
+        :data:`_PLACED_BY_DOMAIN`. The grid this builds is the grid the user
+        navigates, and a trace maidr draws no layer for occupies no cell in
+        it: reserving one would both add an empty cell to tab through and
+        shift every renderable subplot beside it into a different column.
+
         Parameters
         ----------
         layout : dict
@@ -106,6 +125,8 @@ class PlotlyMaidr:
                 y_starts.add(_domain_start(val, "domain"))
 
         for trace in traces:
+            if trace.get("type") not in _PLACED_BY_DOMAIN:
+                continue
             domain = trace.get("domain")
             if isinstance(domain, dict):
                 x_starts.add(_domain_start(domain, "x"))
@@ -162,9 +183,6 @@ class PlotlyMaidr:
         placed covers the whole figure, which is the first cell.
         """
         domain = trace.get("domain")
-        if not isinstance(domain, dict):
-            domain = {}
-
         return _domain_start(domain, "x"), _domain_start(domain, "y")
 
     def _extract_plots(self) -> None:
@@ -954,13 +972,13 @@ class PlotlyMaidr:
         webbrowser.open(f"file://{html_file_path}")
 
 
-def _domain_start(box: dict, key: str) -> float:
+def _domain_start(box: Any, key: str) -> float:
     """
     Return where one ``domain`` interval starts, as a fraction of the figure.
 
     Parameters
     ----------
-    box : dict
+    box : Any
         A layout axis, whose ``domain`` holds the interval, or a trace's
         ``domain``, whose ``x`` and ``y`` hold one each.
     key : str
@@ -973,11 +991,4 @@ def _domain_start(box: dict, key: str) -> float:
         together compare equal, or 0 for an interval that is absent or
         malformed -- the figure's own edge, which is the first row or column.
     """
-    interval = box.get(key, [0, 1])
-    if not isinstance(interval, (list, tuple)) or not interval:
-        return 0.0
-
-    try:
-        return round(float(interval[0]), 6)
-    except (TypeError, ValueError):
-        return 0.0
+    return domain_interval(box, key)[0]

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -70,43 +70,102 @@ class PlotlyMaidr:
         return x_key, y_key
 
     @staticmethod
-    def _subplot_grid_position(
-        layout: dict, xaxis_name: str, yaxis_name: str
-    ) -> tuple[int, int]:
-        """Determine subplot grid position from axis domain values.
+    def _subplot_domain_starts(
+        layout: dict, traces: list[dict]
+    ) -> tuple[list[float], list[float]]:
+        """Collect the fractional start of every subplot in the figure.
 
-        Plotly's ``make_subplots`` assigns each axis a ``domain`` property
-        that specifies its fractional position within the figure.  This
-        method collects all unique domain start values to compute row/col
-        indices.
+        Plotly's ``make_subplots`` places a *cartesian* subplot by giving each
+        of its axes a ``domain``, and a *domain* trace -- ``go.Pie`` has no
+        axes at all -- by giving the trace itself a ``domain`` rectangle.
+        Both are fractions of the same figure, so the two are collected
+        together: a figure mixing a pie with a cartesian subplot has to order
+        their columns against each other, not each against its own kind.
+
+        Parameters
+        ----------
+        layout : dict
+            The Plotly figure layout.
+        traces : list of dict
+            Every trace in the figure.
+
+        Returns
+        -------
+        tuple of (list of float, list of float)
+            The unique x starts left to right, giving column indices, and the
+            unique y starts top to bottom, giving row indices -- a higher y
+            start sits higher on the page, so it is the lower row index.
         """
-        # Collect all x-axis domain starts and y-axis domain starts
         x_starts: set[float] = set()
         y_starts: set[float] = set()
 
         for key, val in layout.items():
             if key.startswith("xaxis") and isinstance(val, dict):
-                domain = val.get("domain", [0, 1])
-                x_starts.add(round(domain[0], 6))
+                x_starts.add(_domain_start(val, "domain"))
             if key.startswith("yaxis") and isinstance(val, dict):
-                domain = val.get("domain", [0, 1])
-                y_starts.add(round(domain[0], 6))
+                y_starts.add(_domain_start(val, "domain"))
 
-        # Sort: x left-to-right gives columns, y top-to-bottom gives rows
-        # y domains: higher start = higher on page = lower row index
-        sorted_x = sorted(x_starts)
-        sorted_y = sorted(y_starts, reverse=True)
+        for trace in traces:
+            domain = trace.get("domain")
+            if isinstance(domain, dict):
+                x_starts.add(_domain_start(domain, "x"))
+                y_starts.add(_domain_start(domain, "y"))
 
-        # Get this axis's domain start
-        xaxis = layout.get(xaxis_name, {})
-        yaxis = layout.get(yaxis_name, {})
-        x_start = round(xaxis.get("domain", [0, 1])[0], 6)
-        y_start = round(yaxis.get("domain", [0, 1])[0], 6)
+        return sorted(x_starts), sorted(y_starts, reverse=True)
 
-        col = sorted_x.index(x_start) if x_start in sorted_x else 0
-        row = sorted_y.index(y_start) if y_start in sorted_y else 0
+    @staticmethod
+    def _grid_position(
+        x_starts: list[float],
+        y_starts: list[float],
+        start: tuple[float, float],
+    ) -> tuple[int, int]:
+        """Return the grid cell one subplot's domain start pair addresses.
+
+        Parameters
+        ----------
+        x_starts, y_starts : list of float
+            The figure's subplot starts, as :meth:`_subplot_domain_starts`
+            ordered them.
+        start : tuple of (float, float)
+            This subplot's own x and y domain start.
+
+        Returns
+        -------
+        tuple of (int, int)
+            The ``(row, col)`` of the cell, falling back to the first row or
+            column for a start the figure does not place.
+        """
+        x_start, y_start = start
+
+        col = x_starts.index(x_start) if x_start in x_starts else 0
+        row = y_starts.index(y_start) if y_start in y_starts else 0
 
         return row, col
+
+    @staticmethod
+    def _axis_domain_start(
+        layout: dict, xaxis_name: str, yaxis_name: str
+    ) -> tuple[float, float]:
+        """Return where a cartesian subplot's axis pair starts in the figure."""
+        return (
+            _domain_start(layout.get(xaxis_name, {}), "domain"),
+            _domain_start(layout.get(yaxis_name, {}), "domain"),
+        )
+
+    @staticmethod
+    def _trace_domain_start(trace: dict) -> tuple[float, float]:
+        """Return where a domain trace's own rectangle starts in the figure.
+
+        A domain trace carries no ``xaxis``/``yaxis``, so this -- not the axis
+        names its group was keyed by, which are the defaults for every one of
+        them -- is what tells two pies of a grid apart. A trace plotly never
+        placed covers the whole figure, which is the first cell.
+        """
+        domain = trace.get("domain")
+        if not isinstance(domain, dict):
+            domain = {}
+
+        return _domain_start(domain, "x"), _domain_start(domain, "y")
 
     def _extract_plots(self) -> None:
         """Extract PlotlyPlot instances from all traces in the figure.
@@ -159,14 +218,18 @@ class PlotlyMaidr:
             axis_pair = self._trace_axis_ref(trace)
             axis_groups[axis_pair].append(trace)
 
+        x_starts, y_starts = self._subplot_domain_starts(layout, traces)
+
         # Process each subplot group independently
         for (xaxis_name, yaxis_name), group_traces in axis_groups.items():
             axis_kwargs = {
                 "xaxis_name": xaxis_name,
                 "yaxis_name": yaxis_name,
             }
-            row, col = self._subplot_grid_position(
-                layout, xaxis_name, yaxis_name
+            row, col = self._grid_position(
+                x_starts,
+                y_starts,
+                self._axis_domain_start(layout, xaxis_name, yaxis_name),
             )
 
             bar_traces = [
@@ -363,6 +426,12 @@ class PlotlyMaidr:
             # knows those positions, so pies are built here rather than left
             # to ``PlotlyPlotFactory``, which sees one trace and has to assume
             # it is the only one.
+            #
+            # That one group is a fact about the selector, not about the grid:
+            # a pie is placed by its own ``domain`` rectangle, so its cell is
+            # read from there. Taking the group's cell instead collapsed every
+            # pie of a grid into the first one, stacked as layers of a single
+            # subplot.
             if pie_traces:
                 from maidr.plotly.pie import PlotlyPiePlot
 
@@ -373,8 +442,11 @@ class PlotlyMaidr:
                         pie_position=position,
                         **axis_kwargs,
                     )
-                    plot.row_index = row
-                    plot.col_index = col
+                    plot.row_index, plot.col_index = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._trace_domain_start(pie_trace),
+                    )
                     self._plots.append(plot)
                 merged.update(id(t) for t in pie_traces)
 
@@ -871,3 +943,32 @@ class PlotlyMaidr:
         temp_file_path = os.path.join(static_temp_dir, "maidr_plotly_plot.html")
         html_file_path = self.save_html(temp_file_path, use_cdn=use_cdn)
         webbrowser.open(f"file://{html_file_path}")
+
+
+def _domain_start(box: dict, key: str) -> float:
+    """
+    Return where one ``domain`` interval starts, as a fraction of the figure.
+
+    Parameters
+    ----------
+    box : dict
+        A layout axis, whose ``domain`` holds the interval, or a trace's
+        ``domain``, whose ``x`` and ``y`` hold one each.
+    key : str
+        The key holding the interval.
+
+    Returns
+    -------
+    float
+        The interval's start, rounded so that two subplots plotly placed
+        together compare equal, or 0 for an interval that is absent or
+        malformed -- the figure's own edge, which is the first row or column.
+    """
+    interval = box.get(key, [0, 1])
+    if not isinstance(interval, (list, tuple)) or not interval:
+        return 0.0
+
+    try:
+        return round(float(interval[0]), 6)
+    except (TypeError, ValueError):
+        return 0.0

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -138,6 +138,9 @@ class PlotlyMaidr:
           carries a single ``stepDirection`` for all of its series.
         * Multiple box traces are merged into a single
           :class:`PlotlyMultiBoxPlot` (matching ``BoxPlot``).
+        * Pie traces stay one layer each, but are built here rather than by
+          the factory so every pie carries its position among the figure's
+          pie traces — the only thing its selector can be scoped by.
 
         Every scatter-family trace is assigned a selector index from its
         position within the subplot, not within the layer it lands in — see
@@ -174,6 +177,9 @@ class PlotlyMaidr:
             ]
             box_traces = [
                 t for t in group_traces if t.get("type") == "box"
+            ]
+            pie_traces = [
+                t for t in group_traces if t.get("type") == "pie"
             ]
 
             # `nth-child` counts within the subplot's SVG `scatterlayer`, so a
@@ -348,6 +354,29 @@ class PlotlyMaidr:
                 plot.col_index = col
                 self._plots.append(plot)
                 merged.update(id(t) for t in box_traces)
+
+            # Pies, one layer each. Plotly draws them into a figure-level
+            # ``pielayer`` instead of a subplot group, so a pie's selector is
+            # scoped by its position among the *pie* traces rather than by an
+            # axis pair -- which a pie does not carry at all, and which is why
+            # every pie in a figure lands in this one group. Only this loop
+            # knows those positions, so pies are built here rather than left
+            # to ``PlotlyPlotFactory``, which sees one trace and has to assume
+            # it is the only one.
+            if pie_traces:
+                from maidr.plotly.pie import PlotlyPiePlot
+
+                for position, pie_trace in enumerate(pie_traces):
+                    plot = PlotlyPiePlot(
+                        pie_trace,
+                        layout,
+                        pie_position=position,
+                        **axis_kwargs,
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in pie_traces)
 
             # Remaining traces
             for trace in group_traces:

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -241,24 +241,42 @@ class PlotlyPlot(ABC):
             return title.get("text", "")
         return str(title) if title else ""
 
+    def _title_anchor(self) -> tuple[float, float]:
+        """Return the point on the page a subplot title annotation sits at.
+
+        ``make_subplots`` puts each subplot's title centred over the top of
+        that subplot, so the pair is the horizontal midpoint and the top edge
+        of whatever rectangle the subplot occupies. A cartesian subplot's
+        rectangle is the product of its two axis domains, which is what this
+        reads. A plot placed some other way — a pie, which has no axis pair at
+        all and so would read the layout defaults here and land at the middle
+        of the figure whatever column it is really in — overrides this with
+        the rectangle it does have.
+
+        Returns
+        -------
+        tuple of (float, float)
+            The ``(x_mid, y_top)`` of this subplot, as fractions of the
+            figure.
+        """
+        x_domain = domain_interval(self._layout.get(self._xaxis_name, {}), "domain")
+        y_domain = domain_interval(self._layout.get(self._yaxis_name, {}), "domain")
+        return (x_domain[0] + x_domain[1]) / 2, y_domain[1]
+
     def _get_subplot_annotation_title(self) -> str | None:
         """Find the annotation that serves as this subplot's title.
 
         Plotly ``make_subplots`` places title annotations at the top of
-        each subplot's y-axis domain.  This matches annotations by
-        checking if their ``y`` position is near the top of this
-        subplot's y-axis domain.
+        each subplot.  This matches annotations against the point
+        :meth:`_title_anchor` reports for this plot, so a plot type that is
+        not placed by an axis pair only has to say where it sits, not repeat
+        the matching.
         """
         annotations = self._layout.get("annotations", [])
         if not annotations:
             return None
 
-        yaxis = self._layout.get(self._yaxis_name, {})
-        xaxis = self._layout.get(self._xaxis_name, {})
-        y_domain = yaxis.get("domain", [0, 1])
-        x_domain = xaxis.get("domain", [0, 1])
-        y_top = y_domain[1]
-        x_mid = (x_domain[0] + x_domain[1]) / 2
+        x_mid, y_top = self._title_anchor()
 
         for ann in annotations:
             if ann.get("xref") != "paper" or ann.get("yref") != "paper":
@@ -415,6 +433,51 @@ class PlotlyPlot(ABC):
         if not self._schema:
             self._schema = self.render()
         return self._schema
+
+
+def domain_interval(box: Any, key: str) -> tuple[float, float]:
+    """
+    Return one ``domain`` interval, as fractions of the figure.
+
+    Plotly places a *cartesian* subplot by giving each of its axes a
+    ``domain`` interval, and a *domain* trace — ``go.Pie`` has no axes at all
+    — by giving the trace's own ``domain`` an ``x`` and a ``y`` interval.
+    Both are fractions of the same figure and are read the same way, so both
+    are read here: :class:`~maidr.plotly.plotly_maidr.PlotlyMaidr` uses it to
+    order subplots into a grid, and
+    :class:`~maidr.plotly.pie.PlotlyPiePlot` to find where its own rectangle
+    sits on the page.
+
+    Parameters
+    ----------
+    box : Any
+        A layout axis, whose ``domain`` holds the interval, or a trace's
+        ``domain``, whose ``x`` and ``y`` hold one each. Anything that is not
+        a dict is treated as absent.
+    key : str
+        The key holding the interval.
+
+    Returns
+    -------
+    tuple of (float, float)
+        The interval's start and end, rounded so that two subplots plotly
+        placed together compare equal. An absent or malformed interval is
+        the whole figure, ``(0.0, 1.0)`` — the first row and column, and the
+        span a figure that was never split into subplots actually has.
+    """
+    whole = (0.0, 1.0)
+
+    if not isinstance(box, dict):
+        return whole
+
+    interval = box.get(key, list(whole))
+    if not isinstance(interval, (list, tuple)) or len(interval) < 2:
+        return whole
+
+    try:
+        return round(float(interval[0]), 6), round(float(interval[1]), 6)
+    except (TypeError, ValueError):
+        return whole
 
 
 def _extract_decimals(fmt: str) -> int | None:

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -115,4 +115,17 @@ class PlotlyPlotFactory:
 
             return PlotlyHistogramPlot(trace, layout, **axis_kwargs)
 
+        if trace_type == "pie":
+            from maidr.plotly.pie import PlotlyPiePlot
+
+            # ``pie_position`` is left at its default here. Plotly draws every
+            # pie into one figure-level ``pielayer``, so a pie's selector is
+            # scoped by its position among *those* traces; this factory sees
+            # one trace with no idea what else the figure holds, so "assume it
+            # is the only pie" is the only assumption available — the same one
+            # the lines branch above makes about scatter positions.
+            # ``PlotlyMaidr`` never reaches here precisely because it does
+            # know, and passes real positions.
+            return PlotlyPiePlot(trace, layout, **axis_kwargs)
+
         return None

--- a/tests/core/plot/test_pieplot.py
+++ b/tests/core/plot/test_pieplot.py
@@ -618,15 +618,18 @@ class TestDataColumnNames:
         "data",
         [
             pytest.param(pd.DataFrame({"units": UNITS}), id="KeyError"),
-            pytest.param([30, 50, 20], id="IndexError"),
-            pytest.param(object(), id="TypeError"),
+            pytest.param(np.array(UNITS), id="IndexError"),
+            pytest.param([30, 50, 20], id="TypeError-list"),
+            pytest.param(object(), id="TypeError-unindexable"),
         ],
     )
     def test_an_unresolvable_name_is_passed_through_unchanged(self, data):
         # Matplotlib treats a name it cannot look up as a plain value, and so
         # must this: raising instead would fail a pie matplotlib drew
         # perfectly well. One case per way an indexable object says "not this
-        # key" -- the three, and only the three, `_resolve` catches.
+        # key" -- the three, and only the three, `_resolve` catches. A numpy
+        # array is what raises `IndexError`; a plain list raises `TypeError`,
+        # so it cannot stand in for that arm.
         assert _resolve("missing_col", data) == "missing_col"
 
     def test_a_name_is_only_looked_up_when_there_is_data_to_look_it_up_in(self):

--- a/tests/core/plot/test_pieplot.py
+++ b/tests/core/plot/test_pieplot.py
@@ -1,0 +1,459 @@
+"""Tests for pie chart support.
+
+A pie is the one plot type whose magnitudes matplotlib throws away.
+``Axes.pie`` plots ``x / sum(x)`` and each ``Wedge`` keeps only its start and
+end angle, so ``ax.pie([30, 50, 20])`` read back off the artists reports the
+fractions 0.3/0.5/0.2 for a plot of counts. The patch reads the call before
+matplotlib rewrites it, and most of what follows pins that down: the emitted
+``y`` values are the caller's own numbers, whatever shape they arrived in.
+
+The rest covers what the wire format asks of a pie layer — a flat row of
+``{x, y}`` points, a per-slice selector in slice order, and an ``axes``
+payload naming the two dimensions of a slice rather than positions on a
+scale it does not have.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import json  # noqa: E402
+import re  # noqa: E402
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+from lxml import etree  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.core.plot.pieplot import PiePlot  # noqa: E402
+
+
+#: A pie whose sizes sum far above 1, so matplotlib normalises them away.
+FRUIT = ["Apples", "Bananas", "Cherries"]
+UNITS = [30, 50, 20]
+
+
+def _stringify(value):
+    """Normalize MaidrKey/PlotType enum keys and values to plain strings."""
+    if isinstance(value, dict):
+        return {
+            (k.value if hasattr(k, "value") else k): _stringify(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_stringify(item) for item in value]
+    return value.value if hasattr(value, "value") else value
+
+
+def _only_layer(fig) -> dict:
+    """Assert the figure registered exactly one layer and return its schema."""
+    maidr_obj = FigureManager.get_maidr(fig)
+    assert len(maidr_obj._plots) == 1, (
+        f"expected exactly one layer, got {[p.type for p in maidr_obj._plots]}"
+    )
+    return _stringify(maidr_obj._plots[0].schema)
+
+
+def _layers(fig) -> list[dict]:
+    """Return every registered layer's schema, in registration order."""
+    return [_stringify(plot.schema) for plot in FigureManager.get_maidr(fig)._plots]
+
+
+def _highlight_groups(fig) -> list[list]:
+    """Render the figure and return the tagged group of each pie slice.
+
+    The emitted selector is ``g[maidr='<id>'] > path``, so the elements it
+    resolves to are the ``<g>`` elements carrying this layer's id, each
+    holding one ``<path>``. Returning them in document order is what lets a
+    test check that data index k and element k describe the same slice.
+    """
+    maidr_obj = FigureManager.get_maidr(fig)
+    html = str(maidr_obj._create_html_tag().get_html_string())
+    svg = re.search(r"<svg.*</svg>", html, re.S)
+    assert svg is not None, "no SVG in the rendered output"
+
+    root = etree.fromstring(svg.group(0).encode())
+    return [
+        [child for child in group if child.tag.endswith("path")]
+        for group in root.xpath('//*[local-name()="g"][@maidr]')
+    ]
+
+
+class TestValuesSurviveNormalisation:
+    """The caller's magnitudes, not the fractions matplotlib kept."""
+
+    def test_counts_are_reported_as_counts(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+    def test_ndarray_sizes_are_reported_as_given(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(np.array(UNITS), labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+    def test_series_sizes_are_reported_as_given(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(pd.Series(UNITS), labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+    def test_column_names_are_resolved_against_data(self):
+        # `Axes.pie` sits behind matplotlib's `_preprocess_data`, so both
+        # arguments may name a column instead of holding one.
+        frame = pd.DataFrame({"units": UNITS, "fruit": FRUIT})
+        fig, ax = plt.subplots()
+        try:
+            ax.pie("units", labels="fruit", data=frame)
+            schema = _only_layer(fig)
+
+            assert schema["data"] == [
+                {"x": "Apples", "y": 30},
+                {"x": "Bananas", "y": 50},
+                {"x": "Cherries", "y": 20},
+            ]
+        finally:
+            plt.close(fig)
+
+    def test_sizes_below_one_are_left_alone(self):
+        # Shares of a whole are already the numbers the caller meant.
+        fig, ax = plt.subplots()
+        try:
+            ax.pie([0.25, 0.75], labels=["Half", "Rest"])
+            schema = _only_layer(fig)
+
+            assert [point["y"] for point in schema["data"]] == [0.25, 0.75]
+        finally:
+            plt.close(fig)
+
+    def test_an_unnormalized_partial_pie_keeps_its_gap(self):
+        # `normalize=False` draws a pie that does not close, and only accepts
+        # sizes summing to at most 1. The sizes are still the caller's.
+        fig, ax = plt.subplots()
+        try:
+            ax.pie([0.2, 0.3], labels=["Done", "Started"], normalize=False)
+            schema = _only_layer(fig)
+
+            assert [point["y"] for point in schema["data"]] == [0.2, 0.3]
+        finally:
+            plt.close(fig)
+
+    def test_a_negative_size_is_rejected(self):
+        # matplotlib refuses to draw one, and so does the layer built from it.
+        fig, ax = plt.subplots()
+        try:
+            with pytest.raises(ValueError, match="non negative"):
+                ax.pie([30, -50, 20])
+        finally:
+            plt.close(fig)
+
+
+class TestReturnShapes:
+    """``Axes.pie`` returns two lists, or three when ``autopct`` is set."""
+
+    def test_wedges_and_texts(self):
+        fig, ax = plt.subplots()
+        try:
+            returned = ax.pie(UNITS, labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert len(returned) == 2
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+    def test_wedges_texts_and_autotexts(self):
+        fig, ax = plt.subplots()
+        try:
+            returned = ax.pie(UNITS, labels=FRUIT, autopct="%1.1f%%")
+            schema = _only_layer(fig)
+
+            assert len(returned) == 3
+            # The percentage labels matplotlib drew are not slices, so the
+            # layer must still describe three of them.
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+            assert [point["x"] for point in schema["data"]] == FRUIT
+        finally:
+            plt.close(fig)
+
+    def test_pyplot_entry_point_registers_the_layer(self):
+        fig = plt.figure()
+        try:
+            plt.pie(UNITS, labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "pie"
+        finally:
+            plt.close(fig)
+
+
+class TestLabels:
+    """Labels argument, then the wedge's own label, then its position."""
+
+    def test_labels_argument_names_the_slices(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert [point["x"] for point in schema["data"]] == FRUIT
+        finally:
+            plt.close(fig)
+
+    def test_an_unlabelled_pie_falls_back_to_positions(self):
+        # Still navigable: every slice can be named, even if only by index.
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS)
+            schema = _only_layer(fig)
+
+            assert [point["x"] for point in schema["data"]] == ["0", "1", "2"]
+        finally:
+            plt.close(fig)
+
+    def test_numeric_labels_stay_json_serializable(self):
+        # A pandas column hands over numpy scalars, which `json.dumps`
+        # refuses -- one of them would otherwise fail the whole figure.
+        frame = pd.DataFrame({"units": UNITS, "year": [2021, 2022, 2023]})
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(frame["units"], labels=frame["year"])
+            schema = _only_layer(fig)
+
+            assert [point["x"] for point in schema["data"]] == [2021, 2022, 2023]
+            json.dumps(schema)
+        finally:
+            plt.close(fig)
+
+
+class TestSliceOrder:
+    """Data index k and drawn wedge k describe the same slice."""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"startangle": 90},
+            {"counterclock": False},
+            {"explode": (0.1, 0, 0)},
+        ],
+        ids=["plain", "startangle", "clockwise", "exploded"],
+    )
+    def test_drawing_options_do_not_reorder_the_data(self, kwargs):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT, **kwargs)
+            schema = _only_layer(fig)
+
+            assert [point["x"] for point in schema["data"]] == FRUIT
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+    def test_the_selector_resolves_to_one_element_per_slice(self):
+        fig, ax = plt.subplots()
+        try:
+            wedges, _ = ax.pie(UNITS, labels=FRUIT)
+            groups = _highlight_groups(fig)
+
+            assert len(groups) == len(wedges)
+            assert all(len(paths) == 1 for paths in groups)
+        finally:
+            plt.close(fig)
+
+    def test_the_elements_are_in_slice_order(self):
+        # The wedge colours come from the property cycle, so matching them
+        # against the drawn wedges pins the order without depending on
+        # geometry.
+        from matplotlib.colors import to_hex
+
+        fig, ax = plt.subplots()
+        try:
+            wedges, _ = ax.pie(UNITS, labels=FRUIT)
+            expected = [to_hex(wedge.get_facecolor()) for wedge in wedges]
+            groups = _highlight_groups(fig)
+
+            drawn = [
+                re.search(r"#[0-9a-f]{6}", paths[0].get("style", "")).group(0)
+                for paths in groups
+            ]
+            assert drawn == expected
+        finally:
+            plt.close(fig)
+
+    def test_a_shadow_is_not_a_slice(self):
+        # `shadow=True` interleaves a `Shadow` patch behind every wedge; a
+        # layer that counted those would report twice as many slices as the
+        # selector resolves to.
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT, shadow=True)
+            schema = _only_layer(fig)
+
+            assert len(schema["data"]) == 3
+            assert len(_highlight_groups(fig)) == 3
+        finally:
+            plt.close(fig)
+
+
+class TestNestedPie:
+    """Two calls on one axes are two layers, each holding its own ring."""
+
+    def test_each_ring_describes_only_its_own_slices(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie([30, 50, 20], labels=FRUIT, radius=1)
+            ax.pie([10, 20, 30, 40], radius=0.7)
+            outer, inner = _layers(fig)
+
+            assert [point["y"] for point in outer["data"]] == [30, 50, 20]
+            assert [point["y"] for point in inner["data"]] == [10, 20, 30, 40]
+        finally:
+            plt.close(fig)
+
+    def test_the_two_rings_get_distinct_selectors(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie([30, 50, 20], labels=FRUIT, radius=1)
+            ax.pie([10, 20, 30, 40], radius=0.7)
+
+            # Rendering resolves each layer's `maidr='true'` placeholder to
+            # its own id, so the two selectors must differ once resolved.
+            maidr_obj = FigureManager.get_maidr(fig)
+            schema = _stringify(maidr_obj._flatten_maidr())
+            layers = schema["subplots"][0][0]["layers"]
+            selectors = [layer["selectors"] for layer in layers]
+
+            assert len(set(selectors)) == 2
+            assert len(_highlight_groups(fig)) == 7
+        finally:
+            plt.close(fig)
+
+
+class TestMixedFigure:
+    """A pie alongside another plot type is still one layer of its own."""
+
+    def test_a_pie_shares_a_figure_with_a_bar(self):
+        fig, axs = plt.subplots(1, 2)
+        try:
+            axs[0].bar(["a", "b"], [1, 2])
+            axs[1].pie(UNITS, labels=FRUIT)
+            bar, pie = _layers(fig)
+
+            assert bar["type"] == "bar"
+            assert pie["type"] == "pie"
+            assert [point["y"] for point in pie["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+    def test_each_panel_keeps_its_own_cell(self):
+        fig, axs = plt.subplots(1, 2)
+        try:
+            axs[0].bar(["a", "b"], [1, 2])
+            axs[1].pie(UNITS, labels=FRUIT)
+
+            maidr_obj = FigureManager.get_maidr(fig)
+            schema = _stringify(maidr_obj._flatten_maidr())
+            cells = schema["subplots"][0]
+
+            assert len(cells) == 2
+            assert cells[1]["layers"][0]["type"] == "pie"
+        finally:
+            plt.close(fig)
+
+
+class TestAxesPayload:
+    """A pie names what a slice *is* and what it *measures*."""
+
+    def test_authored_labels_are_used(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            ax.set_xlabel("Fruit")
+            ax.set_ylabel("Units")
+            schema = _only_layer(fig)
+
+            assert schema["axes"] == {
+                "x": {"label": "Fruit"},
+                "y": {"label": "Units"},
+            }
+        finally:
+            plt.close(fig)
+
+    def test_unlabelled_axes_read_as_english(self):
+        # "X: Apples" is not a sentence; the generic pair of the base class
+        # would be announced against every slice.
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert schema["axes"]["x"]["label"] == "Category"
+            assert schema["axes"]["y"]["label"] == "Value"
+        finally:
+            plt.close(fig)
+
+    def test_no_orientation_and_no_percentage(self):
+        # Percentage is derived from the values by the renderer, and a pie
+        # has no orientation to report.
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert "orientation" not in schema
+            assert "percentage" not in schema
+            assert all(set(point) == {"x", "y"} for point in schema["data"])
+        finally:
+            plt.close(fig)
+
+
+class TestPiePlotDirectly:
+    """The class built without the patch's help, which is all a direct
+    caller can do."""
+
+    def test_it_falls_back_to_the_fractions_matplotlib_kept(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            plot = PiePlot(ax)
+            data = _stringify(plot.schema)["data"]
+
+            assert plot.type == PlotType.PIE
+            # Without the call's own numbers, a slice's share of the whole is
+            # all that is left to report.
+            assert [point["y"] for point in data] == pytest.approx([0.3, 0.5, 0.2])
+            assert [point["x"] for point in data] == FRUIT
+        finally:
+            plt.close(fig)
+
+    def test_a_negative_size_is_rejected(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            plot = PiePlot(ax, values=[30, -50, 20], labels=FRUIT)
+
+            with pytest.raises(ValueError, match="non negative"):
+                _ = plot.schema
+        finally:
+            plt.close(fig)

--- a/tests/core/plot/test_pieplot.py
+++ b/tests/core/plot/test_pieplot.py
@@ -20,7 +20,9 @@ import matplotlib
 matplotlib.use("Agg")
 
 import json  # noqa: E402
+import logging  # noqa: E402
 import re  # noqa: E402
+import warnings  # noqa: E402
 
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
@@ -28,10 +30,12 @@ import pandas as pd  # noqa: E402
 import pytest  # noqa: E402
 from lxml import etree  # noqa: E402
 
-import maidr  # noqa: F401,E402  # activates patches
+import maidr  # noqa: E402  # activates patches
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.core.plot.pieplot import PiePlot  # noqa: E402
+from maidr.exception import ExtractionError  # noqa: E402
+from maidr.patch.pieplot import _resolve  # noqa: E402
 
 
 #: A pie whose sizes sum far above 1, so matplotlib normalises them away.
@@ -455,5 +459,234 @@ class TestPiePlotDirectly:
 
             with pytest.raises(ValueError, match="non negative"):
                 _ = plot.schema
+        finally:
+            plt.close(fig)
+
+    def test_an_axes_with_no_wedges_is_an_extraction_failure(self):
+        # The empty-pie rule below is about a call that legitimately drew
+        # nothing, which the patch reports by handing over an empty wedge
+        # list. A layer built with no list at all falls back to scanning the
+        # axes, and finding nothing there means the pie it was built for
+        # cannot be found -- still an error, and it must stay one.
+        fig, ax = plt.subplots()
+        try:
+            ax.bar(["a", "b"], [1, 2])
+
+            with pytest.raises(ExtractionError):
+                _ = PiePlot(ax).schema
+        finally:
+            plt.close(fig)
+
+
+class TestEmptyPie:
+    """``ax.pie([])`` is a legal call, and an empty layer on the wire.
+
+    The figure is registered by the time the schema is built, so raising on
+    an empty pie takes the whole figure down with it -- including any working
+    plot drawn beside it, which no static-image fallback rescues. An empty
+    layer reaches the wire instead, which is the rule
+    ``PlotlyPiePlot._slices`` already follows on the plotly side.
+    """
+
+    def test_an_empty_pie_is_an_empty_layer(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie([])
+            schema = _only_layer(fig)
+
+            assert schema["type"] == "pie"
+            assert schema["data"] == []
+        finally:
+            plt.close(fig)
+
+    def test_a_bar_beside_an_empty_pie_survives(self):
+        fig, axs = plt.subplots(1, 2)
+        try:
+            axs[0].bar(["a", "b"], [1, 2])
+            axs[1].pie([])
+            bar, pie = _layers(fig)
+
+            assert [point["y"] for point in bar["data"]] == [1, 2]
+            assert pie["data"] == []
+        finally:
+            plt.close(fig)
+
+    def test_the_whole_figure_still_renders(self):
+        # The error used to fire inside `_flatten_maidr`, well past the point
+        # where the figure could be dropped, so nothing below `render()`
+        # proves the fix.
+        fig, axs = plt.subplots(1, 2)
+        try:
+            axs[0].bar(["a", "b"], [1, 2])
+            axs[1].pie([])
+
+            schema = _stringify(FigureManager.get_maidr(fig)._flatten_maidr())
+            cells = schema["subplots"][0]
+            html = maidr.render(fig)
+
+            assert [cell["layers"][0]["type"] for cell in cells] == ["bar", "pie"]
+            assert "<svg" in str(html)
+            json.dumps(schema)
+        finally:
+            plt.close(fig)
+
+
+class TestDonut:
+    """``wedgeprops={"width": ...}`` cuts the middle out and nothing else.
+
+    A donut is a pie whose wedges are annuli. The data behind them is
+    untouched, so the layer must be identical to the same call without it.
+    """
+
+    def test_a_donut_reports_the_callers_magnitudes(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT, wedgeprops={"width": 0.4})
+            schema = _only_layer(fig)
+
+            assert [point["x"] for point in schema["data"]] == FRUIT
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+    def test_a_donut_still_has_one_element_per_slice(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT, wedgeprops={"width": 0.4})
+            groups = _highlight_groups(fig)
+
+            assert len(groups) == 3
+            assert all(len(paths) == 1 for paths in groups)
+        finally:
+            plt.close(fig)
+
+
+class TestZeroValuedSlice:
+    """A zero-sized slice is still a slice.
+
+    ``ax.pie([0, 5, 5])`` draws a `Wedge` spanning no angle at all for the
+    zero. Matplotlib keeps it -- it is in the returned wedge list and in
+    ``ax.patches`` -- so dropping it here would leave the data one entry short
+    of the elements the selector resolves to, landing every later slice on the
+    wrong wedge.
+    """
+
+    def test_the_zero_slice_is_kept_in_place(self):
+        fig, ax = plt.subplots()
+        try:
+            wedges, _ = ax.pie([0, 5, 5], labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert len(wedges) == 3
+            assert [point["y"] for point in schema["data"]] == [0, 5, 5]
+            assert [point["x"] for point in schema["data"]] == FRUIT
+        finally:
+            plt.close(fig)
+
+    def test_the_data_and_the_elements_stay_aligned(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie([0, 5, 5], labels=FRUIT)
+            schema = _only_layer(fig)
+
+            assert len(_highlight_groups(fig)) == len(schema["data"])
+        finally:
+            plt.close(fig)
+
+
+class TestDataColumnNames:
+    """``ax.pie("sales", labels="fruit", data=df)`` names columns, not values.
+
+    ``Axes.pie`` sits behind matplotlib's ``_preprocess_data``, and the patch
+    wraps the outside of that decorator, so it sees the names. It looks them
+    up the way matplotlib does.
+    """
+
+    def test_column_names_are_resolved_against_data(self):
+        frame = pd.DataFrame({"units": UNITS, "fruit": FRUIT})
+        fig, ax = plt.subplots()
+        try:
+            ax.pie("units", labels="fruit", data=frame)
+            schema = _only_layer(fig)
+
+            assert [point["x"] for point in schema["data"]] == FRUIT
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param(pd.DataFrame({"units": UNITS}), id="KeyError"),
+            pytest.param([30, 50, 20], id="IndexError"),
+            pytest.param(object(), id="TypeError"),
+        ],
+    )
+    def test_an_unresolvable_name_is_passed_through_unchanged(self, data):
+        # Matplotlib treats a name it cannot look up as a plain value, and so
+        # must this: raising instead would fail a pie matplotlib drew
+        # perfectly well. One case per way an indexable object says "not this
+        # key" -- the three, and only the three, `_resolve` catches.
+        assert _resolve("missing_col", data) == "missing_col"
+
+    def test_a_name_is_only_looked_up_when_there_is_data_to_look_it_up_in(self):
+        assert _resolve("units", None) == "units"
+
+    def test_an_unresolvable_name_still_describes_the_pie_it_drew(self):
+        # The end-to-end reach of the fallback is narrow: matplotlib rejects
+        # an unresolved `labels` whose length is not the slice count, so the
+        # name has to be as long as the pie is wide. It then labels the wedges
+        # by its own characters, and the layer has to report those -- the
+        # slices really are named "a", "b", "c" on the page.
+        frame = pd.DataFrame({"units": UNITS, "fruit": FRUIT})
+        fig, ax = plt.subplots()
+        try:
+            ax.pie("units", labels="abc", data=frame)
+            schema = _only_layer(fig)
+
+            assert [point["x"] for point in schema["data"]] == ["a", "b", "c"]
+            assert [point["y"] for point in schema["data"]] == [30, 50, 20]
+        finally:
+            plt.close(fig)
+
+
+class TestMismatchDiagnostic:
+    """The values/wedges mismatch is logged, because it cannot be warned.
+
+    ``maidr.patch.pieplot.pie`` installs a persistent, process-wide
+    ``warnings.filterwarnings("ignore")`` on every ``Axes.pie`` -- deliberate
+    parity with ``maidr.patch.common.common``, which does the same on every
+    other plot type. Any ``warnings.warn`` raised later, during ``render()``,
+    is therefore unreachable.
+    """
+
+    def test_the_mismatch_is_reported_through_logging(self, caplog):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            plot = PiePlot(ax, values=[30, 50], labels=FRUIT)
+
+            with caplog.at_level(logging.WARNING, logger="maidr.core.plot.pieplot"):
+                data = _stringify(plot.schema)["data"]
+
+            assert "2 values for 3 wedges" in caplog.text
+            # The fallback still happened: shares of the whole, not 30/50/20.
+            assert [point["y"] for point in data] == pytest.approx([0.3, 0.5, 0.2])
+        finally:
+            plt.close(fig)
+
+    def test_a_warning_would_not_have_been_heard(self):
+        # Pins the reason the line above uses `logging`: the patch's filter is
+        # process-wide and persistent, so it is already in front of any
+        # `warnings.warn` `render()` could raise.
+        fig, ax = plt.subplots()
+        try:
+            ax.pie(UNITS, labels=FRUIT)
+            plot = PiePlot(ax, values=[30, 50], labels=FRUIT)
+
+            with warnings.catch_warnings(record=True) as caught:
+                _ = plot.schema
+
+            assert caught == []
         finally:
             plt.close(fig)

--- a/tests/core/test_axes_schema.py
+++ b/tests/core/test_axes_schema.py
@@ -118,6 +118,33 @@ class TestMatplotlibCanonicalShape:
         finally:
             plt.close(fig)
 
+    def test_pie(self):
+        # A pie has no scale, so its two axes name what a slice is and what
+        # it measures -- still as AxisConfig objects, never bare strings.
+        fig, ax = plt.subplots()
+        try:
+            ax.pie([30, 50, 20], labels=["Apples", "Bananas", "Cherries"])
+            ax.set_xlabel("Fruit")
+            ax.set_ylabel("Units")
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            assert axes["x"]["label"] == "Fruit"
+            assert axes["y"]["label"] == "Units"
+            assert "z" not in axes
+        finally:
+            plt.close(fig)
+
+    def test_pie_without_authored_labels(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.pie([1, 2, 3])
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+        finally:
+            plt.close(fig)
+
     def test_heatmap_has_z_axis_config(self):
         fig, ax = plt.subplots()
         try:

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -35,6 +35,10 @@ def test_create_maidr_with_none_plot_type(mocker):
         # ``ax.step`` delegates to the already-patched ``Axes.plot``; this
         # guards against it registering a STEP *and* a LINE layer.
         (Library.MATPLOTLIB, PlotType.STEP),
+        # ``Axes.pie`` returns a tuple of artist lists rather than an artist,
+        # so its patch resolves the axes off the call instead of the return
+        # value; this guards that it still registers exactly one layer.
+        (Library.MATPLOTLIB, PlotType.PIE),
         # Parametrize seaborn plots.
         (Library.SEABORN, PlotType.BAR),
         (Library.SEABORN, PlotType.BOX),

--- a/tests/core/test_maidr_plot_factory.py
+++ b/tests/core/test_maidr_plot_factory.py
@@ -8,6 +8,7 @@ from maidr.core.plot.heatmap import HeatPlot
 from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
 from maidr.core.plot.maidr_plot_factory import MaidrPlotFactory
+from maidr.core.plot.pieplot import PiePlot
 from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.stepplot import StepPlot
 
@@ -30,6 +31,7 @@ def test_create_with_invalid_plot_type(mocker):
         (PlotType.HEAT, HeatPlot),
         (PlotType.HIST, HistPlot),
         (PlotType.LINE, MultiLinePlot),
+        (PlotType.PIE, PiePlot),
         (PlotType.SCATTER, ScatterPlot),
         (PlotType.STACKED, GroupedBarPlot),
         (PlotType.STEP, StepPlot),

--- a/tests/fixture/matplotlib_factory.py
+++ b/tests/fixture/matplotlib_factory.py
@@ -32,6 +32,8 @@ class MatplotlibFactory(LibraryFactory):
             self.create_boxplot(ax)
         elif PlotType.STEP is plot_type:
             self.create_stepplot(ax)
+        elif PlotType.PIE is plot_type:
+            self.create_pieplot(ax)
 
     def create_barplot(self, ax: Axes) -> Any:
         # TODO: using numbers makes matplotlib to add additional ticks messing with the
@@ -64,3 +66,15 @@ class MatplotlibFactory(LibraryFactory):
         ax.set_title("Test matplotlib step title")
         ax.set_xlabel("Test matplotlib step x label")
         ax.set_ylabel("Test matplotlib step y label")
+
+    def create_pieplot(self, ax: Axes) -> Any:
+        """Draw a pie whose magnitudes do not survive matplotlib.
+
+        The sizes sum well above 1, so ``Axes.pie`` normalises them and the
+        wedges it draws keep only the fractions 0.3/0.5/0.2. The layer must
+        still report 30/50/20, which is what the caller plotted.
+        """
+        ax.pie([30, 50, 20], labels=["A", "B", "C"])
+        ax.set_title("Test matplotlib pie title")
+        ax.set_xlabel("Test matplotlib pie x label")
+        ax.set_ylabel("Test matplotlib pie y label")

--- a/tests/plotly/conftest.py
+++ b/tests/plotly/conftest.py
@@ -99,6 +99,20 @@ def plotly_histogram_fig():
 
 
 @pytest.fixture
+def plotly_pie_fig():
+    """Create a simple Plotly pie chart."""
+    fig = go.Figure(
+        data=[go.Pie(labels=["Apples", "Bananas", "Cherries"], values=[30, 50, 20])],
+        layout=go.Layout(
+            title="Test Pie Chart",
+            xaxis=dict(title="Fruit"),
+            yaxis=dict(title="Units"),
+        ),
+    )
+    return fig
+
+
+@pytest.fixture
 def plotly_dodged_fig():
     """Create a grouped (dodged) bar chart."""
     fig = go.Figure(

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -225,6 +225,46 @@ class TestPlotlyPieFigures:
         assert '"type": "pie"' in html_str
 
 
+class TestPlotlyPieAxisTitles:
+    """A pie only borrows ``layout.xaxis``/``yaxis`` titles when it owns them.
+
+    A pie has no axis pair, so it shares the default group with any cartesian
+    trace that declares none either. Those titles describe that trace's axes,
+    and announcing a bar's "Month" against a pie's slice labels is worse than
+    the generic pair — it is confidently wrong rather than merely vague.
+    """
+
+    @staticmethod
+    def _labels(fig, plot_type: str) -> tuple[str, str]:
+        plot = next(
+            plot for plot in PlotlyMaidr(fig)._plots if plot.type.value == plot_type
+        )
+        axes = plot.schema["axes"]
+        return axes["x"]["label"], axes["y"]["label"]
+
+    def test_a_lone_pie_takes_the_layout_titles(self):
+        fig = go.Figure(go.Pie(labels=["A", "B"], values=[1, 2]))
+        fig.update_layout(xaxis_title="Fruit", yaxis_title="Units")
+
+        assert self._labels(fig, "pie") == ("Fruit", "Units")
+
+    def test_a_pie_sharing_a_figure_with_a_bar_keeps_the_generic_pair(self):
+        fig = go.Figure()
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]))
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]))
+        fig.update_layout(xaxis_title="Month", yaxis_title="Revenue")
+
+        assert self._labels(fig, "pie") == ("Category", "Value")
+
+    def test_the_bar_still_keeps_the_titles_that_are_its_own(self):
+        fig = go.Figure()
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]))
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]))
+        fig.update_layout(xaxis_title="Month", yaxis_title="Revenue")
+
+        assert self._labels(fig, "bar") == ("Month", "Revenue")
+
+
 class TestPlotlyPieSubplotGrid:
     """A pie takes its grid cell from its own ``domain`` rectangle.
 

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -79,13 +79,17 @@ class TestPlotlyMaidr:
         pm = PlotlyMaidr(fig)
         assert len(pm._plots) == 2
 
+    def test_creates_plots_from_pie_fig(self, plotly_pie_fig):
+        pm = PlotlyMaidr(plotly_pie_fig)
+        assert len(pm._plots) == 1
+
     def test_unsupported_trace_skipped(self):
         fig = go.Figure()
-        fig.add_trace(go.Pie(values=[1, 2, 3], labels=["a", "b", "c"]))
+        fig.add_trace(go.Violin(y=[1, 2, 3, 4]))
         fig.add_trace(go.Bar(x=["A"], y=[1]))
 
         pm = PlotlyMaidr(fig)
-        # Pie is unsupported and skipped
+        # Violin is unsupported and skipped
         assert len(pm._plots) == 1
 
     def test_dodged_bar_detection(self, plotly_dodged_fig):
@@ -153,6 +157,72 @@ class TestPlotlyMaidr:
         pm = PlotlyMaidr(plotly_bar_fig)
         assert len(pm._plots) == 1
         assert isinstance(pm._plots[0], PlotlyBarPlot)
+
+
+class TestPlotlyPieFigures:
+    """A pie's selector is scoped by its position among the figure's pies.
+
+    Plotly draws every pie into one figure-level ``pielayer`` rather than into
+    a subplot group, so only ``PlotlyMaidr`` — which sees the whole figure —
+    can say which trace group a given pie is. The factory cannot, which is why
+    these go through ``PlotlyMaidr`` rather than the factory.
+    """
+
+    def test_pie_layer_data_is_flat(self, plotly_pie_fig):
+        from maidr.core.enum.maidr_key import MaidrKey
+        from maidr.plotly.pie import PlotlyPiePlot
+
+        pm = PlotlyMaidr(plotly_pie_fig)
+        assert isinstance(pm._plots[0], PlotlyPiePlot)
+
+        data = pm._plots[0].schema[MaidrKey.DATA]
+        assert all(isinstance(point, dict) for point in data)
+        # Largest first: `sort` is plotly's default.
+        assert [point[MaidrKey.X] for point in data] == [
+            "Bananas",
+            "Apples",
+            "Cherries",
+        ]
+
+    def test_two_pies_get_their_own_positions(self):
+        fig = go.Figure()
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2], domain={"x": [0, 0.5]}))
+        fig.add_trace(go.Pie(labels=["C", "D"], values=[3, 4], domain={"x": [0.5, 1]}))
+
+        pm = PlotlyMaidr(fig)
+        selectors = [plot._get_selector() for plot in pm._plots]
+
+        assert len(pm._plots) == 2
+        assert "nth-child(1)" in selectors[0]
+        assert "nth-child(2)" in selectors[1]
+
+    def test_a_bar_does_not_shift_the_pie_position(self):
+        # The bar is drawn into `.subplot.xy`, not into `.pielayer`, so it
+        # occupies no trace group the pie's selector counts.
+        fig = go.Figure()
+        fig.add_trace(go.Bar(x=["A"], y=[1]))
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]))
+
+        pm = PlotlyMaidr(fig)
+        pie = next(plot for plot in pm._plots if plot.type.value == "pie")
+
+        assert len(pm._plots) == 2
+        assert "nth-child(1)" in pie._get_selector()
+
+    def test_donut_is_a_pie_layer(self):
+        from maidr.plotly.pie import PlotlyPiePlot
+
+        fig = go.Figure(go.Pie(labels=["A", "B"], values=[1, 2], hole=0.4))
+
+        pm = PlotlyMaidr(fig)
+        assert len(pm._plots) == 1
+        assert isinstance(pm._plots[0], PlotlyPiePlot)
+
+    def test_render_contains_the_pie_schema(self, plotly_pie_fig):
+        pm = PlotlyMaidr(plotly_pie_fig)
+        html_str = str(pm.render().get_html_string())
+
+        assert '"type": "pie"' in html_str
 
 
 class TestPlotlyFigureMetadata:

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -372,6 +372,143 @@ class TestPlotlyPieSubplotGrid:
         assert "selector" not in subplots[0][0]
 
 
+class TestPlotlyUnrenderedDomainTraces:
+    """A domain trace maidr draws nothing for occupies no grid cell.
+
+    Pies are placed by their own ``domain`` rectangle, and plotly gives one to
+    every domain trace — ``go.Table``, ``go.Sunburst``, ``go.Treemap``,
+    ``go.Indicator`` — including the ones maidr renders no layer for. Folding
+    *their* rectangles into the figure's column universe would move the
+    cartesian subplots beside them, changing where maidr places a figure that
+    contains no pie at all. The grid describes what maidr can describe.
+    """
+
+    @staticmethod
+    def _cells(fig) -> list[tuple[int, int]]:
+        return [(plot.row_index, plot.col_index) for plot in PlotlyMaidr(fig)._plots]
+
+    @pytest.mark.parametrize(
+        "trace",
+        [
+            pytest.param(
+                go.Table(header={"values": ["a"]}, cells={"values": [[1, 2]]}),
+                id="table",
+            ),
+            pytest.param(go.Sunburst(labels=["a"], parents=[""]), id="sunburst"),
+            pytest.param(go.Treemap(labels=["a"], parents=[""]), id="treemap"),
+            pytest.param(go.Indicator(value=42, mode="number"), id="indicator"),
+        ],
+    )
+    def test_it_does_not_shift_the_cartesian_subplot_beside_it(self, trace):
+        # Without the scoping this bar lands in column 1, behind an empty
+        # cell -- a placement change for a figure holding no pie.
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]]
+        )
+        fig.add_trace(trace, row=1, col=1)
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+        assert self._cells(fig) == [(0, 0)]
+
+    def test_a_pie_beside_it_is_still_placed_by_its_own_domain(self):
+        # The scoping is by trace type, not by "ignore trace domains": a pie
+        # sharing a figure with an unrendered domain trace still gets its own
+        # cell, and the two renderable layers are still ordered against each
+        # other.
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1,
+            cols=3,
+            specs=[[{"type": "domain"}, {"type": "domain"}, {"type": "xy"}]],
+        )
+        fig.add_trace(
+            go.Table(header={"values": ["a"]}, cells={"values": [[1, 2]]}),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]), row=1, col=2)
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=3)
+
+        assert self._cells(fig) == [(0, 0), (0, 1)]
+
+
+class TestPlotlyPieSubplotTitles:
+    """``subplot_titles`` reach a pie, which has no axis pair to match on.
+
+    ``make_subplots`` stores per-subplot titles as paper-referenced
+    annotations centred over each subplot. The base class finds the right one
+    by matching against the rectangle the subplot's axis domains describe —
+    and a pie has no axes, so every pie in a figure reads the same default
+    ``[0, 1]`` domain, anchors itself at the middle of the figure, and matches
+    none of them.
+    """
+
+    @staticmethod
+    def _titles(fig) -> list[str]:
+        return [plot._get_title() for plot in PlotlyMaidr(fig)._plots]
+
+    def test_each_pie_of_a_row_gets_its_own_title(self):
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1,
+            cols=2,
+            specs=[[{"type": "domain"}, {"type": "domain"}]],
+            subplot_titles=("Q1", "Q2"),
+        )
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]), row=1, col=1)
+        fig.add_trace(go.Pie(labels=["C", "D"], values=[3, 4]), row=1, col=2)
+
+        assert self._titles(fig) == ["Q1", "Q2"]
+
+    def test_each_pie_of_a_grid_gets_its_own_title(self):
+        # Two columns and two rows: the row a title belongs to is as much a
+        # part of the match as the column.
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=2,
+            cols=2,
+            specs=[[{"type": "domain"}] * 2] * 2,
+            subplot_titles=("Q1", "Q2", "Q3", "Q4"),
+        )
+        for row in (1, 2):
+            for col in (1, 2):
+                fig.add_trace(
+                    go.Pie(labels=["A", "B"], values=[1, 2]), row=row, col=col
+                )
+
+        assert self._titles(fig) == ["Q1", "Q2", "Q3", "Q4"]
+
+    def test_a_pie_beside_a_bar_takes_the_title_over_its_own_column(self):
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1,
+            cols=2,
+            specs=[[{"type": "xy"}, {"type": "domain"}]],
+            subplot_titles=("Sales", "Share"),
+        )
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=1)
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]), row=1, col=2)
+
+        titles = {
+            plot.type.value: plot._get_title() for plot in PlotlyMaidr(fig)._plots
+        }
+        assert titles == {"bar": "Sales", "pie": "Share"}
+
+    def test_a_lone_pie_still_falls_back_to_the_figure_title(self):
+        # An unplaced pie covers the whole figure and there are no subplot
+        # annotations to match, so the figure-level title is the answer.
+        fig = go.Figure(go.Pie(labels=["A", "B"], values=[1, 2]))
+        fig.update_layout(title="Market share")
+
+        assert self._titles(fig) == ["Market share"]
+
+
 class TestPlotlyFigureMetadata:
     """Figure-wide layout title/subtitle mapped onto the top-level schema.
 

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -248,6 +248,20 @@ class TestPlotlyPieAxisTitles:
 
         assert self._labels(fig, "pie") == ("Fruit", "Units")
 
+    def test_another_domain_trace_does_not_take_the_titles_away(self):
+        # A sunburst lands in the same default group as the pie for the same
+        # reason the pie does -- neither names an axis -- so it has no claim
+        # on those titles, and falling back here would lose a label the
+        # author did write.
+        fig = go.Figure()
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]))
+        fig.add_trace(
+            go.Sunburst(labels=["a", "b"], parents=["", ""], values=[1, 2])
+        )
+        fig.update_layout(xaxis_title="Fruit", yaxis_title="Units")
+
+        assert self._labels(fig, "pie") == ("Fruit", "Units")
+
     def test_a_pie_sharing_a_figure_with_a_bar_keeps_the_generic_pair(self):
         fig = go.Figure()
         fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]))

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -225,6 +225,113 @@ class TestPlotlyPieFigures:
         assert '"type": "pie"' in html_str
 
 
+class TestPlotlyPieSubplotGrid:
+    """A pie takes its grid cell from its own ``domain`` rectangle.
+
+    Every pie in a figure shares one trace group, because a pie carries no
+    axis pair to be grouped by — which is what its selector needs (see
+    :class:`TestPlotlyPieFigures`) and what its *position* must not be taken
+    from. Reading the group's cell instead collapsed a whole grid of pies into
+    one subplot holding all of them as layers.
+    """
+
+    @staticmethod
+    def _cells(fig) -> list[tuple[int, int]]:
+        return [(plot.row_index, plot.col_index) for plot in PlotlyMaidr(fig)._plots]
+
+    @staticmethod
+    def _cell_of(fig, plot_type: str) -> tuple[int, int]:
+        plot = next(
+            plot for plot in PlotlyMaidr(fig)._plots if plot.type.value == plot_type
+        )
+        return plot.row_index, plot.col_index
+
+    def test_two_pies_side_by_side_are_two_subplots(self):
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "domain"}]]
+        )
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]), row=1, col=1)
+        fig.add_trace(go.Pie(labels=["C", "D"], values=[3, 4]), row=1, col=2)
+
+        assert self._cells(fig) == [(0, 0), (0, 1)]
+
+        subplots = PlotlyMaidr(fig)._flatten_maidr()["subplots"]
+        assert len(subplots) == 1
+        assert [len(cell["layers"]) for cell in subplots[0]] == [1, 1]
+
+    def test_a_two_by_two_grid_of_pies_fills_every_cell(self):
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(rows=2, cols=2, specs=[[{"type": "domain"}] * 2] * 2)
+        for row in (1, 2):
+            for col in (1, 2):
+                fig.add_trace(
+                    go.Pie(labels=["A", "B"], values=[1, 2]), row=row, col=col
+                )
+
+        assert self._cells(fig) == [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+    def test_the_grid_still_numbers_the_pielayer_across_subplots(self):
+        # `pie_position` counts the figure's pie traces, not its subplots:
+        # plotly draws all four into one `pielayer` however they are placed.
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(rows=2, cols=2, specs=[[{"type": "domain"}] * 2] * 2)
+        for row in (1, 2):
+            for col in (1, 2):
+                fig.add_trace(
+                    go.Pie(labels=["A", "B"], values=[1, 2]), row=row, col=col
+                )
+
+        selectors = [plot._get_selector() for plot in PlotlyMaidr(fig)._plots]
+
+        assert len(selectors) == 4
+        assert all(
+            f"nth-child({position})" in selector
+            for position, selector in enumerate(selectors, start=1)
+        )
+
+    def test_a_pie_is_ordered_against_a_cartesian_subplot(self):
+        # The pie is placed by a trace domain and the bar by an axis domain;
+        # the two are fractions of the same figure, so the columns have to be
+        # ordered against each other rather than each within its own kind.
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]]
+        )
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]), row=1, col=1)
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+        assert self._cell_of(fig, "pie") == (0, 0)
+        assert self._cell_of(fig, "bar") == (0, 1)
+
+    def test_a_pie_right_of_a_cartesian_subplot_keeps_its_column(self):
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1, cols=2, specs=[[{"type": "xy"}, {"type": "domain"}]]
+        )
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=1)
+        fig.add_trace(go.Pie(labels=["A", "B"], values=[1, 2]), row=1, col=2)
+
+        assert self._cell_of(fig, "pie") == (0, 1)
+        assert self._cell_of(fig, "bar") == (0, 0)
+
+    def test_a_lone_pie_stays_in_the_first_cell(self):
+        # An unplaced pie covers the whole figure, and a single-cell grid is
+        # not a grid: it must not gain a subplot selector.
+        fig = go.Figure(go.Pie(labels=["A", "B"], values=[1, 2]))
+
+        assert self._cells(fig) == [(0, 0)]
+
+        subplots = PlotlyMaidr(fig)._flatten_maidr()["subplots"]
+        assert len(subplots) == 1 and len(subplots[0]) == 1
+        assert "selector" not in subplots[0][0]
+
+
 class TestPlotlyFigureMetadata:
     """Figure-wide layout title/subtitle mapped onto the top-level schema.
 

--- a/tests/plotly/test_plotly_plot_factory.py
+++ b/tests/plotly/test_plotly_plot_factory.py
@@ -9,6 +9,7 @@ from maidr.plotly.line import PlotlyLinePlot
 from maidr.plotly.box import PlotlyBoxPlot
 from maidr.plotly.heatmap import PlotlyHeatmapPlot
 from maidr.plotly.histogram import PlotlyHistogramPlot
+from maidr.plotly.pie import PlotlyPiePlot
 
 
 class TestPlotlyPlotFactory:
@@ -65,7 +66,27 @@ class TestPlotlyPlotFactory:
         assert isinstance(plot, PlotlyHistogramPlot)
         assert plot.type == PlotType.HIST
 
+    def test_pie_trace(self):
+        trace = {"type": "pie", "labels": ["A", "B"], "values": [1, 2]}
+        plot = PlotlyPlotFactory.create(trace, {})
+        assert isinstance(plot, PlotlyPiePlot)
+        assert plot.type == PlotType.PIE
+
+    def test_donut_trace_is_still_a_pie(self):
+        # `hole` cuts the middle out of the wedges; the data is unchanged.
+        trace = {"type": "pie", "labels": ["A", "B"], "values": [1, 2], "hole": 0.4}
+        plot = PlotlyPlotFactory.create(trace, {})
+        assert isinstance(plot, PlotlyPiePlot)
+
+    def test_pie_assumes_it_is_the_only_one(self):
+        # This factory sees one trace and cannot know what else the figure
+        # holds, so it scopes the selector to the first pie. `PlotlyMaidr`
+        # passes real positions precisely because it does know.
+        trace = {"type": "pie", "labels": ["A"], "values": [1]}
+        plot = PlotlyPlotFactory.create(trace, {})
+        assert "nth-child(1)" in plot._get_selector()
+
     def test_unsupported_trace_returns_none(self):
-        trace = {"type": "pie", "values": [1, 2, 3]}
+        trace = {"type": "violin", "y": [1, 2, 3]}
         plot = PlotlyPlotFactory.create(trace, {})
         assert plot is None

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
@@ -12,6 +13,7 @@ from maidr.plotly.heatmap import PlotlyHeatmapPlot
 from maidr.plotly.histogram import PlotlyHistogramPlot
 from maidr.plotly.grouped_bar import PlotlyGroupedBarPlot
 from maidr.plotly.multiline import PlotlyMultiLinePlot
+from maidr.plotly.pie import PlotlyPiePlot
 
 
 class TestPlotlyBarPlot:
@@ -316,6 +318,162 @@ class TestPlotlyGroupedBarPlot:
         assert plot.schema[MaidrKey.TYPE] == PlotType.DODGED
 
 
+class TestPlotlyPiePlot:
+    """One flat point per drawn wedge, in the order plotly draws them.
+
+    Plotly does not draw one wedge per ``values`` entry in the order given:
+    ``pie/calc.js`` builds its own slice list first, dropping and merging
+    entries and then — by default — sorting them. The emitted data has to
+    follow that list exactly, because the selector is positional, so the
+    first divergence lands every later slice on another wedge.
+    """
+
+    def test_extract_data(self):
+        trace = {
+            "type": "pie",
+            "labels": ["Apples", "Bananas", "Cherries"],
+            "values": [30, 50, 20],
+            "sort": False,
+        }
+        plot = PlotlyPiePlot(trace, {})
+        data = plot._extract_plot_data()
+
+        assert data == [
+            {MaidrKey.X: "Apples", MaidrKey.Y: 30},
+            {MaidrKey.X: "Bananas", MaidrKey.Y: 50},
+            {MaidrKey.X: "Cherries", MaidrKey.Y: 20},
+        ]
+
+    def test_data_is_flat_and_carries_no_percentage(self):
+        # Percentage is derived from the values by the renderer, so a layer
+        # that emitted one would be a second source of truth.
+        trace = {"type": "pie", "labels": ["A", "B"], "values": [1, 3]}
+        plot = PlotlyPiePlot(trace, {})
+        schema = plot.schema
+
+        assert schema[MaidrKey.TYPE] == PlotType.PIE
+        data = schema[MaidrKey.DATA]
+        assert all(set(point) == {MaidrKey.X, MaidrKey.Y} for point in data)
+        assert "orientation" not in schema
+
+    def test_sort_default_orders_slices_largest_first(self):
+        # This is the rule that silently misaligns every selector if ignored:
+        # plotly sorts by default, so data order is not slice order.
+        trace = {"type": "pie", "labels": ["A", "B", "C"], "values": [30, 50, 20]}
+        plot = PlotlyPiePlot(trace, {})
+        data = plot._extract_plot_data()
+
+        assert [point[MaidrKey.X] for point in data] == ["B", "A", "C"]
+
+    def test_duplicate_labels_merge_at_the_first_position(self):
+        trace = {
+            "type": "pie",
+            "labels": ["A", "B", "A"],
+            "values": [1, 2, 3],
+            "sort": False,
+        }
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._slices() == [("A", 4), ("B", 2)]
+
+    def test_a_non_numeric_value_draws_no_wedge(self):
+        trace = {
+            "type": "pie",
+            "labels": ["A", "B", "C"],
+            "values": [1, "not a number", 3],
+            "sort": False,
+        }
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._slices() == [("A", 1), ("C", 3)]
+
+    def test_a_negative_wedge_is_dropped(self):
+        trace = {
+            "type": "pie",
+            "labels": ["A", "B"],
+            "values": [-1, 2],
+            "sort": False,
+        }
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._slices() == [("B", 2)]
+
+    def test_a_hidden_label_is_not_emitted(self):
+        trace = {"type": "pie", "labels": ["A", "B"], "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": ["A"]})
+
+        assert plot._slices() == [("B", 2)]
+
+    def test_nothing_positive_draws_nothing(self):
+        trace = {"type": "pie", "labels": ["A", "B"], "values": [0, 0]}
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._extract_plot_data() == []
+
+    def test_labels_without_values_count_the_labels(self):
+        trace = {"type": "pie", "labels": ["A", "B", "A"], "sort": False}
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._slices() == [("A", 2), ("B", 1)]
+
+    def test_values_without_labels_are_numbered(self):
+        trace = {"type": "pie", "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._slices() == [("0", 1), ("1", 2)]
+
+    def test_typed_array_values_are_decoded(self):
+        # ``plotly.express`` exports every numeric column as the base64
+        # typed-array spec plotly.js consumes; iterating it would otherwise
+        # walk the two dict keys.
+        import base64
+
+        bdata = base64.b64encode(np.array([30.0, 50.0, 20.0]).tobytes()).decode()
+        trace = {
+            "type": "pie",
+            "labels": ["A", "B", "C"],
+            "values": {"dtype": "f8", "bdata": bdata},
+            "sort": False,
+        }
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._slices() == [("A", 30.0), ("B", 50.0), ("C", 20.0)]
+
+    def test_selector_is_scoped_to_the_pie_layer(self):
+        # Pies are drawn into a figure-level `pielayer`, never into a
+        # `.subplot.xy` group, so a subplot-prefixed selector would match
+        # nothing.
+        trace = {"type": "pie", "labels": ["A"], "values": [1]}
+        plot = PlotlyPiePlot(trace, {}, pie_position=2)
+        selector = plot.schema[MaidrKey.SELECTOR]
+
+        assert selector == ".pielayer > .trace:nth-child(3) > .slice > path.surface"
+
+    def test_a_negative_position_is_rejected(self):
+        # `nth-child(0)` matches nothing, so the highlight would simply never
+        # appear -- a silent failure worth refusing at construction.
+        trace = {"type": "pie", "labels": ["A"], "values": [1]}
+        with pytest.raises(ValueError, match="pie position"):
+            PlotlyPiePlot(trace, {}, pie_position=-1)
+
+    def test_axes_name_the_slice_dimensions(self):
+        trace = {"type": "pie", "labels": ["A"], "values": [1]}
+        layout = {"xaxis": {"title": "Fruit"}, "yaxis": {"title": "Units"}}
+        plot = PlotlyPiePlot(trace, layout)
+        axes = plot.schema[MaidrKey.AXES]
+
+        assert axes[MaidrKey.X][MaidrKey.LABEL] == "Fruit"
+        assert axes[MaidrKey.Y][MaidrKey.LABEL] == "Units"
+        assert MaidrKey.Z not in axes
+
+    def test_unnamed_axes_read_as_english(self):
+        # Plotly names neither axis of a pie, and MAIDR reads a slice out as
+        # those two names.
+        plot = PlotlyPiePlot({"type": "pie", "labels": ["A"], "values": [1]}, {})
+        axes = plot.schema[MaidrKey.AXES]
+
+        assert axes[MaidrKey.X][MaidrKey.LABEL] == "Label"
+        assert axes[MaidrKey.Y][MaidrKey.LABEL] == "Value"
 
 
 class TestPlotlyMultiLinePlot:

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -468,11 +468,12 @@ class TestPlotlyPiePlot:
 
     def test_unnamed_axes_read_as_english(self):
         # Plotly names neither axis of a pie, and MAIDR reads a slice out as
-        # those two names.
+        # those two names. The pair matches the matplotlib pie's own fallback:
+        # the announcement follows the plot type, not the library behind it.
         plot = PlotlyPiePlot({"type": "pie", "labels": ["A"], "values": [1]}, {})
         axes = plot.schema[MaidrKey.AXES]
 
-        assert axes[MaidrKey.X][MaidrKey.LABEL] == "Label"
+        assert axes[MaidrKey.X][MaidrKey.LABEL] == "Category"
         assert axes[MaidrKey.Y][MaidrKey.LABEL] == "Value"
 
 

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -479,6 +479,27 @@ class TestPlotlyPiePlot:
 
         assert plot._extract_plot_data() == []
 
+    def test_a_pie_with_no_drawn_slice_still_builds_a_schema(self):
+        # An empty layer has to reach the wire intact rather than raise part
+        # way through: the figure around it is still describable, and a plot
+        # that throws here takes every other layer down with it.
+        trace = {"type": "pie", "labels": ["A", "B"], "values": [0, 0]}
+        plot = PlotlyPiePlot(trace, {})
+
+        schema = plot.schema
+
+        assert schema["type"] == PlotType.PIE
+        assert schema["data"] == []
+        assert set(schema["axes"]) == {"x", "y"}
+
+    def test_an_all_hidden_pie_still_builds_a_schema(self):
+        trace = {"type": "pie", "labels": ["A", "B"], "values": [1, 2]}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": ["A", "B"]})
+
+        schema = plot.schema
+
+        assert schema["data"] == []
+
     def test_labels_without_values_count_the_labels(self):
         trace = {"type": "pie", "labels": ["A", "B", "A"], "sort": False}
         plot = PlotlyPiePlot(trace, {})

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -404,6 +404,36 @@ class TestPlotlyPiePlot:
 
         assert plot._slices() == [("B", 2)]
 
+    def test_a_null_label_hides_by_the_none_the_author_wrote(self):
+        # The wedge is named "null", but an author hiding it reaches for the
+        # label they passed. Both sides go through the same normalisation, so
+        # the raw None has to match.
+        trace = {"type": "pie", "labels": [None, "B"], "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": [None]})
+
+        assert plot._slices() == [("B", 2)]
+
+    def test_a_null_label_also_hides_by_its_wedge_name(self):
+        trace = {"type": "pie", "labels": [None, "B"], "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": ["null"]})
+
+        assert plot._slices() == [("B", 2)]
+
+    def test_an_empty_hidden_label_matches_nothing(self):
+        # An empty label became the entry's own index, and a hidden label
+        # carries no index to substitute -- so it names no wedge, which is
+        # what plotly does with one too.
+        trace = {"type": "pie", "labels": ["", "B"], "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": [""]})
+
+        assert plot._slices() == [("0", 1), ("B", 2)]
+
+    def test_an_empty_label_hides_by_the_index_it_became(self):
+        trace = {"type": "pie", "labels": ["", "B"], "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": ["0"]})
+
+        assert plot._slices() == [("B", 2)]
+
     def test_nothing_positive_draws_nothing(self):
         trace = {"type": "pie", "labels": ["A", "B"], "values": [0, 0]}
         plot = PlotlyPiePlot(trace, {})

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -398,31 +398,70 @@ class TestPlotlyPiePlot:
 
         assert plot._slices() == [("B", 2)]
 
+    def test_a_zero_valued_slice_is_kept(self):
+        # Plotly's calc filters `v >= 0`, not `v > 0`, so a zero-valued entry
+        # stays in the slice list and takes a position in it. Dropping it here
+        # would shift every later slice onto the wrong element.
+        trace = {
+            "type": "pie",
+            "labels": ["A", "B", "C"],
+            "values": [0, 5, 3],
+            "sort": False,
+        }
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._slices() == [("A", 0), ("B", 5), ("C", 3)]
+
+    def test_slices_that_cancel_to_zero_are_kept(self):
+        # Two entries sharing a label merge, and the merged total is what the
+        # `>= 0` filter sees.
+        trace = {
+            "type": "pie",
+            "labels": ["A", "A", "B"],
+            "values": [-2, 2, 5],
+            "sort": False,
+        }
+        plot = PlotlyPiePlot(trace, {})
+
+        assert plot._slices() == [("A", 0), ("B", 5)]
+
     def test_a_hidden_label_is_not_emitted(self):
         trace = {"type": "pie", "labels": ["A", "B"], "values": [1, 2], "sort": False}
         plot = PlotlyPiePlot(trace, {"hiddenlabels": ["A"]})
 
         assert plot._slices() == [("B", 2)]
 
-    def test_a_null_label_hides_by_the_none_the_author_wrote(self):
-        # The wedge is named "null", but an author hiding it reaches for the
-        # label they passed. Both sides go through the same normalisation, so
-        # the raw None has to match.
-        trace = {"type": "pie", "labels": [None, "B"], "values": [1, 2], "sort": False}
-        plot = PlotlyPiePlot(trace, {"hiddenlabels": [None]})
-
-        assert plot._slices() == [("B", 2)]
-
-    def test_a_null_label_also_hides_by_its_wedge_name(self):
+    def test_a_null_label_hides_by_its_wedge_name(self):
         trace = {"type": "pie", "labels": [None, "B"], "values": [1, 2], "sort": False}
         plot = PlotlyPiePlot(trace, {"hiddenlabels": ["null"]})
 
         assert plot._slices() == [("B", 2)]
 
+    def test_a_raw_none_hides_nothing_because_plotly_hides_nothing(self):
+        # Plotly compares with `indexOf` against the stringified label, and
+        # `[null].indexOf("null")` is -1 -- so it keeps drawing the wedge.
+        # Dropping it here would leave a drawn wedge with no data point and
+        # shift every later slice onto the wrong element.
+        trace = {"type": "pie", "labels": [None, "B"], "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": [None]})
+
+        assert plot._slices() == [("null", 1), ("B", 2)]
+
+    def test_a_numeric_hidden_entry_hides_nothing(self):
+        # Same rule: `[5].indexOf("5")` is -1, so plotly draws it.
+        trace = {"type": "pie", "labels": [5, "B"], "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": [5]})
+
+        assert plot._slices() == [("5", 1), ("B", 2)]
+
+    def test_a_numeric_label_hides_by_its_stringified_name(self):
+        trace = {"type": "pie", "labels": [5, "B"], "values": [1, 2], "sort": False}
+        plot = PlotlyPiePlot(trace, {"hiddenlabels": ["5"]})
+
+        assert plot._slices() == [("B", 2)]
+
     def test_an_empty_hidden_label_matches_nothing(self):
-        # An empty label became the entry's own index, and a hidden label
-        # carries no index to substitute -- so it names no wedge, which is
-        # what plotly does with one too.
+        # An empty label became the entry's own index, so `""` names no wedge.
         trace = {"type": "pie", "labels": ["", "B"], "values": [1, 2], "sort": False}
         plot = PlotlyPiePlot(trace, {"hiddenlabels": [""]})
 


### PR DESCRIPTION
## Description

Adds pie chart support: `PlotType.PIE`, a `PiePlot` extractor, a `wrapt` patch on `Axes.pie`, and plotly `go.Pie`/donut support. `ax.pie(...)` and `go.Pie(...)` now emit a MAIDR pie layer with no user code change.

Companion to xability/maidr#767, which adds `TraceType.PIE` to the renderer. **That PR must ship first** — the JS `TraceFactory` throws on an unknown trace type, so a pie layer is only renderable once the JS release lands. This PR is correct and tested at the schema level today.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

The last box is deliberately unchecked: it depends on xability/maidr#767 merging and releasing.

# Pull Request

## Description

See above.

## Related Issues

None — implements pie support from scratch. Upstream companion: xability/maidr#767.

## Changes Made

**Core** — `PlotType.PIE`, `maidr/core/plot/pieplot.py`, `maidr/patch/pieplot.py`, registered in `MaidrPlotFactory`, `maidr/patch/__init__.py` and `FigureManager.PLOT_TYPE_PRIORITY`.

**The one subtle bit — where the values come from.** `Axes.pie` normalises its input: when `sum(x) > 1` it plots `x / sum(x)`, and each `Wedge` retains only `theta1`/`theta2`. Recovering magnitudes from the drawn geometry would report `0.3 / 0.5 / 0.2` for a caller who wrote `ax.pie([30, 50, 20])`, and lose float32 precision doing it. So values are taken from the patched call's arguments instead. The angular path survives only as a fallback for a directly-constructed `PiePlot`, where fractions are genuinely all matplotlib kept — documented in-method as a deliberate degradation, not a correct answer.

**Other decisions**

- The patch does not route through `patch/common.py`: `common` feeds the return value to `FigureManager.get_axes`, which handles `list` but not the `tuple` `Axes.pie` returns, and its `kwargs` are simultaneously the wrapped call's and the constructor's, leaving no room for extracted data. It mirrors `common`'s body instead (warning filter, `ContextManager` guard).
- Both `(wedges, texts)` and `(wedges, texts, autotexts)` returns are handled.
- `Axes.pie` sits behind `@_preprocess_data`, so `ax.pie("v", labels="l", data=df)` arrives as bare strings; a `_resolve` helper mirrors matplotlib's `_replacer`. Arguments are read positionally *or* by keyword, since matplotlib ≤3.9 allowed `labels` positionally and 3.10 made it keyword-only.
- Labels resolve as matplotlib does: `labels` argument → `Wedge.get_label()` → slice index. numpy/pandas scalars are unwrapped so a `labels=df["year"]` column does not make `json.dumps` raise.
- Nested pies (two `ax.pie` calls on one axes) use the wedges the patch handed over rather than scanning `ax.patches`, so each layer gets its own ring instead of both seeing all six wedges.
- `axes` emits exactly `{x, y}` per the canonical contract in `CLAUDE.md`, defaulting to `"Category"`/`"Value"` rather than the base class's `"X"`/`"Y"` — "X: Apples" would be announced against every slice.
- Highlighting needed no change to `patch/highlight.py`: `Wedge` subclasses `Patch`, which `tag_elements` already wraps.

**Plotly** — `maidr/plotly/pie.py` handles `go.Pie` and the donut variant (`hole` changes geometry, not data). plotly supplies `labels[]`/`values[]` directly, so there is no normalisation problem.

**Docs** — pie sections in `docs/examples.qmd` and `docs/examples-plotly.qmd`, `docs/llms.txt`, a runnable `example/pie/`, and the stale supported-types list in `CLAUDE.md` brought up to date.

## Screenshots (if applicable)

n/a

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — **660 passed**, 0 failed.

`ruff check` reports 52 findings, but that is the count on `main` too — verified by stashing this branch and re-running. No new lint findings were introduced; the existing ones are pre-existing `F401` re-export warnings across `__init__.py` files.

Tests cover the thing most likely to regress: that `ax.pie([30, 50, 20])` yields `30/50/20` and not matplotlib's normalised fractions. Also covered — the label fallback chain, `data=` column resolution, both return shapes, nested-pie layer separation, per-slice selectors in slice order, and `tests/core/test_axes_schema.py` compliance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_