### PR TITLE
ci: refresh the bundled maidr.js when upstream publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,14 @@ jobs:
         # py-maidr cut its own release.  The refresh is committed locally
         # as ``xabilitylab`` but intentionally *not* pushed here: the
         # semantic-release step below pushes the branch, so this commit
-        # ships only when a release actually happens.  When no release is
-        # pending the commit is discarded with the runner, so the bundle
-        # never trickles onto ``main`` between releases.
+        # ships only when a release actually happens, and when no release is
+        # pending it is discarded with the runner.
+        #
+        # ``main`` may already carry a newer bundle than the last release:
+        # ``update-maidr-js.yml`` refreshes it whenever upstream publishes.
+        # That costs nothing here -- this step re-resolves the newest upstream
+        # either way, and finds nothing to commit when the bundle is already
+        # current -- and this step stays the authority on what users receive.
         run: |
           set -euo pipefail
 

--- a/.github/workflows/update-maidr-js.yml
+++ b/.github/workflows/update-maidr-js.yml
@@ -1,22 +1,40 @@
 name: Update bundled maidr.js
 
-# Manual escape hatch for refreshing the offline-bundled ``maidr.js`` and
-# its assets from the npm registry into ``maidr/static/`` and committing
-# the changes directly to ``main``.
+# Refreshes the offline-bundled ``maidr.js`` and its assets from the npm
+# registry into ``maidr/static/`` and commits the changes directly to
+# ``main``.  Runs when upstream publishes, and on demand.
 #
-# The routine, automatic refresh happens at py-maidr *release* time (see
-# ``release.yml``), so the latest upstream release is bundled *into* each
-# py-maidr release rather than trickling onto ``main`` whenever upstream
-# publishes.  This workflow is kept only for on-demand refreshes between
-# releases and is therefore ``workflow_dispatch``-only -- there is no
-# scheduled trigger.
+# What reaches *users* is still decided at py-maidr release time, not here:
+# ``release.yml`` refreshes the bundle again as part of cutting a release, so
+# a release always ships the upstream version that was current when it was
+# cut.  This workflow moves ``main`` forward in between, which is what makes
+# a freshly published upstream fix testable from a checkout without waiting
+# for the next release.
 #
 # The commit uses the ``chore:`` prefix so python-semantic-release
-# (configured in ``pyproject.toml``) does not treat a bundle refresh
-# as a new py-maidr release.  The next ``feat:`` / ``fix:`` / ``perf:``
-# commit to ``main`` will ship with the refreshed bundle automatically.
+# (configured in ``pyproject.toml``) does not treat a bundle refresh as a new
+# py-maidr release.  That is deliberate, and it is the limit of what this
+# workflow can do: an upstream release alone does not reach PyPI.  It ships
+# with the next ``feat:`` / ``fix:`` / ``perf:`` release, whenever that is.
+#
+# There is no scheduled trigger, and none is needed as a backstop the way
+# r-maidr has one.  r-maidr has no release pipeline -- whatever sits on
+# ``main`` at CRAN submission time is what ships -- so a missed refresh there
+# is a missed shipment.  Here the release-time refresh in ``release.yml``
+# already re-resolves the newest upstream, so a missed dispatch costs only
+# the head-of-``main`` currency, never the released artifact.
 
 on:
+  repository_dispatch:
+    # Sent by maidr's release workflow the moment ``npm publish`` succeeds.
+    # ``client_payload.version`` names the version just published, and the job
+    # fetches that exact version rather than re-resolving ``latest``, which
+    # sidesteps the window where the ``latest`` dist-tag has not propagated.
+    #
+    # repository_dispatch only ever triggers the workflow file as it exists on
+    # the default branch, so changes to this trigger take effect once they are
+    # on ``main`` and not before.
+    types: [maidr-released]
   workflow_dispatch:
     inputs:
       maidr_version:
@@ -31,6 +49,24 @@ jobs:
   update:
     name: Download latest maidr.js
     runs-on: ubuntu-latest
+    # Shares ``release.yml``'s group name on purpose. A concurrency group is
+    # scoped to the repository, not to a workflow, so naming the same group in
+    # both is what serialises them -- and they need serialising, because both
+    # push to ``main``: this job through git-auto-commit-action, that one
+    # through semantic-release. Overlapping, the second push is a
+    # non-fast-forward against a checkout taken before the first landed, and
+    # the loser is a failed release rather than anything corrupted.
+    #
+    # The window is narrow but it is not theoretical: the schedules are an
+    # hour apart precisely because upstream releases on Mondays, and an
+    # off-schedule upstream release now fires a dispatch here at any hour.
+    #
+    # Queuing, not cancelling, since the default is to wait. A refresh held
+    # behind a release then finds the bundle already current and commits
+    # nothing, because the release refreshed it too. If a second dispatch
+    # arrives while one is pending, the pending one is dropped -- the cost is
+    # ``main`` briefly trailing, never the released artifact.
+    concurrency: release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -38,10 +74,18 @@ jobs:
       - name: Resolve, download and verify bundled assets
         id: bundle
         env:
-          # Pass the dispatch input through the environment rather than
+          # Pass the requested version through the environment rather than
           # interpolating ${{ ... }} into the script text, which would be a
-          # shell-injection surface in a job holding contents: write.
-          MAIDR_VERSION: ${{ github.event.inputs.maidr_version }}
+          # shell-injection surface in a job holding contents: write.  The
+          # same reasoning covers ``client_payload``, which is written by
+          # whoever holds the sending token rather than by this repository;
+          # the script validates the version against a strict pattern before
+          # it reaches a URL or a path, and verifies the download against the
+          # registry's published integrity hash.
+          #
+          # Empty when neither is supplied, which is what makes the script
+          # resolve ``latest`` on its own.
+          MAIDR_VERSION: ${{ github.event.inputs.maidr_version || github.event.client_payload.version }}
         run: |
           set -euo pipefail
           # Resolve (or use the requested version), download, and verify the


### PR DESCRIPTION
Receiving half of a two-repo change. The sending half is a PR on xability/maidr, linked below. This mirrors what xability/r-maidr#131 did for the R binding.

## Why

The bundle only ever moved at py-maidr release time, so between releases `main` carried whatever upstream version the last release happened to pin. Checking out `main` to reproduce or test a freshly published upstream fix meant refreshing the bundle by hand first.

## What changes

`update-maidr-js.yml` gains a `repository_dispatch` trigger on `maidr-released`. maidr's release workflow fires it the moment `npm publish` succeeds, carrying the version it published:

```json
{"event_type": "maidr-released", "client_payload": {"version": "4.1.0"}}
```

The job takes the version from `client_payload` when present, falling back to the `workflow_dispatch` input and then to nothing — which makes the script resolve `latest` on its own, exactly as before. Naming the version sidesteps the window right after a publish where the `latest` dist-tag has not propagated.

Everything downstream of that is unchanged: same shared `fetch-maidr-bundle.sh`, same strict version-pattern check, same registry integrity verification, same `chore:`-prefixed commit to `main`.

## What does *not* change, deliberately

**An upstream release still does not reach PyPI on its own.** The commit keeps its `chore:` prefix, so python-semantic-release does not treat a bundle refresh as a py-maidr release; the refreshed bundle ships with the next `feat:` / `fix:` / `perf:` release, whenever that is.

That is the explicit choice here, and it is worth stating plainly because it is the limitation of this approach: it makes `main` current, not PyPI. Making an upstream release cut a py-maidr release would have meant typing the bundle commit as `fix:`, which would let upstream drive py-maidr's version numbers — a bigger change to what a py-maidr version *means*, and not what was asked for.

`release.yml` remains the authority on what users actually receive: it re-resolves the newest upstream when a release is cut, and now simply finds nothing to commit when `main` is already current.

## No scheduled backstop, unlike r-maidr

r-maidr pairs its dispatch with a daily cron. That is right there and wrong here.

r-maidr has no release pipeline — whatever sits on `main` at CRAN submission time is what ships — so a missed refresh there is a missed shipment, and the cron bounds that. Here the release-time refresh in `release.yml` already re-resolves the newest upstream, so a missed dispatch costs only the currency of `main` and never the released artifact. A cron would be redundant with a step that already runs.

## Trust

No new trust is granted. `client_payload` is written by whoever holds the sending token, but that token needs write access to this repository to send a `repository_dispatch` at all, and anyone holding it could push to `main` directly. The version still passes the `^[0-9]+\.[0-9]+\.[0-9]+([-+.][0-9A-Za-z.-]+)*$` check in `fetch-maidr-bundle.sh` before it reaches a URL or a path, and the download is still verified against the registry's published integrity hash.

## Also in this PR

`release.yml` carried a comment stating the bundle "never trickles onto `main` between releases". This change makes that untrue, so it is corrected in the same commit rather than left to contradict the code next to it.

## Verification

`actionlint` passes on both changed workflows. Both files parse, and the trigger sets are `[repository_dispatch, workflow_dispatch]` for the updater and `[schedule, workflow_dispatch]` for the release, as intended.

Note that `repository_dispatch` only ever triggers the workflow file as it exists on the default branch, so nothing can be received until this is on `main`.

CI-only; no Python code, no tests, and nothing in the package itself changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZocjnGTiRvLDCbcvqYqa3)_