### PR TITLE
fix(patch): draw every patched plot type through the scoped warning filter

### DIFF
--- a/maidr/patch/boxplot.py
+++ b/maidr/patch/boxplot.py
@@ -6,21 +6,21 @@ from matplotlib.axes import Axes
 from maidr.core.context_manager import BoxplotContextManager, ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import resolve_orientation
+from maidr.patch.common import _draw_quietly, resolve_orientation
 
 
 @wrapt.patch_function_wrapper(Axes, "bxp")
 def mpl_box(wrapped, _, args, kwargs) -> dict:
     # Don't proceed if the call is made internally by the patched function.
     if BoxplotContextManager.is_internal_context():
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
         BoxplotContextManager.add_bxp_context(plot)
         return plot
 
     # Set the internal context to avoid cyclic processing.
     with ContextManager.set_internal_context():
         # Patch `ax.boxplot()` and `ax.bxp()`.
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
 
     # Set the orientation of the boxplot
     orientation = resolve_orientation(wrapped, args, kwargs)
@@ -40,7 +40,7 @@ def sns_box(wrapped, _, args, kwargs) -> Axes:
     # Set the internal context to avoid cyclic processing.
     with BoxplotContextManager.set_internal_context() as bxp_context:
         # Patch `ax.boxplot()` and `ax.bxp()`.
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
         bxp_container = bxp_context
 
     # Set the orientation of the boxplot
@@ -64,7 +64,7 @@ def sns_infer_new_orient(wrapped, instance, args, kwargs) -> str:
         orientation = instance.orient
         BoxplotContextManager.set_bxp_orientation(orientation)
 
-    return wrapped(*args, **kwargs)
+    return _draw_quietly(wrapped, args, kwargs)
 
 
 def patch_seaborn():

--- a/maidr/patch/candlestick.py
+++ b/maidr/patch/candlestick.py
@@ -7,6 +7,7 @@ import numpy as np
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import _draw_quietly
 
 
 def candlestick(
@@ -45,7 +46,7 @@ def candlestick(
     """
     with ContextManager.set_internal_context():
         # Patch the plotting function.
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
 
     original_data = None
     date_nums = None

--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -7,6 +7,7 @@ from matplotlib.image import AxesImage
 
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import _draw_quietly
 
 
 def heat(wrapped, _, args, kwargs) -> Axes | AxesImage:
@@ -19,7 +20,7 @@ def heat(wrapped, _, args, kwargs) -> Axes | AxesImage:
         optional_params["fmt"] = kwargs["fmt"]
 
     # Patch `ax.imshow()` and `seaborn.heatmap`.
-    plot = wrapped(*args, **kwargs)
+    plot = _draw_quietly(wrapped, args, kwargs)
 
     # Extract the heatmap data points for MAIDR from the plots.
     ax = FigureManager.get_axes(plot)

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -12,7 +12,7 @@ import uuid
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import common
+from maidr.patch.common import _draw_quietly, common
 
 
 @wrapt.patch_function_wrapper(Axes, "hist")
@@ -28,12 +28,12 @@ def mpl_hist(
     """
     # Don't proceed if the call is made internally by the patched function.
     if ContextManager.is_internal_context():
-        return wrapped(*args, **kwargs)
+        return _draw_quietly(wrapped, args, kwargs)
 
     # Set the internal context to avoid cyclic processing.
     with ContextManager.set_internal_context():
         # Patch `ax.hist()`.
-        n, bins, plot = wrapped(*args, **kwargs)
+        n, bins, plot = _draw_quietly(wrapped, args, kwargs)
 
     # Extract the histogram data points for MAIDR from the plots.
     ax = FigureManager.get_axes(plot)

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -7,7 +7,7 @@ from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 from matplotlib.collections import PolyCollection
 from maidr.core.enum import PlotType
-from maidr.patch.common import common
+from maidr.patch.common import _draw_quietly, common
 from maidr.core.context_manager import ContextManager
 from maidr.util.svg_utils import unique_lines_by_xy
 
@@ -17,7 +17,7 @@ def kde(wrapped, instance, args, kwargs) -> Axes | Line2D | PolyCollection:
     Patch for seaborn.kdeplot: register all unique lines and/or filled boundaries as SMOOTH.
     """
     with ContextManager.set_internal_context():
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
     ax = plot if isinstance(plot, Axes) else getattr(plot, "axes", None)
     if ax is not None:
         # Register all unique Line2D objects

--- a/maidr/patch/lineplot.py
+++ b/maidr/patch/lineplot.py
@@ -5,7 +5,7 @@ from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 
 from maidr.core.enum import PlotType
-from maidr.patch.common import common
+from maidr.patch.common import _draw_quietly, common
 from maidr.core.context_manager import ContextManager
 from maidr.core.figure_manager import FigureManager
 from maidr.util.step_utils import is_step_axes
@@ -28,12 +28,12 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
     """
     # Don't proceed if the call is made internally by the patched function.
     if ContextManager.is_internal_context():
-        return wrapped(*args, **kwargs)
+        return _draw_quietly(wrapped, args, kwargs)
 
     # Set the internal context to avoid cyclic processing.
     with ContextManager.set_internal_context():
         # Patch the plotting function.
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
 
     # Get the axes from the plot result (works for both matplotlib and seaborn)
     ax = FigureManager.get_axes(plot)

--- a/maidr/patch/mplfinance.py
+++ b/maidr/patch/mplfinance.py
@@ -6,7 +6,7 @@ from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.patches import Rectangle
 from matplotlib.lines import Line2D
 from maidr.core.enum import PlotType
-from maidr.patch.common import common
+from maidr.patch.common import _draw_quietly, common
 from maidr.core.context_manager import ContextManager
 from maidr.util.datetime_conversion import create_datetime_converter
 
@@ -27,7 +27,7 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
     kwargs["returnfig"] = True
 
     with ContextManager.set_internal_context():
-        result = wrapped(*args, **kwargs)
+        result = _draw_quietly(wrapped, args, kwargs)
 
     # Validate that we received the expected figure and axes tuple
     if not (isinstance(result, tuple) and len(result) >= 2):

--- a/maidr/patch/regplot.py
+++ b/maidr/patch/regplot.py
@@ -4,7 +4,7 @@ import wrapt
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 from maidr.core.enum import PlotType
-from maidr.patch.common import common
+from maidr.patch.common import _draw_quietly, common
 from maidr.core.context_manager import ContextManager
 import uuid
 from maidr.core.enum.smooth_keywords import SMOOTH_KEYWORDS
@@ -21,7 +21,7 @@ def regplot(wrapped, instance, args, kwargs) -> Axes:
     else:
         # Prevent any MAIDR layer registration during plotting when scatter=False
         with ContextManager.set_internal_context():
-            ax = wrapped(*args, **kwargs)
+            ax = _draw_quietly(wrapped, args, kwargs)
 
     axes = ax if isinstance(ax, Axes) else ax.axes if hasattr(ax, "axes") else None
     if axes is not None:
@@ -58,7 +58,7 @@ def patched_plot(wrapped, instance, args, kwargs):
     Patch matplotlib Axes.plot to register SMOOTH layers for MAIDR if the label matches SMOOTH_KEYWORDS.
     """
     # Call the original plot function
-    lines = wrapped(*args, **kwargs)
+    lines = _draw_quietly(wrapped, args, kwargs)
 
     # Check each line for smooth keywords and register if found
     for line in lines:

--- a/maidr/patch/violinplot.py
+++ b/maidr/patch/violinplot.py
@@ -23,7 +23,7 @@ from maidr.core.enum import PlotType
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.violinplot import ViolinDataExtractor
-from maidr.patch.common import resolve_orientation
+from maidr.patch.common import _draw_quietly, resolve_orientation
 from maidr.util.mixin.extractor_mixin import LevelExtractorMixin
 
 
@@ -36,7 +36,7 @@ def patch_violinplot(
 ) -> Any:
     """Intercept ``seaborn.violinplot`` and register box + KDE layers."""
     if ContextManager.is_internal_context():
-        return wrapped(*args, **kwargs)
+        return _draw_quietly(wrapped, args, kwargs)
 
     # Snapshot existing Line2D objects so we can detect new ones later.
     pre_ax = kwargs.get("ax", None)
@@ -45,7 +45,7 @@ def patch_violinplot(
     )
 
     with ContextManager.set_internal_context():
-        ax = wrapped(*args, **kwargs)
+        ax = _draw_quietly(wrapped, args, kwargs)
 
     plot_ax = kwargs.get("ax", ax) or ax
 
@@ -80,10 +80,10 @@ def patch_violinplot(
 def mpl_violinplot(wrapped: Callable, instance: Axes, args: tuple, kwargs: dict) -> Any:
     """Intercept ``Axes.violinplot`` and register box + KDE layers."""
     if ContextManager.is_internal_context():
-        return wrapped(*args, **kwargs)
+        return _draw_quietly(wrapped, args, kwargs)
 
     with ContextManager.set_internal_context():
-        plot = wrapped(*args, **kwargs)
+        plot = _draw_quietly(wrapped, args, kwargs)
 
     plot_ax: Axes = instance
     orientation = resolve_orientation(wrapped, args, kwargs)

--- a/tests/core/test_patch_warning_scope.py
+++ b/tests/core/test_patch_warning_scope.py
@@ -8,28 +8,25 @@ muted every ``warnings.warn`` raised afterwards — anywhere, arbitrarily far
 from any figure, including MAIDR's own diagnostics, which are raised while the
 schema is built rather than while the figure is drawn.
 
-``common`` is where most plot types are drawn, so it is pinned here rather
-than only through pie, which has its own patch.
+Scoping it to the call exposed the other half of the same problem: only
+``common`` and the pie patch went through the helper, and the nine modules
+that called ``wrapped()`` directly had been inheriting the process-wide filter
+by accident — so whether a violin plot was quiet depended on whether a bar
+chart had been drawn first. Those modules now draw through the helper too, and
+the parametrisation below therefore covers one draw per patch module rather
+than only the ``common``-routed ones.
 
-How each kind below reaches the helper is worth stating, because it is not
-uniform and the parametrisation would otherwise read as claiming more than
-it pins:
+Two properties are pinned for every kind:
 
-* ``bar``, ``barh`` and ``scatter`` are drawn through ``common`` directly —
-  these are the cases where the fix does its work.
-* ``hist`` is not routed through ``common`` by its own patch, but
-  ``Axes.hist`` draws its bars with the patched ``Axes.bar``, so the helper
-  wraps that internal draw.
-* ``plot`` reaches ``common`` with a *no-op lambda* — ``lineplot.line``
-  calls ``wrapped()`` itself first — so the helper suppresses nothing for
-  it. Its own draw is unsuppressed both before and after this change.
+* a warning raised *during* the draw does not reach the caller — the
+  suppression the helper exists for, and what #328 changed;
+* a warning raised *after* it still does — the leak the scoping fixed.
 
-All five nevertheless pin the property under test, which is that nothing is
-left installed afterwards: under the filter this replaced, ``common``
-installed one unconditionally, no-op lambda included. Each fails in
-isolation against that code, so none of them depends on another having run
-first. What ``plot`` does *not* demonstrate is its own draw being scoped;
-that it never was is tracked in #328.
+The during-the-draw warning is raised from temporarily wrapped
+``Axes.add_line``/``add_patch``/``add_collection``/``add_image``. Every one of
+these draws passes through one of them, so the same injection works for all
+kinds, and it does not depend on any particular library version choosing to
+warn about the data it was handed.
 """
 
 from __future__ import annotations
@@ -38,12 +35,60 @@ import matplotlib
 
 matplotlib.use("Agg")
 
+import contextlib  # noqa: E402
 import warnings  # noqa: E402
+from typing import Iterator  # noqa: E402
 
 import matplotlib.pyplot as plt  # noqa: E402
+import mplfinance as mpf  # noqa: E402
+import pandas as pd  # noqa: E402
 import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+from matplotlib.axes import Axes  # noqa: E402
+from mplfinance.original_flavor import candlestick_ohlc  # noqa: E402
 
 import maidr  # noqa: E402, F401  # imported for its side effect: activates the patches
+
+DURING_THE_DRAW = "raised while the figure was being drawn"
+
+# One kind per patch module, so a module left calling `wrapped()` directly
+# fails on its own row rather than hiding behind another module's coverage.
+KINDS = [
+    "bar",  # common
+    "barh",  # common
+    "scatter",  # common
+    "plot",  # lineplot
+    "hist",  # histogram
+    "hist_step",  # histogram
+    "pie",  # pieplot
+    "imshow",  # heatmap
+    "boxplot",  # boxplot
+    "violinplot",  # violinplot
+    "candlestick",  # candlestick
+    "mplfinance",  # mplfinance
+    "sns_boxplot",  # boxplot
+    "sns_violinplot",  # violinplot
+    "sns_heatmap",  # heatmap
+    "sns_histplot",  # histogram
+    "sns_kdeplot",  # kdeplot
+    "sns_lineplot",  # lineplot
+    "sns_regplot",  # regplot
+    "sns_regplot_line_only",  # regplot
+]
+
+
+def _ohlc_frame() -> pd.DataFrame:
+    """Build the smallest frame ``mplfinance.plot`` accepts."""
+    return pd.DataFrame(
+        {
+            "Open": [1.0, 2.0, 3.0],
+            "High": [3.0, 4.0, 5.0],
+            "Low": [0.5, 1.5, 2.5],
+            "Close": [2.0, 3.0, 4.0],
+            "Volume": [10, 20, 30],
+        },
+        index=pd.date_range("2024-01-01", periods=3),
+    )
 
 
 def _draw(kind: str, ax) -> None:
@@ -52,19 +97,117 @@ def _draw(kind: str, ax) -> None:
         ax.bar(["a", "b"], [1, 2])
     elif kind == "barh":
         ax.barh(["a", "b"], [1, 2])
-    elif kind == "plot":
-        ax.plot([1, 2, 3], [4, 5, 6])
     elif kind == "scatter":
         ax.scatter([1, 2, 3], [4, 5, 6])
+    elif kind == "plot":
+        ax.plot([1, 2, 3], [4, 5, 6])
     elif kind == "hist":
         ax.hist([1, 1, 2, 3, 3, 3])
+    elif kind == "hist_step":
+        # A stepped histogram is outlined rather than filled with the patched
+        # `Axes.bar`, so nothing else suppresses `Axes.hist` for it.
+        ax.hist([1, 1, 2, 3, 3, 3], histtype="step")
+    elif kind == "pie":
+        ax.pie([30, 50, 20])
+    elif kind == "imshow":
+        ax.imshow([[1, 2], [3, 4]])
+    elif kind == "boxplot":
+        ax.boxplot([[1, 2, 3, 4, 5]])
+    elif kind == "violinplot":
+        ax.violinplot([[1, 2, 3, 4, 5]])
+    elif kind == "candlestick":
+        candlestick_ohlc(ax, [(1.0, 1.0, 3.0, 0.5, 2.0), (2.0, 2.0, 4.0, 1.5, 3.0)])
+    elif kind == "mplfinance":
+        # `mpf.plot` lays out its own figure, so `ax` is unused for this kind
+        # and the test closes every figure rather than only the one it made.
+        mpf.plot(_ohlc_frame(), type="candle", volume=True)
+    elif kind == "sns_boxplot":
+        sns.boxplot(x=[1, 2, 3, 4, 5], ax=ax)
+    elif kind == "sns_violinplot":
+        sns.violinplot(x=[1, 2, 3, 4, 5], ax=ax)
+    elif kind == "sns_heatmap":
+        sns.heatmap([[1.0, 2.0], [3.0, 4.0]], ax=ax)
+    elif kind == "sns_histplot":
+        sns.histplot(x=[1, 1, 2, 3, 3, 3], ax=ax)
+    elif kind == "sns_kdeplot":
+        sns.kdeplot(x=[1.0, 2.0, 3.0, 4.0, 5.0], ax=ax)
+    elif kind == "sns_lineplot":
+        sns.lineplot(x=[1, 2, 3], y=[4, 5, 6], ax=ax)
+    elif kind == "sns_regplot":
+        sns.regplot(x=[1.0, 2.0, 3.0, 4.0], y=[1.0, 3.0, 2.0, 5.0], ax=ax)
+    elif kind == "sns_regplot_line_only":
+        # `scatter=False` is the branch that draws without going through
+        # `common`, so it is the one the regplot patch had to route itself.
+        sns.regplot(
+            x=[1.0, 2.0, 3.0, 4.0], y=[1.0, 3.0, 2.0, 5.0], scatter=False, ax=ax
+        )
     else:  # pragma: no cover - guards a typo in the parametrisation
         raise AssertionError(f"unknown plot kind: {kind}")
 
 
-@pytest.mark.parametrize("kind", ["bar", "barh", "plot", "scatter", "hist"])
+@contextlib.contextmanager
+def _warning_from_inside_the_draw() -> Iterator[None]:
+    """
+    Make the first artist any draw adds raise one warning.
+
+    Adding an artist happens inside the plotting call the patch wrapped, which
+    is the only place `_draw_quietly` can scope anything, and every kind above
+    reaches one of these four methods. Warning from here therefore stands in
+    for whatever matplotlib itself would have warned about, without depending
+    on a particular version choosing to warn.
+    """
+    adders = ("add_line", "add_patch", "add_collection", "add_image")
+    # These are defined on a base of `Axes`, so patch and restore them where
+    # they live rather than shadowing them on `Axes` itself.
+    owners = {
+        name: next(cls for cls in Axes.__mro__ if name in cls.__dict__)
+        for name in adders
+    }
+    originals = {name: owners[name].__dict__[name] for name in adders}
+    fired = False
+
+    def _noisy(original):
+        def add(self, *args, **kwargs):
+            nonlocal fired
+            if not fired:
+                fired = True
+                warnings.warn(DURING_THE_DRAW, UserWarning)
+            return original(self, *args, **kwargs)
+
+        return add
+
+    for name, original in originals.items():
+        setattr(owners[name], name, _noisy(original))
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            setattr(owners[name], name, original)
+
+    assert fired, "no artist was added, so nothing warned during the draw"
+
+
+@pytest.mark.parametrize("kind", KINDS)
+def test_a_warning_raised_during_the_plot_does_not_reach_the_caller(kind):
+    _, ax = plt.subplots()
+    try:
+        # "always" here so the recorder cannot silently drop a repeat of a
+        # warning an earlier parametrisation already reported from the same
+        # line. It does not mask what is under test: `_draw_quietly` installs
+        # its "ignore" *inside* this scope, and an inner filter wins.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with _warning_from_inside_the_draw():
+                _draw(kind, ax)
+
+        assert DURING_THE_DRAW not in [str(w.message) for w in caught]
+    finally:
+        plt.close("all")
+
+
+@pytest.mark.parametrize("kind", KINDS)
 def test_a_warning_raised_after_the_plot_still_reaches_the_caller(kind):
-    fig, ax = plt.subplots()
+    _, ax = plt.subplots()
     try:
         _draw(kind, ax)
 
@@ -76,7 +219,7 @@ def test_a_warning_raised_after_the_plot_still_reaches_the_caller(kind):
 
         assert [str(w.message) for w in caught] == [f"heard after the {kind}"]
     finally:
-        plt.close(fig)
+        plt.close("all")
 
 
 def test_the_plot_call_leaves_the_filter_list_as_it_found_it():

--- a/tests/core/test_patch_warning_scope.py
+++ b/tests/core/test_patch_warning_scope.py
@@ -67,6 +67,7 @@ KINDS = [
     "candlestick",  # candlestick
     "mplfinance",  # mplfinance
     "sns_boxplot",  # boxplot
+    "sns_catplot_box",  # boxplot
     "sns_violinplot",  # violinplot
     "sns_heatmap",  # heatmap
     "sns_histplot",  # histogram
@@ -123,6 +124,16 @@ def _draw(kind: str, ax) -> None:
         mpf.plot(_ohlc_frame(), type="candle", volume=True)
     elif kind == "sns_boxplot":
         sns.boxplot(x=[1, 2, 3, 4, 5], ax=ax)
+    elif kind == "sns_catplot_box":
+        # Reaches `_CategoricalPlotter.plot_boxes` without going through
+        # `seaborn.boxplot`, which is the only path for which wrapping
+        # `plot_boxes` buys anything. This row does not on its own prove that
+        # wrap works -- the injected warning lands inside `Axes.bxp`, which is
+        # suppressed in its own right, so it passes either way. It covers the
+        # path; `test_catplot_suppresses_what_plot_boxes_raises_around_the_draw`
+        # covers the wrap. Like `mpf.plot`, it lays out its own figure, so
+        # `ax` is unused.
+        sns.catplot(x=[1, 2, 3, 4, 5], kind="box")
     elif kind == "sns_violinplot":
         sns.violinplot(x=[1, 2, 3, 4, 5], ax=ax)
     elif kind == "sns_heatmap":
@@ -219,6 +230,43 @@ def test_a_warning_raised_after_the_plot_still_reaches_the_caller(kind):
 
         assert [str(w.message) for w in caught] == [f"heard after the {kind}"]
     finally:
+        plt.close("all")
+
+
+def test_catplot_suppresses_what_plot_boxes_raises_around_the_draw():
+    """
+    The one path for which wrapping ``_CategoricalPlotter.plot_boxes`` buys
+    anything, and it needs its own injection point.
+
+    Reached through ``seaborn.boxplot`` the wrap is a no-op — ``plot_boxes``
+    is already nested inside a suppressed call. ``seaborn.catplot`` reaches it
+    without going through ``seaborn.boxplot``, so that is the path under test.
+
+    ``_warning_from_inside_the_draw`` cannot see the difference: the first
+    artist a box draw adds is added *inside* ``Axes.bxp``, which is patched
+    and suppressed in its own right, so the warning never reaches the region
+    the ``plot_boxes`` wrap covers and the assertion holds either way. What
+    the wrap covers is what ``plot_boxes`` itself raises around its call to
+    ``bxp`` — so the warning is raised from a wrapper installed *over*
+    maidr's ``Axes.bxp``, which runs inside ``plot_boxes`` and outside the
+    suppression ``bxp`` installs for itself.
+    """
+    raised = 'raised by plot_boxes, outside the bxp it calls'
+    outer = Axes.bxp
+
+    def noisy_bxp(self, *args, **kwargs):
+        warnings.warn(raised, UserWarning)
+        return outer(self, *args, **kwargs)
+
+    Axes.bxp = noisy_bxp
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            sns.catplot(x=[1, 2, 3, 4, 5], kind="box")
+
+        assert raised not in [str(w.message) for w in caught]
+    finally:
+        Axes.bxp = outer
         plt.close("all")
 
 


### PR DESCRIPTION
Closes #328.

## Description

Only `common` and the pie patch drew through `_draw_quietly`. Nine modules called `wrapped()` directly and had been inheriting the old process-wide filter **by accident** — so whether a violin plot was quiet depended on whether a bar chart had been drawn first in that process. #327 scoped the filter to its call, which removed the accident and left those nine consistently unsuppressed instead.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description

See above.

## Related Issues

Closes #328. Follows #327, which introduced `_draw_quietly` and disclosed this gap.

## Changes Made

**Reproduced before fixing.** A warning was injected into the draw itself via a data object that warns when numpy converts it. On unmodified `main`, `ax.bar`/`ax.hist`/`ax.pie` were silent (routed through `common`) while all of these leaked:

`ax.plot`, `ax.imshow`, `ax.boxplot`, `ax.violinplot`, `sns.boxplot`, `sns.violinplot`, `sns.kdeplot`, `sns.lineplot`, `candlestick_ohlc`, `mpf.plot`

`sns.boxplot` additionally leaked a real matplotlib 3.10 `PendingDeprecationWarning` ("vert: bool will be deprecated…"), which is now suppressed.

**18 call sites** across the nine modules — several have two, the internal-context early return as well as the main draw:

```
4  boxplot.py     1  candlestick.py   1  heatmap.py
2  histogram.py   1  kdeplot.py       2  lineplot.py
1  mplfinance.py  2  regplot.py       4  violinplot.py
```

Return values and `FigureManager` registration are untouched; only which call is wrapped changed.

Two sites are judgement calls, both wrapped:

- `boxplot.sns_infer_new_orient` wraps seaborn's `_CategoricalPlotter.plot_boxes`. Reached via `seaborn.boxplot` it is already nested inside a suppressed call, so wrapping is a no-op there — but `seaborn.catplot(kind="box")` reaches `plot_boxes` without going through `seaborn.boxplot`, so it genuinely adds suppression for that path. Confirmed by spying on both: a catplot records `plot_boxes` and never `seaborn.boxplot`.
- `regplot.patched_plot` wraps `Axes.plot`, which `lineplot.line` also wraps. Nesting two suppressions is harmless.

`lineplot`'s no-op lambda handed to `common()` was deliberately left alone — the real draw is the direct call above it, and that is what got wrapped.

No module needed to stay unsuppressed; nothing in these nine depends on a warning propagating out of the draw.

## Screenshots (if applicable)

n/a

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest -q` → **805 passed** (baseline 767). `ruff check` → 52, identical to `main`; `ruff check --diff` on the touched paths produced no output.

`tests/core/test_patch_warning_scope.py` grew from 5 kinds to **21**, one or more per patch module, so a module left calling `wrapped()` directly fails on its own row rather than hiding behind another's coverage. There are two parametrised tests: the during-the-draw suppression (what changed here) and the after-the-draw leak guard (what #327 fixed), run for every kind.

The during-the-draw warning is injected by temporarily wrapping `Axes.add_line`/`add_patch`/`add_collection`/`add_image`, so the injection point is strictly inside the wrapped call for every kind and does not depend on a library version choosing to warn about its input. The helper asserts it actually fired, so a kind that stops drawing cannot pass vacuously.

**Verified the tests bite:** with `maidr/` stashed, **13 of the during-the-draw rows fail**, and those 13 cover all nine modules — plot and sns_lineplot (lineplot), hist_step (histogram), imshow and sns_heatmap (heatmap), boxplot and sns_boxplot (boxplot), violinplot and sns_violinplot (violinplot), candlestick, mplfinance, sns_kdeplot (kdeplot), sns_regplot_line_only (regplot).

`hist` and plain `sns_regplot` pass both before and after — those paths were already suppressed through `common`. They are kept as regression guards, with `hist_step` and `sns_regplot_line_only` added alongside because those are the branches the histogram and regplot patches actually had to route themselves.

**The `plot_boxes` wrap needed its own test, and the obvious one is vacuous.** A `sns_catplot_box` row passes with the wrap reverted: the shared injection fires on the first artist added, and for a box draw that is inside `Axes.bxp` — patched and suppressed in its own right — so the warning never reaches the region this wrap covers. What it does cover is what `plot_boxes` raises *around* its call to `bxp`, so `test_catplot_suppresses_what_plot_boxes_raises_around_the_draw` raises from a wrapper installed over maidr's `Axes.bxp`: inside `plot_boxes`, outside `bxp`'s own suppression. That one fails with the wrap reverted. The `sns_catplot_box` row is kept for path coverage, with a comment recording that it does not prove the wrap.

**Worth knowing:** `ax.boxplot` computes its statistics in `Axes.boxplot` and only then calls `Axes.bxp`, which is what maidr patches. Warnings from that statistics pass are outside the patched call and were never suppressible; this does not change that.

This widens the number of call sites subject to the `catch_warnings` thread-safety caveat tracked in #329 — not a regression, since those sites were previously covered by a never-restored process-wide filter, but the window now exists in nine more places.