### PR TITLE
feat(pointplot): read a seaborn point plot's estimates with their intervals

### DIFF
--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -657,6 +657,40 @@ ax.set_ylabel("Response")
 plt.show() #<<
 ```
 
+### Point Plot
+
+`sns.pointplot()` is the same reading from the other direction: it estimates a
+group mean from raw observations and draws the interval around it for you. It
+reads as an error bar layer, so navigation is the same grid — left and right
+walk the groups, up and down walk the lower bound, the estimate and the upper
+bound.
+
+`capsize`, `orient` and `errorbar=` change how the chart is drawn, not how it
+is read; the bounds come from the drawn interval either way. A `hue` splits the
+chart into several series, which the error bar layer cannot yet carry
+alongside its intervals, so a hued point plot reads as the multi-line chart it
+is.
+
+```{python}
+#| fig-alt: Mean body mass by penguin species with 95% confidence intervals
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+import maidr #<<
+
+fig, ax = plt.subplots(figsize=(8, 5))
+sns.pointplot( #<<
+    penguins, x="species", y="body_mass_g", capsize=0.1, ax=ax
+)
+
+ax.set_title("Mean Body Mass by Species, with 95% Confidence Intervals")
+ax.set_xlabel("Species")
+ax.set_ylabel("Body Mass (g)")
+
+plt.show() #<<
+```
+
 ### Scatter Plot
 
 ```{python}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > py-maidr is a Python library that makes matplotlib, seaborn, and plotly data visualizations accessible to blind and low-vision users through sonification, braille, text, and AI-powered conversational modalities. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
 
-maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, pie, box, violin, heatmap, scatter, smooth/regression, candlestick, error bar, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
+maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, pie, box, violin, heatmap, scatter, smooth/regression, candlestick, error bar, point, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
 
 ## Docs
 - [Documentation Home](https://py.maidr.ai/): Installation, quick start, and overview

--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -1,6 +1,7 @@
-from typing import List, Union
+from typing import List, Optional, Union
 
 from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
@@ -26,6 +27,12 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
         The layer type to emit, by default ``PlotType.LINE``. Subclasses that
         share this extraction logic but describe a different chart — notably
         :class:`maidr.core.plot.stepplot.StepPlot` — override it.
+    lines : list of Line2D, optional
+        The lines to describe, by default every line on the axes. A patch
+        passes this when some of what was drawn is not a series: seaborn's
+        point plot renders each confidence interval as a line of its own, and
+        describing those alongside the estimates announces cap geometry as
+        data.
     **kwargs : dict
         Additional keyword arguments to pass to the parent class.
 
@@ -42,8 +49,30 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
       (fill values) for each point.
     """
 
-    def __init__(self, ax: Axes, plot_type: PlotType = PlotType.LINE, **kwargs):
+    def __init__(
+        self,
+        ax: Axes,
+        plot_type: PlotType = PlotType.LINE,
+        lines: Optional[List[Line2D]] = None,
+        **kwargs,
+    ):
         super().__init__(ax, plot_type)
+        self._lines = lines
+
+    def _series(self) -> List[Line2D]:
+        """
+        Return the lines this layer describes.
+
+        Returns
+        -------
+        list[Line2D]
+            The lines a patch narrowed the layer to, or every line on the axes
+            when it did not.
+        """
+        if self._lines is not None:
+            return self._lines
+
+        return self.ax.get_lines()
 
     def _extract_axes_data(self) -> dict:
         """
@@ -66,7 +95,7 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
 
     def _get_selector(self) -> Union[str, List[str]]:
         # Return selectors for all lines that have data
-        all_lines = self.ax.get_lines()
+        all_lines = self._series()
         if not all_lines:
             return ["g[maidr='true'] > path"]
 
@@ -105,7 +134,7 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
             List of lists, where each inner list contains dictionaries with x,y coordinates
             and line identifiers for one line, or None if the plot data is invalid.
         """
-        all_lines = self.ax.get_lines()
+        all_lines = self._series()
         if not all_lines:
             return None
 

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -11,6 +11,7 @@ from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.core.plot.pieplot import PiePlot
+from maidr.core.plot.pointplot import PointPlot
 from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.regplot import SmoothPlot
 from maidr.core.plot.stepplot import StepPlot
@@ -56,6 +57,12 @@ class MaidrPlotFactory:
         elif PlotType.BOX == plot_type:
             return BoxPlot(single_ax, **kwargs)
         elif PlotType.ERRORBAR == plot_type:
+            # Both read an estimate and the interval around it, and both emit
+            # the same layer; they differ only in what the library drew.
+            # `Axes.errorbar` leaves a container, while seaborn's point plot
+            # leaves the lines the patch resolved and hands them over here.
+            if "estimate" in kwargs:
+                return PointPlot(single_ax, **kwargs)
             return ErrorBarPlot(single_ax, **kwargs)
         elif PlotType.HEAT == plot_type:
             return HeatPlot(single_ax, **kwargs)

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
 from maidr.core.enum import PlotType
 from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.boxplot import BoxPlot
@@ -61,7 +62,7 @@ class MaidrPlotFactory:
             # the same layer; they differ only in what the library drew.
             # `Axes.errorbar` leaves a container, while seaborn's point plot
             # leaves the lines the patch resolved and hands them over here.
-            if "estimate" in kwargs:
+            if isinstance(kwargs.get("estimate"), Line2D):
                 return PointPlot(single_ax, **kwargs)
             return ErrorBarPlot(single_ax, **kwargs)
         elif PlotType.HEAT == plot_type:

--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -214,7 +214,15 @@ class PointPlot(ErrorBarPlot):
         if finite.size == 0:
             return None
 
-        return float(finite.min()), float(finite.max())
+        # Cleaned the same way `ErrorBarPlot` cleans its own bounds, and for
+        # the same reason: a bound is computed rather than authored, and
+        # `5 - 4.0497` is not exactly representable. Reusing the base class's
+        # helper rather than restating the rule keeps the two from drifting to
+        # different precisions for the same quantity.
+        return (
+            ErrorBarPlot._without_float_noise(float(finite.min())),
+            ErrorBarPlot._without_float_noise(float(finite.max())),
+        )
 
     @staticmethod
     def _extent(coordinates: Sequence) -> float:
@@ -235,6 +243,11 @@ class PointPlot(ErrorBarPlot):
         values = np.asarray(coordinates, dtype=float)
         finite = values[np.isfinite(values)]
         if finite.size == 0:
-            return 0.0
+            # NaN rather than 0: a polyline with nothing finite on this axis is
+            # not *flat* along it, it is absent from it, and the caller reads a
+            # zero extent as evidence that this is the category axis. Answering
+            # 0 here made a chart whose intervals carried no value at all look
+            # like a chart drawn the other way round.
+            return float("nan")
 
         return float(finite.max() - finite.min())

--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.axis import Axis
+from matplotlib.lines import Line2D
+
+from maidr.core.enum import MaidrKey
+from maidr.core.plot.errorbar import ErrorBarPlot
+from maidr.exception import ExtractionError
+
+
+class PointPlot(ErrorBarPlot):
+    """
+    A seaborn point plot: a group estimate drawn with the interval around it.
+
+    ``sns.pointplot`` renders the same quantity ``Axes.errorbar`` does, and the
+    reader needs the same thing from it -- whether two group means differ is
+    answered by whether their intervals overlap -- so it emits the same layer
+    type and this class extends :class:`ErrorBarPlot` rather than restating
+    it. What differs is only where the numbers are read from: seaborn draws no
+    ``ErrorbarContainer`` at all, but one ``Line2D`` per group, so none of the
+    container machinery in the base class applies.
+
+    Each interval line is a polyline the caller's ``capsize`` decides the shape
+    of: two points when it is zero, and eight -- lower cap, spine, upper cap,
+    NaN-separated -- when it is not. Both forms are read the same way, by
+    taking the extremes along the value axis, because a cap is drawn *at* the
+    bound it marks.
+
+    Before this existed, a point plot was not merely missing its intervals: the
+    interval polylines reached the reader as data. A four-category chart
+    announced five series, four of them cap geometry with NaN coordinates and
+    raw category offsets like 1.95 among the category names -- so the fix is as
+    much a removal as an addition.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the point plot was drawn on.
+    **kwargs
+        ``estimate`` is the ``Line2D`` carrying the group estimates, and
+        ``intervals`` the per-group interval lines in category order. The
+        patch resolves both and verifies they pair up before constructing
+        this.
+
+    See Also
+    --------
+    ErrorBarPlot : The base class, which reads an ``ErrorbarContainer``.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        self._estimate: Line2D | None = kwargs.pop("estimate", None)
+        self._intervals: list[Line2D] = list(kwargs.pop("intervals", []))
+
+        super().__init__(ax, **kwargs)
+
+    def _extract_plot_data(self) -> list[dict]:
+        if self._estimate is None or not self._intervals:
+            raise ExtractionError(self.type, self.ax)
+
+        xs, ys = self._estimate.get_data()
+        if len(xs) != len(self._intervals):
+            raise ExtractionError(self.type, self.ax)
+
+        is_vertical = self._is_vertical()
+        self._orientation = "vert" if is_vertical else "horz"
+
+        # Cleared rather than appended to. A layer is rendered more than once
+        # -- `set_id` renders again when the schema is not yet cached -- and
+        # the tagged elements have to stay one per point, in point order, or
+        # the consumer highlights the wrong group.
+        self._elements.clear()
+
+        # The category runs along the axis the intervals do NOT span. The
+        # schema names them `x` and `y` in both orientations and lets
+        # `orientation` say which is on screen where -- see `ErrorBarPlot`,
+        # whose docstring explains why this differs from how a bar travels.
+        categories, values = (xs, ys) if is_vertical else (ys, xs)
+        labels = self._category_labels(is_vertical)
+
+        data = []
+        for category, value, interval in zip(categories, values, self._intervals):
+            coordinate = float(category)
+            bounds = self._interval_bounds(interval, is_vertical)
+            # Rounded as well as exact: a `dodge` shifts a group aside from
+            # the tick that names it, and the group is still that group.
+            label = labels.get(coordinate) or labels.get(float(round(coordinate)))
+            point = {
+                MaidrKey.X: label if label is not None else self._scalar(category),
+                MaidrKey.Y: self._scalar(value),
+            }
+            if bounds is not None:
+                point[MaidrKey.Y_MIN], point[MaidrKey.Y_MAX] = bounds
+                # Tag for highlighting only the intervals that produced a
+                # bound. One path per sample, in the order the points are
+                # emitted, which is the shape the consumer repeats across its
+                # three sections.
+                self._elements.append(interval)
+            data.append(point)
+
+        if not data:
+            raise ExtractionError(self.type, self.ax)
+
+        if not self._elements:
+            # Every interval was empty -- a group with a single observation
+            # has no interval to draw -- so nothing carries the `maidr`
+            # attribute the selector goes looking for, and emitting one would
+            # promise highlightable paths the document does not contain.
+            self._support_highlighting = False
+
+        return data
+
+    def _is_vertical(self) -> bool:
+        """
+        Decide which axis the categories run along.
+
+        Read from the axes rather than from the caller's ``orient``, which is
+        usually absent: seaborn infers the orientation from which variable is
+        categorical and does not report what it decided. Two signals do report
+        it, in order of authority:
+
+        1. Seaborn draws its categorical axis through matplotlib's string-
+           category machinery, which leaves ``UnitData`` on that axis and
+           nothing on the other. That holds whatever the category *values*
+           are -- a numeric grouping column still travels this way -- so it
+           is the whole answer whenever it fires.
+        2. Under ``native_scale=True`` the category axis is an ordinary
+           numeric one and signal 1 is silent. Then the intervals themselves
+           say it: an interval spans the value axis and, at the default
+           ``capsize=0``, occupies a single coordinate on the category axis.
+
+        Returns
+        -------
+        bool
+            True when the categories run along x, which is seaborn's default
+            and the answer when neither signal fires.
+        """
+        x_is_category = self.ax.xaxis.units is not None
+        y_is_category = self.ax.yaxis.units is not None
+        if x_is_category != y_is_category:
+            return x_is_category
+
+        x_flat = all(self._extent(line.get_xdata()) == 0 for line in self._intervals)
+        y_flat = all(self._extent(line.get_ydata()) == 0 for line in self._intervals)
+        if x_flat != y_flat:
+            return x_flat
+
+        return True
+
+    def _category_labels(self, is_vertical: bool) -> dict[float, str]:
+        """
+        Map category coordinates to the names drawn beside them.
+
+        Seaborn places the groups at 0, 1, 2, ... and writes their names on
+        the ticks, so without this the reader hears the positions instead of
+        the groups -- "0" where the chart says "Thur".
+
+        Parameters
+        ----------
+        is_vertical : bool
+            Whether the categories run along x.
+
+        Returns
+        -------
+        dict
+            Coordinate to label, for the labelled ticks only.
+        """
+        axis: Axis = self.ax.xaxis if is_vertical else self.ax.yaxis
+        if axis.units is None:
+            # A numeric axis under `native_scale=True`. Its tick labels are
+            # renderings of the coordinates rather than names, and returning
+            # them would replace a group's value with whatever rounding the
+            # tick formatter happened to apply.
+            return {}
+
+        labels = {}
+        for position, tick in zip(axis.get_ticklocs(), axis.get_ticklabels()):
+            text = tick.get_text()
+            if text:
+                labels[float(position)] = text
+        return labels
+
+    @staticmethod
+    def _interval_bounds(line: Line2D, is_vertical: bool) -> tuple[float, float] | None:
+        """
+        Return the ends of one interval along the value axis.
+
+        Taking the extremes rather than a designated pair of vertices is what
+        makes ``capsize`` irrelevant here: a cap is drawn at the bound it
+        marks, so the polyline's furthest points along the value axis are the
+        bounds whether the shape has two vertices or eight.
+
+        Parameters
+        ----------
+        line : Line2D
+            The polyline drawing one group's interval.
+        is_vertical : bool
+            Whether the value axis is y.
+
+        Returns
+        -------
+        tuple of float, or None
+            The lower and upper bound, or None when the group has no interval
+            -- a single observation has nothing to estimate one from, and
+            seaborn draws it as an empty line rather than as a zero-width one.
+        """
+        values = np.asarray(
+            line.get_ydata() if is_vertical else line.get_xdata(), dtype=float
+        )
+        finite = values[np.isfinite(values)]
+        if finite.size == 0:
+            return None
+
+        return float(finite.min()), float(finite.max())
+
+    @staticmethod
+    def _extent(coordinates: Sequence) -> float:
+        """
+        Return how far a polyline reaches along one axis, ignoring gaps.
+
+        Parameters
+        ----------
+        coordinates : sequence
+            One axis of a polyline's vertices, possibly holding the NaNs that
+            separate a capped interval's three segments.
+
+        Returns
+        -------
+        float
+            The distance between the extremes, or 0 when nothing is finite.
+        """
+        values = np.asarray(coordinates, dtype=float)
+        finite = values[np.isfinite(values)]
+        if finite.size == 0:
+            return 0.0
+
+        return float(finite.max() - finite.min())

--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -104,11 +104,18 @@ class PointPlot(ErrorBarPlot):
         if not data:
             raise ExtractionError(self.type, self.ax)
 
-        if not self._elements:
-            # Every interval was empty -- a group with a single observation
-            # has no interval to draw -- so nothing carries the `maidr`
-            # attribute the selector goes looking for, and emitting one would
-            # promise highlightable paths the document does not contain.
+        if len(self._elements) != len(data):
+            # The consumer resolves the selector to one element per point, in
+            # point order, and discards the result outright when the count
+            # disagrees. A chart where only some groups have an interval --
+            # ordinary imbalanced data, where one category holds a single
+            # observation -- would therefore emit a selector that resolves
+            # short and silently highlights nothing at all.
+            #
+            # Better to say so: the layer promises a selector only when it can
+            # deliver one element for every point, and the announcement, which
+            # is the reading, is unaffected either way.
+            self._elements.clear()
             self._support_highlighting = False
 
         return data

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -9,6 +9,7 @@ from . import (  # noqa: F401
     histogram,
     lineplot,
     pieplot,
+    pointplot,
     scatterplot,
     regplot,
     kdeplot,

--- a/maidr/patch/pointplot.py
+++ b/maidr/patch/pointplot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
+import numpy as np
 import wrapt
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
@@ -75,6 +76,13 @@ def point(wrapped, instance, args, kwargs) -> Axes:
     estimates, intervals = _split(drawn)
 
     if not estimates:
+        # Nothing looked like an estimate line, so the split says nothing and
+        # every drawn line is described -- the same fallback the verification
+        # below takes, and for the same reason. Registering no layer at all
+        # would leave the chart unreadable, which is a worse answer than the
+        # one the generic wrapper already gave.
+        if drawn:
+            FigureManager.create_maidr(ax, PlotType.LINE, lines=drawn)
         return ax
 
     paired = _pairs_up(estimates, intervals)
@@ -148,12 +156,41 @@ def _split(lines: list[Line2D]) -> tuple[list[Line2D], list[Line2D]]:
         if vertices is None or not len(vertices):
             # The proxy artists a `hue` legend is built from carry no data.
             continue
-        if line.get_marker() == _INTERVAL_MARKER:
-            intervals.append(line)
-        else:
+        if line.get_marker() != _INTERVAL_MARKER:
             estimates.append(line)
+        elif _is_drawn(vertices):
+            intervals.append(line)
 
     return estimates, intervals
+
+
+def _is_drawn(vertices: np.ndarray) -> bool:
+    """
+    Check that a candidate interval is a shape the chart actually drew.
+
+    A group with a single observation has nothing to estimate an interval
+    from, and seaborn renders that as a polyline whose value coordinates are
+    all NaN -- the cap positions survive, the interval does not. Such a line
+    carries no bound, and treating it as one hands the reader the cap's own
+    width as the interval, which is neither a measurement nor even in the
+    right units.
+
+    Tested as "two vertices finite in both coordinates", which is what it
+    takes to draw a segment at all, so the check needs no view on which axis
+    is which.
+
+    Parameters
+    ----------
+    vertices : numpy.ndarray
+        The line's vertices, as an ``(n, 2)`` array.
+
+    Returns
+    -------
+    bool
+        True when at least one segment of the polyline was drawable.
+    """
+    finite = np.isfinite(np.asarray(vertices, dtype=float)).all(axis=1)
+    return bool(finite.sum() >= 2)
 
 
 def _pairs_up(estimates: list[Line2D], intervals: list[Line2D]) -> bool:

--- a/maidr/patch/pointplot.py
+++ b/maidr/patch/pointplot.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import wrapt
+from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import _draw_quietly
+
+# The marker seaborn leaves on the lines it draws the intervals with. The
+# estimate line carries a real one -- `"o"` by default, and the empty string
+# when the caller turns it off, which is why this tests for the literal rather
+# than for falsiness.
+_INTERVAL_MARKER = "None"
+
+# The most vertices one interval can have: lower cap, spine and upper cap, each
+# two vertices, with a NaN between them. A polyline longer than this is not an
+# interval, whatever else it is.
+_MAX_INTERVAL_VERTICES = 8
+
+
+def point(wrapped, instance, args, kwargs) -> Axes:
+    """
+    Register a ``seaborn.pointplot`` call as the layer it actually drew.
+
+    A point plot is patched by name rather than left to the ``Axes.plot``
+    wrapper it goes through, because only the name says the artists mean
+    something other than what they look like. Seaborn draws the intervals as
+    ordinary lines, so the generic wrapper described a four-category chart as
+    five series: the estimates, and then four interval polylines whose cap
+    geometry reached the reader as data, NaN coordinates and raw offsets like
+    ``1.95`` among the category names.
+
+    Sorting them out needs the estimates and the intervals told apart, and the
+    split is verified rather than assumed: the estimates must pair one-to-one
+    with the intervals, group by group. When they do not -- because a future
+    seaborn renders this differently -- the layer falls back to describing
+    every drawn line, which is what the generic wrapper did, rather than
+    emitting bounds read off artists that are not intervals.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``seaborn.pointplot``.
+    instance : Any
+        Unused; ``pointplot`` is a module-level function.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    Axes
+        Whatever the wrapped function returned, unchanged.
+    """
+    # Don't proceed if the call is made internally by the patched function.
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    existing = _lines_before(kwargs)
+
+    # Set the internal context so the `Axes.plot` calls seaborn makes inside
+    # do not register a line layer of their own.
+    with ContextManager.set_internal_context():
+        ax = _draw_quietly(wrapped, args, kwargs)
+
+    if not isinstance(ax, Axes):
+        return ax
+
+    drawn = [line for line in ax.lines if line not in existing]
+    estimates, intervals = _split(drawn)
+
+    if not estimates:
+        return ax
+
+    paired = _pairs_up(estimates, intervals)
+
+    if paired and intervals and len(estimates) == 1:
+        FigureManager.create_maidr(
+            ax, PlotType.ERRORBAR, estimate=estimates[0], intervals=intervals
+        )
+        return ax
+
+    # Everything else is a line chart. `errorbar=None` draws no intervals to
+    # carry, and more than one estimate means a `hue` split the chart into
+    # groups while the MAIDR error bar layer carries a single series -- so
+    # those intervals are dropped rather than mis-assigned. Both are still a
+    # repair over describing every drawn line, since the interval polylines no
+    # longer travel as series of their own.
+    FigureManager.create_maidr(
+        ax, PlotType.LINE, lines=estimates if paired else drawn
+    )
+
+    return ax
+
+
+def _lines_before(kwargs: dict) -> list[Line2D]:
+    """
+    Return the lines already on the axes seaborn is about to draw on.
+
+    Anything left over from an earlier call is not this point plot's, and
+    sweeping it up would hand the layer another chart's line as an estimate.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    list of Line2D
+        The lines present beforehand, empty when there is no axes yet.
+    """
+    ax = kwargs.get("ax")
+    if isinstance(ax, Axes):
+        return list(ax.lines)
+
+    # Without `ax`, seaborn draws on the current axes. Asking for it here can
+    # create one, but only in the case where the call itself is about to
+    # create the same one, so nothing exists afterwards that would not have.
+    if plt.get_fignums():
+        return list(plt.gca().lines)
+
+    return []
+
+
+def _split(lines: list[Line2D]) -> tuple[list[Line2D], list[Line2D]]:
+    """
+    Sort the drawn lines into estimates and intervals.
+
+    Parameters
+    ----------
+    lines : list of Line2D
+        The lines this call drew, in the order it drew them.
+
+    Returns
+    -------
+    tuple of list
+        The estimate lines and the interval lines, each in drawing order.
+    """
+    estimates, intervals = [], []
+    for line in lines:
+        vertices = line.get_xydata()
+        if vertices is None or not len(vertices):
+            # The proxy artists a `hue` legend is built from carry no data.
+            continue
+        if line.get_marker() == _INTERVAL_MARKER:
+            intervals.append(line)
+        else:
+            estimates.append(line)
+
+    return estimates, intervals
+
+
+def _pairs_up(estimates: list[Line2D], intervals: list[Line2D]) -> bool:
+    """
+    Check that every estimate has one interval per group, or none has any.
+
+    This is the guard on reading another library's rendering. Seaborn emits an
+    estimate line and then one short polyline per group; if some future
+    version emits a shape this does not describe, the counts stop matching and
+    the caller can fall back rather than pair the wrong artists up.
+
+    Parameters
+    ----------
+    estimates : list of Line2D
+        The lines carrying the group estimates.
+    intervals : list of Line2D
+        The candidate interval lines.
+
+    Returns
+    -------
+    bool
+        True when the intervals can be handed over as they stand.
+    """
+    if not intervals:
+        # `errorbar=None` draws the estimates alone, which is a point plot
+        # with nothing to pair.
+        return True
+
+    groups = {len(estimate.get_xydata()) for estimate in estimates}
+    if len(groups) != 1:
+        return False
+
+    if len(intervals) != len(estimates) * groups.pop():
+        return False
+
+    return all(
+        len(interval.get_xydata()) <= _MAX_INTERVAL_VERTICES
+        for interval in intervals
+    )
+
+
+# Patch seaborn function.
+wrapt.wrap_function_wrapper("seaborn", "pointplot", point)

--- a/maidr/patch/pointplot.py
+++ b/maidr/patch/pointplot.py
@@ -86,19 +86,25 @@ def point(wrapped, instance, args, kwargs) -> Axes:
         return ax
 
     paired = _pairs_up(estimates, intervals)
+    measured = any(_is_drawn(line.get_xydata()) for line in intervals)
 
-    if paired and intervals and len(estimates) == 1:
+    if paired and measured and len(estimates) == 1:
         FigureManager.create_maidr(
             ax, PlotType.ERRORBAR, estimate=estimates[0], intervals=intervals
         )
         return ax
 
     # Everything else is a line chart. `errorbar=None` draws no intervals to
-    # carry, and more than one estimate means a `hue` split the chart into
-    # groups while the MAIDR error bar layer carries a single series -- so
-    # those intervals are dropped rather than mis-assigned. Both are still a
+    # carry, a chart whose every group holds one observation has none to draw,
+    # and more than one estimate means a `hue` split the chart into groups
+    # while the MAIDR error bar layer carries a single series -- so those
+    # intervals are dropped rather than mis-assigned. All three are still a
     # repair over describing every drawn line, since the interval polylines no
     # longer travel as series of their own.
+    #
+    # A chart where only *some* groups have an interval takes the branch above,
+    # not this one: the undrawable lines stay in the list to hold their
+    # positions, and the layer omits the bound for those groups alone.
     FigureManager.create_maidr(
         ax, PlotType.LINE, lines=estimates if paired else drawn
     )
@@ -158,7 +164,12 @@ def _split(lines: list[Line2D]) -> tuple[list[Line2D], list[Line2D]]:
             continue
         if line.get_marker() != _INTERVAL_MARKER:
             estimates.append(line)
-        elif _is_drawn(vertices):
+        else:
+            # Kept whether or not it carries a bound. The list is read against
+            # the estimates *by position*, so dropping the line a group with a
+            # single observation leaves behind would shift every later group's
+            # interval onto the wrong estimate. `_is_drawn` decides what to do
+            # with it; it does not decide whether it is there.
             intervals.append(line)
 
     return estimates, intervals
@@ -174,6 +185,11 @@ def _is_drawn(vertices: np.ndarray) -> bool:
     carries no bound, and treating it as one hands the reader the cap's own
     width as the interval, which is neither a measurement nor even in the
     right units.
+
+    Answering False does not remove the line: it stays in the list to hold its
+    group's position, and the layer omits that one group's bound. What this
+    decides is whether the chart draws *any* interval, and so whether it is an
+    error bar chart at all.
 
     Tested as "two vertices finite in both coordinates", which is what it
     takes to draw a segment at all, so the check needs no view on which axis

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -158,6 +158,17 @@ class LineExtractorMixin:
             if text
         }
 
+        # A string-category axis puts its groups on consecutive integers, so a
+        # point drawn off one is a group a `dodge` shifted aside to make room
+        # for its neighbour -- still that group, and still named by the tick it
+        # was moved from. Rounding recovers the name; without it a dodged
+        # series announces "-0.025" where the chart says "Thur".
+        #
+        # Gated on the axis really being categorical, because on a numeric axis
+        # the same rounding would rename a measurement after whichever tick it
+        # happens to fall nearest.
+        is_categorical = ax.xaxis.units is not None
+
         # If we have categorical labels, map numeric coordinates to labels
         if tick_map:
             result: List[Tuple[Union[str, float], float]] = []
@@ -166,6 +177,8 @@ class LineExtractorMixin:
                 # Look up by coordinate value; fall back to the numeric x when
                 # the data point doesn't sit exactly on a labelled tick.
                 label_value = tick_map.get(x_coord)
+                if label_value is None and is_categorical:
+                    label_value = tick_map.get(float(round(x_coord)))
                 x_value: Union[str, float] = (
                     label_value if label_value is not None else x_coord
                 )

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -482,7 +482,7 @@ def test_errorbar_supports_highlighting():
     ("draw", "expected"),
     [
         (lambda ax, df: sns.barplot(df, x="g", y="v", ax=ax), PlotType.BAR),
-        (lambda ax, df: sns.pointplot(df, x="g", y="v", ax=ax), PlotType.LINE),
+        (lambda ax, df: sns.pointplot(df, x="g", y="v", ax=ax), PlotType.ERRORBAR),
     ],
     ids=["barplot", "pointplot"],
 )
@@ -498,6 +498,11 @@ def test_seaborn_error_bars_do_not_register_a_second_layer(draw, expected):
     Pinned rather than assumed, because it is a claim about another library's
     internals: current seaborn renders those intervals itself, and the day it
     switches, this test is what says so.
+
+    The point plot's single layer *is* an error bar layer, registered by
+    ``maidr.patch.pointplot`` off the lines seaborn drew rather than by this
+    patch -- so what the count proves is that the two paths do not both fire,
+    not that the intervals went undescribed.
     """
     rng = np.random.default_rng(20260811)
     df = pd.DataFrame({"g": ["a"] * 20 + ["b"] * 20, "v": rng.normal(size=40)})

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -1,0 +1,388 @@
+"""Tests for seaborn point plots.
+
+``sns.pointplot`` draws a group estimate with the interval around it, and the
+reader needs the same thing from it that ``Axes.errorbar`` exists to give:
+whether two group means differ is answered by whether their intervals overlap.
+
+Reading it is a different problem, though, because seaborn draws no
+``ErrorbarContainer``. It draws the estimates as one line and each interval as
+another, so before this the generic ``Axes.plot`` wrapper described a
+four-category chart as *five* series -- the estimates, and four interval
+polylines whose cap geometry reached the reader as data. These tests are
+written against that: the intervals have to arrive as bounds, and the cap
+geometry has to stop arriving at all.
+
+The assertions are on drawn geometry rather than on the input frame, because
+the estimate seaborn computes is a bootstrap by default and reproducing its
+arithmetic here would test this file against itself.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.core.plot.pointplot import PointPlot  # noqa: E402
+
+
+#: Three groups whose observations differ enough per group that the intervals
+#: are wide, distinct, and asymmetric -- so a reading that took the wrong
+#: bound cannot coincide with the right one.
+FRAME = pd.DataFrame(
+    {
+        "group": ["a"] * 6 + ["b"] * 6 + ["c"] * 6,
+        "value": [
+            1.0, 2.0, 3.0, 4.0, 9.0, 11.0,
+            20.0, 21.0, 22.0, 23.0, 24.0, 30.0,
+            5.0, 5.5, 6.0, 6.5, 7.0, 7.5,
+        ],
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _plots(fig):
+    """
+    Return the MAIDR plots registered for a figure, or an empty list.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to read.
+
+    Returns
+    -------
+    list
+        The registered plots.
+    """
+    maidr_instance = FigureManager.figs.get(fig)
+    return list(maidr_instance._plots) if maidr_instance else []
+
+
+def _schema(fig) -> dict:
+    """
+    Return the layer schema of a figure's only plot.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to read.
+
+    Returns
+    -------
+    dict
+        The MAIDR layer schema.
+    """
+    return _plots(fig)[0].render()
+
+
+def test_a_point_plot_reads_as_an_error_bar_layer():
+    """
+    The estimates and their intervals travel together, in one layer.
+
+    A point plot carries the same quantity ``Axes.errorbar`` does, so it emits
+    the same layer type rather than a line layer that happens to sit beside
+    some intervals -- the consumer then steps through lower, value and upper at
+    each group with no special case for where the chart came from.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", ax=ax)
+
+    plots = _plots(fig)
+
+    assert len(plots) == 1
+    assert isinstance(plots[0], PointPlot)
+    assert plots[0].type == PlotType.ERRORBAR
+
+
+def test_the_interval_polylines_do_not_travel_as_series():
+    """
+    The regression that motivated patching ``pointplot`` by name.
+
+    Left to the generic ``Axes.plot`` wrapper, a three-group chart announced
+    four series: the estimates, and three interval polylines. Their vertices
+    are not observations -- with ``capsize`` they carry NaN separators and cap
+    offsets like ``1.95`` among the category names -- so a reader arrowing
+    through the chart walked cap geometry believing it was data.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", capsize=0.1, ax=ax)
+
+    data = _schema(fig)["data"]
+
+    # One entry per group, not one per drawn artist.
+    assert len(data) == 3
+    assert [point["x"] for point in data] == ["a", "b", "c"]
+    assert not any(np.isnan(point["y"]) for point in data)
+
+
+def test_the_bounds_are_the_interval_the_chart_drew():
+    """
+    Each group's bounds bracket its estimate, and differ between groups.
+
+    Asserted as relations rather than as numbers because the default estimator
+    is a bootstrap: pinning literals would make this a change-detector for
+    seaborn's RNG rather than a test of what was read.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", ax=ax)
+
+    data = _schema(fig)["data"]
+
+    for point in data:
+        assert point["yMin"] < point["y"] < point["yMax"]
+
+    # Group 'c' is tightly clustered and 'a' is not, so their intervals must
+    # not come out the same width -- which they would if the bounds were being
+    # synthesised rather than read.
+    widths = [point["yMax"] - point["yMin"] for point in data]
+    assert widths[0] > widths[2]
+
+
+def test_caps_do_not_move_the_bounds():
+    """
+    ``capsize`` changes the drawn shape, and the interval is the same.
+
+    Without caps an interval is a two-vertex line; with them it is an
+    eight-vertex NaN-separated polyline whose caps sit *at* the bounds. Reading
+    the extremes along the value axis is what makes those the same answer, and
+    this is the test that says so.
+    """
+    fig, bare = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", errorbar="sd", ax=bare)
+
+    fig_capped, capped = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", errorbar="sd", capsize=0.3, ax=capped)
+
+    # `sd` rather than the default bootstrap, so the two draws are comparable
+    # without depending on seaborn's RNG.
+    for plain, with_caps in zip(_schema(fig)["data"], _schema(fig_capped)["data"]):
+        assert plain["yMin"] == pytest.approx(with_caps["yMin"])
+        assert plain["yMax"] == pytest.approx(with_caps["yMax"])
+
+
+def test_groups_are_named_rather_than_numbered():
+    """
+    Seaborn places the groups at 0, 1, 2 and writes their names on the ticks.
+
+    Emitting the positions would announce "0" where the chart says "a", which
+    is the whole content of a categorical axis.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", ax=ax)
+
+    assert [point["x"] for point in _schema(fig)["data"]] == ["a", "b", "c"]
+
+
+def test_a_horizontal_point_plot_reports_horz():
+    """
+    The categories can run along y, and the layer says which axis they use.
+
+    Detected from the axes seaborn set up rather than from the caller's
+    ``orient``, which is usually absent. Note the data stays orientation-
+    invariant -- category in ``x``, magnitude in ``y`` -- while the axis labels
+    stay screen-aligned, exactly as ``ErrorBarPlot`` emits them; both halves
+    are asserted here because a change to either alone would transpose the
+    announcement.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, y="group", x="value", ax=ax)
+    ax.set_xlabel("Response")  # the magnitude, on the real x axis
+    ax.set_ylabel("Group")  # the category, on the real y axis
+
+    schema = _schema(fig)
+
+    assert schema["orientation"] == "horz"
+    assert schema["axes"]["x"]["label"] == "Response"
+    assert schema["axes"]["y"]["label"] == "Group"
+    assert schema["data"][0]["x"] == "a"
+    assert schema["data"][0]["yMin"] < schema["data"][0]["y"]
+
+
+def test_native_scale_still_finds_the_category_axis():
+    """
+    Under ``native_scale`` the category axis is an ordinary numeric one.
+
+    The string-category machinery seaborn normally leaves behind is the first
+    signal the orientation is read from, and this is the case where it is
+    silent -- so the intervals themselves have to answer it, by spanning the
+    value axis and standing on a single coordinate of the other.
+    """
+    numeric = FRAME.assign(group=FRAME["group"].map({"a": 1, "b": 2, "c": 3}))
+
+    fig, ax = plt.subplots()
+    sns.pointplot(numeric, x="group", y="value", native_scale=True, ax=ax)
+
+    schema = _schema(fig)
+
+    assert schema["orientation"] == "vert"
+    # Numeric groups keep their values: the ticks under `native_scale` are
+    # renderings of the coordinates rather than names, so borrowing them would
+    # replace a group with whatever rounding the formatter applied.
+    assert [point["x"] for point in schema["data"]] == [1.0, 2.0, 3.0]
+
+
+def test_a_symmetric_interval_does_not_flip_the_orientation():
+    """
+    ``errorbar='sd'`` draws bounds equidistant from the estimate.
+
+    That symmetry defeats any rule that looks for the estimate sitting at the
+    centre of its interval, because it then sits at the centre along *both*
+    axes. The signals actually used are unaffected by it, and this is what
+    holds them to that.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, y="group", x="value", errorbar="sd", ax=ax)
+
+    assert _schema(fig)["orientation"] == "horz"
+
+
+def test_a_point_plot_with_no_interval_stays_a_line():
+    """
+    ``errorbar=None`` draws the estimates alone.
+
+    There is no interval to carry, and an error bar layer whose bounds are all
+    absent would announce an interval the chart does not draw -- so it travels
+    as the line chart it is.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", errorbar=None, ax=ax)
+
+    schema = _schema(fig)
+
+    assert schema["type"] == PlotType.LINE.value
+    assert [point["x"] for point in schema["data"][0]] == ["a", "b", "c"]
+
+
+def test_a_hue_reads_as_the_multi_line_chart_it_is():
+    """
+    A ``hue`` splits the chart into groups, and the layer carries one series.
+
+    The intervals are dropped rather than mis-assigned -- carrying one group's
+    bounds under another's estimate would be worse than carrying none -- and a
+    follow-up covers giving the layer more than one series. What this pins is
+    that the interval polylines still do not travel as series of their own, and
+    that each remaining series is named after its hue level rather than after
+    whichever line index it happened to land on.
+    """
+    fig, ax = plt.subplots()
+    frame = FRAME.assign(half=["x", "y"] * 9)
+    sns.pointplot(frame, x="group", y="value", hue="half", dodge=True, ax=ax)
+
+    schema = _schema(fig)
+
+    assert schema["type"] == PlotType.LINE.value
+    assert len(schema["data"]) == 2
+    assert {point["z"] for series in schema["data"] for point in series} == {"x", "y"}
+
+
+def test_a_dodged_group_is_still_named_by_its_tick():
+    """
+    ``dodge`` shifts a series aside from the tick that names it.
+
+    The point is drawn at 0.955 rather than at 1, and looking the label up by
+    exact coordinate then misses -- so a dodged chart announced "-0.025" where
+    it says "a". It is the same group either way, and the reader has no other
+    way to know which.
+    """
+    fig, ax = plt.subplots()
+    frame = FRAME.assign(half=["x", "y"] * 9)
+    sns.pointplot(frame, x="group", y="value", hue="half", dodge=True, ax=ax)
+
+    for series in _schema(fig)["data"]:
+        assert [point["x"] for point in series] == ["a", "b", "c"]
+
+
+def test_a_numeric_axis_is_not_snapped_to_its_ticks():
+    """
+    The guard on the rounding above: it must fire on category axes only.
+
+    On a numeric axis the ticks are renderings of coordinates, so rounding to
+    the nearest one would rename a measurement after whichever tick it fell
+    closest to -- silently reporting a value the chart never drew.
+
+    Every coordinate here sits off a tick, since one landing on a tick is
+    already answered by the exact lookup and would prove nothing about the
+    rounding.
+    """
+    fig, ax = plt.subplots()
+    ax.plot([0.4, 10.4, 20.7], [1.0, 2.0, 3.0])
+
+    data = _schema(fig)["data"][0]
+
+    assert [point["x"] for point in data] == [0.4, 10.4, 20.7]
+
+
+def test_the_intervals_are_tagged_for_highlighting():
+    """
+    One drawn element per point, in the order the points are emitted.
+
+    That is the shape the consumer repeats across its lower, value and upper
+    sections, so a mismatch here shows up as the highlight landing on the wrong
+    group rather than as an error.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", ax=ax)
+
+    plot = _plots(fig)[0]
+    plot.render()
+
+    assert plot._support_highlighting is True
+    assert len(plot.elements) == 3
+
+
+def test_an_earlier_chart_on_the_same_axes_is_left_alone():
+    """
+    Only the lines this call drew are its own.
+
+    A point plot over an existing line chart would otherwise sweep that line up
+    as an estimate, describing another chart's data as this one's groups.
+    """
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2], [10.0, 11.0, 12.0])
+    sns.pointplot(FRAME, x="group", y="value", ax=ax)
+
+    plots = _plots(fig)
+
+    # The line layer registered first, then the point plot's own.
+    assert [plot.type for plot in plots] == [PlotType.LINE, PlotType.ERRORBAR]
+    assert len(plots[1].render()["data"]) == 3
+
+
+def test_an_unrecognised_rendering_falls_back_to_describing_the_lines():
+    """
+    The split between estimates and intervals is verified, not assumed.
+
+    It is a claim about another library's rendering: seaborn draws one estimate
+    line and then one short polyline per group. Should that change, the counts
+    stop matching, and the layer describes the drawn lines the way the generic
+    wrapper did rather than reading bounds off artists that are not intervals.
+    """
+    from maidr.patch.pointplot import _pairs_up
+
+    fig, ax = plt.subplots()
+    (estimate,) = ax.plot([0, 1, 2], [1.0, 2.0, 3.0], marker="o")
+    # One interval short of a group each -- the shape a changed renderer would
+    # produce, and the one that must not be paired up.
+    intervals = [
+        ax.plot([index, index], [0.0, 1.0], marker="None")[0] for index in range(2)
+    ]
+
+    assert _pairs_up([estimate], intervals) is False
+    assert _pairs_up([estimate], []) is True

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -477,3 +477,67 @@ def test_a_horizontal_dodge_still_reports_raw_category_offsets():
         for series in schema["data"]
         for point in series
     )
+
+
+#: Two groups of five observations and one of a single observation -- ordinary
+#: imbalanced categorical data, and the shape where only *some* groups have an
+#: interval to draw.
+MIXED = pd.DataFrame(
+    {
+        "g": ["a"] * 5 + ["b"] * 5 + ["c"] * 1,
+        "v": [1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 11.0, 12.0, 13.0, 14.0, 7.0],
+    }
+)
+
+
+def test_a_group_without_an_interval_does_not_cost_the_others_theirs():
+    """
+    Only some groups having an interval is the common case, not the exotic one.
+
+    An imbalanced frame -- one category with a single observation among several
+    larger ones -- draws intervals for the groups that have them and a NaN
+    polyline for the group that does not. Dropping that polyline would leave the
+    list one short of the estimates and shift every later group's interval onto
+    the wrong estimate, so it stays in place and only its own bound is omitted.
+
+    Before this, the count check failed and the layer fell back to describing
+    every drawn line: four series for a three-group chart, one of them a pair of
+    NaNs -- the exact rendering this module exists to remove.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(MIXED, x="g", y="v", ax=ax)
+
+    schema = _schema(fig)
+    data = schema["data"]
+
+    assert schema["type"] == PlotType.ERRORBAR.value
+    assert [point["x"] for point in data] == ["a", "b", "c"]
+    # The two measurable groups keep their bounds, correctly paired.
+    assert data[0]["yMin"] < data[0]["y"] < data[0]["yMax"]
+    assert data[1]["yMin"] < data[1]["y"] < data[1]["yMax"]
+    assert data[1]["yMin"] > data[0]["yMax"]
+    # The single-observation group carries its estimate and no interval.
+    assert data[2]["y"] == 7.0
+    assert "yMin" not in data[2]
+    assert "yMax" not in data[2]
+
+
+def test_a_partial_interval_promises_no_highlight():
+    """
+    The selector resolves to one element per point, or the consumer drops it.
+
+    A chart where only some groups have an interval has fewer drawn elements
+    than points, so the selector resolves short and the consumer discards the
+    whole result -- highlighting nothing while the schema said it would. Saying
+    so is better than promising it; the announcement is unaffected either way.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(MIXED, x="g", y="v", ax=ax)
+
+    plot = _plots(fig)[0]
+    schema = plot.render()
+
+    assert len(schema["data"]) == 3
+    assert plot._support_highlighting is False
+    assert not plot.elements
+    assert "selectors" not in schema

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -541,3 +541,65 @@ def test_a_partial_interval_promises_no_highlight():
     assert plot._support_highlighting is False
     assert not plot.elements
     assert "selectors" not in schema
+
+
+def test_a_hue_level_missing_a_category_does_not_break_the_pairing():
+    """
+    Seaborn NaN-pads a hue level that never appears in some category.
+
+    Which is what makes the pairing survive an unbalanced hue-by-category set:
+    both estimate lines carry one vertex per category whether or not the data
+    had one, so the counts still match and the chart does not fall back to
+    describing the raw interval polylines.
+
+    Pinned rather than assumed, because it is a claim about another library's
+    rendering. Were seaborn to *omit* the point instead, the two estimate lines
+    would differ in length, the pairing would fail, and the cap geometry this
+    module exists to remove would travel as data again -- so this is the test
+    that would say so.
+    """
+    # Hue level 'y' never appears in category 'c'.
+    unbalanced = pd.DataFrame(
+        {
+            "g": ["a"] * 4 + ["b"] * 4 + ["c"] * 2,
+            "half": ["x", "x", "y", "y", "x", "x", "y", "y", "x", "x"],
+            "v": [1.0, 2.0, 5.0, 6.0, 10.0, 11.0, 14.0, 15.0, 20.0, 21.0],
+        }
+    )
+
+    fig, ax = plt.subplots()
+    sns.pointplot(unbalanced, x="g", y="v", hue="half", dodge=True, ax=ax)
+
+    schema = _schema(fig)
+    data = schema["data"]
+
+    assert schema["type"] == PlotType.LINE.value
+    # Two series, not two series plus six interval polylines.
+    assert len(data) == 2
+    assert all(len(series) == 3 for series in data)
+    assert [point["x"] for point in data[1]] == ["a", "b", "c"]
+    # The combination the data does not have arrives as a gap, which the
+    # consumer names rather than reading out -- not as cap geometry.
+    assert np.isnan(data[1][2]["y"])
+
+
+def test_an_estimate_line_without_a_marker_is_still_an_estimate():
+    """
+    The split tests the literal marker seaborn gives its interval lines.
+
+    ``markers=""`` turns the estimate's own marker off, leaving it as the empty
+    string -- while an interval line carries the string ``"None"``. Simplifying
+    the check to ``if not line.get_marker()`` would therefore classify the
+    estimates as intervals, the counts would stop matching, and the chart would
+    fall back to describing every drawn line.
+
+    This is the test that fails if someone makes that simplification.
+    """
+    fig, ax = plt.subplots()
+    sns.pointplot(FRAME, x="group", y="value", marker="", ax=ax)
+
+    schema = _schema(fig)
+
+    assert schema["type"] == PlotType.ERRORBAR.value
+    assert len(schema["data"]) == 3
+    assert all("yMin" in point for point in schema["data"])

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -386,3 +386,94 @@ def test_an_unrecognised_rendering_falls_back_to_describing_the_lines():
 
     assert _pairs_up([estimate], intervals) is False
     assert _pairs_up([estimate], []) is True
+
+
+def test_bounds_are_not_spelled_out_to_seventeen_digits():
+    """
+    A bound is computed, not authored, and comes off the drawn vertex raw.
+
+    ``mean - sd`` for these two observations is ``0.07928932188134526`` -- a
+    number a screen reader reads digit by digit, and one whose tail is an
+    artifact of how it was arrived at rather than a measurement. ``ErrorBarPlot``
+    already cuts its own bounds to twelve significant figures; a point plot's
+    bounds are the same quantity reached the same way, so they are cut the same.
+    """
+    pair = pd.DataFrame({"g": ["a", "a"], "v": [0.1, 0.2]})
+
+    fig, ax = plt.subplots()
+    sns.pointplot(pair, x="g", y="v", errorbar="sd", ax=ax)
+
+    point = _schema(fig)["data"][0]
+
+    assert point["yMin"] == 0.0792893218813
+    assert point["yMax"] == 0.220710678119
+
+
+def test_a_group_of_one_carries_no_interval():
+    """
+    A single observation has nothing to estimate an interval from.
+
+    Seaborn still draws the polyline, with the cap positions intact and the
+    value coordinates NaN. Read as an interval it hands the reader the *cap's
+    own width* -- roughly 0.05 either side of the group's position -- which is
+    not a measurement and is not even in the units of the value axis.
+
+    So the chart reads as the line of estimates it is. This was found by the
+    ``native_scale`` case, where seaborn groups by every distinct value and
+    every group therefore has one observation.
+    """
+    singles = pd.DataFrame({"g": ["a", "b", "c"], "v": [1.0, 2.0, 3.0]})
+
+    fig, ax = plt.subplots()
+    sns.pointplot(singles, x="g", y="v", capsize=0.2, ax=ax)
+
+    schema = _schema(fig)
+
+    assert schema["type"] == PlotType.LINE.value
+    assert [point["y"] for point in schema["data"][0]] == [1.0, 2.0, 3.0]
+
+
+def test_nothing_recognisable_still_describes_the_lines():
+    """
+    The one path that used to register no layer at all.
+
+    Every other verification failure falls back to describing what was drawn,
+    which is what the generic wrapper did; dropping the chart entirely is a
+    worse answer than the one it already gave. Reached here by drawing lines
+    that all look like intervals, which is what a renderer that stopped marking
+    its estimates would produce.
+    """
+    fig, ax = plt.subplots()
+    for index in range(2):
+        ax.plot([0, 1], [index, index + 1], marker="None")
+
+    plots = _plots(fig)
+
+    assert len(plots) == 1
+    assert plots[0].type == PlotType.LINE
+
+
+def test_a_horizontal_dodge_still_reports_raw_category_offsets():
+    """
+    The known limit of the tick-rounding fix, pinned rather than left implicit.
+
+    ``extract_line_data_with_categorical_labels`` reads the *x* ticks only, so
+    the label recovery helps a vertical dodged chart and not a horizontal one,
+    whose categories sit on y. Recorded here so the gap is visible and so the
+    day the shared helper learns to follow the category axis, this test turns
+    red rather than the behaviour changing unnoticed. Tracked in #353.
+    """
+    frame = FRAME.assign(half=["x", "y"] * 9)
+
+    fig, ax = plt.subplots()
+    sns.pointplot(frame, y="group", x="value", hue="half", dodge=True, ax=ax)
+
+    schema = _schema(fig)
+
+    # Category positions on y, still numeric and still dodged aside.
+    assert schema["type"] == PlotType.LINE.value
+    assert all(
+        isinstance(point["y"], float)
+        for series in schema["data"]
+        for point in series
+    )

--- a/tests/core/test_axes_schema.py
+++ b/tests/core/test_axes_schema.py
@@ -19,6 +19,7 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
 import seaborn as sns  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
@@ -111,6 +112,24 @@ class TestMatplotlibCanonicalShape:
             _assert_canonical_axes(axes)
             assert axes["x"]["label"] == "Response"
             assert axes["y"]["label"] == "Group"
+        finally:
+            plt.close(fig)
+
+    def test_pointplot(self):
+        # The same layer type reached by a different route: seaborn builds the
+        # axes itself, so the canonical shape has to survive a chart this
+        # package did not lay out.
+        frame = pd.DataFrame({"g": ["a", "a", "b", "b"], "v": [1.0, 3.0, 5.0, 9.0]})
+        fig, ax = plt.subplots()
+        try:
+            sns.pointplot(frame, x="g", y="v", ax=ax)
+            ax.set_xlabel("Group")
+            ax.set_ylabel("Response")
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            assert axes["x"]["label"] == "Group"
+            assert axes["y"]["label"] == "Response"
         finally:
             plt.close(fig)
 


### PR DESCRIPTION
Closes #246.

A point plot estimates a group mean and draws the interval around it. That is the same quantity `Axes.errorbar` carries and the same thing a reader needs from it — **whether two group means differ is answered by whether their intervals overlap** — so it now emits the same `error_bar` layer, and the consumer steps through lower / value / upper at each group with no special case for where the chart came from.

## This is as much a removal as an addition

`sns.pointplot` was already reaching MAIDR, through the generic `Axes.plot` wrapper. What it produced was not "missing intervals" — it was wrong. A three-group chart announced **four series**:

```json
[{"x": "Sat", "y": 22.49}, {"x": NaN, "y": NaN}, {"x": 1.95, "y": 22.49}, {"x": 2.05, "y": 22.49}]
```

That is one of the interval polylines: a NaN separator, and cap offsets like `1.95` sitting among the category names. A reader arrowing through the chart walked cap geometry believing it was data.

| | before | after |
|---|---|---|
| series announced (3 groups) | 4 | 1 |
| interval carried | ✗ | ✓ `yMin`/`yMax` |
| dodged group label | `-0.025` | `Thur` |
| hue series names | off-by-N from `legend_labels[i]` | correct |

## Why patch `pointplot` by name

Only the name says the artists mean something other than what they look like. Seaborn draws no `ErrorbarContainer` — it draws the estimates as one `Line2D` and each interval as another, so nothing downstream can tell an interval from a series.

The split is **verified, not assumed**, since it is a claim about another library's rendering: the estimates have to pair one-to-one with the intervals, group by group, and each interval has to be short enough to be one. When that fails — because a future seaborn renders this differently — the layer falls back to describing the drawn lines the way the generic wrapper did, rather than reading bounds off artists that are not intervals.

## Design notes

**Orientation** is read from the axes, not from the caller's `orient`, which is usually absent — seaborn infers it and does not report what it decided. Two signals do, in order of authority:

1. Seaborn draws its categorical axis through matplotlib's string-category machinery, leaving `UnitData` on that axis and nothing on the other. True whatever the category *values* are, so a numeric grouping column still travels this way.
2. Under `native_scale=True` that machinery is silent, and the intervals answer it themselves: an interval spans the value axis and stands on a single coordinate of the other.

A rule based on "the estimate sits at the centre of its interval" would have looked simpler and been wrong — `errorbar='sd'` draws bounds equidistant from the estimate, so it then sits at the centre along *both* axes. There is a test for exactly that.

**Bounds are the extremes along the value axis**, which is what makes `capsize` irrelevant: a cap is drawn *at* the bound it marks, so a two-vertex line and an eight-vertex NaN-separated polyline give the same answer. Pinned by comparing a capped draw against a bare one.

**`hue` reads as the multi-line chart it is.** `ErrorBarPoint[]` on the consumer side is a single flat series, so a hued point plot cannot carry both its groups and its intervals. The intervals are dropped rather than mis-assigned — one group's bounds under another's estimate would be worse than none — and I will open a follow-up for multi-series intervals, which needs the JS grammar first. The estimates still travel correctly, which they did not before.

**A dodged group is named by the tick it was shifted from.** `dodge` draws the point at `0.975` rather than `1`, the exact-coordinate lookup misses, and the reader heard `-0.025` where the chart says `Thur`. Rounding recovers it, gated on the axis really being categorical — on a numeric axis the same rounding would rename a measurement after whichever tick it fell nearest, and there is a test that fails if that gate is removed.

## Verification actually run

| Step | Result |
|---|---|
| `uv run pytest` | **954 passed** (was 938) |
| `ruff check` on changed files | clean |
| `ruff check` repo-wide | 52 errors, unchanged from `main` (all pre-existing `F401` in `__init__.py`) |

Two of the new tests failed first and found real defects, which is why they are in this shape:

- extraction was **not idempotent** — a layer is rendered more than once, and `_elements` accumulated, so the highlight would land on the wrong group. Now cleared per extraction.
- the numeric-axis guard test initially passed for the wrong reason (a coordinate that happened to sit exactly on a tick). Rewritten so every coordinate sits off one, which is the only way it tests the rounding at all.

`tests/core/plot/test_errorbar.py::test_seaborn_error_bars_do_not_register_a_second_layer[pointplot]` changed from `LINE` to `ERRORBAR`. Its purpose is unchanged — that patching `Axes.errorbar` does not add a *second* layer to seaborn's own charts — and its docstring now says the single layer is registered by the new patch rather than that one.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_