### PR TITLE
fix(plotly): keep data and selector aligned when a series is empty

### DIFF
--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot
 
 
 class PlotlyMultiLinePlot(PlotlyPlot):
@@ -72,7 +71,13 @@ class PlotlyMultiLinePlot(PlotlyPlot):
             One CSS selector per line, in trace order; empty for a WebGL
             layer.
         """
-        return self._scatter_line_selectors(self._traces, self._scatter_positions)
+        # Positions filtered by the same predicate that filters the data, so
+        # series *i* always addresses the element series *i* is drawn as --
+        # see `_line_series_with_positions`.
+        _, drawn_positions = self._line_series_with_positions(
+            self._traces, self._scatter_positions
+        )
+        return self._scatter_line_selectors(self._traces, drawn_positions)
 
     def _extract_plot_data(self) -> list[list[dict]]:
         """Return multi-line data as a list-of-lists.
@@ -80,24 +85,7 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         Each inner list contains ``{x, y}`` dicts for one line, with an
         optional ``z`` key set to the trace name.
         """
-        all_lines: list[list[dict]] = []
-
-        for trace in self._traces:
-            x = as_list(trace.get("x"))
-            y = as_list(trace.get("y"))
-            name = trace.get("name", "")
-
-            line_data: list[dict] = []
-            for xv, yv in zip(x, y):
-                point: dict = {
-                    MaidrKey.X: self._to_native(xv),
-                    MaidrKey.Y: self._to_native(yv),
-                }
-                if name:
-                    point[MaidrKey.Z] = name
-                line_data.append(point)
-
-            if line_data:
-                all_lines.append(line_data)
-
-        return all_lines
+        lines, _ = self._line_series_with_positions(
+            self._traces, self._scatter_positions
+        )
+        return lines

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -166,6 +166,68 @@ class PlotlyPlot(ABC):
             return []
         return [self._scatter_line_selector(position) for position in positions]
 
+    def _line_series_with_positions(
+        self, traces: list[dict], positions: list[int]
+    ) -> tuple[list[list[dict]], list[int]]:
+        """
+        Build the drawn series and the positions they were drawn at, together.
+
+        ``data`` and ``selector`` are paired positionally by the frontend, so
+        they have to be filtered by the same predicate. They were not: a trace
+        whose ``x``/``y`` came out empty was dropped from the data and still
+        consumed a selector, which slid every later series onto its
+        predecessor's element (#316). The audio, braille and text stayed
+        correct, so only a sighted collaborator could see the wrong line
+        highlighted -- the failure was invisible to the person using it.
+
+        Returning both from one pass is the fix, and is what stops the two
+        drifting apart again. The alternative, keeping the empty series so the
+        lists stay parallel, would emit a zero-point series for the frontend
+        to tolerate; dropping the position costs nothing and leaves ``data``
+        exactly as it is today.
+
+        An empty ``x``/``y`` is not exotic. It is what a series filtered to
+        nothing produces, which is routine in a dashboard or a faceted export
+        where one category has no rows in the current slice.
+
+        Parameters
+        ----------
+        traces : list of dict
+            The traces this layer covers, in series order.
+        positions : list of int
+            Each trace's zero-based position among the subplot's
+            scatter-family traces, in the same order.
+
+        Returns
+        -------
+        tuple of (list of list of dict, list of int)
+            The non-empty series, and the positions of the traces that
+            produced them -- index-aligned, and the same length.
+        """
+        series_list: list[list[dict]] = []
+        drawn_positions: list[int] = []
+
+        for trace, position in zip(traces, positions):
+            x_values = as_list(trace.get("x"))
+            y_values = as_list(trace.get("y"))
+            name = trace.get("name", "")
+
+            series: list[dict] = []
+            for x_value, y_value in zip(x_values, y_values):
+                point: dict = {
+                    MaidrKey.X: self._to_native(x_value),
+                    MaidrKey.Y: self._to_native(y_value),
+                }
+                if name:
+                    point[MaidrKey.Z] = name
+                series.append(point)
+
+            if series:
+                series_list.append(series)
+                drawn_positions.append(position)
+
+        return series_list, drawn_positions
+
     @staticmethod
     def _validate_scatter_positions(positions: list[int], trace_count: int) -> None:
         """

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot
 from maidr.plotly.step_shape import step_direction_of
 
 
@@ -87,7 +87,13 @@ class PlotlyStepPlot(PlotlyPlot):
             One CSS selector per series, in trace order; empty for a WebGL
             layer.
         """
-        return self._scatter_line_selectors(self._traces, self._scatter_positions)
+        # Positions filtered by the same predicate that filters the data, so
+        # series *i* always addresses the element series *i* is drawn as --
+        # see `_line_series_with_positions`.
+        _, drawn_positions = self._line_series_with_positions(
+            self._traces, self._scatter_positions
+        )
+        return self._scatter_line_selectors(self._traces, drawn_positions)
 
     def render(self) -> dict:
         """
@@ -141,24 +147,7 @@ class PlotlyStepPlot(PlotlyPlot):
             ``{x, y}`` per point, with ``z`` set to the trace name when it has
             one. Empty series are dropped, matching ``PlotlyMultiLinePlot``.
         """
-        all_series: list[list[dict]] = []
-
-        for trace in self._traces:
-            x_values = as_list(trace.get("x"))
-            y_values = as_list(trace.get("y"))
-            name = trace.get("name", "")
-
-            series: list[dict] = []
-            for x_value, y_value in zip(x_values, y_values):
-                point: dict = {
-                    MaidrKey.X: self._to_native(x_value),
-                    MaidrKey.Y: self._to_native(y_value),
-                }
-                if name:
-                    point[MaidrKey.Z] = name
-                series.append(point)
-
-            if series:
-                all_series.append(series)
-
-        return all_series
+        series, _ = self._line_series_with_positions(
+            self._traces, self._scatter_positions
+        )
+        return series

--- a/tests/plotly/test_plotly_empty_series_alignment.py
+++ b/tests/plotly/test_plotly_empty_series_alignment.py
@@ -1,0 +1,202 @@
+"""``data`` and ``selector`` are paired positionally, so they must stay aligned.
+
+The frontend pairs selector *i* with series *i*. ``PlotlyStepPlot`` and
+``PlotlyMultiLinePlot`` built the two lists from the same traces by two
+different rules: a trace whose ``x``/``y`` came out empty was dropped from the
+data and still consumed a selector. Every series after the empty one then
+addressed its predecessor's element (#316).
+
+The failure is silent in the way ``nth-child`` failures always are. Audio,
+braille and text are all correct, and only the visual highlight is wrong -- so
+a sighted collaborator sees the wrong line highlighted while the person using
+the announcements has no way to notice. That is why these assert on the
+selector *strings* rather than only on the two lengths matching: equal lengths
+would also be satisfied by pointing every series at the wrong element.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.plotly.multiline import PlotlyMultiLinePlot
+from maidr.plotly.step import PlotlyStepPlot
+
+plotly = pytest.importorskip("plotly")
+
+
+def _step(x: list, y: list, name: str) -> dict:
+    """
+    Build a staircase trace.
+
+    Parameters
+    ----------
+    x, y : list
+        Sample coordinates; either may be empty.
+    name : str
+        Trace name.
+
+    Returns
+    -------
+    dict
+        A scatter trace whose ``line.shape`` makes plotly draw risers.
+    """
+    return {
+        "type": "scatter",
+        "mode": "lines",
+        "x": x,
+        "y": y,
+        "line": {"shape": "hv"},
+        "name": name,
+    }
+
+
+def _line(x: list, y: list, name: str) -> dict:
+    """
+    Build a plain line trace.
+
+    Parameters
+    ----------
+    x, y : list
+        Sample coordinates; either may be empty.
+    name : str
+        Trace name.
+
+    Returns
+    -------
+    dict
+        A scatter/lines trace dict.
+    """
+    return {"type": "scatter", "mode": "lines", "x": x, "y": y, "name": name}
+
+
+def nth_child(selector: str) -> int:
+    """
+    Read the ``nth-child`` index out of a selector.
+
+    Parameters
+    ----------
+    selector : str
+        A selector built by ``_scatter_line_selector``.
+
+    Returns
+    -------
+    int
+        The one-based index the selector addresses.
+    """
+    marker = "nth-child("
+    start = selector.index(marker) + len(marker)
+    return int(selector[start : selector.index(")", start)])
+
+
+#: The two classes share the defect and the fix, and the issue asked that they
+#: stay consistent with each other, so every case runs against both.
+CLASSES = [
+    pytest.param(PlotlyStepPlot, _step, id="step"),
+    pytest.param(PlotlyMultiLinePlot, _line, id="multiline"),
+]
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_an_empty_series_does_not_shift_the_ones_after_it(plot_class, make) -> None:
+    """The series after an empty trace addresses its own element.
+
+    This is the reported bug. ``'c'`` is the figure's third trace and renders
+    at ``nth-child(3)``; paired with the empty trace's selector it highlighted
+    ``nth-child(2)`` instead.
+    """
+    traces = [
+        make([0, 1], [1, 2], "a"),
+        make([], [], "empty"),
+        make([0, 1], [2, 1], "c"),
+    ]
+
+    schema = plot_class(traces, {}, scatter_positions=[0, 1, 2]).schema
+    data = schema[MaidrKey.DATA]
+    selectors = schema[MaidrKey.SELECTOR]
+
+    assert len(data) == len(selectors)
+    assert [nth_child(s) for s in selectors] == [1, 3]
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_a_leading_empty_series_shifts_nothing_either(plot_class, make) -> None:
+    """The empty trace need not be in the middle for the lists to diverge."""
+    traces = [
+        make([], [], "empty"),
+        make([0, 1], [1, 2], "b"),
+        make([0, 1], [2, 1], "c"),
+    ]
+
+    schema = plot_class(traces, {}, scatter_positions=[0, 1, 2]).schema
+
+    assert [nth_child(s) for s in schema[MaidrKey.SELECTOR]] == [2, 3]
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_the_data_contract_is_unchanged(plot_class, make) -> None:
+    """An empty trace still produces no series, as it did before.
+
+    The alternative fix -- keeping the empty series so the lists stay
+    parallel -- would have emitted a zero-point series for the frontend to
+    tolerate. Dropping the position instead leaves ``data`` exactly as it was.
+    """
+    traces = [
+        make([0, 1], [1, 2], "a"),
+        make([], [], "empty"),
+        make([0, 1], [2, 1], "c"),
+    ]
+
+    data = plot_class(traces, {}, scatter_positions=[0, 1, 2]).schema[MaidrKey.DATA]
+
+    assert len(data) == 2
+    assert [point[MaidrKey.Z] for series in data for point in series[:1]] == ["a", "c"]
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_a_layer_with_no_empty_trace_is_untouched(plot_class, make) -> None:
+    """The common case keeps every position it was given."""
+    traces = [make([0, 1], [1, 2], "a"), make([0, 1], [2, 1], "b")]
+
+    schema = plot_class(traces, {}, scatter_positions=[3, 4]).schema
+
+    assert len(schema[MaidrKey.DATA]) == 2
+    assert [nth_child(s) for s in schema[MaidrKey.SELECTOR]] == [4, 5]
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_every_trace_empty_emits_no_selectors_at_all(plot_class, make) -> None:
+    """Nothing drawn, nothing to address.
+
+    ``render()`` omits the key entirely when the selector list is empty, which
+    is the path a WebGL layer already takes and which the base class documents
+    as the honest answer for a layer with no highlightable geometry. This case
+    now joins it. Before, it was the defect at its purest: no data, and a
+    selector for every trace anyway.
+    """
+    traces = [make([], [], "a"), make([], [], "b")]
+
+    schema = plot_class(traces, {}, scatter_positions=[0, 1]).schema
+
+    assert schema[MaidrKey.DATA] == []
+    assert MaidrKey.SELECTOR not in schema
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_a_trace_with_no_y_counts_as_empty_too(plot_class, make) -> None:
+    """``zip`` stops at the shorter side, so an absent y draws nothing.
+
+    A trace carrying x but no y produces no points and therefore no element,
+    which is the same case as an empty x reaching the same guard by a
+    different route.
+    """
+    traces = [
+        make([0, 1], [1, 2], "a"),
+        make([0, 1], [], "no y"),
+        make([0, 1], [2, 1], "c"),
+    ]
+
+    schema = plot_class(traces, {}, scatter_positions=[0, 1, 2]).schema
+
+    assert len(schema[MaidrKey.DATA]) == 2
+    assert [nth_child(s) for s in schema[MaidrKey.SELECTOR]] == [1, 3]


### PR DESCRIPTION
## Description

Closes #316.

`data` and `selector` are paired positionally by the frontend, but `PlotlyStepPlot` and `PlotlyMultiLinePlot` built them from the same traces by **two different rules** — the data dropped a trace that produced no points, the selectors did not. Every series after an empty one then addressed its predecessor's element.

Measured on the issue's own snippet, before:

```
step       len(data)=2  len(selector)=3
           nth-child(1), nth-child(2), nth-child(3)
```

Series `'c'` is the figure's **third** trace and renders at `nth-child(3)`, but was paired with `nth-child(2)` — the empty trace's element. After:

```
step       len(data)=2  len(selector)=2
           nth-child(1), nth-child(3)
```

## Related Issues

Closes #316.

## Changes Made

**Option 2 of the three the issue set out**: drop the position alongside the data, from one shared pass — `PlotlyPlot._line_series_with_positions()` returns the drawn series *and* the positions that produced them, so the two cannot be filtered by different predicates.

Why not the other two:

- **Keeping the empty series** so the lists stay parallel would emit a zero-point series for the frontend to tolerate. Dropping the position costs nothing and leaves `data` exactly as it is today — pinned by a test.
- **Rejecting an empty trace** at construction turns a legitimate input into a crash. An empty `x`/`y` is what a series filtered to nothing produces, which is routine in a dashboard or a faceted export where one category has no rows in the current slice.

Building both lists in one pass is the part worth having. `_scatter_line_selectors` already documents this exact hazard from the other direction — *"Dropping one entry from the middle would slide every later series onto the wrong element"* — and the data side was doing precisely that.

**Both classes are fixed together**, as the issue asked, and now share the pass rather than each owning a near-identical copy.

### One behaviour change worth flagging

An all-empty layer now emits **no `selectors` key at all**. `render()` omits it when the list is empty, which is the path a WebGL layer already takes and which the base class documents as the honest answer for a layer with no highlightable geometry. Before, this case was the defect at its purest: zero data, and a selector per trace anyway.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| Gate | Result |
|---|---|
| `uv run pytest` | **950 passed** (from 938) |
| `ruff check` | clean on every touched file; 52 repo-wide, unchanged |

12 cases in `tests/plotly/test_plotly_empty_series_alignment.py`, each parametrized across both classes. They assert the selector **strings**, not just that the two lengths match — equal lengths would also be satisfied by pointing every series at the wrong element, which is the failure being fixed.

- an empty trace in the middle does not shift the ones after it;
- nor does a **leading** empty trace;
- `data` is unchanged, so the alternative fix's cost is pinned as not paid;
- a layer with no empty trace keeps every position it was given;
- an all-empty layer emits neither list;
- a trace with **x but no y** counts as empty too — `zip` stops at the shorter side, so it reaches the same guard by a different route.

**Verified they bite:** against the code this replaces, **8 of the 12 fail**.

Worth noting why this stayed hidden: the failure is silent in the way `nth-child` failures always are. Audio, braille and text are all correct, and only the visual highlight is wrong — so a sighted collaborator sees the wrong line highlighted while the person relying on the announcements has no way to notice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_