### PR TITLE
feat(heatmap): highlight a pcolor grid, and cover z_label

### DIFF
--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy.ma as ma
 from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
-from matplotlib.collections import QuadMesh
+from matplotlib.collections import PolyQuadMesh, QuadMesh
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
@@ -64,11 +64,16 @@ class HeatPlot(
             return None
 
         array = sm.get_array().data
-        if isinstance(sm, QuadMesh):
-            # Data gets flattened in ScalarMappable, when the plot is from QuadMesh.
-            # So, reshaping the data to reflect the original quadrilaterals
-            m, n, _ = ma.shape(sm.get_coordinates())
-            array = array.reshape(m - 1, n - 1)  # Coordinates shape is (M + 1, N + 1)
+        if isinstance(sm, (QuadMesh, PolyQuadMesh)):
+            # The two mesh classes disagree about the shape they keep their
+            # values in: `pcolormesh`'s QuadMesh flattens them, while
+            # `pcolor`'s PolyQuadMesh keeps the grid. Reshaping unconditionally
+            # would fail on the one that is already two-dimensional, so the
+            # recovery is driven by the array rather than by the class.
+            if array.ndim == 1:
+                m, n, _ = ma.shape(sm.get_coordinates())
+                # Coordinates shape is (M + 1, N + 1)
+                array = array.reshape(m - 1, n - 1)
 
             # Tag the elements for highlighting
             self._elements.append(sm)

--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -52,6 +52,38 @@ def _declares_fmt(wrapped: Callable) -> bool:
 
 
 def heat(wrapped, _, args, kwargs) -> Axes | AxesImage | Collection:
+    """
+    Draw a patched heatmap call and register the layer it produced with MAIDR.
+
+    Wraps every way a heatmap reaches the canvas: ``Axes.imshow``,
+    ``Axes.pcolormesh``, ``Axes.pcolor`` and ``seaborn.heatmap``. Two MAIDR-only
+    parameters are lifted out of ``kwargs`` before the draw — ``z_label``, which
+    names the colour dimension and which matplotlib has never heard of, and
+    ``fmt``, which only ``seaborn.heatmap`` declares.
+
+    This does not route through :func:`maidr.patch.common.common` precisely
+    because of that lifting: ``common`` forwards ``kwargs`` untouched, and these
+    two have to be removed first.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original plotting function.
+    _ : Any
+        The instance wrapt bound the patched function to, or None for a
+        module-level function. Unused here, and named for that.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    Axes or AxesImage or Collection
+        Whatever the wrapped function returned: an ``Axes`` from seaborn, an
+        ``AxesImage`` from ``imshow``, or the mesh the two ``pcolor`` variants
+        render.
+    """
     # `seaborn.heatmap` draws through `Axes.pcolormesh`, and both are patched
     # here. Without this guard the inner call registers a second HEAT layer for
     # the same axes, so one `sns.heatmap()` would be announced as two identical

--- a/maidr/patch/highlight.py
+++ b/maidr/patch/highlight.py
@@ -4,7 +4,12 @@ import uuid
 
 import wrapt
 from matplotlib.backends.backend_svg import XMLWriter
-from matplotlib.collections import LineCollection, PathCollection, QuadMesh
+from matplotlib.collections import (
+    LineCollection,
+    PathCollection,
+    PolyQuadMesh,
+    QuadMesh,
+)
 from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
 
@@ -32,3 +37,14 @@ wrapt.wrap_function_wrapper(QuadMesh, "draw", tag_elements)
 wrapt.wrap_function_wrapper(Line2D, "draw", tag_elements)
 wrapt.wrap_function_wrapper(LineCollection, "draw", tag_elements)
 wrapt.wrap_function_wrapper(PathCollection, "draw", tag_elements)
+
+# `Axes.pcolor` renders a PolyQuadMesh rather than the QuadMesh `pcolormesh`
+# gives, so a pcolor heatmap read but carried no visual highlight.
+#
+# The wrapper goes on PolyQuadMesh and deliberately NOT on its PolyCollection
+# base. PolyCollection also backs violin bodies and `fill_between`, and tagging
+# it would hand every one of those a maidr gid and a highlight context they
+# were never extracted for. PolyQuadMesh inherits `draw` rather than defining
+# one, so wrapping it here installs a subclass-only override: the base class
+# and its other subclasses keep the unwrapped method.
+wrapt.wrap_function_wrapper(PolyQuadMesh, "draw", tag_elements)

--- a/tests/core/plot/test_pcolormesh.py
+++ b/tests/core/plot/test_pcolormesh.py
@@ -22,8 +22,10 @@ import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 import seaborn as sns  # noqa: E402
+from matplotlib.collections import PolyCollection, PolyQuadMesh  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum import MaidrKey  # noqa: E402
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 
@@ -114,15 +116,13 @@ def test_pcolormesh_supports_highlighting():
     assert plot.elements, "the QuadMesh should be tagged for highlighting"
 
 
-def test_pcolor_reads_without_highlighting():
+def test_pcolor_supports_highlighting():
     """
-    ``pcolor`` renders as a ``PolyQuadMesh``, which `patch/highlight.py` does
-    not tag, so the layer reads through audio, text and braille but carries no
-    visual highlight.
+    ``pcolor`` renders a ``PolyQuadMesh``, which is tagged for highlighting
+    just as ``pcolormesh``'s ``QuadMesh`` is.
 
-    Asserted rather than left implicit: it is the one way the two entry points
-    differ, and a future change that starts tagging ``PolyCollection`` should
-    have to come back and update this.
+    This replaces an earlier assertion that ``pcolor`` read *without* a
+    highlight, which was true only because nothing tagged its class yet.
     """
     fig, ax = plt.subplots()
     ax.pcolor(X_EDGES, Y_EDGES, VALUES)
@@ -130,7 +130,22 @@ def test_pcolor_reads_without_highlighting():
     plot = _sole_plot(fig)
     plot._extract_plot_data()
 
-    assert plot._support_highlighting is False
+    assert plot._support_highlighting is True
+    assert plot.elements, "the PolyQuadMesh should be tagged for highlighting"
+
+
+def test_tagging_pcolor_leaves_other_poly_collections_alone():
+    """
+    Only ``PolyQuadMesh`` is tagged, never its ``PolyCollection`` base.
+
+    ``PolyCollection`` also backs violin bodies and ``fill_between``. Tagging
+    it would hand every one of those a maidr gid and a highlight context they
+    were never extracted for, which is why the wrapper is installed on the
+    subclass — one that inherits ``draw`` rather than defining its own, so
+    wrapping it shadows the method for ``pcolor`` alone.
+    """
+    assert "draw" in PolyQuadMesh.__dict__, "the subclass override is what scopes this"
+    assert "draw" not in PolyCollection.__dict__, "the base must stay unwrapped"
 
 
 def test_seaborn_heatmap_still_registers_one_layer():
@@ -175,6 +190,36 @@ def test_fmt_is_read_but_not_forwarded_to_matplotlib(draw):
     # being dropped along with the kwarg.
     points = _sole_plot(fig)._extract_plot_data()["points"]
     assert points == VALUES.tolist()
+
+
+@pytest.mark.parametrize("draw", ["pcolormesh", "pcolor", "imshow"])
+def test_z_label_reaches_the_schema_and_not_matplotlib(draw):
+    """
+    ``z_label`` names the colour dimension and is MAIDR's own — matplotlib has
+    never heard of it, so it must be lifted out of ``kwargs`` before the draw
+    and still reach the emitted axes.
+
+    Parametrized across all three matplotlib entry points because the lifting
+    happens once, before the wrapped call, and a per-entry-point regression
+    would be invisible from any single one of them.
+    """
+    fig, ax = plt.subplots()
+    if draw == "imshow":
+        ax.imshow(VALUES, z_label="Temperature")
+    else:
+        getattr(ax, draw)(X_EDGES, Y_EDGES, VALUES, z_label="Temperature")
+
+    axes = _sole_plot(fig)._extract_axes_data()
+
+    assert axes[MaidrKey.Z] == {"label": "Temperature"}
+
+
+def test_z_label_defaults_when_the_caller_omits_it():
+    """A heatmap drawn without a ``z_label`` still names its colour axis."""
+    fig, ax = plt.subplots()
+    ax.pcolormesh(X_EDGES, Y_EDGES, VALUES)
+
+    assert _sole_plot(fig)._extract_axes_data()[MaidrKey.Z] == {"label": "Z"}
 
 
 def test_seaborn_heatmap_still_receives_fmt():


### PR DESCRIPTION
## Description

`Axes.pcolor` renders a `PolyQuadMesh` where `pcolormesh` renders a `QuadMesh`, and `patch/highlight.py` tagged only the latter. A pcolor heatmap therefore read through audio, text and braille but carried **no visual highlight** — low-vision users lost the cursor on a chart every other reader could follow.

This is the follow-up #346 explicitly deferred, along with the two review notes it left open.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

**The scoping is the whole point of this change, so it is worth reviewing first.** The obvious fix — tagging `PolyCollection` — is the wrong one: `PolyCollection` also backs violin bodies and `fill_between`, and tagging it would hand every one of those a maidr gid and a highlight context they were never extracted for. That blast radius is exactly why #346 left this alone.

`PolyQuadMesh` **inherits** `draw` rather than defining one, so wrapping it installs a subclass-only override and the base class keeps the unwrapped method. Verified rather than assumed:

```
PolyCollection.draw wrapped:  False
PolyQuadMesh owns draw now:   True
```

A test asserts both halves, so a later change that reaches for the base class has to come through here.

**Reshape now driven by the array, not the class.** The two mesh classes disagree about the shape they keep values in — `QuadMesh` flattens them, `PolyQuadMesh` keeps the grid — so reshaping unconditionally would fail on the one that is already two-dimensional.

**`z_label` coverage**, the gap the last review named. Parametrized across all three matplotlib entry points, because the lifting happens once before the wrapped call and a per-entry-point regression would be invisible from any single one of them. Plus a default case.

**`heat()` docstring**, NumPy-style per CLAUDE.md, including why this patch cannot route through `common()`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

**One assertion in #346 is deliberately inverted here.** `test_pcolor_reads_without_highlighting` pinned the old behaviour and said in its docstring that a change which starts tagging `PolyCollection` "should have to come back and update this". That is what happened; it is now `test_pcolor_supports_highlighting`.

Verification actually run:

| Step | Result |
|---|---|
| `uv run pytest` | **828 passed** (was 823), 0 failures |
| `ruff check` on the changed files | clean |

The full-suite count matters more than usual here: violin plots and `fill_between` both go through `PolyCollection`, so an over-broad patch would have shown up as failures across those suites rather than in the heatmap tests. It did not.

`ruff check maidr/` reports 7 findings repo-wide, all pre-existing — confirmed by stashing this branch and re-running on the base, which reproduces the same 7. Untouched here.

**Documentation unticked deliberately**, same as #346: the supported-plots list is tracked in #229 / #170 and I would rather not half-update it from here.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_