### PR TITLE
fix(patch): serialise the warning suppression so concurrent draws cannot leak it

### DIFF
--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import threading
 import warnings
 from typing import Any, Callable
 
@@ -9,6 +10,12 @@ from matplotlib.axes import Axes
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+
+# Serialises the warning-filter save/restore in `_draw_quietly`; see its
+# docstring for why interleaving those corrupts the global filter list.
+# Reentrant because patches nest: `regplot.patched_plot` wraps `Axes.plot`,
+# which `lineplot.line` wraps as well, so one draw can enter twice.
+_FILTER_LOCK = threading.RLock()
 
 
 def _argument(name: str, wrapped: Callable, args: tuple, kwargs: dict) -> Any:
@@ -112,13 +119,32 @@ def _draw_quietly(wrapped: Callable, args: tuple, kwargs: dict) -> Any:
     MAIDR's own diagnostics, which are raised while the schema is built and
     not while the figure is drawn.
 
-    ``catch_warnings`` saves and restores the *global* filter list, so it is
-    not thread safe: two threads drawing at once can restore each other's
-    state, and one may briefly miss a warning the other suppressed. The
-    process-wide filter this replaced shared that flaw and never restored at
-    all, so this is not a regression -- but the window is now per call rather
-    than permanent, which is what makes it reachable in a threaded server.
-    Python 3.14's context-aware filters would close it.
+    ``catch_warnings`` saves and restores the *global* filter list, which two
+    threads drawing at once will corrupt outright rather than merely race on.
+    Interleave one pair of calls and the restores nest wrongly::
+
+        A enters, saving S0          filters = ignore + S0
+        B enters, saving S1          S1 already contains A's ignore
+        A exits,  restoring S0       filters = S0        (correct, for now)
+        B exits,  restoring S1       filters = ignore + S0
+
+    B puts back a snapshot it took while A was suppressing, so a process-wide
+    ``ignore`` survives every draw -- exactly the leak this helper was written
+    to remove, reintroduced under concurrency and permanently. Measured: eight
+    threads drawing sixty times each leave one ``('ignore', None, Warning,
+    None, 0)`` behind.
+
+    Serialising the draw is what prevents it, since the save and restore have
+    to pair up. The cost is real but narrow: drawing is already effectively
+    single-threaded for the caller that motivated this (Shiny renders on one
+    asyncio loop), and matplotlib's own guidance is that a figure belongs to
+    one thread anyway. Python 3.14's context-aware filters would remove the
+    need for the lock.
+
+    What the lock does *not* fix is that a draw's ``ignore`` is global while
+    it is held, so another thread warning at that moment is still silenced.
+    That one is transient -- it ends with the draw -- rather than surviving
+    it, and closing it would mean not touching the global filters at all.
 
     Parameters
     ----------
@@ -134,7 +160,7 @@ def _draw_quietly(wrapped: Callable, args: tuple, kwargs: dict) -> Any:
     Any
         Whatever the wrapped function returned.
     """
-    with warnings.catch_warnings():
+    with _FILTER_LOCK, warnings.catch_warnings():
         warnings.simplefilter("ignore")
         return wrapped(*args, **kwargs)
 

--- a/tests/core/test_patch_warning_threads.py
+++ b/tests/core/test_patch_warning_threads.py
@@ -1,0 +1,140 @@
+"""Concurrent draws must not leave a filter behind.
+
+``_draw_quietly`` suppresses matplotlib's warnings with
+``warnings.catch_warnings()``, which saves the *global* filter list on entry
+and restores it on exit. Two threads drawing at once do not merely race on
+that list -- they corrupt it, because the restores nest wrongly::
+
+    A enters, saving S0          filters = ignore + S0
+    B enters, saving S1          S1 already contains A's ignore
+    A exits,  restoring S0       filters = S0
+    B exits,  restoring S1       filters = ignore + S0
+
+B puts back a snapshot it took while A was suppressing, so a process-wide
+``ignore`` outlives every draw -- which is precisely the leak #327 removed,
+reintroduced under concurrency and this time permanently.
+
+Serialising the suppression is what makes the save and restore pair up, and
+that is what these tests pin. They are about the *filter list*, not about
+drawing: the work under the lock is a plain sleep rather than a plot, so the
+failure is attributable to the suppression rather than to matplotlib's own
+thread-safety, and the test does not depend on concurrent plotting working.
+"""
+
+from __future__ import annotations
+
+import copy
+import threading
+import time
+import warnings
+
+import pytest
+
+from maidr.patch.common import _draw_quietly
+
+THREADS = 8
+DRAWS = 40
+
+
+def _slow_draw() -> str:
+    """Stand in for a plotting call long enough for the calls to overlap."""
+    time.sleep(0.002)
+    return "drawn"
+
+
+def _draw_repeatedly() -> None:
+    for _ in range(DRAWS):
+        _draw_quietly(_slow_draw, (), {})
+
+
+def _run_concurrently(target) -> None:
+    threads = [threading.Thread(target=target) for _ in range(THREADS)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+
+def test_concurrent_draws_leave_the_filter_list_as_they_found_it():
+    # Without the lock this leaves one ('ignore', None, Warning, None, 0)
+    # behind at position 0 -- a process-wide "swallow everything" that no
+    # later draw removes.
+    before = copy.copy(warnings.filters)
+
+    _run_concurrently(_draw_repeatedly)
+
+    assert warnings.filters == before
+
+
+def test_a_warning_after_concurrent_draws_still_reaches_the_caller():
+    # The consequence of the leak, stated the way a user meets it: a warning
+    # raised long after every draw has finished, and nowhere near a figure.
+    # No `simplefilter` here -- the recorder must inherit whatever the draws
+    # left installed, which is the whole point.
+    _run_concurrently(_draw_repeatedly)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.warn("heard after the threads", UserWarning)
+
+    assert [str(w.message) for w in caught] == ["heard after the threads"]
+
+
+def test_the_suppression_still_works_under_concurrency():
+    # Serialising must not cost the property the helper exists for.
+    heard: list[str] = []
+
+    def draw_and_warn() -> None:
+        for _ in range(DRAWS):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                _draw_quietly(_warn_then_draw, (), {})
+            heard.extend(str(w.message) for w in caught)
+
+    def _warn_then_draw() -> str:
+        warnings.warn("from inside the draw", UserWarning)
+        return _slow_draw()
+
+    _run_concurrently(draw_and_warn)
+
+    assert heard == []
+
+
+def test_a_nested_draw_does_not_deadlock():
+    # `regplot.patched_plot` wraps `Axes.plot`, which `lineplot.line` wraps
+    # too, so one draw enters the helper twice on the same thread. A plain
+    # Lock would deadlock here; the RLock is why it does not.
+    def outer() -> str:
+        return _draw_quietly(lambda: "inner", (), {})
+
+    finished = []
+
+    def run() -> None:
+        finished.append(_draw_quietly(outer, (), {}))
+
+    thread = threading.Thread(target=run)
+    thread.start()
+    thread.join(timeout=10)
+
+    assert not thread.is_alive(), "nested _draw_quietly deadlocked"
+    assert finished == ["inner"]
+
+
+@pytest.mark.parametrize("threads", [2, THREADS])
+def test_the_return_value_survives_concurrency(threads: int):
+    # Serialising changes when a draw runs, never what it returns.
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def collect() -> None:
+        for _ in range(DRAWS):
+            value = _draw_quietly(_slow_draw, (), {})
+            with lock:
+                results.append(value)
+
+    workers = [threading.Thread(target=collect) for _ in range(threads)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert results == ["drawn"] * (threads * DRAWS)

--- a/tests/core/test_patch_warning_threads.py
+++ b/tests/core/test_patch_warning_threads.py
@@ -55,6 +55,23 @@ def _run_concurrently(target) -> None:
         thread.join()
 
 
+@pytest.fixture(autouse=True)
+def _restore_filters():
+    """
+    Put the filter list back however the test ended.
+
+    The failure this file guards against *is* a corrupted global filter list,
+    so a failing run here would otherwise hand every later test a leaked
+    ``ignore`` -- turning one legible failure into a cascade of unrelated
+    ones somewhere else entirely.
+    """
+    saved = copy.copy(warnings.filters)
+    try:
+        yield
+    finally:
+        warnings.filters[:] = saved
+
+
 def test_concurrent_draws_leave_the_filter_list_as_they_found_it():
     # Without the lock this leaves one ('ignore', None, Warning, None, 0)
     # behind at position 0 -- a process-wide "swallow everything" that no
@@ -79,24 +96,35 @@ def test_a_warning_after_concurrent_draws_still_reaches_the_caller():
     assert [str(w.message) for w in caught] == ["heard after the threads"]
 
 
-def test_the_suppression_still_works_under_concurrency():
-    # Serialising must not cost the property the helper exists for.
-    heard: list[str] = []
+def test_every_concurrent_draw_sees_its_own_suppression():
+    """
+    Serialising must not cost the property the helper exists for.
 
-    def draw_and_warn() -> None:
+    Asserted by *reading* the filter list from inside each draw rather than by
+    recording warnings around it. A recorder would need its own
+    ``catch_warnings``, and that reassigns the same module-global the code
+    under test is manipulating -- unsynchronised, on every thread, outside the
+    lock. It would reproduce this PR's own bug one layer up, in the test
+    harness: intermittently failing, and passing for the wrong reason when it
+    did pass. Reading races with nothing.
+    """
+    suppressed: list[bool] = []
+
+    def inspect() -> str:
+        # `simplefilter("ignore")` prepends ('ignore', None, Warning, None, 0),
+        # so the head of the list is this draw's own suppression.
+        suppressed.append(bool(warnings.filters) and warnings.filters[0][0] == "ignore")
+        time.sleep(0.002)
+        return "drawn"
+
+    def run() -> None:
         for _ in range(DRAWS):
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                _draw_quietly(_warn_then_draw, (), {})
-            heard.extend(str(w.message) for w in caught)
+            _draw_quietly(inspect, (), {})
 
-    def _warn_then_draw() -> str:
-        warnings.warn("from inside the draw", UserWarning)
-        return _slow_draw()
+    _run_concurrently(run)
 
-    _run_concurrently(draw_and_warn)
-
-    assert heard == []
+    assert len(suppressed) == THREADS * DRAWS
+    assert all(suppressed)
 
 
 def test_a_nested_draw_does_not_deadlock():


### PR DESCRIPTION
Closes #329.

## Description

**I filed #329 describing this as a narrow race. Measuring it first showed the description was wrong — it is neither narrow nor transient.**

`catch_warnings` saves the global filter list on entry and restores it on exit. Two threads drawing at once do not merely race on that list; they corrupt it, because the restores nest wrongly:

```
A enters, saving S0          filters = ignore + S0
B enters, saving S1          S1 already contains A's ignore
A exits,  restoring S0       filters = S0            (correct, for now)
B exits,  restoring S1       filters = ignore + S0
```

B puts back a snapshot it took while A was suppressing, so a process-wide `ignore` outlives every draw — **the exact leak #327 removed, reintroduced under concurrency and this time permanently.**

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Related Issues

Closes #329. Follows #327 (which scoped the filter) and #330 (which routed every patch module through the helper).

## Changes Made

**Reproduced before fixing.** Eight threads, sixty draws each, against `main`:

```
filters restored to baseline: False
baseline len: 13   after len: 14
  baseline[0]: ('default', None, DeprecationWarning, re.compile('mplfinance'), 0)
  after[0]   : ('ignore', None, Warning, None, 0)
```

A `('ignore', None, Warning, None, 0)` survives at position 0 and no later draw removes it. Separately, a thread warning during a draw loses its warning **200 times out of 200** — while any draw is in flight the suppression is total, not occasional.

So #329's own wording — a thread "may briefly miss a warning" — understated both halves. The transient half is the *lesser* problem; the leak is the one that matters, because it is permanent and it is what #327 existed to remove.

**The fix** is an `RLock` around the suppression, so the save and restore pair up.

**Reentrant, deliberately:** `regplot.patched_plot` wraps `Axes.plot`, which `lineplot.line` wraps too, so one draw enters the helper twice on the same thread. A plain `Lock` deadlocks there — one of the new tests pins it.

**The cost, stated plainly:** concurrent draws serialise. That is narrow rather than free — Shiny renders on one asyncio loop, so the caller that motivated the ticket sees no contention, and matplotlib's own guidance is that a figure belongs to one thread. It is a real cost for someone drawing separate `Figure` objects on several threads, which is the matplotlib-supported threading pattern.

**What the lock does not fix**, recorded in the docstring rather than left for someone to rediscover: the `ignore` is global while held, so another thread warning at that instant is still silenced. That one ends with the draw rather than surviving it. Closing it would mean not touching the global filters at all — the `showwarning`-dispatch idea from option 4 in the issue — which changes what `catch_warnings(record=True)` callers observe and would need the existing suppression tests' premise revisited. Not folded in here.

Python 3.14's context-aware filters remove the need for the lock entirely; this is the fix for 3.9–3.13.

## Screenshots (if applicable)

n/a

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest -q` → **811 passed** (was 805). `ruff check` → 52, identical to `main`.

`tests/core/test_patch_warning_threads.py` adds six cases. They are about the *filter list*, not about drawing: the work under the lock is a plain `sleep` rather than a plot, so a failure is attributable to the suppression rather than to matplotlib's own thread-safety, and the suite does not depend on concurrent plotting being supported.

**Verified they bite.** With the lock reverted:

```
FAILED test_concurrent_draws_leave_the_filter_list_as_they_found_it
FAILED test_a_warning_after_concurrent_draws_still_reaches_the_caller
2 failed, 4 passed
```

The other four pass either way, and are guards rather than reproductions — that the suppression still works under concurrency, that a nested draw does not deadlock, and that return values are unchanged at two thread counts. Saying so rather than implying all six reproduce the bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_