### PR TITLE
feat(plotly): name a 100% stacked bar as the chart it is

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -12,6 +12,7 @@ class PlotType(str, Enum):
     HEAT = "heat"
     HIST = "hist"
     LINE = "line"
+    NORMALIZED = "stacked_normalized_bar"
     PIE = "pie"
     SCATTER = "point"
     STACKED = "stacked_bar"
@@ -49,6 +50,7 @@ _DISPLAY_NAMES = {
     PlotType.ERRORBAR: "error bar",
     PlotType.HEAT: "heatmap",
     PlotType.HIST: "histogram",
+    PlotType.NORMALIZED: "100% stacked bar",
     PlotType.SCATTER: "scatter",
     PlotType.STACKED: "stacked bar",
     PlotType.VIOLIN_BOX: "violin",

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -46,6 +46,7 @@ class FigureManager:
         PlotType.BAR: 1,
         PlotType.STACKED: 2,
         PlotType.DODGED: 2,  # DODGED and STACKED have same priority
+        PlotType.NORMALIZED: 2,  # a stacked bar, drawn to a common total
         PlotType.LINE: 1,
         PlotType.STEP: 1,
         PlotType.SCATTER: 1,

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -434,7 +434,11 @@ class Maidr:
         """Return the top-level MAIDR schema for this figure."""
         # Handle DODGED/STACKED plots: only keep one plot per subplot position
         # because GroupedBarPlot extracts all containers from the axes itself
-        if self.plot_type in (PlotType.DODGED, PlotType.STACKED):
+        if self.plot_type in (
+            PlotType.DODGED,
+            PlotType.STACKED,
+            PlotType.NORMALIZED,
+        ):
             self._plots = self._merge_plots_by_subplot_position()
 
         # Deduplicate: if any SMOOTH plots exist, remove LINE plots

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -72,7 +72,7 @@ class MaidrPlotFactory:
             return PiePlot(single_ax, **kwargs)
         elif PlotType.SCATTER == plot_type:
             return ScatterPlot(single_ax)
-        elif PlotType.DODGED == plot_type or PlotType.STACKED == plot_type:
+        elif plot_type in (PlotType.DODGED, PlotType.STACKED, PlotType.NORMALIZED):
             return GroupedBarPlot(single_ax, plot_type, **kwargs)
         elif PlotType.SMOOTH == plot_type:
             return SmoothPlot(single_ax, **kwargs)

--- a/maidr/plotly/grouped_bar.py
+++ b/maidr/plotly/grouped_bar.py
@@ -15,7 +15,11 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
     layout : dict
         The Plotly figure layout.
     plot_type : PlotType
-        Either ``PlotType.DODGED`` or ``PlotType.STACKED``.
+        ``PlotType.DODGED``, ``PlotType.STACKED``, or
+        ``PlotType.NORMALIZED`` when the layout declares ``barnorm``. The
+        extraction is identical for all three -- plotly normalises at render
+        time, so the trace arrays hold the same absolute values either way,
+        and it is the type that tells the frontend which chart it is.
     """
 
     def __init__(

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -353,11 +353,21 @@ class PlotlyMaidr:
                 from maidr.core.enum.plot_type import PlotType
                 from maidr.plotly.grouped_bar import PlotlyGroupedBarPlot
 
-                plot_type = (
-                    PlotType.DODGED
-                    if barmode == "group"
-                    else PlotType.STACKED
-                )
+                # `barnorm` is what makes a stack a 100% stack. Plotly
+                # normalises at render time and leaves the trace arrays
+                # absolute, so nothing in the data says the bars were drawn
+                # to a common total -- read as `stacked_bar`, the chart is
+                # announced under the wrong name, and the equal bar heights
+                # a sighted reader sees have no counterpart in what is said.
+                # It is declared on the layout rather than computed, which is
+                # why this is the one place normalisation is detectable at
+                # all (#338).
+                if barmode == "group":
+                    plot_type = PlotType.DODGED
+                elif layout.get("barnorm") in ("fraction", "percent"):
+                    plot_type = PlotType.NORMALIZED
+                else:
+                    plot_type = PlotType.STACKED
                 plot = PlotlyGroupedBarPlot(
                     bar_traces, layout, plot_type, **axis_kwargs
                 )

--- a/tests/plotly/test_plotly_normalized_bar.py
+++ b/tests/plotly/test_plotly_normalized_bar.py
@@ -1,0 +1,112 @@
+"""A 100% stacked bar is its own chart, not a stacked bar with other numbers.
+
+Plotly declares normalisation on the layout as ``barnorm`` and applies it at
+render time, leaving the trace arrays absolute. So nothing in the data says
+the bars were drawn to a common total: read as ``stacked_bar``, the chart is
+announced under the wrong name, and the equal bar heights a sighted reader
+sees have no counterpart in what is said (#338).
+
+``barnorm`` being declared rather than computed is what makes this detectable
+here at all. matplotlib and seaborn have no equivalent -- a caller who wants
+100% bars normalises the data first, so by the time py-maidr sees it there is
+nothing left to distinguish it from a stacked bar of shares.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_maidr import PlotlyMaidr
+
+plotly = pytest.importorskip("plotly")
+go = pytest.importorskip("plotly.graph_objects")
+
+
+def _two_bar_figure(**layout):
+    """
+    Build a two-trace bar figure with the given layout.
+
+    Parameters
+    ----------
+    **layout
+        Passed straight to ``update_layout`` -- ``barmode``, ``barnorm``.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        A figure with two bar traces over the same two categories.
+    """
+    figure = go.Figure(
+        data=[
+            go.Bar(name="x", x=["a", "b"], y=[1, 2]),
+            go.Bar(name="y", x=["a", "b"], y=[3, 2]),
+        ]
+    )
+    figure.update_layout(**layout)
+    return figure
+
+
+@pytest.mark.parametrize("barnorm", ["percent", "fraction"])
+def test_a_normalised_stack_is_its_own_type(barnorm: str) -> None:
+    """Both of plotly's normalisations produce the 100% type.
+
+    ``fraction`` and ``percent`` differ only in the units drawn on the axis;
+    both draw every bar to the same length, which is the thing being named.
+    """
+    figure = _two_bar_figure(barmode="stack", barnorm=barnorm)
+
+    assert PlotlyMaidr(figure)._plots[0].type is PlotType.NORMALIZED
+
+
+def test_a_plain_stack_is_unchanged() -> None:
+    """Without ``barnorm`` the bars carry their own totals, as before."""
+    figure = _two_bar_figure(barmode="stack")
+
+    assert PlotlyMaidr(figure)._plots[0].type is PlotType.STACKED
+
+
+def test_a_grouped_bar_is_unchanged() -> None:
+    """``barmode='group'`` wins regardless: nothing is stacked to normalise.
+
+    Plotly ignores ``barnorm`` for grouped bars, so reading it here would
+    rename a chart whose bars were never drawn to a common total.
+    """
+    figure = _two_bar_figure(barmode="group", barnorm="percent")
+
+    assert PlotlyMaidr(figure)._plots[0].type is PlotType.DODGED
+
+
+def test_an_unknown_barnorm_is_not_treated_as_normalised() -> None:
+    """Only the two values plotly defines count.
+
+    A typo or a future value must fall back to the honest ``stacked_bar``
+    rather than claiming a normalisation that plotly will not have drawn.
+    """
+    figure = _two_bar_figure(barmode="stack", barnorm="")
+
+    assert PlotlyMaidr(figure)._plots[0].type is PlotType.STACKED
+
+
+def test_the_emitted_values_stay_absolute() -> None:
+    """The type changes; the numbers do not.
+
+    Plotly leaves the trace arrays absolute and normalises when drawing, and
+    the Vega-Lite adapter -- the only other producer of this type -- emits its
+    rows unchanged for ``NORMALIZED`` too. Following that keeps one wire
+    meaning for the field rather than two that depend on the producer.
+    """
+    figure = _two_bar_figure(barmode="stack", barnorm="percent")
+
+    layer = PlotlyMaidr(figure)._plots[0].render()
+
+    assert layer[MaidrKey.TYPE] is PlotType.NORMALIZED
+    assert [point[MaidrKey.Y.value] for point in layer[MaidrKey.DATA][0]] == [1, 2]
+    assert [point[MaidrKey.Y.value] for point in layer[MaidrKey.DATA][1]] == [3, 2]
+
+
+def test_the_type_reads_as_a_user_would_name_it() -> None:
+    """The display name is what someone would call the chart."""
+    assert PlotType.NORMALIZED.display_name == "100% stacked bar"
+    assert PlotType.NORMALIZED.value == "stacked_normalized_bar"


### PR DESCRIPTION
## Description

Refs #338.

The JS core has routed `stacked_normalized_bar` through `SegmentedTrace` for some time, but `PlotType` had no member for it — so the type was unreachable from Python and only the Vega-Lite adapter could produce one.

A plotly 100% stack is **declared, not computed**: `layout.barnorm` is `fraction` or `percent`, and plotly normalises when drawing while leaving the trace arrays absolute:

```python
fig.update_layout(barmode='stack', barnorm='percent')
# layout.barnorm == 'percent'
# raw y stays [1, 2] and [3, 2]
```

So nothing in the data says the bars were drawn to a common total. Read as `stacked_bar`, the chart is announced under the wrong name, and the equal bar heights a sighted reader sees have no counterpart in what is said.

## Changes Made

- `PlotType.NORMALIZED = "stacked_normalized_bar"`, displaying as **"100% stacked bar"**
- `plotly_maidr.py` reads `barnorm` when `barmode == "stack"`
- The three sites that already special-case the segmented family — `PLOT_TYPE_PRIORITY`, `MaidrPlotFactory`, and `Maidr._flatten_maidr`'s subplot merge — now include it

**The emitted values stay absolute.** That is not an omission: the Vega-Lite adapter, the only other producer of this type, calls `extractSegmentedData` identically for `STACKED`, `DODGED` and `NORMALIZED`, so following it keeps one wire meaning for the field rather than two that depend on which binding drew the chart.

## Scope — please read before merging

Two limits, both measured rather than assumed:

**1. matplotlib and seaborn cannot be detected, and I did not try.** #338's scope says "detect normalization in the bar patch". There is nothing to detect: neither library has a 100% bar mode, so a caller normalises the data first, and by the time py-maidr sees it a 100% chart is indistinguishable from a stacked bar of shares. Guessing from "the totals all look like 1.0" would misname an ordinary stacked bar whose categories happen to be equal. `barnorm` being declared is exactly what makes the plotly path tractable.

**2. The share is not announced yet, and that is a core-side gap.** #338 also asks to "announce the share". I checked what the type currently buys, and it is less than the issue implies: `TraceFactory` routes `NORMALIZED` to `SegmentedTrace`, and **`SegmentedTrace` never branches on the trace type**. The only difference today is `CHART_TYPE_LABEL` — the chart is *named* "Normalized Stacked Bar Chart" instead of "Stacked Bar Chart".

That is a real fix for a real wrong reading, and it is the whole of what a binding can deliver. Making the announcement say "25%" means teaching `SegmentedTrace` to divide by its own summary row, which is core work and belongs in its own issue against xability/maidr rather than being smuggled in here.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| Gate | Result |
|---|---|
| `uv run pytest` | **945 passed** (from 938) |
| `ruff check maidr/` | 7, unchanged from `main` — the new files are clean |

Seven cases in `tests/plotly/test_plotly_normalized_bar.py`:

- both `fraction` and `percent` produce the type — they differ only in the units on the axis, and both draw every bar to the same length, which is the thing being named;
- a plain stack is unchanged;
- **`barmode='group'` wins even with `barnorm` set** — plotly ignores it there, so reading it would rename a chart whose bars were never drawn to a common total;
- an unknown `barnorm` falls back to `stacked_bar` rather than claiming a normalisation plotly will not have drawn;
- the emitted values stay absolute;
- the display name reads as a user would say it.

**Verified they bite:** against `main`, **4 of the 7 fail**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmSHGxAWRw5wVWqDKdaZm6)_