### PR TITLE
fix(plotly): decode typed arrays in every extractor, and stop a plot call muting the process

### DIFF
--- a/maidr/core/plot/pieplot.py
+++ b/maidr/core/plot/pieplot.py
@@ -189,12 +189,13 @@ class PiePlot(MaidrPlot):
         # future bug that decouples the two is visible rather than quietly
         # rescaling every announcement.
         #
-        # This is logged rather than warned because a warning cannot be heard
-        # from here: `maidr.patch.pieplot.pie` calls
-        # `warnings.filterwarnings("ignore")` on every `Axes.pie`, so by the
-        # time `render()` reaches this line the process has a persistent
-        # catch-all "ignore" filter in front of it. `logging` is the channel
-        # that patch does not close, and the one `maidr.backend` already uses.
+        # This is logged rather than warned because it reports a MAIDR bug,
+        # not anything the caller wrote or can act on -- a warning would put
+        # it in front of the reader of an otherwise correct pie. `logging` is
+        # the channel `maidr.backend` already uses for exactly that, and
+        # `maidr.patch.pieplot.pie` suppresses warnings only for the duration
+        # of the `Axes.pie` call, so this line is reached with neither channel
+        # closed.
         if values is not None:
             _logger.warning(
                 "maidr: pie has %d values for %d wedges; reporting each "

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -112,6 +112,14 @@ def _draw_quietly(wrapped: Callable, args: tuple, kwargs: dict) -> Any:
     MAIDR's own diagnostics, which are raised while the schema is built and
     not while the figure is drawn.
 
+    ``catch_warnings`` saves and restores the *global* filter list, so it is
+    not thread safe: two threads drawing at once can restore each other's
+    state, and one may briefly miss a warning the other suppressed. The
+    process-wide filter this replaced shared that flaw and never restored at
+    all, so this is not a regression -- but the window is now per call rather
+    than permanent, which is what makes it reachable in a threaded server.
+    Python 3.14's context-aware filters would close it.
+
     Parameters
     ----------
     wrapped : Callable

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -101,6 +101,36 @@ def resolve_orientation(wrapped: Callable, args: tuple, kwargs: dict) -> str:
     return "horz" if orientation == "horizontal" else "vert"
 
 
+def _draw_quietly(wrapped: Callable, args: tuple, kwargs: dict) -> Any:
+    """
+    Call a patched plotting function with its warnings suppressed.
+
+    The suppression is not to confuse screen-reader users with warnings they
+    did not ask for and cannot act on. It is scoped to the call rather than
+    installed process-wide, because a filter that outlives the call goes on
+    swallowing warnings raised much later and far from any plot -- including
+    MAIDR's own diagnostics, which are raised while the schema is built and
+    not while the figure is drawn.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original plotting function.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    Any
+        Whatever the wrapped function returned.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return wrapped(*args, **kwargs)
+
+
 def common(
     plot_type: PlotType | Callable[[Axes], PlotType], wrapped, _, args, kwargs
 ) -> Any:
@@ -130,17 +160,14 @@ def common(
     Any
         Whatever the wrapped function returned.
     """
-    # Suppress warnings not to confuse screen-reader users
-    warnings.filterwarnings("ignore")
-
     # Don't proceed if the call is made internally by the patched function.
     if ContextManager.is_internal_context():
-        return wrapped(*args, **kwargs)
+        return _draw_quietly(wrapped, args, kwargs)
 
     # Set the internal context to avoid cyclic processing.
     with ContextManager.set_internal_context():
         # Patch the plotting function.
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
 
     # Extract the data points for MAIDR from the plot.
     ax = FigureManager.get_axes(plot)

--- a/maidr/patch/pieplot.py
+++ b/maidr/patch/pieplot.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Any, Callable
 
 import wrapt
@@ -9,7 +8,7 @@ from matplotlib.axes import Axes
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _argument
+from maidr.patch.common import _argument, _draw_quietly
 
 
 def pie(wrapped: Callable, instance: Axes, args: tuple, kwargs: dict) -> tuple:
@@ -46,23 +45,18 @@ def pie(wrapped: Callable, instance: Axes, args: tuple, kwargs: dict) -> tuple:
         `(wedges, texts)`, or `(wedges, texts, autotexts)` when the caller
         passed `autopct` — whichever the original function returned.
     """
-    # Suppress warnings not to confuse screen-reader users.
+    # The call is drawn through the same helper `maidr.patch.common.common`
+    # uses, so a pie suppresses matplotlib's warnings exactly as every other
+    # patched plot type does -- they neither appear nor disappear depending on
+    # which type the user happened to draw.
     #
-    # This is a process-wide, persistent catch-all, which is broader than this
-    # call needs -- but it is exactly what `maidr.patch.common.common` does on
-    # every other patched plot type, and a pie that filtered differently would
-    # make matplotlib's warnings appear or disappear depending on which plot
-    # type the user happened to draw. Parity is kept deliberately; narrowing
-    # it is a change to make in `common` for all plot types at once.
-    warnings.filterwarnings("ignore")
-
     # Don't proceed if the call is made internally by the patched function.
     if ContextManager.is_internal_context():
-        return wrapped(*args, **kwargs)
+        return _draw_quietly(wrapped, args, kwargs)
 
     # Set the internal context to avoid cyclic processing.
     with ContextManager.set_internal_context():
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
 
     data = _argument("data", wrapped, args, kwargs)
     values = _resolve(_argument("x", wrapped, args, kwargs), data)

--- a/maidr/plotly/bar.py
+++ b/maidr/plotly/bar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
 class PlotlyBarPlot(PlotlyPlot):
@@ -15,8 +15,8 @@ class PlotlyBarPlot(PlotlyPlot):
         return f"{self._subplot_css_prefix()}.trace.bars .point > path"
 
     def _extract_plot_data(self) -> list[dict]:
-        x = self._trace.get("x", [])
-        y = self._trace.get("y", [])
+        x = as_list(self._trace.get("x"))
+        y = as_list(self._trace.get("y"))
 
         return [
             {MaidrKey.X: self._to_native(xv), MaidrKey.Y: self._to_native(yv)}

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -121,8 +121,8 @@ class PlotlyBoxPlot(PlotlyPlot):
         q1_vals = as_list(self._trace.get("q1"))
         median_vals = as_list(self._trace.get("median"))
         q3_vals = as_list(self._trace.get("q3"))
-        lowerfence = as_list(self._trace.get("lowerfence", q1_vals))
-        upperfence = as_list(self._trace.get("upperfence", q3_vals))
+        lowerfence = as_list(self._trace.get("lowerfence")) or q1_vals
+        upperfence = as_list(self._trace.get("upperfence")) or q3_vals
 
         results = []
         for i in range(len(median_vals)):

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -183,9 +183,8 @@ class PlotlyBoxPlot(PlotlyPlot):
         data = y if y is not None else x
         if data is not None:
             arr = np.array(as_list(data), dtype=float)
-            return [
-                self._compute_stats(arr, label=self._trace.get("name", ""))
-            ]
+            stats = self._compute_stats(arr, label=self._trace.get("name", ""))
+            return [stats] if stats is not None else []
 
         return []
 
@@ -202,11 +201,30 @@ class PlotlyBoxPlot(PlotlyPlot):
         results = []
         for cat in categories:
             arr = np.array(groups[cat], dtype=float)
-            results.append(self._compute_stats(arr, label=str(cat)))
+            stats = self._compute_stats(arr, label=str(cat))
+            if stats is not None:
+                results.append(stats)
         return results
 
-    def _compute_stats(self, arr: np.ndarray, label: str = "") -> dict:
-        """Compute box plot statistics for a numeric array."""
+    def _compute_stats(self, arr: np.ndarray, label: str = "") -> dict | None:
+        """
+        Compute box plot statistics for a numeric array.
+
+        Answers None for an empty array. Every quartile of a box with no
+        samples is undefined -- `np.percentile` raises rather than inventing
+        one -- and an array arrives empty when the samples behind it could not
+        be read, a corrupt typed-array spec being the way that happens. The
+        caller drops the box; letting the raise through would take the whole
+        figure with it, including the layers that read perfectly well. The
+        precomputed path bounds its loop for the same reason.
+        """
+        if arr.size == 0:
+            _logger.warning(
+                "maidr: box %r has no samples to summarise; dropping it.",
+                label or "<unnamed>",
+            )
+            return None
+
         q1 = float(np.percentile(arr, 25))
         q2 = float(np.percentile(arr, 50))
         q3 = float(np.percentile(arr, 75))

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import numpy as np
@@ -7,6 +8,8 @@ import numpy as np
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+_logger = logging.getLogger(__name__)
 
 
 def _build_box_selector(
@@ -117,15 +120,39 @@ class PlotlyBoxPlot(PlotlyPlot):
         return "q1" in self._trace and "median" in self._trace
 
     def _extract_precomputed(self) -> list[dict]:
-        """Extract box stats from pre-computed values in the trace."""
+        """
+        Extract box stats from pre-computed values in the trace.
+
+        Only as many boxes are described as every statistic has a value for.
+        The five arrays are decoded independently, so one of them failing --
+        a corrupt typed-array spec comes back empty -- would otherwise leave
+        the loop indexing past the end of it. A short layer is the same answer
+        the rest of this module gives to data it cannot read; a crash would
+        take the whole figure with it.
+        """
         q1_vals = as_list(self._trace.get("q1"))
         median_vals = as_list(self._trace.get("median"))
         q3_vals = as_list(self._trace.get("q3"))
         lowerfence = as_list(self._trace.get("lowerfence")) or q1_vals
         upperfence = as_list(self._trace.get("upperfence")) or q3_vals
 
+        count = min(
+            len(q1_vals),
+            len(median_vals),
+            len(q3_vals),
+            len(lowerfence),
+            len(upperfence),
+        )
+        if count < len(median_vals):
+            _logger.warning(
+                "maidr: box has %d medians but only %d complete boxes; "
+                "describing those and dropping the rest.",
+                len(median_vals),
+                count,
+            )
+
         results = []
-        for i in range(len(median_vals)):
+        for i in range(count):
             results.append(
                 {
                     MaidrKey.LOWER_OUTLIER.value: [],

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
 def _build_box_selector(
@@ -118,11 +118,11 @@ class PlotlyBoxPlot(PlotlyPlot):
 
     def _extract_precomputed(self) -> list[dict]:
         """Extract box stats from pre-computed values in the trace."""
-        q1_vals = self._trace.get("q1", [])
-        median_vals = self._trace.get("median", [])
-        q3_vals = self._trace.get("q3", [])
-        lowerfence = self._trace.get("lowerfence", q1_vals)
-        upperfence = self._trace.get("upperfence", q3_vals)
+        q1_vals = as_list(self._trace.get("q1"))
+        median_vals = as_list(self._trace.get("median"))
+        q3_vals = as_list(self._trace.get("q3"))
+        lowerfence = as_list(self._trace.get("lowerfence", q1_vals))
+        upperfence = as_list(self._trace.get("upperfence", q3_vals))
 
         results = []
         for i in range(len(median_vals)):
@@ -155,7 +155,7 @@ class PlotlyBoxPlot(PlotlyPlot):
         # Single box — data may be in y (vertical) or x (horizontal)
         data = y if y is not None else x
         if data is not None:
-            arr = np.array(data, dtype=float)
+            arr = np.array(as_list(data), dtype=float)
             return [
                 self._compute_stats(arr, label=self._trace.get("name", ""))
             ]
@@ -164,8 +164,8 @@ class PlotlyBoxPlot(PlotlyPlot):
 
     def _extract_grouped(self, x: list[Any], y: list[Any]) -> list[dict]:
         """Extract stats grouped by x categories."""
-        x = list(x)
-        y = list(y)
+        x = as_list(x)
+        y = as_list(y)
         # Preserve order of appearance
         categories = list(dict.fromkeys(x))
         groups: dict[Any, list] = {cat: [] for cat in categories}

--- a/maidr/plotly/grouped_bar.py
+++ b/maidr/plotly/grouped_bar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
 class PlotlyGroupedBarPlot(PlotlyPlot):
@@ -41,8 +41,8 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
         data: list[list[dict]] = []
 
         for trace in self._traces:
-            x_vals = trace.get("x", [])
-            y_vals = trace.get("y", [])
+            x_vals = as_list(trace.get("x"))
+            y_vals = as_list(trace.get("y"))
             fill = trace.get("name", "")
 
             group: list[dict] = []

--- a/maidr/plotly/heatmap.py
+++ b/maidr/plotly/heatmap.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
 class PlotlyHeatmapPlot(PlotlyPlot):
@@ -33,7 +33,10 @@ class PlotlyHeatmapPlot(PlotlyPlot):
             return val
 
     def _extract_plot_data(self) -> dict:
-        z = self._trace.get("z", [])
+        # ``z`` is the one two-dimensional array a trace carries, so it is
+        # also the one whose exported spec names a ``shape``; decoding it
+        # restores the rows the loop below reads.
+        z = as_list(self._trace.get("z"))
         x = self._trace.get("x", None)
         y = self._trace.get("y", None)
 
@@ -45,9 +48,9 @@ class PlotlyHeatmapPlot(PlotlyPlot):
         result: dict = {MaidrKey.POINTS: points}
 
         if x is not None:
-            result[MaidrKey.X] = [self._to_native(v) for v in x]
+            result[MaidrKey.X] = [self._to_native(v) for v in as_list(x)]
         if y is not None:
-            result[MaidrKey.Y] = [self._to_native(v) for v in y]
+            result[MaidrKey.Y] = [self._to_native(v) for v in as_list(y)]
 
         return result
 

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
 def _plotly_round_up(val: float, array: list[float], reverse: bool = False) -> float:
@@ -176,9 +176,10 @@ class PlotlyHistogramPlot(PlotlyPlot):
         return f"{self._subplot_css_prefix()}.trace.bars .point > path"
 
     def _extract_plot_data(self) -> list[dict]:
-        x = self._trace.get("x", None)
-        if x is None:
+        raw_x = self._trace.get("x", None)
+        if raw_x is None:
             return []
+        x = as_list(raw_x)
 
         # Detect categorical (string) data — Plotly renders these as
         # count bar charts.  Mirror how seaborn countplot is handled:

--- a/maidr/plotly/line.py
+++ b/maidr/plotly/line.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 from maidr.plotly.step_shape import renders_through_webgl
 
 
@@ -66,8 +66,8 @@ class PlotlyLinePlot(PlotlyPlot):
         return [self._scatter_line_selector(self._scatter_position)]
 
     def _extract_plot_data(self) -> list[list[dict]]:
-        x = self._trace.get("x", [])
-        y = self._trace.get("y", [])
+        x = as_list(self._trace.get("x"))
+        y = as_list(self._trace.get("y"))
         name = self._trace.get("name", "")
 
         line_data = []

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import numpy as np
@@ -8,6 +9,8 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.box import _build_box_selector
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+_logger = logging.getLogger(__name__)
 
 
 class PlotlyMultiBoxPlot(PlotlyPlot):
@@ -104,15 +107,39 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         return all_boxes
 
     def _extract_precomputed(self, trace: dict) -> list[dict]:
-        """Extract box stats from pre-computed values."""
+        """
+        Extract box stats from pre-computed values.
+
+        Only as many boxes are described as every statistic has a value for.
+        The five arrays are decoded independently, so one of them failing --
+        a corrupt typed-array spec comes back empty -- would otherwise leave
+        the loop indexing past the end of it. A short layer is the same answer
+        the rest of this module gives to data it cannot read; a crash would
+        take the whole figure with it.
+        """
         q1_vals = as_list(trace.get("q1"))
         median_vals = as_list(trace.get("median"))
         q3_vals = as_list(trace.get("q3"))
         lowerfence = as_list(trace.get("lowerfence")) or q1_vals
         upperfence = as_list(trace.get("upperfence")) or q3_vals
 
+        count = min(
+            len(q1_vals),
+            len(median_vals),
+            len(q3_vals),
+            len(lowerfence),
+            len(upperfence),
+        )
+        if count < len(median_vals):
+            _logger.warning(
+                "maidr: box has %d medians but only %d complete boxes; "
+                "describing those and dropping the rest.",
+                len(median_vals),
+                count,
+            )
+
         results = []
-        for i in range(len(median_vals)):
+        for i in range(count):
             results.append(
                 {
                     MaidrKey.LOWER_OUTLIER.value: [],

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -108,8 +108,8 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         q1_vals = as_list(trace.get("q1"))
         median_vals = as_list(trace.get("median"))
         q3_vals = as_list(trace.get("q3"))
-        lowerfence = as_list(trace.get("lowerfence", q1_vals))
-        upperfence = as_list(trace.get("upperfence", q3_vals))
+        lowerfence = as_list(trace.get("lowerfence")) or q1_vals
+        upperfence = as_list(trace.get("upperfence")) or q3_vals
 
         results = []
         for i in range(len(median_vals)):

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -94,7 +94,9 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
             data = y if y is not None else x
             if data is not None:
                 arr = np.array(as_list(data), dtype=float)
-                all_boxes.append(self._compute_stats(arr, label=name))
+                stats = self._compute_stats(arr, label=name)
+                if stats is not None:
+                    all_boxes.append(stats)
 
         # Record outlier counts so _get_selector can split them.
         self._outlier_counts = [
@@ -167,11 +169,30 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         results = []
         for cat in categories:
             arr = np.array(groups[cat], dtype=float)
-            results.append(self._compute_stats(arr, label=str(cat)))
+            stats = self._compute_stats(arr, label=str(cat))
+            if stats is not None:
+                results.append(stats)
         return results
 
-    def _compute_stats(self, arr: np.ndarray, label: str = "") -> dict:
-        """Compute box plot statistics for a numeric array."""
+    def _compute_stats(self, arr: np.ndarray, label: str = "") -> dict | None:
+        """
+        Compute box plot statistics for a numeric array.
+
+        Answers None for an empty array. Every quartile of a box with no
+        samples is undefined -- `np.percentile` raises rather than inventing
+        one -- and an array arrives empty when the samples behind it could not
+        be read, a corrupt typed-array spec being the way that happens. The
+        caller drops the box; letting the raise through would take the whole
+        figure with it, including the layers that read perfectly well. The
+        precomputed path bounds its loop for the same reason.
+        """
+        if arr.size == 0:
+            _logger.warning(
+                "maidr: box %r has no samples to summarise; dropping it.",
+                label or "<unnamed>",
+            )
+            return None
+
         q1 = float(np.percentile(arr, 25))
         q2 = float(np.percentile(arr, 50))
         q3 = float(np.percentile(arr, 75))

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -7,7 +7,7 @@ import numpy as np
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.box import _build_box_selector
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
 class PlotlyMultiBoxPlot(PlotlyPlot):
@@ -90,7 +90,7 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
             # Single box — data may be in y (vertical) or x (horizontal)
             data = y if y is not None else x
             if data is not None:
-                arr = np.array(data, dtype=float)
+                arr = np.array(as_list(data), dtype=float)
                 all_boxes.append(self._compute_stats(arr, label=name))
 
         # Record outlier counts so _get_selector can split them.
@@ -105,11 +105,11 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
 
     def _extract_precomputed(self, trace: dict) -> list[dict]:
         """Extract box stats from pre-computed values."""
-        q1_vals = trace.get("q1", [])
-        median_vals = trace.get("median", [])
-        q3_vals = trace.get("q3", [])
-        lowerfence = trace.get("lowerfence", q1_vals)
-        upperfence = trace.get("upperfence", q3_vals)
+        q1_vals = as_list(trace.get("q1"))
+        median_vals = as_list(trace.get("median"))
+        q3_vals = as_list(trace.get("q3"))
+        lowerfence = as_list(trace.get("lowerfence", q1_vals))
+        upperfence = as_list(trace.get("upperfence", q3_vals))
 
         results = []
         for i in range(len(median_vals)):
@@ -130,8 +130,8 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         self, x: list[Any], y: list[Any]
     ) -> list[dict]:
         """Extract stats grouped by x categories."""
-        x_list = list(x)
-        y_list = list(y)
+        x_list = as_list(x)
+        y_list = as_list(y)
         categories = list(dict.fromkeys(x_list))
         groups: dict[Any, list] = {cat: [] for cat in categories}
         for xi, yi in zip(x_list, y_list):

--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
 class PlotlyMultiLinePlot(PlotlyPlot):
@@ -83,8 +83,8 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         all_lines: list[list[dict]] = []
 
         for trace in self._traces:
-            x = trace.get("x", [])
-            y = trace.get("y", [])
+            x = as_list(trace.get("x"))
+            y = as_list(trace.get("y"))
             name = trace.get("name", "")
 
             line_data: list[dict] = []

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import base64
 import math
 from typing import Any
 
-import numpy as np
-
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, domain_interval
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list, domain_interval
 
 
 class PlotlyPiePlot(PlotlyPlot):
@@ -155,8 +152,8 @@ class PlotlyPiePlot(PlotlyPlot):
         """
         raw_labels = self._trace.get("labels")
         raw_values = self._trace.get("values")
-        labels = _as_list(raw_labels)
-        values = _as_list(raw_values)
+        labels = as_list(raw_labels)
+        values = as_list(raw_values)
 
         # Each array bounds the other, and an array the author never supplied
         # bounds nothing -- an empty one still bounds the pie down to nothing.
@@ -217,7 +214,7 @@ class PlotlyPiePlot(PlotlyPlot):
         # would shift every later slice onto the wrong element.
         hidden = {
             label
-            for label in _as_list(self._layout.get("hiddenlabels"))
+            for label in as_list(self._layout.get("hiddenlabels"))
             if isinstance(label, str)
         }
         return [(label, value) for label, value in wedges if label not in hidden]
@@ -278,52 +275,6 @@ def _wedge_label(label: Any, index: int) -> str:
     if label == "":
         return str(index)
     return str(label)
-
-
-def _as_list(value: Any) -> list:
-    """
-    Return a plotly data array as a plain list.
-
-    ``Figure.to_dict()`` hands back the arrays the author supplied, plus one
-    shape they never wrote: a numeric numpy array is exported as the
-    ``{"dtype": ..., "bdata": ...}`` base64 spec plotly.js consumes, which is
-    what ``plotly.express`` produces for every numeric column. Decoding it
-    here keeps ``px.pie`` on the same path as a hand-built ``go.Pie``, where
-    iterating the dict would otherwise walk its two keys. Anything that will
-    not decode comes back empty rather than as something worse.
-
-    Parameters
-    ----------
-    value : Any
-        A plotly data array, a typed-array spec, or None.
-
-    Returns
-    -------
-    list
-        The array's entries, or an empty list.
-    """
-    if value is None:
-        return []
-
-    if isinstance(value, dict):
-        dtype = value.get("dtype")
-        bdata = value.get("bdata")
-        if dtype is None or bdata is None:
-            return []
-        try:
-            return np.frombuffer(base64.b64decode(bdata), dtype=dtype).tolist()
-        except (TypeError, ValueError):
-            return []
-
-    # A string is iterable, so without this it would decompose into one
-    # single-character entry per letter instead of being rejected.
-    if isinstance(value, str):
-        return []
-
-    try:
-        return list(value)
-    except TypeError:
-        return []
 
 
 def _as_number(value: Any) -> float | None:

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import base64
 import re
 import uuid
 from abc import ABC, abstractmethod
 from typing import Any
+
+import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
@@ -478,6 +481,84 @@ def domain_interval(box: Any, key: str) -> tuple[float, float]:
         return round(float(interval[0]), 6), round(float(interval[1]), 6)
     except (TypeError, ValueError):
         return whole
+
+
+def as_list(value: Any) -> list:
+    """
+    Return a plotly data array as a plain list.
+
+    ``Figure.to_dict()`` hands back the arrays the author supplied, plus two
+    shapes they never wrote: a numeric array is exported as the
+    ``{"dtype": ..., "bdata": ...}`` base64 typed-array spec plotly.js
+    consumes, and a non-numeric one stays a numpy array. ``plotly.express``
+    produces one or the other for every column it plots, so every extractor
+    reads its trace arrays through here -- iterating the spec directly walks
+    its two keys and emits ``"dtype"`` and ``"bdata"`` as the data.
+
+    A multi-dimensional array carries its extents alongside the buffer and is
+    restored to nested lists, so a heatmap's ``z`` still arrives as rows.
+
+    Plain lists, tuples and None are handed back as they are, so a hand-built
+    ``go.Bar(y=[1, 2, 3])`` travels this path unchanged.
+
+    Parameters
+    ----------
+    value : Any
+        A plotly data array, a typed-array spec, or None.
+
+    Returns
+    -------
+    list
+        The array's entries, or an empty list.
+    """
+    if value is None:
+        return []
+
+    if isinstance(value, dict):
+        return _decode_typed_array(value)
+
+    # A string is iterable, so without this it would decompose into one
+    # single-character entry per letter instead of being rejected.
+    if isinstance(value, str):
+        return []
+
+    try:
+        return list(value)
+    except TypeError:
+        return []
+
+
+def _decode_typed_array(spec: dict) -> list:
+    """
+    Decode one exported ``{"dtype": ..., "bdata": ...}`` typed-array spec.
+
+    Parameters
+    ----------
+    spec : dict
+        The exported spec. ``shape`` is present only for an array of more
+        than one dimension, and names its extents as a comma-separated
+        string.
+
+    Returns
+    -------
+    list
+        The buffer's entries, nested when ``shape`` says so. Anything that
+        will not decode comes back empty rather than as something worse.
+    """
+    dtype = spec.get("dtype")
+    bdata = spec.get("bdata")
+    if dtype is None or bdata is None:
+        return []
+
+    try:
+        array = np.frombuffer(base64.b64decode(bdata), dtype=dtype)
+        shape = spec.get("shape")
+        if shape is not None:
+            extents = shape.split(",") if isinstance(shape, str) else shape
+            array = array.reshape([int(extent) for extent in extents])
+        return array.tolist()
+    except (TypeError, ValueError):
+        return []
 
 
 def _extract_decimals(fmt: str) -> int | None:

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -10,6 +10,10 @@ import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
+# This is the import that makes the cycle: `step_shape` reads its trace arrays
+# through `as_list`, defined below, and so imports this module back. It does so
+# inside the function rather than here. Moving either import to the other's
+# level closes the cycle and breaks both — see `step_shape._trace_point_count`.
 from maidr.plotly.step_shape import renders_through_webgl
 
 
@@ -498,8 +502,11 @@ def as_list(value: Any) -> list:
     A multi-dimensional array carries its extents alongside the buffer and is
     restored to nested lists, so a heatmap's ``z`` still arrives as rows.
 
-    Plain lists, tuples and None are handed back as they are, so a hand-built
-    ``go.Bar(y=[1, 2, 3])`` travels this path unchanged.
+    A plain list or tuple is handed back as a list, so a hand-built
+    ``go.Bar(y=[1, 2, 3])`` travels this path unchanged. An absent array
+    becomes an empty list rather than staying ``None``: every caller reads a
+    trace key that may simply not be there, and one empty answer for "no
+    array" saves each of them a null check.
 
     Parameters
     ----------

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import logging
 import re
 import uuid
 from abc import ABC, abstractmethod
@@ -15,6 +16,8 @@ from maidr.core.enum.plot_type import PlotType
 # inside the function rather than here. Moving either import to the other's
 # level closes the cycle and breaks both — see `step_shape._trace_point_count`.
 from maidr.plotly.step_shape import renders_through_webgl
+
+_logger = logging.getLogger(__name__)
 
 
 class PlotlyPlot(ABC):
@@ -551,10 +554,22 @@ def _decode_typed_array(spec: dict) -> list:
     list
         The buffer's entries, nested when ``shape`` says so. Anything that
         will not decode comes back empty rather than as something worse.
+
+    Notes
+    -----
+    Failure is logged, not swallowed. An empty layer is a safer answer than a
+    garbled one, but silence here would be the same fault this decoder exists
+    to fix: a chart that draws correctly while its accessible layer is wrong
+    and nothing says so. The log is what turns "the plot reads as empty" into
+    something diagnosable.
     """
     dtype = spec.get("dtype")
     bdata = spec.get("bdata")
     if dtype is None or bdata is None:
+        _logger.warning(
+            "maidr: typed array names no %s; reporting no data for it.",
+            "dtype" if dtype is None else "bdata",
+        )
         return []
 
     try:
@@ -562,9 +577,21 @@ def _decode_typed_array(spec: dict) -> list:
         shape = spec.get("shape")
         if shape is not None:
             extents = shape.split(",") if isinstance(shape, str) else shape
+            # Three ways this raises, and the two clauses below cover all of
+            # them: an unknown `dtype` is a TypeError, base64 that will not
+            # decode is a `binascii.Error` (a ValueError), and a `shape` that
+            # is not integral, or does not multiply out to the buffer's
+            # length, is a ValueError from `int()` or from `reshape`.
             array = array.reshape([int(extent) for extent in extents])
         return array.tolist()
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as error:
+        _logger.warning(
+            "maidr: could not decode a typed array (dtype=%r, shape=%r): %s; "
+            "reporting no data for it.",
+            dtype,
+            spec.get("shape"),
+            error,
+        )
         return []
 
 

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -577,14 +577,21 @@ def _decode_typed_array(spec: dict) -> list:
         shape = spec.get("shape")
         if shape is not None:
             extents = shape.split(",") if isinstance(shape, str) else shape
-            # Three ways this raises, and the two clauses below cover all of
+            # Three ways this raises, and the clauses below cover all of
             # them: an unknown `dtype` is a TypeError, base64 that will not
             # decode is a `binascii.Error` (a ValueError), and a `shape` that
             # is not integral, or does not multiply out to the buffer's
             # length, is a ValueError from `int()` or from `reshape`.
+            #
+            # `OverflowError` is listed for an extent too large to be a
+            # dimension. numpy 2.4 answers that with a ValueError, so it is
+            # unreachable on the version pinned here — but the project accepts
+            # numpy>=1.26, and the cost of being wrong about one release in
+            # that range is an uncaught exception taking down the whole
+            # figure, which is what this decoder exists to prevent.
             array = array.reshape([int(extent) for extent in extents])
         return array.tolist()
-    except (TypeError, ValueError) as error:
+    except (TypeError, ValueError, OverflowError) as error:
         _logger.warning(
             "maidr: could not decode a typed array (dtype=%r, shape=%r): %s; "
             "reporting no data for it.",

--- a/maidr/plotly/scatter.py
+++ b/maidr/plotly/scatter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 from maidr.plotly.step_shape import renders_through_webgl
 
 
@@ -54,8 +54,8 @@ class PlotlyScatterPlot(PlotlyPlot):
         y_fmt = format_config.get("y")
 
         # Get range: explicit from layout OR compute from trace data
-        x_data = self._trace.get("x", [])
-        y_data = self._trace.get("y", [])
+        x_data = as_list(self._trace.get("x"))
+        y_data = as_list(self._trace.get("y"))
         x_min, x_max = self._get_axis_range(xaxis, x_data)
         y_min, y_max = self._get_axis_range(yaxis, y_data)
 
@@ -214,8 +214,8 @@ class PlotlyScatterPlot(PlotlyPlot):
         return True
 
     def _extract_plot_data(self) -> list[dict]:
-        x = self._trace.get("x", [])
-        y = self._trace.get("y", [])
+        x = as_list(self._trace.get("x"))
+        y = as_list(self._trace.get("y"))
 
         return [
             {MaidrKey.X: self._to_native(xv), MaidrKey.Y: self._to_native(yv)}

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 from maidr.plotly.step_shape import step_direction_of
 
 
@@ -144,8 +144,8 @@ class PlotlyStepPlot(PlotlyPlot):
         all_series: list[list[dict]] = []
 
         for trace in self._traces:
-            x_values = trace.get("x", [])
-            y_values = trace.get("y", [])
+            x_values = as_list(trace.get("x"))
+            y_values = as_list(trace.get("y"))
             name = trace.get("name", "")
 
             series: list[dict] = []

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -100,6 +100,12 @@ def _trace_point_count(trace: dict) -> int:
     ``y`` — matching plotly generating ``x`` as ``0..n-1`` — and an
     ``x``-only trace counts ``x``.
 
+    The count is taken off the decoded array, not off the exported one: a
+    numeric array leaves ``Figure.to_dict()`` as a two-key typed-array spec,
+    whose own length is 2 whatever it holds. Reading that literally caps
+    every numpy-backed trace at two points and hands :func:`default_mode` the
+    wrong answer.
+
     Parameters
     ----------
     trace : dict
@@ -110,8 +116,13 @@ def _trace_point_count(trace: dict) -> int:
     int
         The number of drawn points; 0 when neither axis carries a sequence.
     """
+    # Imported here rather than at module scope: `plotly_plot` reads
+    # `renders_through_webgl` from this module, so naming it at the top would
+    # close the cycle.
+    from maidr.plotly.plotly_plot import as_list
+
     lengths = [
-        len(values)
+        len(as_list(values))
         for values in (trace.get("x"), trace.get("y"))
         if values is not None and hasattr(values, "__len__")
     ]

--- a/tests/core/plot/test_pieplot.py
+++ b/tests/core/plot/test_pieplot.py
@@ -654,13 +654,13 @@ class TestDataColumnNames:
 
 
 class TestMismatchDiagnostic:
-    """The values/wedges mismatch is logged, because it cannot be warned.
+    """The values/wedges mismatch is logged, and the log is reachable.
 
-    ``maidr.patch.pieplot.pie`` installs a persistent, process-wide
-    ``warnings.filterwarnings("ignore")`` on every ``Axes.pie`` -- deliberate
-    parity with ``maidr.patch.common.common``, which does the same on every
-    other plot type. Any ``warnings.warn`` raised later, during ``render()``,
-    is therefore unreachable.
+    ``maidr.patch.pieplot.pie`` suppresses warnings only for the duration of
+    the ``Axes.pie`` call it wraps -- the same scope
+    ``maidr.patch.common.common`` uses on every other plot type -- so nothing
+    the patch installs is still in front of ``render()`` when the diagnostic
+    is emitted.
     """
 
     def test_the_mismatch_is_reported_through_logging(self, caplog):
@@ -678,18 +678,17 @@ class TestMismatchDiagnostic:
         finally:
             plt.close(fig)
 
-    def test_a_warning_would_not_have_been_heard(self):
-        # Pins the reason the line above uses `logging`: the patch's filter is
-        # process-wide and persistent, so it is already in front of any
-        # `warnings.warn` `render()` could raise.
+    def test_the_patch_leaves_no_filter_behind_to_swallow_it(self):
+        # The diagnostic above is only reachable because `Axes.pie` no longer
+        # leaves an "ignore" filter installed behind it. Pin that: a warning
+        # raised after the pie is drawn still reaches the caller.
         fig, ax = plt.subplots()
         try:
             ax.pie(UNITS, labels=FRUIT)
-            plot = PiePlot(ax, values=[30, 50], labels=FRUIT)
 
             with warnings.catch_warnings(record=True) as caught:
-                _ = plot.schema
+                warnings.warn("heard after the pie", UserWarning)
 
-            assert caught == []
+            assert [str(w.message) for w in caught] == ["heard after the pie"]
         finally:
             plt.close(fig)

--- a/tests/core/test_patch_warning_scope.py
+++ b/tests/core/test_patch_warning_scope.py
@@ -8,8 +8,28 @@ muted every ``warnings.warn`` raised afterwards — anywhere, arbitrarily far
 from any figure, including MAIDR's own diagnostics, which are raised while the
 schema is built rather than while the figure is drawn.
 
-``common`` is the path every plot type but pie takes, so it is pinned here
-rather than only through the one type that has its own patch.
+``common`` is where most plot types are drawn, so it is pinned here rather
+than only through pie, which has its own patch.
+
+How each kind below reaches the helper is worth stating, because it is not
+uniform and the parametrisation would otherwise read as claiming more than
+it pins:
+
+* ``bar``, ``barh`` and ``scatter`` are drawn through ``common`` directly —
+  these are the cases where the fix does its work.
+* ``hist`` is not routed through ``common`` by its own patch, but
+  ``Axes.hist`` draws its bars with the patched ``Axes.bar``, so the helper
+  wraps that internal draw.
+* ``plot`` reaches ``common`` with a *no-op lambda* — ``lineplot.line``
+  calls ``wrapped()`` itself first — so the helper suppresses nothing for
+  it. Its own draw is unsuppressed both before and after this change.
+
+All five nevertheless pin the property under test, which is that nothing is
+left installed afterwards: under the filter this replaced, ``common``
+installed one unconditionally, no-op lambda included. Each fails in
+isolation against that code, so none of them depends on another having run
+first. What ``plot`` does *not* demonstrate is its own draw being scoped;
+that it never was is tracked in #328.
 """
 
 from __future__ import annotations

--- a/tests/core/test_patch_warning_scope.py
+++ b/tests/core/test_patch_warning_scope.py
@@ -23,7 +23,7 @@ import warnings  # noqa: E402
 import matplotlib.pyplot as plt  # noqa: E402
 import pytest  # noqa: E402
 
-import maidr  # noqa: E402  # activates patches
+import maidr  # noqa: E402, F401  # imported for its side effect: activates the patches
 
 
 def _draw(kind: str, ax) -> None:

--- a/tests/core/test_patch_warning_scope.py
+++ b/tests/core/test_patch_warning_scope.py
@@ -1,0 +1,87 @@
+"""The warnings a patched plot suppresses stay inside that plot's call.
+
+Every patched plotting function is drawn through
+``maidr.patch.common._draw_quietly``, which silences matplotlib's own warnings
+so they do not reach a screen-reader user mid-render. That suppression used to
+be installed process-wide and never removed, so the first plot of a session
+muted every ``warnings.warn`` raised afterwards — anywhere, arbitrarily far
+from any figure, including MAIDR's own diagnostics, which are raised while the
+schema is built rather than while the figure is drawn.
+
+``common`` is the path every plot type but pie takes, so it is pinned here
+rather than only through the one type that has its own patch.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import warnings  # noqa: E402
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: E402  # activates patches
+
+
+def _draw(kind: str, ax) -> None:
+    """Draw one patched plot of the named kind on ``ax``."""
+    if kind == "bar":
+        ax.bar(["a", "b"], [1, 2])
+    elif kind == "barh":
+        ax.barh(["a", "b"], [1, 2])
+    elif kind == "plot":
+        ax.plot([1, 2, 3], [4, 5, 6])
+    elif kind == "scatter":
+        ax.scatter([1, 2, 3], [4, 5, 6])
+    elif kind == "hist":
+        ax.hist([1, 1, 2, 3, 3, 3])
+    else:  # pragma: no cover - guards a typo in the parametrisation
+        raise AssertionError(f"unknown plot kind: {kind}")
+
+
+@pytest.mark.parametrize("kind", ["bar", "barh", "plot", "scatter", "hist"])
+def test_a_warning_raised_after_the_plot_still_reaches_the_caller(kind):
+    fig, ax = plt.subplots()
+    try:
+        _draw(kind, ax)
+
+        # Deliberately no `simplefilter` here: the recorder inherits whatever
+        # filters are installed, which is the whole point. Forcing "always"
+        # would override a leaked "ignore" and the test would pass either way.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.warn(f"heard after the {kind}", UserWarning)
+
+        assert [str(w.message) for w in caught] == [f"heard after the {kind}"]
+    finally:
+        plt.close(fig)
+
+
+def test_the_plot_call_leaves_the_filter_list_as_it_found_it():
+    # `catch_warnings` restores what it saved, so drawing must be neutral --
+    # the leak this guards against was a filter that outlived the call.
+    fig, ax = plt.subplots()
+    try:
+        before = list(warnings.filters)
+        ax.bar(["a", "b"], [1, 2])
+
+        assert warnings.filters == before
+    finally:
+        plt.close(fig)
+
+
+def test_repeated_plots_do_not_accumulate_filters():
+    # Not a growth guard -- CPython's `warnings._add_filter` de-duplicates, so
+    # even the old process-wide call could not accumulate. This pins that
+    # drawing is neutral however many times it happens.
+    fig, ax = plt.subplots()
+    try:
+        before = len(warnings.filters)
+        for _ in range(25):
+            ax.bar(["a", "b"], [1, 2])
+
+        assert len(warnings.filters) == before
+    finally:
+        plt.close(fig)

--- a/tests/plotly/test_plotly_typed_arrays.py
+++ b/tests/plotly/test_plotly_typed_arrays.py
@@ -322,3 +322,59 @@ class TestPartialDecodeFailure:
         plot = PlotlyMultiBoxPlot([self._trace(q3=broken)], {})
 
         assert plot._extract_plot_data() == []
+
+    def test_an_undecodable_raw_sample_array_drops_the_box(self):
+        from maidr.plotly.box import PlotlyBoxPlot
+
+        broken = {"dtype": "i1", "bdata": "!!!not base64!!!"}
+        plot = PlotlyBoxPlot({"type": "box", "y": broken}, {})
+
+        assert plot._extract_plot_data() == []
+
+    def test_an_undecodable_grouped_sample_array_drops_its_boxes(self):
+        from maidr.plotly.box import PlotlyBoxPlot
+
+        broken = {"dtype": "i1", "bdata": "!!!not base64!!!"}
+        plot = PlotlyBoxPlot(
+            {"type": "box", "x": {"dtype": "i1", "bdata": "ChQe"}, "y": broken}, {}
+        )
+
+        assert plot._extract_plot_data() == []
+
+    def test_the_multi_box_raw_path_drops_it_too(self):
+        from maidr.plotly.multibox import PlotlyMultiBoxPlot
+
+        broken = {"dtype": "i1", "bdata": "!!!not base64!!!"}
+        plot = PlotlyMultiBoxPlot([{"type": "box", "y": broken}], {})
+
+        assert plot._extract_plot_data() == []
+
+    def test_a_dropped_raw_box_is_reported(self, caplog):
+        from maidr.plotly.box import PlotlyBoxPlot
+
+        broken = {"dtype": "i1", "bdata": "!!!not base64!!!"}
+        plot = PlotlyBoxPlot({"type": "box", "name": "north", "y": broken}, {})
+        with caplog.at_level(logging.WARNING, logger="maidr.plotly.box"):
+            plot._extract_plot_data()
+
+        assert "no samples to summarise" in caplog.text
+        assert "north" in caplog.text
+
+    def test_a_readable_box_beside_an_unreadable_one_survives(self):
+        # The point of dropping rather than raising: one corrupt trace must
+        # not cost the figure the layers that read perfectly well.
+        from maidr.plotly.multibox import PlotlyMultiBoxPlot
+
+        broken = {"dtype": "i1", "bdata": "!!!not base64!!!"}
+        plot = PlotlyMultiBoxPlot(
+            [
+                {"type": "box", "name": "bad", "y": broken},
+                {"type": "box", "name": "good", "y": [1.0, 2.0, 3.0, 4.0, 5.0]},
+            ],
+            {},
+        )
+        boxes = plot._extract_plot_data()
+
+        assert len(boxes) == 1
+        assert boxes[0]["z"] == "good"
+        assert boxes[0]["q2"] == pytest.approx(3.0)

--- a/tests/plotly/test_plotly_typed_arrays.py
+++ b/tests/plotly/test_plotly_typed_arrays.py
@@ -15,6 +15,7 @@ why it stayed green.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import numpy as np
@@ -227,3 +228,29 @@ class TestAsList:
     )
     def test_an_undecodable_spec_comes_back_empty(self, spec: dict):
         assert as_list(spec) == []
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            {"dtype": "i1"},
+            {"bdata": "ChQe"},
+            {"dtype": "not-a-dtype", "bdata": "ChQe"},
+            {"dtype": "i1", "bdata": "!!!not base64!!!"},
+            {"dtype": "i1", "bdata": "ChQe", "shape": "5, 5"},
+        ],
+    )
+    def test_an_undecodable_spec_says_so(self, spec: dict, caplog):
+        # An empty layer is the safe answer, but a silent one repeats the very
+        # fault this decoder exists to fix: a chart that draws while its
+        # accessible layer is wrong and nothing says so.
+        with caplog.at_level(logging.WARNING, logger="maidr.plotly.plotly_plot"):
+            as_list(spec)
+
+        assert "maidr" in caplog.text
+        assert "no data" in caplog.text
+
+    def test_a_spec_that_decodes_says_nothing(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="maidr.plotly.plotly_plot"):
+            assert as_list({"dtype": "i1", "bdata": "ChQe"}) == [10, 20, 30]
+
+        assert caplog.text == ""

--- a/tests/plotly/test_plotly_typed_arrays.py
+++ b/tests/plotly/test_plotly_typed_arrays.py
@@ -254,3 +254,71 @@ class TestAsList:
             assert as_list({"dtype": "i1", "bdata": "ChQe"}) == [10, 20, 30]
 
         assert caplog.text == ""
+
+
+class TestPartialDecodeFailure:
+    """One unreadable statistic shortens a boxplot; it does not crash it.
+
+    The five precomputed arrays decode independently, so a corrupt spec in
+    one of them leaves the others populated. Indexing the short one is what
+    a crash would look like, and a crash here takes the whole figure with it
+    — including every layer that decoded perfectly well.
+    """
+
+    @staticmethod
+    def _trace(**overrides: Any) -> dict:
+        good = {"dtype": "i1", "bdata": "ChQe"}  # 10, 20, 30
+        trace = {
+            "type": "box",
+            "q1": good,
+            "median": good,
+            "q3": good,
+        }
+        trace.update(overrides)
+        return trace
+
+    @pytest.mark.parametrize("field", ["q1", "median", "q3"])
+    def test_an_undecodable_statistic_shortens_the_layer(self, field: str):
+        from maidr.plotly.box import PlotlyBoxPlot
+
+        broken = {"dtype": "i1", "bdata": "!!!not base64!!!"}
+        plot = PlotlyBoxPlot(self._trace(**{field: broken}), {})
+
+        assert plot._extract_plot_data() == []
+
+    def test_a_short_statistic_describes_only_the_complete_boxes(self):
+        from maidr.plotly.box import PlotlyBoxPlot
+
+        # One q1 for three medians: two boxes have no lower quartile.
+        plot = PlotlyBoxPlot(self._trace(q1={"dtype": "i1", "bdata": "Cg=="}), {})
+        boxes = plot._extract_plot_data()
+
+        assert len(boxes) == 1
+        assert boxes[0]["q1"] == 10
+
+    def test_the_shortening_is_reported(self, caplog):
+        from maidr.plotly.box import PlotlyBoxPlot
+
+        plot = PlotlyBoxPlot(self._trace(q1={"dtype": "i1", "bdata": "Cg=="}), {})
+        with caplog.at_level(logging.WARNING, logger="maidr.plotly.box"):
+            plot._extract_plot_data()
+
+        assert "3 medians but only 1" in caplog.text
+
+    def test_a_complete_trace_is_unaffected_and_silent(self, caplog):
+        from maidr.plotly.box import PlotlyBoxPlot
+
+        plot = PlotlyBoxPlot(self._trace(), {})
+        with caplog.at_level(logging.WARNING, logger="maidr.plotly.box"):
+            boxes = plot._extract_plot_data()
+
+        assert len(boxes) == 3
+        assert caplog.text == ""
+
+    def test_the_multi_box_extractor_behaves_the_same(self):
+        from maidr.plotly.multibox import PlotlyMultiBoxPlot
+
+        broken = {"dtype": "i1", "bdata": "!!!not base64!!!"}
+        plot = PlotlyMultiBoxPlot([self._trace(q3=broken)], {})
+
+        assert plot._extract_plot_data() == []

--- a/tests/plotly/test_plotly_typed_arrays.py
+++ b/tests/plotly/test_plotly_typed_arrays.py
@@ -378,3 +378,18 @@ class TestPartialDecodeFailure:
         assert len(boxes) == 1
         assert boxes[0]["z"] == "good"
         assert boxes[0]["q2"] == pytest.approx(3.0)
+
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            "99999999999999999999, 2",
+            "1000000000000000000000000, 1",
+            "-1, -1",
+            "abc, 2",
+        ],
+    )
+    def test_an_impossible_shape_comes_back_empty(self, shape: str):
+        # numpy 2.4 answers an out-of-range extent with a ValueError, but the
+        # project accepts numpy>=1.26 and the except clause names
+        # OverflowError too. Either way nothing escapes to the caller.
+        assert as_list({"dtype": "i1", "bdata": "ChQe", "shape": shape}) == []

--- a/tests/plotly/test_plotly_typed_arrays.py
+++ b/tests/plotly/test_plotly_typed_arrays.py
@@ -1,0 +1,229 @@
+"""Figures built by ``plotly.express`` report their own numbers.
+
+Since plotly 6.x, ``Figure.to_dict()`` exports a numeric array as the
+``{"dtype": ..., "bdata": ...}`` base64 typed-array spec plotly.js consumes,
+and a non-numeric one as a numpy array. ``plotly.express`` produces one or the
+other for every column it plots, so an extractor that iterates a trace array
+literally walks the spec's two keys and emits ``"dtype"`` and ``"bdata"`` as
+the data.
+
+Every figure here is therefore built through ``plotly.express`` from a
+DataFrame. A hand-built ``go.Bar(y=[1, 2, 3])`` passes a plain list and does
+not reproduce any of this, which is what the rest of ``tests/plotly`` uses and
+why it stayed green.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+plotly = pytest.importorskip("plotly")
+pd = pytest.importorskip("pandas")
+
+import plotly.express as px  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+from maidr.plotly.plotly_plot import as_list  # noqa: E402
+from maidr.plotly.step_shape import default_mode  # noqa: E402
+
+FRAME = pd.DataFrame(
+    {
+        "category": ["a", "b", "c"],
+        "value": [10, 20, 30],
+    }
+)
+
+
+def _leaves(value: Any) -> list:
+    """Return every scalar reachable in a nested schema payload."""
+    if isinstance(value, dict):
+        return [leaf for item in value.values() for leaf in _leaves(item)]
+    if isinstance(value, (list, tuple)):
+        return [leaf for item in value for leaf in _leaves(item)]
+    return [value]
+
+
+def _data_of(fig: go.Figure) -> list:
+    """Return the emitted ``data`` payload of every layer the figure produces."""
+    return [plot.schema["data"] for plot in PlotlyMaidr(fig)._plots]
+
+
+def _values_for(key: str, payload: Any) -> list:
+    """Collect one key's values out of a payload, whatever depth they sit at.
+
+    The extractors disagree on how deep their points are nested and on whether
+    they key them by :class:`~maidr.core.enum.maidr_key.MaidrKey` or by its
+    string value, so both are looked through rather than assumed.
+    """
+    if isinstance(payload, dict):
+        found = [
+            value
+            for name, value in payload.items()
+            if getattr(name, "value", name) == key
+        ]
+        return found + [
+            value for item in payload.values() for value in _values_for(key, item)
+        ]
+    if isinstance(payload, (list, tuple)):
+        return [value for item in payload for value in _values_for(key, item)]
+    return []
+
+
+# One case per extractor under `maidr/plotly/`, each built through px so its
+# numeric columns arrive as typed-array specs.
+EXPRESS_FIGURES = {
+    "bar": lambda: px.bar(FRAME, x="category", y="value"),
+    "line": lambda: px.line(FRAME, x="category", y="value"),
+    "scatter": lambda: px.scatter(_wide(), x="x", y="y"),
+    "multiline": lambda: px.line(_wide(), x="x", y="y", color="group"),
+    "grouped_bar": lambda: px.bar(
+        _wide(), x="label", y="y", color="group", barmode="group"
+    ),
+    "step": lambda: px.line(_wide(), x="x", y="y", line_shape="hv"),
+    "histogram": lambda: px.histogram(_wide(), x="y"),
+    "box": lambda: px.box(_wide(), y="y"),
+    "multibox": lambda: px.box(_wide(), x="label", y="y", color="group"),
+    "heatmap": lambda: px.imshow(np.array([[1, 2, 3], [4, 5, 6]])),
+    "pie": lambda: px.pie(FRAME, names="category", values="value"),
+}
+
+
+def _wide() -> Any:
+    """Return a frame wide enough for the binning and grouping extractors."""
+    return pd.DataFrame(
+        {
+            "x": list(range(12)),
+            "y": [float(i) for i in range(12)],
+            "label": list("abcd") * 3,
+            "group": ["p", "q"] * 6,
+        }
+    )
+
+
+@pytest.mark.parametrize("name", sorted(EXPRESS_FIGURES))
+def test_no_extractor_emits_the_typed_array_keys_as_data(name: str):
+    leaves = _leaves(_data_of(EXPRESS_FIGURES[name]()))
+
+    assert leaves, f"{name} emitted nothing to check"
+    assert "dtype" not in leaves
+    assert "bdata" not in leaves
+    assert "shape" not in leaves
+
+
+def test_bar_reports_the_frames_own_magnitudes():
+    assert _values_for("y", _data_of(px.bar(FRAME, x="category", y="value"))) == [
+        10,
+        20,
+        30,
+    ]
+
+
+def test_line_reports_every_point_not_just_the_specs_two_keys():
+    data = _data_of(px.line(FRAME, x="category", y="value"))
+
+    assert _values_for("x", data) == ["a", "b", "c"]
+    assert _values_for("y", data) == [10, 20, 30]
+
+
+def test_scatter_reports_both_axes():
+    data = _data_of(px.scatter(_wide(), x="x", y="y"))
+
+    assert _values_for("x", data) == list(range(12))
+    assert _values_for("y", data) == [float(i) for i in range(12)]
+
+
+def test_heatmap_keeps_its_rows_rather_than_flattening_them():
+    # `z` is the one two-dimensional trace array, so it is the one exported
+    # with a `shape`; losing it would collapse the rows into a flat run.
+    points = _data_of(px.imshow(np.array([[1, 2, 3], [4, 5, 6]])))[0]["points"]
+
+    assert points == [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+
+
+def test_box_computes_its_quartiles_from_the_decoded_samples():
+    stats = _data_of(px.box(_wide(), y="y"))[0][0]
+
+    assert stats["q2"] == pytest.approx(5.5)
+    assert stats["min"] == pytest.approx(0.0)
+    assert stats["max"] == pytest.approx(11.0)
+
+
+def test_histogram_bins_the_samples_rather_than_counting_the_spec_keys():
+    data = _data_of(px.histogram(_wide(), x="y"))[0]
+
+    assert sum(_values_for("y", data)) == 12
+
+
+def test_pie_is_unchanged_by_moving_its_decoder():
+    data = _data_of(px.pie(FRAME, names="category", values="value"))
+
+    # Plotly sorts wedges by value, largest first.
+    assert _values_for("x", data) == ["c", "b", "a"]
+    assert _values_for("y", data) == [30, 20, 10]
+
+
+def test_a_numpy_backed_trace_is_counted_by_its_points_not_its_spec_keys():
+    # `default_mode` resolves the mode plotly applies when the author sets
+    # none, and it decides that on the point count. A spec's own length is 2
+    # whatever it holds, which capped every numpy-backed trace below the
+    # marker threshold and read a 30-point line as "lines+markers".
+    numpy_trace = go.Figure(
+        go.Scatter(x=np.arange(30), y=np.arange(30, dtype=float))
+    ).to_dict()["data"][0]
+    list_trace = go.Figure(
+        go.Scatter(x=list(range(30)), y=[float(i) for i in range(30)])
+    ).to_dict()["data"][0]
+
+    assert "mode" not in numpy_trace
+    assert default_mode(numpy_trace) == default_mode(list_trace) == "lines"
+
+
+class TestAsList:
+    """The decoder leaves everything that already worked alone."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ([1, 2, 3], [1, 2, 3]),
+            ((1, 2, 3), [1, 2, 3]),
+            (["a", "b"], ["a", "b"]),
+            ([], []),
+            (None, []),
+        ],
+    )
+    def test_plain_sequences_and_none_pass_through(self, value: Any, expected: list):
+        assert as_list(value) == expected
+
+    def test_a_string_is_rejected_rather_than_split_into_letters(self):
+        assert as_list("abc") == []
+
+    def test_a_one_dimensional_spec_decodes_to_its_numbers(self):
+        spec = go.Figure(go.Bar(y=np.array([10, 20, 30]))).to_dict()["data"][0]["y"]
+
+        assert isinstance(spec, dict)
+        assert as_list(spec) == [10, 20, 30]
+
+    def test_a_spec_carrying_a_shape_decodes_to_nested_rows(self):
+        spec = go.Figure(go.Heatmap(z=np.array([[1, 2, 3], [4, 5, 6]]))).to_dict()[
+            "data"
+        ][0]["z"]
+
+        assert spec["shape"] == "2, 3"
+        assert as_list(spec) == [[1, 2, 3], [4, 5, 6]]
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            {"dtype": "i1"},
+            {"bdata": "ChQe"},
+            {"dtype": "not-a-dtype", "bdata": "ChQe"},
+            {"dtype": "i1", "bdata": "!!!not base64!!!"},
+            {"dtype": "i1", "bdata": "ChQe", "shape": "5, 5"},
+        ],
+    )
+    def test_an_undecodable_spec_comes_back_empty(self, spec: dict):
+        assert as_list(spec) == []


### PR DESCRIPTION
Closes #325. Refs #326.

## Description

Two follow-ups filed off #322. Both were reproduced before being fixed, and **one of them turned out to be half wrong — see below.**

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description

### #325 — typed arrays, and it is wider than the issue said

Since plotly 6.x, `Figure.to_dict()` exports a numeric column as a base64 typed-array spec rather than a list:

```python
{"dtype": "i1", "bdata": "ChQe"}
```

The issue named bar, line and scatter. Auditing every extractor with `px` figures found **all of them affected except pie**, in three distinct ways:

| Extractor | Baseline symptom |
|---|---|
| bar, line, multiline, scatter, grouped_bar, step | emitted `'dtype'`/`'bdata'` as data, truncated to 2 points |
| box, multibox | **raised** — `TypeError: float() argument must be … not 'dict'` |
| histogram | fell to the categorical path, emitted `[{'x':'dtype','y':1},{'x':'bdata','y':1}]` |
| heatmap | emitted `[['d','t','y','p','e'],['b','d','a','t','a'],['s','h','a','p','e']]` |

The chart draws correctly in every case, so nothing looks wrong — only the accessible layer is, and it is wrong confidently rather than visibly.

Pie's decoder moves to `plotly_plot.as_list` and is called wherever a trace array is read. A spec that will not decode now **logs** and returns empty: silently-empty is better than silently-garbled, but it is still silent, and silence is the fault this decoder exists to fix.

**Two things the issue did not name:**

1. **Heatmap's 2-D spec carries its own extents** (`{'dtype':'i1','bdata':'AQIDBAUG','shape':'2, 3'}`), so the decode reshapes rather than flattening — otherwise `for v in row` would iterate a float.
2. **`_trace_point_count` was silently miscounting.** `len()` of a spec is 2 whatever it holds, so a 30-point numpy-backed scatter counted as 2 and `default_mode` returned `lines+markers` where the same data as a list returned `lines`. That is a plot-type misclassification, not just wrong data. Only reachable via a hand-built `go.Scatter` with no `mode` (px always writes one), which is why nothing caught it.

Also fixed a latent `ValueError: truth value of an array … is ambiguous` in `scatter._get_axis_range`, from px exporting string columns as object ndarrays.

### #326 — the leak is real, the growth claim is not

**I filed #326 and half of it was wrong.** There is no unbounded growth: CPython's `warnings._add_filter` removes an identical entry before inserting, so 1000 identical `filterwarnings("ignore")` calls add one entry, and 500 patched `ax.bar` calls leave exactly one. No code was changed for that half. I've corrected the issue.

The leakage harm is real and reproduced: the filter is process-wide and persistent, so one patched plot call swallowed any `warnings.warn` raised **later, anywhere** — arbitrarily far from the plot. Suppression is now scoped to the wrapped call through a shared `_draw_quietly` helper, which `pieplot` reuses, so its parity with `common` is enforced by construction rather than by a comment.

## Behaviour changes a reviewer should weigh

**1. Render-time warnings are no longer suppressed — deliberately.**

`_extract_plot_data` runs **lazily**, when `.schema` is read at render time, not inside `create_maidr`:

```
after the patched call:  []
after touching .schema:  ['extract']
```

Extraction warnings were previously suppressed not because they sat inside any scope, but because the filter installed during the draw was *still in effect* at render time — which is precisely the leak this PR removes. So a numpy `RuntimeWarning` from a percentile or histogram edge case now reaches the user where it did not before.

That is the point rather than a side effect: the leak's most concrete casualty was MAIDR's own diagnostics — `PiePlot._extract_values`'s "values and wedges have come apart" warning was unhearable for exactly this reason and had to be rerouted through `logging` to be seen at all. Re-suppressing render time to keep numpy quiet would re-break that, and every future diagnostic with it. If extraction warnings prove noisy in practice, the fix belongs at the numpy call sites that raise them, not in re-muting the process.

**2. Nine patch modules lose incidental suppression.**

`boxplot`, `violinplot`, `candlestick`, `heatmap`, `histogram`, `lineplot`, `kdeplot`, `regplot`, `mplfinance` call `wrapped()` directly and were getting suppression only if a `common`-routed call had already run — already order-dependent, so a fresh process whose first plot was `ax.violinplot` was never suppressed. Now consistently off for them. Tracked in #328.

**3. `as_list` rejects a bare string**, returning `[]`. Inherited verbatim from pie's decoder so it is not new for pie, but it now applies everywhere: a trace whose `x` is a bare string previously decomposed into one point per letter and now yields nothing. Not valid plotly input, and the one case where this is not a strict superset of the old behaviour.

## Additional Notes

`uv run pytest -q` → **751 passed** (706 before). `ruff check --output-format=concise` diffed against the pre-edit capture: **identical**, no new findings.

New `tests/plotly/test_plotly_typed_arrays.py` uses `px` figures built from a DataFrame — a hand-built `go.Bar(y=[1,2,3])` passes a plain list and does **not** reproduce this, which is exactly why the existing suite was green. Reverting only the extractors makes **16 of 32 fail**.

`tests/core/test_patch_warning_scope.py` pins the suppression fix on `common`'s path — what every plot type but pie is drawn through. All seven fail against the process-wide filter they replace. The recorder deliberately installs no filter of its own; `simplefilter("always")` would override a leaked "ignore" and the tests would pass either way, which is how the first draft of them did.

Follow-ups filed: #328 (inconsistent suppression across patch modules), #329 (thread safety of the scoped filter).