### PR TITLE
feat(deps): warn that the placeholder maidr.css accessors are going

### DIFF
--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -582,7 +582,7 @@ def maidr_js_cdn_url() -> str:
     return cdn_url(MAIDR_JS_FILENAME)
 
 
-def _warn_placeholder_css(name: str) -> None:
+def _warn_placeholder_css(name: str, instead: str) -> None:
     """
     Announce that a ``maidr.css`` accessor is going away.
 
@@ -604,14 +604,19 @@ def _warn_placeholder_css(name: str) -> None:
     name : str
         The function being called, so the message names the caller's own
         call rather than this helper.
+    instead : str
+        What to call in its place, in the same form the caller wanted.  The
+        two accessors return different things -- a local :class:`Path` and a
+        remote URL -- so a single suggestion would hand one of them the
+        wrong type, which is the opposite of what a deprecation message is
+        for.
     """
     warnings.warn(
         f"maidr.{name}() is deprecated and will be removed in the next major "
         "release, along with the bundled maidr.css it resolves. That file has "
         "carried no rules since maidr 3.75.1 and nothing in py-maidr links "
-        "it. Use bundled_math_css_path() for the stylesheet that does carry "
-        "rules, or link no stylesheet at all -- MAIDR styles its interface at "
-        "runtime.",
+        f"it. Use {instead} for the stylesheet that does carry rules, or link "
+        "no stylesheet at all -- MAIDR styles its interface at runtime.",
         FutureWarning,
         stacklevel=3,
     )
@@ -622,9 +627,11 @@ def maidr_css_cdn_url() -> str:
 
     .. deprecated::
         Linking this buys nothing and will be removed, along with
-        ``maidr.css`` itself, in the next major release.  Use
-        :func:`bundled_math_css_path` if what you wanted was the
-        stylesheet that carries rules, or link nothing at all -- MAIDR
+        ``maidr.css`` itself, in the next major release.  If what you
+        wanted was the stylesheet that carries rules, and you want it from
+        the CDN as this function returns it, call
+        ``cdn_url(MAIDR_MATH_CSS_FILENAME)``; :func:`bundled_math_css_path`
+        is the local-file counterpart.  Or link nothing at all -- MAIDR
         styles its interface at runtime.
 
     Nothing in ``maidr/`` emits this any more.  From maidr 3.75.1 the file
@@ -643,7 +650,7 @@ def maidr_css_cdn_url() -> str:
     FutureWarning
         Always.  See :func:`_warn_placeholder_css` for why this category.
     """
-    _warn_placeholder_css("maidr_css_cdn_url")
+    _warn_placeholder_css("maidr_css_cdn_url", "cdn_url(MAIDR_MATH_CSS_FILENAME)")
     return cdn_url(MAIDR_CSS_FILENAME)
 
 
@@ -1433,7 +1440,7 @@ def bundled_css_path() -> Path:
     FutureWarning
         Always.  See :func:`_warn_placeholder_css` for why this category.
     """
-    _warn_placeholder_css("bundled_css_path")
+    _warn_placeholder_css("bundled_css_path", "bundled_math_css_path()")
     return _bundled_asset_path(MAIDR_CSS_FILENAME)
 
 

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -602,8 +602,12 @@ def _warn_placeholder_css(name: str, instead: str) -> None:
     Parameters
     ----------
     name : str
-        The function being called, so the message names the caller's own
-        call rather than this helper.
+        The function being called, spelled as a path that actually
+        imports, so the message names the caller's own call rather than
+        this helper.  Fully qualified rather than assumed: only one of
+        these two is re-exported from the top-level package, so a fixed
+        ``maidr.`` prefix would name a path that raises
+        :class:`AttributeError` for the other.
     instead : str
         What to call in its place, in the same form the caller wanted.  The
         two accessors return different things -- a local :class:`Path` and a
@@ -612,7 +616,7 @@ def _warn_placeholder_css(name: str, instead: str) -> None:
         for.
     """
     warnings.warn(
-        f"maidr.{name}() is deprecated and will be removed in the next major "
+        f"{name}() is deprecated and will be removed in the next major "
         "release, along with the bundled maidr.css it resolves. That file has "
         "carried no rules since maidr 3.75.1 and nothing in py-maidr links "
         f"it. Use {instead} for the stylesheet that does carry rules, or link "
@@ -630,9 +634,11 @@ def maidr_css_cdn_url() -> str:
         ``maidr.css`` itself, in the next major release.  If what you
         wanted was the stylesheet that carries rules, and you want it from
         the CDN as this function returns it, call
-        ``cdn_url(MAIDR_MATH_CSS_FILENAME)``; :func:`bundled_math_css_path`
-        is the local-file counterpart.  Or link nothing at all -- MAIDR
-        styles its interface at runtime.
+        ``cdn_url(MAIDR_MATH_CSS_FILENAME)`` -- both from this module, which
+        is also the only place this function itself is importable from.
+        :func:`bundled_math_css_path` is the local-file counterpart, and is
+        re-exported as ``maidr.bundled_math_css_path``.  Or link nothing at
+        all -- MAIDR styles its interface at runtime.
 
     Nothing in ``maidr/`` emits this any more.  From maidr 3.75.1 the file
     it points at is a placeholder with no rules in it, published only so
@@ -650,7 +656,10 @@ def maidr_css_cdn_url() -> str:
     FutureWarning
         Always.  See :func:`_warn_placeholder_css` for why this category.
     """
-    _warn_placeholder_css("maidr_css_cdn_url", "cdn_url(MAIDR_MATH_CSS_FILENAME)")
+    _warn_placeholder_css(
+        "maidr.util.dependencies.maidr_css_cdn_url",
+        "cdn_url(MAIDR_MATH_CSS_FILENAME) from maidr.util.dependencies",
+    )
     return cdn_url(MAIDR_CSS_FILENAME)
 
 
@@ -1440,7 +1449,7 @@ def bundled_css_path() -> Path:
     FutureWarning
         Always.  See :func:`_warn_placeholder_css` for why this category.
     """
-    _warn_placeholder_css("bundled_css_path", "bundled_math_css_path()")
+    _warn_placeholder_css("maidr.bundled_css_path", "maidr.bundled_math_css_path()")
     return _bundled_asset_path(MAIDR_CSS_FILENAME)
 
 

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -582,8 +582,50 @@ def maidr_js_cdn_url() -> str:
     return cdn_url(MAIDR_JS_FILENAME)
 
 
+def _warn_placeholder_css(name: str) -> None:
+    """
+    Announce that a ``maidr.css`` accessor is going away.
+
+    ``FutureWarning`` rather than ``DeprecationWarning``, which is the more
+    usual category for an API removal. Python's own guidance splits them by
+    audience: ``DeprecationWarning`` is for warnings aimed at other library
+    authors, ``FutureWarning`` for those aimed at end users of applications
+    written in Python. Someone calling this is building a dashboard or a
+    report, not extending py-maidr.
+
+    The practical half matters more. ``DeprecationWarning`` is silenced by
+    default outside ``__main__``, so a caller inside a Shiny app or an
+    imported module would never see it and would meet the removal as a
+    breakage instead of a warning -- which is the one thing a deprecation
+    cycle exists to prevent.
+
+    Parameters
+    ----------
+    name : str
+        The function being called, so the message names the caller's own
+        call rather than this helper.
+    """
+    warnings.warn(
+        f"maidr.{name}() is deprecated and will be removed in the next major "
+        "release, along with the bundled maidr.css it resolves. That file has "
+        "carried no rules since maidr 3.75.1 and nothing in py-maidr links "
+        "it. Use bundled_math_css_path() for the stylesheet that does carry "
+        "rules, or link no stylesheet at all -- MAIDR styles its interface at "
+        "runtime.",
+        FutureWarning,
+        stacklevel=3,
+    )
+
+
 def maidr_css_cdn_url() -> str:
     """Return the CDN URL for ``maidr.css`` at the resolved version.
+
+    .. deprecated::
+        Linking this buys nothing and will be removed, along with
+        ``maidr.css`` itself, in the next major release.  Use
+        :func:`bundled_math_css_path` if what you wanted was the
+        stylesheet that carries rules, or link nothing at all -- MAIDR
+        styles its interface at runtime.
 
     Nothing in ``maidr/`` emits this any more.  From maidr 3.75.1 the file
     it points at is a placeholder with no rules in it, published only so
@@ -595,7 +637,13 @@ def maidr_css_cdn_url() -> str:
     -------
     str
         A fully qualified jsDelivr URL.
+
+    Warns
+    -----
+    FutureWarning
+        Always.  See :func:`_warn_placeholder_css` for why this category.
     """
+    _warn_placeholder_css("maidr_css_cdn_url")
     return cdn_url(MAIDR_CSS_FILENAME)
 
 
@@ -1368,11 +1416,24 @@ def bundled_js_path() -> Path:
 def bundled_css_path() -> Path:
     """Return the filesystem path to the bundled MAIDR stylesheet.
 
+    .. deprecated::
+        The file this resolves has no rules in it, and both it and this
+        function will be removed in the next major release.  Use
+        :func:`bundled_math_css_path` if what you wanted was the
+        stylesheet that carries rules, or link nothing at all -- MAIDR
+        styles its interface at runtime.
+
     Kept for callers that predate maidr 3.75.1.  Since that release the
     file is a placeholder with no rules in it, and nothing in ``maidr/``
     links it; :func:`bundled_math_css_path` is the stylesheet that
     carries content.
+
+    Warns
+    -----
+    FutureWarning
+        Always.  See :func:`_warn_placeholder_css` for why this category.
     """
+    _warn_placeholder_css("bundled_css_path")
     return _bundled_asset_path(MAIDR_CSS_FILENAME)
 
 

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -34,7 +34,7 @@ from maidr.util import dependencies
 # warning is noise here rather than the subject. Matched by message, so any
 # other FutureWarning still surfaces.
 pytestmark = pytest.mark.filterwarnings(
-    "ignore:maidr.maidr_css_cdn_url:FutureWarning"
+    r"ignore:maidr\.maidr_css_cdn_url:FutureWarning"
 )
 
 

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -28,6 +28,16 @@ import maidr
 from maidr.util import dependencies
 
 
+# `maidr_css_cdn_url` is deprecated (#333) and warns on every call. These tests
+# call it incidentally -- as a second helper sharing the version-resolution
+# cache with `maidr_js_cdn_url`, which is the property under test -- so the
+# warning is noise here rather than the subject. Matched by message, so any
+# other FutureWarning still surfaces.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:maidr.maidr_css_cdn_url:FutureWarning"
+)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -33,8 +33,14 @@ from maidr.util import dependencies
 # cache with `maidr_js_cdn_url`, which is the property under test -- so the
 # warning is noise here rather than the subject. Matched by message, so any
 # other FutureWarning still surfaces.
+# The message field is matched with ``re.match``, so it is anchored at the
+# start.  The leading ``.*`` skips whatever module path the warning happens to
+# spell the function with -- that path has changed once already, which silently
+# killed this filter -- while the rest stays specific enough to mute only this
+# deprecation.  ``test_the_cdn_version_suite_really_silences_the_deprecation``
+# in ``test_offline_bundle.py`` fails if it ever stops matching again.
 pytestmark = pytest.mark.filterwarnings(
-    r"ignore:maidr\.maidr_css_cdn_url:FutureWarning"
+    r"ignore:.*maidr_css_cdn_url\(\) is deprecated:FutureWarning"
 )
 
 

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 import re
 from pathlib import Path
 
@@ -26,8 +27,14 @@ def test_bundled_maidr_js_exists():
 
 
 def test_bundled_maidr_css_exists():
-    """The bundled stylesheet must ship alongside ``maidr.js``."""
-    css_path = dependencies.bundled_css_path()
+    """The bundled stylesheet must ship alongside ``maidr.js``.
+
+    Still shipped, and still resolvable, through the deprecation cycle: the
+    accessor warns (#333) but must keep working until the file goes with it,
+    or a caller mid-cycle gets a breakage rather than a warning.
+    """
+    with pytest.warns(FutureWarning, match="bundled_css_path"):
+        css_path = dependencies.bundled_css_path()
     assert css_path.is_file()
     assert css_path.stat().st_size > 0, "bundled maidr.css looks empty"
 
@@ -624,7 +631,8 @@ def test_bundled_js_path_is_top_level_export():
     assert js_path.is_file()
     assert js_path.stat().st_size > 1_000
 
-    css_path = maidr.bundled_css_path()
+    with pytest.warns(FutureWarning, match="bundled_css_path"):
+        css_path = maidr.bundled_css_path()
     assert css_path.is_file()
 
     assert callable(maidr.bundled_math_css_path)
@@ -702,3 +710,44 @@ def test_no_connectivity_probe_remains():
     assert not hasattr(maidr_api, "_reset_connectivity_cache")
     assert not hasattr(maidr_api, "_connectivity_cache")
     assert not hasattr(maidr_api, "_connectivity_cache_time")
+
+
+def test_the_placeholder_css_accessors_warn_before_they_go():
+    """
+    Both accessors for the rule-less ``maidr.css`` announce their removal.
+
+    ``FutureWarning`` rather than ``DeprecationWarning`` on purpose: the
+    latter is silenced by default outside ``__main__``, so a caller inside a
+    Shiny app or an imported module would never see it and would meet the
+    removal as a breakage. The category is the difference between a
+    deprecation cycle and a surprise (#333).
+    """
+    from maidr.util.dependencies import maidr_css_cdn_url
+
+    for call, name in (
+        (maidr.bundled_css_path, "bundled_css_path"),
+        (maidr_css_cdn_url, "maidr_css_cdn_url"),
+    ):
+        with pytest.warns(FutureWarning, match=name) as caught:
+            call()
+
+        message = str(caught[0].message)
+        # The way out has to be in the message: a warning that says only
+        # "deprecated" leaves the reader to guess what replaces it.
+        assert "bundled_math_css_path" in message
+        assert "next major" in message
+
+
+def test_the_stylesheet_that_carries_rules_does_not_warn():
+    """
+    Only the placeholder is deprecated.
+
+    ``maidr-math.css`` is fetched at runtime by ``maidr.js`` and is the one
+    stylesheet with content, so its accessors must stay quiet -- warning on
+    them would push callers off the asset they should be using.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+
+        assert maidr.bundled_math_css_path().is_file()
+        assert maidr.read_bundled_math_css()

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -713,7 +713,7 @@ def test_no_connectivity_probe_remains():
     assert not hasattr(maidr_api, "_connectivity_cache_time")
 
 
-def test_the_placeholder_css_accessors_warn_before_they_go():
+def test_placeholder_css_accessors_warn():
     """
     Both accessors for the rule-less ``maidr.css`` announce their removal.
 
@@ -779,7 +779,7 @@ def _importable(dotted: str) -> bool:
         return False
 
 
-def test_every_path_the_deprecation_names_can_be_imported():
+def test_deprecation_names_only_importable_symbols():
     """A message that names an unimportable path misdirects the reader.
 
     Only one of the two accessors is re-exported from the top-level
@@ -788,9 +788,11 @@ def test_every_path_the_deprecation_names_can_be_imported():
     suggested replacement lands in the same place. Substring assertions
     cannot see this: the name is present either way.
 
-    So this resolves every dotted path the messages contain rather than
-    checking for the ones expected today, which is what makes it catch the
-    next wrong path as well as this one.
+    So this resolves everything the messages name rather than checking for
+    the symbols expected today, which is what makes it catch the next wrong
+    one as well as this one -- including the bare names, which a message
+    that says "from <module>" is just as capable of misspelling as it is a
+    dotted path.
     """
     from maidr.util.dependencies import maidr_css_cdn_url
 
@@ -799,24 +801,53 @@ def test_every_path_the_deprecation_names_can_be_imported():
             call()
 
         message = str(caught[0].message)
-        # Dotted paths only: a bare word in prose is not a claim about the
-        # import system. ``maidr.css`` and ``maidr.js`` match the same shape
-        # while being filenames, and both have to appear in a message about
-        # a stylesheet -- so they are excluded by name rather than by making
+        # ``maidr.css`` and ``maidr.js`` have the shape of a dotted path
+        # while being filenames, and a message about a stylesheet has to
+        # mention them -- so they are excluded by name rather than by making
         # the pattern clever enough to tell a module from a file, which it
         # cannot be.
-        named = set(re.findall(r"\bmaidr(?:\.[A-Za-z_]\w*)+", message))
-        named -= {"maidr.css", "maidr.js"}
-        assert named, f"the message names no importable path at all: {message}"
+        dotted = set(re.findall(r"\bmaidr(?:\.[A-Za-z_]\w*)+", message))
+        dotted -= {"maidr.css", "maidr.js"}
+        assert dotted, f"the message names no importable path at all: {message}"
 
-        unresolvable = sorted(path for path in named if not _importable(path))
+        # A bare ``name()`` or ``CONSTANT`` is a claim about whatever module
+        # the message points at, so resolve it against each of them. The
+        # top-level package is always a candidate: an unqualified suggestion
+        # is only useful if it is reachable from somewhere the reader has.
+        modules = [path for path in dotted if _importable(path)] + ["maidr"]
+        # A constant here carries an underscore. Without that the pattern
+        # also claims "MAIDR", which these messages say as the product's
+        # name rather than as a symbol.
+        bare = set(re.findall(r"\b([a-z_]\w*)\(", message))
+        bare |= set(re.findall(r"\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)\b", message))
+
+        unresolvable = sorted(
+            symbol
+            for symbol in dotted | bare
+            if not any(_importable(f"{module}.{symbol}") for module in modules)
+            and not _importable(symbol)
+        )
         assert not unresolvable, (
-            f"the deprecation for {call.__name__} names paths that do not "
-            f"import: {unresolvable}"
+            f"the deprecation for {call.__name__} names symbols that do not "
+            f"resolve: {unresolvable}"
+        )
+
+        # The docstring paraphrases the same guidance, and nothing keeps the
+        # two in step, so a replacement renamed in one can survive in the
+        # other. Whatever the message says to call, the docstring says too.
+        suggestion = re.search(r"Use (\S+)", message)
+        assert suggestion, f"the message suggests nothing: {message}"
+        # Compare the symbol, not its spelling: the message qualifies it so
+        # a reader can import it, while the docstring uses Sphinx's ``:func:``
+        # role, which takes the bare name.
+        instead = suggestion.group(1).split("(")[0].rpartition(".")[2]
+        assert instead in (call.__doc__ or ""), (
+            f"{call.__name__}'s docstring no longer names the replacement its "
+            f"warning does: {instead}"
         )
 
 
-def test_the_cdn_version_suite_really_silences_the_deprecation():
+def test_cdn_version_filter_still_matches_the_warning():
     """A warning filter that stops matching goes dead without a sound.
 
     ``test_cdn_version.py`` mutes this deprecation so that it tests CDN
@@ -854,7 +885,7 @@ def test_the_cdn_version_suite_really_silences_the_deprecation():
     )
 
 
-def test_the_cdn_accessor_is_not_sent_to_a_local_path():
+def test_cdn_accessor_replacement_returns_a_url():
     """The replacement each accessor names must return that accessor's type.
 
     ``maidr_css_cdn_url`` returns a URL string. Pointing its caller at
@@ -878,7 +909,7 @@ def test_the_cdn_accessor_is_not_sent_to_a_local_path():
     assert cdn_url(MAIDR_MATH_CSS_FILENAME).endswith("/dist/maidr-math.css")
 
 
-def test_the_stylesheet_that_carries_rules_does_not_warn():
+def test_math_css_accessors_do_not_warn():
     """
     Only the placeholder is deprecated.
 

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import warnings
 import re
+import warnings
 from pathlib import Path
 
 import matplotlib.pyplot as plt

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import re
 import warnings
 from pathlib import Path
@@ -730,19 +731,89 @@ def test_the_placeholder_css_accessors_warn_before_they_go():
     # wrong type. A deprecation that misdirects is worse than one that only
     # says "deprecated".
     for call, name, instead in (
-        (maidr.bundled_css_path, "bundled_css_path", "bundled_math_css_path()"),
+        (
+            maidr.bundled_css_path,
+            "maidr.bundled_css_path",
+            "maidr.bundled_math_css_path()",
+        ),
         (
             maidr_css_cdn_url,
-            "maidr_css_cdn_url",
+            "maidr.util.dependencies.maidr_css_cdn_url",
             "cdn_url(MAIDR_MATH_CSS_FILENAME)",
         ),
     ):
-        with pytest.warns(FutureWarning, match=name) as caught:
+        with pytest.warns(FutureWarning, match=re.escape(name)) as caught:
             call()
 
         message = str(caught[0].message)
         assert instead in message
         assert "next major" in message
+
+
+def _importable(dotted: str) -> bool:
+    """Report whether a dotted path resolves to something real.
+
+    Parameters
+    ----------
+    dotted : str
+        A module path, or a module path followed by an attribute.
+
+    Returns
+    -------
+    bool
+        ``True`` if the path can be imported, or names an attribute of a
+        module that can be.
+    """
+    try:
+        importlib.import_module(dotted)
+        return True
+    except ImportError:
+        pass
+
+    module, _, attribute = dotted.rpartition(".")
+    if not module:
+        return False
+    try:
+        return hasattr(importlib.import_module(module), attribute)
+    except ImportError:
+        return False
+
+
+def test_every_path_the_deprecation_names_can_be_imported():
+    """A message that names an unimportable path misdirects the reader.
+
+    Only one of the two accessors is re-exported from the top-level
+    package, so a fixed ``maidr.`` prefix names something that raises
+    ``AttributeError`` for the other -- and a reader following the
+    suggested replacement lands in the same place. Substring assertions
+    cannot see this: the name is present either way.
+
+    So this resolves every dotted path the messages contain rather than
+    checking for the ones expected today, which is what makes it catch the
+    next wrong path as well as this one.
+    """
+    from maidr.util.dependencies import maidr_css_cdn_url
+
+    for call in (maidr.bundled_css_path, maidr_css_cdn_url):
+        with pytest.warns(FutureWarning) as caught:
+            call()
+
+        message = str(caught[0].message)
+        # Dotted paths only: a bare word in prose is not a claim about the
+        # import system. ``maidr.css`` and ``maidr.js`` match the same shape
+        # while being filenames, and both have to appear in a message about
+        # a stylesheet -- so they are excluded by name rather than by making
+        # the pattern clever enough to tell a module from a file, which it
+        # cannot be.
+        named = set(re.findall(r"\bmaidr(?:\.[A-Za-z_]\w*)+", message))
+        named -= {"maidr.css", "maidr.js"}
+        assert named, f"the message names no importable path at all: {message}"
+
+        unresolvable = sorted(path for path in named if not _importable(path))
+        assert not unresolvable, (
+            f"the deprecation for {call.__name__} names paths that do not "
+            f"import: {unresolvable}"
+        )
 
 
 def test_the_cdn_accessor_is_not_sent_to_a_local_path():

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -724,18 +724,49 @@ def test_the_placeholder_css_accessors_warn_before_they_go():
     """
     from maidr.util.dependencies import maidr_css_cdn_url
 
-    for call, name in (
-        (maidr.bundled_css_path, "bundled_css_path"),
-        (maidr_css_cdn_url, "maidr_css_cdn_url"),
+    # The way out has to be in the message, and it has to return what the
+    # caller was already holding: one of these resolves a local file and the
+    # other a remote URL, so a single suggestion would hand one of them the
+    # wrong type. A deprecation that misdirects is worse than one that only
+    # says "deprecated".
+    for call, name, instead in (
+        (maidr.bundled_css_path, "bundled_css_path", "bundled_math_css_path()"),
+        (
+            maidr_css_cdn_url,
+            "maidr_css_cdn_url",
+            "cdn_url(MAIDR_MATH_CSS_FILENAME)",
+        ),
     ):
         with pytest.warns(FutureWarning, match=name) as caught:
             call()
 
         message = str(caught[0].message)
-        # The way out has to be in the message: a warning that says only
-        # "deprecated" leaves the reader to guess what replaces it.
-        assert "bundled_math_css_path" in message
+        assert instead in message
         assert "next major" in message
+
+
+def test_the_cdn_accessor_is_not_sent_to_a_local_path():
+    """The replacement each accessor names must return that accessor's type.
+
+    ``maidr_css_cdn_url`` returns a URL string. Pointing its caller at
+    ``bundled_math_css_path()`` would hand them a :class:`Path`, which is
+    the one mistake a deprecation message can make that leaves the reader
+    worse off than no message at all.
+    """
+    from maidr.util.dependencies import (
+        MAIDR_MATH_CSS_FILENAME,
+        cdn_url,
+        maidr_css_cdn_url,
+    )
+
+    with pytest.warns(FutureWarning) as caught:
+        maidr_css_cdn_url()
+
+    message = str(caught[0].message)
+    assert "bundled_math_css_path" not in message
+
+    # And what it does name resolves to a real URL, not just a plausible one.
+    assert cdn_url(MAIDR_MATH_CSS_FILENAME).endswith("/dist/maidr-math.css")
 
 
 def test_the_stylesheet_that_carries_rules_does_not_warn():

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -816,6 +816,44 @@ def test_every_path_the_deprecation_names_can_be_imported():
         )
 
 
+def test_the_cdn_version_suite_really_silences_the_deprecation():
+    """A warning filter that stops matching goes dead without a sound.
+
+    ``test_cdn_version.py`` mutes this deprecation so that it tests CDN
+    version resolution rather than the warning. Nothing in this repo turns
+    warnings into errors, so a filter that no longer matches changes
+    nothing and no test notices -- which has already happened once, when
+    the warning grew the module path that makes it importable.
+
+    So this reads the filter off that module and applies it to the message
+    the accessor really emits, rather than trusting the two to stay in
+    step.
+    """
+    from maidr.util.dependencies import maidr_css_cdn_url
+
+    from tests.core import test_cdn_version
+
+    marks = test_cdn_version.pytestmark
+    specs = [
+        argument
+        for mark in (marks if isinstance(marks, list) else [marks])
+        for argument in mark.mark.args
+    ]
+    assert specs, "test_cdn_version.py no longer filters anything"
+
+    with pytest.warns(FutureWarning) as caught:
+        maidr_css_cdn_url()
+    message = str(caught[0].message)
+
+    # ``action:message:category:module:lineno`` -- the message field is a
+    # regex applied with ``re.match``, which is what pytest does with it.
+    matched = [spec for spec in specs if re.match(spec.split(":")[1], message)]
+    assert matched, (
+        f"no filter in test_cdn_version.py matches the warning it means to "
+        f"silence.\n  filters: {specs}\n  message: {message}"
+    )
+
+
 def test_the_cdn_accessor_is_not_sent_to_a_local_path():
     """The replacement each accessor names must return that accessor's type.
 


### PR DESCRIPTION
## Description

`maidr/static/maidr.css` has been a 406-byte placeholder since maidr 3.75.1 — a comment header and nothing else. Nothing in `maidr/` links a stylesheet, and the module's own comment already said as much. r-maidr, taking the same upstream release, stopped bundling it. py-maidr kept both the file and the two public functions that resolve it.

It cannot simply be deleted. `bundled_css_path` is in `__all__`, so removing the file would leave a public function returning a path that does not exist. So: both accessors warn now, the file keeps shipping, and the two go away together at the next major.

## Related Issues

Refs #333.

## Changes Made

- `maidr/util/dependencies.py`: `_warn_placeholder_css()` emits a `FutureWarning` from `bundled_css_path()` and `maidr_css_cdn_url()`, at `stacklevel=3` so the warning points at the caller rather than at py-maidr's own frame. Both functions gained a `.. deprecated::` directive and a `Warns` section.
- `tests/core/test_offline_bundle.py`: the deliberate calls are wrapped in `pytest.warns(FutureWarning, match=...)`; two new cases — one asserting both accessors warn, one asserting `maidr-math.css` (which does carry rules) stays silent.
- `tests/core/test_cdn_version.py`: a module-level `filterwarnings` for the incidental calls, so the file tests CDN version resolution rather than the deprecation.

### Two deliberate choices worth reviewing

**`FutureWarning`, not `DeprecationWarning`.** Python's guidance splits the two by audience: `DeprecationWarning` for warnings aimed at other library authors, `FutureWarning` for end users of applications written in Python. Someone calling `bundled_css_path()` is assembling a dashboard, not extending py-maidr. The practical half matters more — `DeprecationWarning` is silenced by default outside `__main__`, so a caller inside a Shiny app or any imported module would never see it, and would meet the removal as a breakage instead of a warning. That is the one outcome a deprecation cycle exists to prevent.

**`feat`, not `feat!`.** Nothing breaks here: both functions return exactly what they returned before, and the file they point at still ships. The `!` belongs on the removal — the commit that actually takes something away. I originally typed this `feat(deps)!` and amended it, because `python-semantic-release` honours the marker (verified: `ConventionalCommitParser` returns `bump: major` for that subject), which would have cut **2.0.0 for a change no caller has to react to yet**.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable. — no user-facing docs reference these accessors.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Gates.** `uv run pytest` → **813 passed** (from 811). `ruff check` → 52 findings, unchanged from the baseline on `main`. Bite check: deleting the two `_warn_placeholder_css(...)` call sites turns the new assertions red — `3 failed, 41 passed` — so the tests are testing the change and not the scaffolding.

**Not touched, deliberately.** `maidr-math.css` keeps its base64 KaTeX fonts. r-maidr strips them to fit CRAN's package size limit, at the cost of every math glyph falling back to a system font. py-maidr has no such limit, and the saving is under 9% of a package whose JS bundle is five times larger. The two repositories differing here is correct, not drift — #333 records the reasoning so nobody "fixes" the asymmetry later.

**Separate bug found while checking the release wiring, not fixed here.** The `exclude_commit_patterns` allowlist in `pyproject.toml` matches `feat: ` and `feat\(.*\): `, neither of which matches a `!`-marked subject. So every breaking commit in this repository triggers a major version bump and is then **omitted from the changelog** — the worst combination of the two. Filed separately rather than smuggled into this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_