### PR TITLE
feat(errorbar): read an estimate together with its interval

### DIFF
--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -617,6 +617,46 @@ ax.yaxis.set_major_formatter("{x:,.0f}")
 plt.show() #<<
 ```
 
+### Error Bar Plot
+
+Uncertainty is usually the finding, not the decoration: whether two group means
+differ is answered by whether their intervals overlap. `ax.errorbar()` draws
+that, and maidr reads the estimate **and** its interval, so the comparison the
+chart was drawn to support can be made by ear.
+
+Navigation is a grid. Left and right walk the samples; up and down at one
+sample walk the lower bound, the estimate and the upper bound — so a reader
+traces one interval rather than rebuilding it from three passes over the chart.
+
+The bounds are read off the drawn bars rather than from the `yerr` you passed,
+so asymmetric errors, one-sided errors, `uplims`/`lolims` and `fmt="none"` all
+read correctly without you having to present them any particular way.
+
+```{python}
+#| fig-alt: Mean response by dose with 95% confidence intervals
+
+import matplotlib.pyplot as plt
+
+import maidr #<<
+
+groups = ["control", "low dose", "high dose"]
+means = [4.2, 5.1, 7.3]
+
+# Asymmetric intervals, as a real confidence interval usually is: the lower
+# and upper distances from the mean are given separately.
+lower = [0.4, 1.1, 0.2]
+upper = [0.4, 1.5, 0.1]
+
+fig, ax = plt.subplots(figsize=(8, 5))
+ax.errorbar(groups, means, yerr=[lower, upper], fmt="o", capsize=5)
+
+ax.set_title("Mean Response by Dose, with 95% Confidence Intervals")
+ax.set_xlabel("Group")
+ax.set_ylabel("Response")
+
+plt.show() #<<
+```
+
 ### Scatter Plot
 
 ```{python}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > py-maidr is a Python library that makes matplotlib, seaborn, and plotly data visualizations accessible to blind and low-vision users through sonification, braille, text, and AI-powered conversational modalities. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
 
-maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, pie, box, violin, heatmap, scatter, smooth/regression, candlestick, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
+maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, pie, box, violin, heatmap, scatter, smooth/regression, candlestick, error bar, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
 
 ## Docs
 - [Documentation Home](https://py.maidr.ai/): Installation, quick start, and overview

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -8,6 +8,7 @@ class PlotType(str, Enum):
     BOX = "box"
     COUNT = "count"
     DODGED = "dodged_bar"
+    ERRORBAR = "error_bar"
     HEAT = "heat"
     HIST = "hist"
     LINE = "line"
@@ -45,6 +46,7 @@ class PlotType(str, Enum):
 #: plot, and callers de-duplicate.
 _DISPLAY_NAMES = {
     PlotType.DODGED: "dodged bar",
+    PlotType.ERRORBAR: "error bar",
     PlotType.HEAT: "heatmap",
     PlotType.HIST: "histogram",
     PlotType.SCATTER: "scatter",

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -58,6 +58,7 @@ class FigureManager:
         PlotType.CANDLESTICK: 1,
         PlotType.VIOLIN_KDE: 1,
         PlotType.VIOLIN_BOX: 1,
+        PlotType.ERRORBAR: 1,
     }
 
     _instance = None

--- a/maidr/core/plot/errorbar.py
+++ b/maidr/core/plot/errorbar.py
@@ -99,9 +99,17 @@ class ErrorBarPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
             self._elements.append(bars)
 
         # The category runs along the axis the bars do NOT span, and the
-        # magnitude along the one they do. The schema names them x and y in
-        # every orientation and lets `orientation` say which is on screen
-        # where, matching how the box plot already travels.
+        # magnitude along the one they do. The schema names them `x` and `y`
+        # in BOTH orientations, and lets `orientation` say which is on screen
+        # where.
+        #
+        # That differs from how a bar or a histogram travels, and deliberately
+        # so: the shape is set by the consumer. `ErrorBarTrace` reads the
+        # magnitude as `y`/`yMin`/`yMax` with no orientation branch, and
+        # `ErrorBarPoint` declares no `xMin`/`xMax` to put a bound in --
+        # so emitting the screen-aligned form a bar uses would leave a
+        # horizontal chart with no interval at all, which is the one thing the
+        # trace type exists to convey.
         categories, values = (xs, ys) if is_vertical else (ys, xs)
         component = 1 if is_vertical else 0
 

--- a/maidr/core/plot/errorbar.py
+++ b/maidr/core/plot/errorbar.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+from matplotlib.container import ErrorbarContainer
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot import MaidrPlot
+from maidr.exception import ExtractionError
+from maidr.util.mixin import ContainerExtractorMixin, DictMergerMixin
+
+
+class ErrorBarPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
+    """
+    A plot that draws an estimate together with the interval around it.
+
+    Uncertainty is not decoration in a statistical graphic; it is frequently
+    the finding. Whether two group means differ is answered by whether their
+    intervals overlap, and before this existed a MAIDR reader got the estimate
+    and nothing else, so the comparison the chart was drawn to support could
+    not be made at all.
+
+    The bounds are read off the **drawn geometry** rather than recomputed from
+    the ``yerr`` the caller passed. Those are not the same quantity:
+    matplotlib takes an *offset* while the MAIDR schema carries an *absolute
+    position*, and the offset form has three shapes -- scalar, ``(N,)``, and
+    ``(2, N)`` -- before ``uplims``/``lolims`` change what the bar means again.
+    The ``LineCollection`` matplotlib actually rendered has already resolved
+    every one of those into two endpoints, so reading it is both shorter and
+    correct for cases this module would otherwise have to enumerate.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the error bars were drawn on.
+    **kwargs
+        ``container`` is the ``ErrorbarContainer`` the patched call returned;
+        ``x`` and ``y`` are the centre coordinates the caller passed, used
+        only when the container carries no data line.
+
+    See Also
+    --------
+    MaidrPlot : The base class for MAIDR plot data objects.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        super().__init__(ax, PlotType.ERRORBAR)
+
+        # The patch hands over the exact container its call produced. Looking
+        # one up on the axes instead would break the moment a figure carries
+        # two `errorbar` calls: both layers would find the first container and
+        # describe the same series twice, silently losing the second.
+        self._container = kwargs.pop("container", None)
+        self._fallback_x = kwargs.pop("x", None)
+        self._fallback_y = kwargs.pop("y", None)
+
+        # Resolved from the drawn container during extraction, which `render`
+        # runs before it reads this.
+        self._orientation = "vert"
+
+    def render(self) -> dict:
+        """
+        Build the layer schema, adding the orientation the bars were drawn in.
+
+        Returns
+        -------
+        dict
+            The MAIDR layer schema.
+        """
+        base_schema = super().render()
+        return self.merge_dict(
+            base_schema, {MaidrKey.ORIENTATION: self._orientation}
+        )
+
+    def _extract_plot_data(self) -> list[dict]:
+        container = self._resolve_container()
+        if container is None:
+            raise ExtractionError(self.type, self.ax)
+
+        # `has_yerr` decides the value axis, and an errorbar carrying neither
+        # is still a legitimate call -- it draws bare points -- so it reads as
+        # vertical rather than as a failure.
+        is_vertical = bool(container.has_yerr) or not bool(container.has_xerr)
+        self._orientation = "vert" if is_vertical else "horz"
+
+        centers = self._extract_centers(container)
+        if centers is None:
+            raise ExtractionError(self.type, container)
+        xs, ys = centers
+
+        bars = self._extract_interval_bars(container, is_vertical)
+        segments = bars.get_segments() if bars is not None else []
+        if bars is not None:
+            # Tag for highlighting. One path per sample, in data order, which
+            # is the shape the JS trace repeats across its three sections.
+            self._elements.append(bars)
+
+        # The category runs along the axis the bars do NOT span, and the
+        # magnitude along the one they do. The schema names them x and y in
+        # every orientation and lets `orientation` say which is on screen
+        # where, matching how the box plot already travels.
+        categories, values = (xs, ys) if is_vertical else (ys, xs)
+        component = 1 if is_vertical else 0
+
+        data = []
+        for index, (category, value) in enumerate(zip(categories, values)):
+            point = {
+                MaidrKey.X: self._scalar(category),
+                MaidrKey.Y: self._scalar(value),
+            }
+            bounds = self._extract_bounds(segments, index, component)
+            if bounds is not None:
+                point[MaidrKey.Y_MIN], point[MaidrKey.Y_MAX] = bounds
+            data.append(point)
+
+        if not data:
+            raise ExtractionError(self.type, container)
+
+        return data
+
+    def _resolve_container(self) -> ErrorbarContainer | None:
+        """
+        Return the container to describe.
+
+        Returns
+        -------
+        ErrorbarContainer or None
+            The container the patch supplied, falling back to the first one on
+            the axes, or None when the axes carries none.
+        """
+        if self._container is not None:
+            return self._container
+
+        containers = self.extract_container(
+            self.ax, ErrorbarContainer, include_all=True
+        )
+        return containers[0] if containers else None
+
+    def _extract_centers(
+        self, container: ErrorbarContainer
+    ) -> tuple[Sequence, Sequence] | None:
+        """
+        Return the estimate coordinates the bars are centred on.
+
+        Parameters
+        ----------
+        container : ErrorbarContainer
+            The container to read.
+
+        Returns
+        -------
+        tuple of sequence, or None
+            The x and y coordinates, or None when neither the container nor
+            the caller's arguments supply them.
+        """
+        data_line = container.lines[0]
+        if data_line is not None:
+            x_data, y_data = data_line.get_data()
+            return x_data, y_data
+
+        # `fmt="none"` draws the intervals without the estimate markers, so
+        # the container has no data line to read. The centres are genuinely
+        # unrecoverable from the geometry -- an asymmetric bar is not centred
+        # on its own midpoint -- so they come from the arguments the caller
+        # passed, which the patch kept for exactly this case.
+        if self._fallback_x is None or self._fallback_y is None:
+            return None
+        return np.atleast_1d(self._fallback_x), np.atleast_1d(self._fallback_y)
+
+    @staticmethod
+    def _extract_interval_bars(
+        container: ErrorbarContainer, is_vertical: bool
+    ) -> LineCollection | None:
+        """
+        Return the collection drawing the interval along the value axis.
+
+        A call passing both ``xerr`` and ``yerr`` renders two collections, x
+        first and then y. Only one interval fits the schema, so the value axis
+        picks the collection and the other is left undescribed.
+
+        Parameters
+        ----------
+        container : ErrorbarContainer
+            The container to read.
+        is_vertical : bool
+            Whether the value axis is y.
+
+        Returns
+        -------
+        LineCollection or None
+            The collection spanning the value axis, or None when the call
+            passed no error at all.
+        """
+        bar_collections = container.lines[2]
+        if not bar_collections:
+            return None
+
+        if container.has_xerr and container.has_yerr:
+            return bar_collections[1] if is_vertical else bar_collections[0]
+        return bar_collections[0]
+
+    @staticmethod
+    def _extract_bounds(
+        segments: list, index: int, component: int
+    ) -> tuple[float, float] | None:
+        """
+        Return one sample's interval endpoints, low then high.
+
+        Parameters
+        ----------
+        segments : list
+            The drawn bar segments, one per sample.
+        index : int
+            Which sample to read.
+        component : int
+            0 to read the x coordinate of each endpoint, 1 to read y.
+
+        Returns
+        -------
+        tuple of float, or None
+            The lower and upper bound, or None when this sample has no bar.
+        """
+        if index >= len(segments):
+            return None
+
+        segment = segments[index]
+        # A NaN error drops that one sample's bar to an empty segment while
+        # keeping its position in the list, so the sample still lines up with
+        # its neighbours -- but there is no endpoint to read. Emitting no
+        # bounds is what the JS trace treats as "this sample has none".
+        if len(segment) == 0:
+            return None
+
+        magnitudes = [float(point[component]) for point in segment]
+        if not all(np.isfinite(magnitude) for magnitude in magnitudes):
+            return None
+
+        return (
+            ErrorBarPlot._without_float_noise(min(magnitudes)),
+            ErrorBarPlot._without_float_noise(max(magnitudes)),
+        )
+
+    @staticmethod
+    def _without_float_noise(value: float) -> float:
+        """
+        Strip binary floating-point noise from a derived bound.
+
+        A bound is not authored, it is computed: matplotlib draws the bar at
+        ``y - err``, and ``4.2 - 0.4`` is ``3.8000000000000003`` in IEEE 754.
+        The estimate itself is left exact because nothing subtracted it -- only
+        the endpoints arithmetic touched are cleaned.
+
+        Twelve significant figures rather than a fixed number of decimals,
+        because the decimals a chart needs depend on its scale: rounding to two
+        would report a bound of 0.003 as zero, which is a worse answer than the
+        noise it was meant to remove.
+
+        Parameters
+        ----------
+        value : float
+            A bound obtained from the drawn geometry.
+
+        Returns
+        -------
+        float
+            The same bound without the trailing artifact.
+        """
+        return float(f"{value:.12g}")
+
+    @staticmethod
+    def _scalar(value: Any) -> Any:
+        """
+        Convert one coordinate to a JSON-serialisable scalar.
+
+        Parameters
+        ----------
+        value : Any
+            A coordinate read off a matplotlib artist.
+
+        Returns
+        -------
+        Any
+            A float, or the string a categorical axis carries.
+        """
+        if isinstance(value, (str, np.str_)):
+            return str(value)
+        return float(value)

--- a/maidr/core/plot/errorbar.py
+++ b/maidr/core/plot/errorbar.py
@@ -10,10 +10,10 @@ from matplotlib.container import ErrorbarContainer
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
-from maidr.util.mixin import ContainerExtractorMixin, DictMergerMixin
+from maidr.util.mixin import DictMergerMixin
 
 
-class ErrorBarPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
+class ErrorBarPlot(MaidrPlot, DictMergerMixin):
     """
     A plot that draws an estimate together with the interval around it.
 
@@ -97,6 +97,14 @@ class ErrorBarPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
             # Tag for highlighting. One path per sample, in data order, which
             # is the shape the JS trace repeats across its three sections.
             self._elements.append(bars)
+        else:
+            # A call passing no error at all draws bare estimates: there is no
+            # bar collection, so nothing carries the `maidr` attribute the
+            # selector goes looking for. Leaving the flag set would emit a
+            # selector promising highlightable paths that the document does
+            # not contain. Cleared the same way `HeatPlot` clears it when the
+            # artist is not a mesh.
+            self._support_highlighting = False
 
         # The category runs along the axis the bars do NOT span, and the
         # magnitude along the one they do. The schema names them `x` and `y`
@@ -133,19 +141,22 @@ class ErrorBarPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         """
         Return the container to describe.
 
+        There is deliberately no fallback to "the first container on the
+        axes". That lookup is precisely the bug this class is built to avoid:
+        a figure with two ``errorbar`` calls carries two containers, and both
+        layers searching for one would find the first, describing one series
+        twice and losing the other with no error to say so. Falling back to it
+        when the patch has not supplied a container would reintroduce that
+        silently on any future path that constructed this class directly.
+
         Returns
         -------
         ErrorbarContainer or None
-            The container the patch supplied, falling back to the first one on
-            the axes, or None when the axes carries none.
+            The container the patched call supplied, or None when there is
+            none -- which the caller turns into an ``ExtractionError`` rather
+            than guessing.
         """
-        if self._container is not None:
-            return self._container
-
-        containers = self.extract_container(
-            self.ax, ErrorbarContainer, include_all=True
-        )
-        return containers[0] if containers else None
+        return self._container
 
     def _extract_centers(
         self, container: ErrorbarContainer

--- a/maidr/core/plot/errorbar.py
+++ b/maidr/core/plot/errorbar.py
@@ -79,6 +79,9 @@ class ErrorBarPlot(MaidrPlot, DictMergerMixin):
         dict
             The MAIDR layer schema.
         """
+        # `super().render()` runs `_extract_plot_data`, which is what resolves
+        # `self._orientation` -- so the read below has to come after it, not
+        # alongside it.
         base_schema = super().render()
         return self.merge_dict(
             base_schema, {MaidrKey.ORIENTATION: self._orientation}
@@ -92,7 +95,7 @@ class ErrorBarPlot(MaidrPlot, DictMergerMixin):
         # `has_yerr` decides the value axis, and an errorbar carrying neither
         # is still a legitimate call -- it draws bare points -- so it reads as
         # vertical rather than as a failure.
-        is_vertical = bool(container.has_yerr) or not bool(container.has_xerr)
+        is_vertical = container.has_yerr or not container.has_xerr
         self._orientation = "vert" if is_vertical else "horz"
 
         centers = self._extract_centers(container)

--- a/maidr/core/plot/errorbar.py
+++ b/maidr/core/plot/errorbar.py
@@ -283,8 +283,18 @@ class ErrorBarPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         Returns
         -------
         Any
-            A float, or the string a categorical axis carries.
+            A float, or a string for a coordinate that is not numeric.
         """
         if isinstance(value, (str, np.str_)):
             return str(value)
-        return float(value)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            # A date axis is the case that reaches here: `ax.errorbar(dates,
+            # ...)` is ordinary on a time series, and matplotlib hands the
+            # dates back as `datetime` objects rather than as the ordinals it
+            # drew. Raising would take out the user's whole figure over an axis
+            # matplotlib is perfectly happy with, so the label travels as a
+            # string -- which the schema allows for `x`, and which reads better
+            # than the bare ordinal a scatter emits.
+            return str(value)

--- a/maidr/core/plot/errorbar.py
+++ b/maidr/core/plot/errorbar.py
@@ -32,6 +32,15 @@ class ErrorBarPlot(MaidrPlot, DictMergerMixin):
     every one of those into two endpoints, so reading it is both shorter and
     correct for cases this module would otherwise have to enumerate.
 
+    Note that ``x`` and ``y`` mean *category* and *magnitude* here in both
+    orientations, which is **not** how ``BarPlot`` and ``HistPlot`` travel --
+    they emit screen-aligned keys that swap with orientation. The difference
+    is not an oversight: the shape is set by the consumer, and ``ErrorBarTrace``
+    reads the magnitude as ``y``/``yMin``/``yMax`` with no orientation branch,
+    while ``ErrorBarPoint`` declares no ``xMin``/``xMax`` to hold a bound.
+    Emitting the bar convention would leave a horizontal chart with no interval
+    at all.
+
     Parameters
     ----------
     ax : Axes

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -4,6 +4,7 @@ from matplotlib.axes import Axes
 from maidr.core.enum import PlotType
 from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.boxplot import BoxPlot
+from maidr.core.plot.errorbar import ErrorBarPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
 from maidr.core.plot.heatmap import HeatPlot
 from maidr.core.plot.histogram import HistPlot
@@ -54,6 +55,8 @@ class MaidrPlotFactory:
                 return BarPlot(single_ax)
         elif PlotType.BOX == plot_type:
             return BoxPlot(single_ax, **kwargs)
+        elif PlotType.ERRORBAR == plot_type:
+            return ErrorBarPlot(single_ax, **kwargs)
         elif PlotType.HEAT == plot_type:
             return HeatPlot(single_ax, **kwargs)
         elif PlotType.HIST == plot_type:

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -3,6 +3,7 @@ from . import (  # noqa: F401
     barplot,
     boxplot,
     clear,
+    errorbar,
     heatmap,
     highlight,
     histogram,

--- a/maidr/patch/errorbar.py
+++ b/maidr/patch/errorbar.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import wrapt
+from matplotlib.axes import Axes
+from matplotlib.container import ErrorbarContainer
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import _argument, _draw_quietly
+
+
+def errorbar(wrapped, instance, args, kwargs) -> ErrorbarContainer:
+    """
+    Register an ``Axes.errorbar`` call as a MAIDR error bar layer.
+
+    The container the call returns is handed to the layer rather than looked
+    up from the axes afterwards. Two ``errorbar`` calls on one axes leave two
+    containers behind, and a layer that searched for "the" container would
+    find the first one both times -- describing the first series twice and
+    dropping the second without any error to say so.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``Axes.errorbar``.
+    instance : Any
+        The Axes the method was bound to.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    ErrorbarContainer
+        Whatever the wrapped function returned, unchanged.
+    """
+    # Don't proceed if the call is made internally by the patched function.
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    # Read the centres before drawing. `fmt="none"` renders the intervals
+    # without the estimate markers, leaving the container with no data line,
+    # and an asymmetric bar is not centred on its own midpoint -- so for that
+    # case the arguments are the only place the estimate still exists.
+    x = _argument("x", wrapped, args, kwargs)
+    y = _argument("y", wrapped, args, kwargs)
+
+    # Set the internal context to avoid cyclic processing.
+    with ContextManager.set_internal_context():
+        container = _draw_quietly(wrapped, args, kwargs)
+
+    ax = instance if isinstance(instance, Axes) else getattr(instance, "axes", None)
+    if ax is None:
+        ax = FigureManager.get_axes(container)
+
+    FigureManager.create_maidr(
+        ax, PlotType.ERRORBAR, container=container, x=x, y=y
+    )
+
+    return container
+
+
+# Patch matplotlib function.
+wrapt.wrap_function_wrapper(Axes, "errorbar", errorbar)

--- a/maidr/patch/errorbar.py
+++ b/maidr/patch/errorbar.py
@@ -51,9 +51,13 @@ def errorbar(wrapped, instance, args, kwargs) -> ErrorbarContainer:
     with ContextManager.set_internal_context():
         container = _draw_quietly(wrapped, args, kwargs)
 
+    # `instance` is the bound Axes, always: this wraps `Axes.errorbar`, so
+    # wrapt has an instance to bind by construction. Reading it directly
+    # rather than routing through `FigureManager.get_axes` is deliberate --
+    # that helper has no branch for an `ErrorbarContainer`, which is a
+    # `Container` rather than an `Artist`, so it would answer None and the
+    # failure would surface as a bare "No plot found."
     ax = instance if isinstance(instance, Axes) else getattr(instance, "axes", None)
-    if ax is None:
-        ax = FigureManager.get_axes(container)
 
     FigureManager.create_maidr(
         ax, PlotType.ERRORBAR, container=container, x=x, y=y

--- a/maidr/patch/errorbar.py
+++ b/maidr/patch/errorbar.py
@@ -51,12 +51,16 @@ def errorbar(wrapped, instance, args, kwargs) -> ErrorbarContainer:
     with ContextManager.set_internal_context():
         container = _draw_quietly(wrapped, args, kwargs)
 
-    # `instance` is the bound Axes, always: this wraps `Axes.errorbar`, so
-    # wrapt has an instance to bind by construction. Reading it directly
-    # rather than routing through `FigureManager.get_axes` is deliberate --
-    # that helper has no branch for an `ErrorbarContainer`, which is a
-    # `Container` rather than an `Artist`, so it would answer None and the
-    # failure would surface as a bare "No plot found."
+    # Read the axes off `instance` rather than routing through
+    # `FigureManager.get_axes`: that helper has no branch for an
+    # `ErrorbarContainer`, which is a `Container` rather than an `Artist`, so
+    # it would answer None and the failure would surface as a bare "No plot
+    # found." rather than as anything to do with error bars.
+    #
+    # Wrapping `Axes.errorbar` means `instance` is the bound Axes on every
+    # call this patch can actually receive. The `getattr` keeps the same shape
+    # `lineplot.py` uses rather than asserting, so a wrapper installed on some
+    # other holder of the method degrades instead of raising here.
     ax = instance if isinstance(instance, Axes) else getattr(instance, "axes", None)
 
     FigureManager.create_maidr(

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -16,6 +16,8 @@ coincide.
 
 from __future__ import annotations
 
+import datetime
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -286,6 +288,29 @@ def test_categorical_x_keeps_its_labels():
     points = _schema(fig)["data"]
 
     assert [point["x"] for point in points] == ["control", "low", "high"]
+
+
+def test_a_date_axis_does_not_break_the_figure():
+    """
+    Error bars on a time series read, rather than raising.
+
+    ``ax.errorbar(dates, ...)`` is ordinary on a time series, and matplotlib
+    hands the dates back as ``datetime`` objects rather than as the ordinals it
+    drew. Coercing those to float raises, which would take out the user's whole
+    figure over an axis matplotlib is perfectly happy with -- so the label
+    travels as a string, which the schema allows for ``x``.
+    """
+    dates = [datetime.date(2026, 1, day) for day in (1, 2, 3)]
+
+    fig, ax = plt.subplots()
+    ax.errorbar(dates, Y, yerr=0.5)
+
+    points = _schema(fig)["data"]
+
+    assert [point["x"] for point in points] == ["2026-01-01", "2026-01-02", "2026-01-03"]
+    # The magnitude and its bounds are still numbers, so sonification works.
+    assert points[0]["y"] == 4.2
+    assert points[0]["yMin"] == 3.7
 
 
 def test_two_calls_register_two_distinct_layers():

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -235,6 +235,40 @@ def test_horizontal_error_reports_horz_orientation():
     assert schema["data"][0] == {"x": 4.2, "y": 0.0, "yMin": -0.3, "yMax": 0.3}
 
 
+def test_horizontal_axes_labels_pair_with_the_swapped_data():
+    """
+    The axis labels stay screen-aligned, and still pair correctly.
+
+    This is the half of the horizontal case that looks wrong in isolation: the
+    labels are emitted screen-aligned (``x`` is the axis the magnitude is drawn
+    on) while the data is orientation-invariant (``x`` is the category). Read
+    naively as "axes.x with data.x" that pairs "Response" with "control".
+
+    It resolves in the consumer, which swaps which label goes with which value
+    exactly when the layer is horizontal::
+
+        main  = { label: yAxis,  value: point.x }  -> "Group: control"
+        cross = { label: xAxis,  value: magnitude } -> "Response: 4.2"
+
+    So both halves have to be asserted together, or a future change to either
+    one alone would silently transpose every horizontal chart's announcement.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(Y, ["control", "low", "high"], xerr=0.3)
+    ax.set_xlabel("Response")  # the magnitude, on the real x axis
+    ax.set_ylabel("Group")  # the category, on the real y axis
+
+    schema = _schema(fig)
+
+    assert schema["orientation"] == "horz"
+    # Labels: screen-aligned, as every other plot type emits them.
+    assert schema["axes"]["x"]["label"] == "Response"
+    assert schema["axes"]["y"]["label"] == "Group"
+    # Data: category in x, magnitude in y, in both orientations.
+    assert schema["data"][0]["x"] == "control"
+    assert schema["data"][0]["y"] == 4.2
+
+
 def test_vertical_error_reports_vert_orientation():
     """``yerr`` is the vertical case, and the default."""
     fig, ax = plt.subplots()

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -1,0 +1,375 @@
+"""Tests for error bar plots.
+
+``Axes.errorbar`` is the call that carries uncertainty, and uncertainty is
+frequently the finding rather than the decoration: whether two group means
+differ is answered by whether their intervals overlap. Until this was patched
+a MAIDR reader got the estimate and nothing else.
+
+The bounds are read off the drawn ``LineCollection`` rather than recomputed
+from the ``yerr`` the caller passed, because those are different quantities --
+matplotlib takes an offset, the schema carries an absolute position -- and the
+offset has three shapes before ``uplims``/``lolims`` change the meaning again.
+These tests are written against the cases that distinguish those, so an
+implementation that reverted to arithmetic on ``yerr`` would fail rather than
+coincide.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+#: Three group means with asymmetric intervals. Every number is distinct, so a
+#: reading that took the wrong bound, or the wrong sample, cannot coincide with
+#: the right one.
+X = [0, 1, 2]
+Y = [4.2, 5.1, 7.3]
+#: Lower and upper offsets, deliberately unequal per side and per sample.
+YERR = [[0.4, 1.1, 0.2], [0.4, 1.5, 0.1]]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _plots(fig):
+    """
+    Return the MAIDR plots registered for a figure, or an empty list.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to read.
+
+    Returns
+    -------
+    list
+        The registered plots; empty when the figure registered nothing.
+    """
+    try:
+        return FigureManager.get_maidr(fig).plots
+    except KeyError:
+        return []
+
+
+def _schema(fig):
+    """
+    Render the sole registered layer's schema.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to read.
+
+    Returns
+    -------
+    dict
+        The layer schema.
+    """
+    plots = _plots(fig)
+    assert len(plots) == 1, f"expected exactly one layer, got {len(plots)}"
+    return plots[0].render()
+
+
+def test_errorbar_registers_an_error_bar_layer():
+    """A call with error bars registers as the error bar type."""
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=YERR)
+
+    assert _plots(fig)[0].type == PlotType.ERRORBAR
+
+
+def test_asymmetric_bounds_are_absolute_positions():
+    """
+    The emitted bounds are where the bar was drawn, not the offsets passed.
+
+    This is the distinction the schema exists to fix. A reader told "0.4"
+    instead of "3.8" is being given a number the chart does not draw anywhere,
+    and for an asymmetric interval the two offsets differ per side, so an
+    implementation that emitted offsets would be wrong twice per sample.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=YERR)
+
+    points = _schema(fig)["data"]
+
+    assert points[0] == {"x": 0.0, "y": 4.2, "yMin": 3.8, "yMax": 4.6}
+    assert points[1] == {"x": 1.0, "y": 5.1, "yMin": 4.0, "yMax": 6.6}
+    assert points[2] == {"x": 2.0, "y": 7.3, "yMin": 7.1, "yMax": 7.4}
+
+
+def test_bounds_carry_no_float_noise():
+    """
+    A derived bound is announced as the chart draws it, not to 17 digits.
+
+    matplotlib computes the bar endpoint as ``y - err``, and ``4.2 - 0.4`` is
+    ``3.8000000000000003`` in IEEE 754. A screen reader spells every one of
+    those digits out, so the exact comparison here is the assertion -- not an
+    approximate one, which would pass on the noisy value it exists to reject.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=YERR)
+
+    lower = _schema(fig)["data"][0]["yMin"]
+
+    assert repr(lower) == "3.8"
+
+
+def test_a_tiny_interval_survives_the_noise_stripping():
+    """
+    Cleaning the noise must not round a small interval away to nothing.
+
+    Rounding to a fixed number of decimals would report this bound as equal to
+    the estimate, which is a worse answer than the noise it was meant to
+    remove.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar([0], [1.0], yerr=[0.0005])
+
+    point = _schema(fig)["data"][0]
+
+    assert point["yMin"] == 0.9995
+    assert point["yMax"] == 1.0005
+
+
+def test_symmetric_error_expands_to_both_bounds():
+    """A scalar ``yerr`` applies to both sides of every sample."""
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=0.5)
+
+    points = _schema(fig)["data"]
+
+    assert [point["yMin"] for point in points] == [3.7, 4.6, 6.8]
+    assert [point["yMax"] for point in points] == [4.7, 5.6, 7.8]
+
+
+def test_one_sided_error_reads_the_bound_that_exists():
+    """
+    A zero on one side is a real bound at the estimate, not a missing one.
+
+    ``uplims``/``lolims`` and a zero offset both draw a bar that stops at the
+    estimate. Reading the drawn geometry gets that right without special
+    casing, which is the reason for reading geometry at all.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=[[0, 0, 0], [0.4, 0.5, 0.6]])
+
+    points = _schema(fig)["data"]
+
+    # The lower bound coincides with the estimate; the upper is above it.
+    assert [point["yMin"] for point in points] == Y
+    assert [point["yMax"] for point in points] == [4.6, 5.6, 7.9]
+
+
+def test_horizontal_error_reports_horz_orientation():
+    """
+    ``xerr`` draws the interval along x, and the layer says so.
+
+    The schema names the category ``x`` and the magnitude ``y`` in both
+    orientations, exactly as the box plot already travels, and lets
+    ``orientation`` say which is on screen where. Asserting the swap is what
+    stops the axes being read back to front.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, xerr=0.3)
+
+    schema = _schema(fig)
+
+    assert schema["orientation"] == "horz"
+    # Category is the y position, magnitude is the x value it spans.
+    assert schema["data"][0] == {"x": 4.2, "y": 0.0, "yMin": -0.3, "yMax": 0.3}
+
+
+def test_vertical_error_reports_vert_orientation():
+    """``yerr`` is the vertical case, and the default."""
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=0.5)
+
+    assert _schema(fig)["orientation"] == "vert"
+
+
+def test_both_axes_of_error_describe_the_vertical_interval():
+    """
+    A call passing both errors describes the y interval.
+
+    Only one interval fits the trace, and ``yerr`` is the conventional
+    reading. Pinned because matplotlib renders the two collections x-first:
+    taking ``lines[2][0]`` unconditionally would silently describe the x
+    interval on every chart that passes both.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, xerr=0.3, yerr=0.5)
+
+    schema = _schema(fig)
+
+    assert schema["orientation"] == "vert"
+    assert schema["data"][0] == {"x": 0.0, "y": 4.2, "yMin": 3.7, "yMax": 4.7}
+
+
+def test_fmt_none_still_reports_the_estimates():
+    """
+    ``fmt="none"`` draws intervals without markers, and still reads.
+
+    The container has no data line in this mode, and the estimate is not
+    recoverable from the geometry -- an asymmetric bar is not centred on its
+    own midpoint -- so the centres come from the call's arguments. Asymmetric
+    on purpose: a midpoint fallback would pass on a symmetric fixture.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=YERR, fmt="none")
+
+    points = _schema(fig)["data"]
+
+    assert [point["y"] for point in points] == Y
+    assert points[1] == {"x": 1.0, "y": 5.1, "yMin": 4.0, "yMax": 6.6}
+
+
+def test_a_nan_error_drops_only_that_sample_s_bounds():
+    """
+    One unmeasured sample leaves its neighbours intact.
+
+    matplotlib renders a NaN error as an empty segment that keeps its place in
+    the list, so the samples stay aligned -- but there is no endpoint to read.
+    Emitting no bounds is what the JS trace treats as "this sample has none";
+    emitting NaN would poison the trace's whole pitch range.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=[0.4, np.nan, 0.2])
+
+    points = _schema(fig)["data"]
+
+    assert points[1] == {"x": 1.0, "y": 5.1}
+    assert points[0]["yMin"] == 3.8
+    assert points[2]["yMax"] == 7.5
+
+
+def test_a_call_with_no_error_still_registers_its_points():
+    """
+    ``errorbar`` without any error is a legitimate call, and reads as points.
+
+    It draws bare estimates, so the layer carries them with no bounds rather
+    than failing -- a chart that raised here would break the user's figure over
+    a call matplotlib is perfectly happy with.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y)
+
+    points = _schema(fig)["data"]
+
+    assert points == [
+        {"x": 0.0, "y": 4.2},
+        {"x": 1.0, "y": 5.1},
+        {"x": 2.0, "y": 7.3},
+    ]
+
+
+def test_categorical_x_keeps_its_labels():
+    """A categorical axis is announced by name, not by tick position."""
+    fig, ax = plt.subplots()
+    ax.errorbar(["control", "low", "high"], Y, yerr=0.5)
+
+    points = _schema(fig)["data"]
+
+    assert [point["x"] for point in points] == ["control", "low", "high"]
+
+
+def test_two_calls_register_two_distinct_layers():
+    """
+    Each ``errorbar`` call describes its own series.
+
+    The layer is handed the container its own call produced. Looking one up on
+    the axes instead would find the first container both times, describing the
+    first series twice and dropping the second with no error to say so -- which
+    is the failure this pins.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=0.5)
+    ax.errorbar(X, [1.0, 2.0, 3.0], yerr=0.2)
+
+    plots = _plots(fig)
+    assert len(plots) == 2
+
+    first, second = (plot.render()["data"] for plot in plots)
+    assert [point["y"] for point in first] == Y
+    assert [point["y"] for point in second] == [1.0, 2.0, 3.0]
+
+
+def test_errorbar_supports_highlighting():
+    """
+    The bar collection is tagged, so the interval under the cursor highlights.
+
+    Both halves are asserted because the flag alone is weak:
+    ``_support_highlighting`` starts True and is only ever cleared, so it
+    cannot detect a dropped tagging call. ``elements`` is what the claim
+    actually rests on.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=0.5)
+
+    plot = _plots(fig)[0]
+    plot._extract_plot_data()
+
+    assert plot._support_highlighting is True
+    assert plot.elements, "the bar LineCollection should be tagged"
+
+
+@pytest.mark.parametrize(
+    ("draw", "expected"),
+    [
+        (lambda ax, df: sns.barplot(df, x="g", y="v", ax=ax), PlotType.BAR),
+        (lambda ax, df: sns.pointplot(df, x="g", y="v", ax=ax), PlotType.LINE),
+    ],
+    ids=["barplot", "pointplot"],
+)
+def test_seaborn_error_bars_do_not_register_a_second_layer(draw, expected):
+    """
+    Patching ``Axes.errorbar`` must not add a layer to seaborn's own charts.
+
+    ``sns.barplot`` and ``sns.pointplot`` both draw a confidence interval by
+    default. Were either to route through ``Axes.errorbar``, this patch would
+    hand the user a second layer describing the same chart -- an extra thing to
+    navigate that the figure does not contain.
+
+    Pinned rather than assumed, because it is a claim about another library's
+    internals: current seaborn renders those intervals itself, and the day it
+    switches, this test is what says so.
+    """
+    rng = np.random.default_rng(20260811)
+    df = pd.DataFrame({"g": ["a"] * 20 + ["b"] * 20, "v": rng.normal(size=40)})
+
+    fig, ax = plt.subplots()
+    draw(ax, df)
+
+    plots = _plots(fig)
+    assert len(plots) == 1
+    assert plots[0].type == expected
+
+
+def test_the_selector_reaches_one_element_per_sample():
+    """
+    The layer's selector addresses the drawn bars, one path per sample.
+
+    matplotlib renders the bar ``LineCollection`` as a group of paths in data
+    order, which is the shape the JS trace repeats across its three sections.
+    A selector resolving to a different count makes that trace drop the
+    highlight entirely rather than fail loudly.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=0.5)
+
+    assert _schema(fig)["selectors"] == "g[maidr='true'] > path"

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -180,6 +180,37 @@ def test_one_sided_error_reads_the_bound_that_exists():
     assert [point["yMax"] for point in points] == [4.6, 5.6, 7.9]
 
 
+@pytest.mark.parametrize(
+    ("limit", "expected_lower", "expected_upper"),
+    [
+        # `uplims` marks the estimate as an upper limit: the bar runs from
+        # below up to the estimate, so the upper bound coincides with it.
+        ("uplims", [3.7, 4.6, 6.8], Y),
+        # `lolims` is the mirror image.
+        ("lolims", Y, [4.7, 5.6, 7.8]),
+    ],
+)
+def test_a_one_sided_limit_reads_the_bar_that_was_drawn(
+    limit, expected_lower, expected_upper
+):
+    """
+    ``uplims``/``lolims`` change what the bar means, and are read correctly.
+
+    These are the kwargs the zero-offset case only approximates: they do not
+    change the offset at all, they change which side of the estimate the bar
+    is drawn on and swap the cap for an arrow. Reading the drawn geometry
+    handles them with no special casing -- which is the whole argument for
+    reading geometry -- but only this test actually pins it.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=0.5, **{limit: True})
+
+    points = _schema(fig)["data"]
+
+    assert [point["yMin"] for point in points] == expected_lower
+    assert [point["yMax"] for point in points] == expected_upper
+
+
 def test_horizontal_error_reports_horz_orientation():
     """
     ``xerr`` draws the interval along x, and the layer says so.

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -389,6 +389,34 @@ def test_a_date_axis_does_not_break_the_figure():
     assert points[0]["yMin"] == 3.7
 
 
+@pytest.mark.parametrize(
+    "make_axis",
+    [
+        lambda: [pd.Timestamp("2026-01-01"), pd.Timestamp("2026-01-02")],
+        lambda: np.array(["2026-01-01", "2026-01-02"], dtype="datetime64[D]"),
+    ],
+    ids=["pandas-timestamp", "numpy-datetime64"],
+)
+def test_other_timestamp_types_read_rather_than_raising(make_axis):
+    """
+    Every timestamp type reaches the string fallback rather than raising.
+
+    ``ax.errorbar(df.index, ...)`` hands back a ``Timestamp`` or a
+    ``datetime64`` rather than a ``date``, so pinning only ``datetime.date``
+    would leave the crash this fallback exists to prevent reachable by the
+    types most likely to appear in practice. Their ``str()`` forms differ from
+    each other -- one carries a time component -- so the assertion is that the
+    label is a non-empty string naming the year, not one exact spelling.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(make_axis(), [4.2, 5.1], yerr=0.5)
+
+    labels = [point["x"] for point in _schema(fig)["data"]]
+
+    assert all(isinstance(label, str) for label in labels)
+    assert all(label.startswith("2026-01-0") for label in labels)
+
+
 def test_two_calls_register_two_distinct_layers():
     """
     Each ``errorbar`` call describes its own series.

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -417,6 +417,27 @@ def test_other_timestamp_types_read_rather_than_raising(make_axis):
     assert all(label.startswith("2026-01-0") for label in labels)
 
 
+def test_a_date_axis_reads_the_same_with_no_markers():
+    """
+    The two fallbacks compose: a date axis drawn with ``fmt="none"``.
+
+    Each is covered alone, but they meet on one code path -- ``fmt="none"``
+    takes the centres from the call arguments rather than from a data line, so
+    the labels travel through ``np.atleast_1d`` before reaching ``_scalar``.
+    Were that to coerce the dates to ``datetime64``, the labels would silently
+    gain a time component that the ordinary path does not produce, and the
+    same chart would read two different ways depending on its marker style.
+    """
+    dates = [datetime.date(2026, 1, day) for day in (1, 2, 3)]
+
+    fig, ax = plt.subplots()
+    ax.errorbar(dates, Y, yerr=0.5, fmt="none")
+
+    labels = [point["x"] for point in _schema(fig)["data"]]
+
+    assert labels == ["2026-01-01", "2026-01-02", "2026-01-03"]
+
+
 def test_two_calls_register_two_distinct_layers():
     """
     Each ``errorbar`` call describes its own series.

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -183,9 +183,14 @@ def test_horizontal_error_reports_horz_orientation():
     ``xerr`` draws the interval along x, and the layer says so.
 
     The schema names the category ``x`` and the magnitude ``y`` in both
-    orientations, exactly as the box plot already travels, and lets
-    ``orientation`` say which is on screen where. Asserting the swap is what
-    stops the axes being read back to front.
+    orientations, and lets ``orientation`` say which is on screen where.
+
+    That is the consumer's shape, not a convention borrowed from another plot
+    type: ``ErrorBarTrace`` reads the magnitude as ``y``/``yMin``/``yMax``
+    with no orientation branch, and ``ErrorBarPoint`` declares no
+    ``xMin``/``xMax``. Emitting the screen-aligned form a bar uses would leave
+    a horizontal chart with no interval at all, so this assertion is what
+    keeps the two repositories agreeing.
     """
     fig, ax = plt.subplots()
     ax.errorbar(X, Y, xerr=0.3)

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -31,6 +31,8 @@ import seaborn as sns  # noqa: E402
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.core.plot.errorbar import ErrorBarPlot  # noqa: E402
+from maidr.exception import ExtractionError  # noqa: E402
 
 
 #: Three group means with asymmetric intervals. Every number is distinct, so a
@@ -312,7 +314,11 @@ def test_a_date_axis_does_not_break_the_figure():
 
     points = _schema(fig)["data"]
 
-    assert [point["x"] for point in points] == ["2026-01-01", "2026-01-02", "2026-01-03"]
+    assert [point["x"] for point in points] == [
+        "2026-01-01",
+        "2026-01-02",
+        "2026-01-03",
+    ]
     # The magnitude and its bounds are still numbers, so sonification works.
     assert points[0]["y"] == 4.2
     assert points[0]["yMin"] == 3.7
@@ -388,6 +394,62 @@ def test_seaborn_error_bars_do_not_register_a_second_layer(draw, expected):
     plots = _plots(fig)
     assert len(plots) == 1
     assert plots[0].type == expected
+
+
+def test_a_call_with_no_error_promises_no_highlight():
+    """
+    Nothing is tagged when nothing is drawn, so no selector is emitted.
+
+    A bare ``ax.errorbar(x, y)`` renders no bar collection, so no element ever
+    carries the ``maidr`` attribute the selector goes looking for. Emitting the
+    selector anyway would promise the frontend highlightable paths the document
+    does not contain.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y)
+
+    plot = _plots(fig)[0]
+    schema = plot.render()
+
+    assert plot._support_highlighting is False
+    assert not plot.elements
+    assert "selectors" not in schema
+
+
+def test_caps_do_not_disturb_the_bounds():
+    """
+    ``capsize`` adds cap artists, and the bounds are read the same.
+
+    The caps are separate ``Line2D`` artists in ``container.lines[1]``, while
+    the bounds come from the collection in ``lines[2]``. Pinned because
+    ``capsize`` is the one rendering permutation that changes how many artists
+    the container holds without changing what the interval is.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=YERR, capsize=5)
+
+    points = _schema(fig)["data"]
+
+    assert points[0] == {"x": 0.0, "y": 4.2, "yMin": 3.8, "yMax": 4.6}
+    assert points[1] == {"x": 1.0, "y": 5.1, "yMin": 4.0, "yMax": 6.6}
+
+
+def test_a_layer_built_without_its_container_refuses_to_guess():
+    """
+    Constructed outside the patch, the layer raises rather than guessing.
+
+    The tempting fallback -- take the first ``ErrorbarContainer`` on the axes
+    -- is exactly the bug the patch's container hand-off exists to prevent, so
+    it must not be reachable by another route either. A figure with two calls
+    would otherwise describe the first series twice.
+    """
+    fig, ax = plt.subplots()
+    ax.errorbar(X, Y, yerr=0.5)
+
+    orphan = ErrorBarPlot(ax)
+
+    with pytest.raises(ExtractionError):
+        orphan._extract_plot_data()
 
 
 def test_the_selector_reaches_one_element_per_sample():

--- a/tests/core/test_axes_schema.py
+++ b/tests/core/test_axes_schema.py
@@ -83,6 +83,37 @@ class TestMatplotlibCanonicalShape:
         finally:
             plt.close(fig)
 
+    def test_errorbar(self):
+        fig, ax = plt.subplots()
+        try:
+            ax.errorbar([0, 1, 2], [4.2, 5.1, 7.3], yerr=0.5)
+            ax.set_xlabel("Group")
+            ax.set_ylabel("Response")
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            assert axes["x"]["label"] == "Group"
+            assert axes["y"]["label"] == "Response"
+        finally:
+            plt.close(fig)
+
+    def test_errorbar_horizontal_keeps_axes_screen_aligned(self):
+        # The layer's data is orientation-invariant while its axis labels are
+        # not, so the canonical shape has to hold for the orientation where
+        # the two disagree, not only the one where they happen to line up.
+        fig, ax = plt.subplots()
+        try:
+            ax.errorbar([4.2, 5.1, 7.3], ["a", "b", "c"], xerr=0.3)
+            ax.set_xlabel("Response")
+            ax.set_ylabel("Group")
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            assert axes["x"]["label"] == "Response"
+            assert axes["y"]["label"] == "Group"
+        finally:
+            plt.close(fig)
+
     def test_scatter_emits_per_axis_object(self):
         fig, ax = plt.subplots()
         try:


### PR DESCRIPTION
## Description

Closes #340. The Python binding for the `error_bar` trace type, which landed in core as xability/maidr#819.

`Axes.errorbar` was not patched, so any chart carrying uncertainty — the majority of published statistical figures — lost that information entirely. The estimate was announced and the interval dropped, so the comparison the chart was drawn to support could not be made at all.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

`PlotType.ERRORBAR` (wire value `error_bar`, matching core), `maidr/patch/errorbar.py`, `maidr/core/plot/errorbar.py`, factory dispatch, and 18 tests.

### Bounds come from the drawn geometry, not from `yerr`

The issue called the matplotlib container layout "the fiddly part, not the schema", and that is exactly right — so I probed it rather than reasoning about it. The decision that follows from what I found: **read the rendered `LineCollection`, not the caller's `yerr`.**

Those are different quantities. matplotlib takes an *offset*; the MAIDR schema carries an *absolute position*. And the offset arrives in three shapes — scalar, `(N,)`, `(2, N)` — before `uplims`/`lolims` change what the bar means again. The collection matplotlib actually rendered has already resolved every one of those into two endpoints, so reading it is both shorter and correct for cases the arithmetic route would have to enumerate one at a time.

### What the probe turned up, and what each cost

| Case | Finding | Handling |
|---|---|---|
| `fmt="none"` | Container has **no data line** | Centres come from the call arguments. They are genuinely unrecoverable from geometry — an asymmetric bar is *not* centred on its own midpoint |
| `yerr` containing `NaN` | Renders an **empty segment that keeps its position** | Samples stay aligned; that one is emitted with no bounds. Emitting `NaN` would poison the trace's whole pitch range |
| `xerr` **and** `yerr` | Two collections, **x first** | `lines[2][0]` unconditionally would have silently described the x interval on every such chart |
| Two `errorbar` calls | Two containers on one axes | The patch hands over the container **its own call produced** |
| `uplims` / zero on one side | Bar stops at the estimate | Falls out of reading geometry with no special-casing — the reason for reading geometry |
| Categorical x | Labels survive on the data line | Announced by name, not tick position |

The two-container one is worth calling out: a layer that looked up "the" container on the axes would find the first one **both times**, describing the first series twice and dropping the second with no error anywhere. Passing the container from the patch removes the ambiguity rather than papering over it.

### Float noise

A derived bound is not authored. matplotlib draws at `y - err`, and `4.2 - 0.4` is `3.8000000000000003` — which a screen reader spells out in full. Cleaned to 12 significant figures, *not* fixed decimals: rounding to two would report a bound of 0.003 as zero, a worse answer than the noise. The estimate itself is left exact, because nothing subtracted it — only the endpoints arithmetic touched are cleaned.

## A correction to the issue

#340 says #246 (`sns.pointplot`) "produces error bars through this same path and should share the extraction." **That is not true of current seaborn** — `sns.barplot` and `sns.pointplot` render their confidence intervals themselves and never reach `Axes.errorbar`. So this PR does not advance #246, and #246 will need its own extraction.

I've pinned that as a parametrized regression test rather than leaving it as a claim about another library's internals: if seaborn ever does route through `Axes.errorbar`, users would silently get a **second layer** describing the same chart, and that test is what says so.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Verification actually run

| Step | Result |
|---|---|
| `uv run pytest` | **853 passed** (was 835), 0 failures |
| `uv run pytest tests/core/plot/test_errorbar.py` | **18 passed** |
| `ruff check` on every changed file | clean |

Depends on xability/maidr#819 (merged) for the core trace type.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_