### PR TITLE
feat(area): read a stackplot as the area chart it is

### DIFF
--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -657,6 +657,43 @@ ax.set_ylabel("Response")
 plt.show() #<<
 ```
 
+### Area Plot
+
+`ax.stackplot()` reads as an area chart rather than a line one, and the
+distinction matters: a stacked area draws **two** numbers at each point that a
+line would conflate. The band's height is the series' own value; its top edge
+is the running total. maidr announces the value and reports the total beside
+it, so a reader always knows which they heard.
+
+A single band is a plain area — nothing is stacked on it, so a running total
+equal to its own value would be noise. `baseline="wiggle"` (a streamgraph)
+reads the same way as any stacked area: floating the stack moves where the
+bands sit without changing what any band measures.
+
+```{python}
+#| fig-alt: Stacked area chart of revenue by source over four years
+
+import matplotlib.pyplot as plt
+
+import maidr #<<
+
+years = [2019, 2020, 2021, 2022]
+subscriptions = [10, 20, 25, 30]
+services = [5, 8, 12, 14]
+
+fig, ax = plt.subplots(figsize=(8, 5))
+ax.stackplot( #<<
+    years, subscriptions, services, labels=["Subscriptions", "Services"]
+)
+
+ax.set_title("Revenue by Source")
+ax.set_xlabel("Year")
+ax.set_ylabel("Revenue (millions)")
+ax.legend(loc="upper left")
+
+plt.show() #<<
+```
+
 ### Point Plot
 
 `sns.pointplot()` is the same reading from the other direction: it estimates a

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > py-maidr is a Python library that makes matplotlib, seaborn, and plotly data visualizations accessible to blind and low-vision users through sonification, braille, text, and AI-powered conversational modalities. Developed by the (x)Ability Design Lab at the University of Illinois Urbana-Champaign.
 
-maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, pie, box, violin, heatmap, scatter, smooth/regression, candlestick, error bar, point, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
+maidr (pronounced "mader") monkey-patches matplotlib, seaborn, and plotly at import time so users just `import maidr` and call `maidr.show(plot)` to generate interactive HTML with keyboard-navigable sonification, braille, text, and AI chat support. Supported plot types: bar, stacked bar, dodged bar, count, histogram, KDE, line, multi-line, step, pie, box, violin, heatmap, scatter, smooth/regression, candlestick, error bar, point, area, stacked area, multi-panel, and facet plots. Works in Jupyter, Colab, VS Code, Streamlit, Shiny, and Quarto.
 
 ## Docs
 - [Documentation Home](https://py.maidr.ai/): Installation, quick start, and overview

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -12,6 +12,14 @@ class PlotType(str, Enum):
     HEAT = "heat"
     HIST = "hist"
     LINE = "line"
+    #: A filled band between a series and a baseline. Emitted for a single
+    #: `stackplot` band, which has nothing stacked on it.
+    AREA = "area"
+    #: Bands stacked on one another, so a band's height is its own series'
+    #: value while its top edge is the running total. A distinct type because
+    #: a line layer announces one number per point with nothing to say which
+    #: of those two it is.
+    STACKED_AREA = "stacked_area"
     PIE = "pie"
     SCATTER = "point"
     STACKED = "stacked_bar"

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -59,6 +59,7 @@ _DISPLAY_NAMES = {
     PlotType.HIST: "histogram",
     PlotType.SCATTER: "scatter",
     PlotType.STACKED: "stacked bar",
+    PlotType.STACKED_AREA: "stacked area",
     PlotType.VIOLIN_BOX: "violin",
     PlotType.VIOLIN_KDE: "violin",
 }

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -59,6 +59,8 @@ class FigureManager:
         PlotType.VIOLIN_KDE: 1,
         PlotType.VIOLIN_BOX: 1,
         PlotType.ERRORBAR: 1,
+        PlotType.AREA: 1,
+        PlotType.STACKED_AREA: 2,
     }
 
     _instance = None

--- a/maidr/core/plot/areaplot.py
+++ b/maidr/core/plot/areaplot.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any, Sequence
+
+import numpy as np
+from matplotlib.axes import Axes
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot import MaidrPlot
+from maidr.exception import ExtractionError
+
+
+class AreaPlot(MaidrPlot):
+    """
+    A chart drawing one or more filled bands against a baseline.
+
+    Reads ``Axes.stackplot`` and the single-bound form of ``Axes.fill_between``.
+
+    Emitted as an area layer rather than a line one because a stacked area
+    draws **two** numbers at each point that a line would conflate: the band's
+    height is the series' own value, and its top edge is the running total. A
+    line layer announces one number per point with nothing to say which of the
+    two it is; the area trace announces the value and reports the total beside
+    it.
+
+    The values come from the **caller's arguments** rather than from the drawn
+    polygons, which is the one place this differs from the rest of this package
+    -- ``ErrorBarPlot`` and ``PointPlot`` both read geometry precisely because
+    the arguments they were given are not the quantity the schema carries.
+    Here it is the other way round: ``stackplot`` is handed each series' own
+    values and does the accumulation itself, so the arguments are exactly what
+    the consumer needs, while the drawn polygon is a closed outline whose
+    vertices run forward along the baseline and back along the top with the
+    endpoints repeated. Recovering per-series values from that means undoing
+    both the accumulation and the closure, to arrive back at what the caller
+    passed in.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the bands were drawn on.
+    **kwargs
+        ``x`` is the shared position array, ``series`` the per-series values in
+        drawing order, ``labels`` their names when the caller supplied any, and
+        ``collections`` the drawn artists. The patch resolves all four.
+
+    See Also
+    --------
+    MaidrPlot : The base class for MAIDR plot data objects.
+    """
+
+    def __init__(self, ax: Axes, plot_type: PlotType, **kwargs) -> None:
+        super().__init__(ax, plot_type)
+
+        self._x = kwargs.pop("x", None)
+        self._series = list(kwargs.pop("series", []))
+        self._labels = list(kwargs.pop("labels", []))
+        self._collections = list(kwargs.pop("collections", []))
+
+    def _extract_plot_data(self) -> list[list[dict]]:
+        if self._x is None or not self._series:
+            raise ExtractionError(self.type, self.ax)
+
+        positions = np.atleast_1d(np.asarray(self._x, dtype=object))
+
+        # Cleared rather than appended to: a layer is rendered more than once,
+        # and the tagged elements have to stay one per series, in series order.
+        self._elements.clear()
+
+        data: list[list[dict]] = []
+        for index, values in enumerate(self._series):
+            magnitudes = np.atleast_1d(np.asarray(values))
+            if len(magnitudes) != len(positions):
+                raise ExtractionError(self.type, self.ax)
+
+            label = self._labels[index] if index < len(self._labels) else None
+            points = []
+            for position, magnitude in zip(positions, magnitudes):
+                point = {
+                    MaidrKey.X: self._scalar(position),
+                    MaidrKey.Y: self._scalar(magnitude),
+                }
+                if label:
+                    point[MaidrKey.Z] = str(label)
+                points.append(point)
+
+            data.append(points)
+            if index < len(self._collections):
+                collection = self._collections[index]
+                # Assigned here rather than relied upon: a gid is otherwise
+                # only stamped at draw time, and the schema is built first.
+                # `MultiLinePlot` does the same for the same reason.
+                if collection.get_gid() is None:
+                    collection.set_gid(f"maidr-{uuid.uuid4()}")
+                self._elements.append(collection)
+
+        if len(self._elements) != len(data):
+            # The consumer resolves the selector to one element per series and
+            # discards the result outright when the count disagrees, so a
+            # partial list would emit a selector that silently highlights
+            # nothing. Saying so is better than promising it.
+            self._elements.clear()
+            self._support_highlighting = False
+
+        return data
+
+    def _get_selector(self) -> list[str]:
+        """
+        Return one selector per drawn band, in series order.
+
+        Parameters
+        ----------
+        None
+
+        Only reached when every series was tagged: extraction clears the flag
+        otherwise, so this never has to describe a partial list.
+
+        Returns
+        -------
+        list of str
+            One selector per band.
+        """
+        return [f"g[id='{element.get_gid()}'] path" for element in self._elements]
+
+    @staticmethod
+    def _scalar(value: Any) -> Any:
+        """
+        Convert one coordinate to a JSON-serialisable scalar.
+
+        Parameters
+        ----------
+        value : Any
+            A coordinate read off the caller's arguments.
+
+        Returns
+        -------
+        Any
+            A float, or a string for a coordinate that is not numeric.
+        """
+        if isinstance(value, (str, np.str_)):
+            return str(value)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return str(value)
+
+    @staticmethod
+    def resolve_type(series: Sequence) -> PlotType:
+        """
+        Decide which area layer a call produced.
+
+        A single band has nothing stacked on it, so announcing a running total
+        equal to its own value at every point would be noise -- it is a plain
+        area. Several bands stack, and the two numbers a stack draws are what
+        the dedicated type keeps apart.
+
+        The count is the whole rule. ``baseline`` looks like it should matter
+        and does not: ``sym`` and ``wiggle`` move where the stack sits on the
+        value axis without changing what any band measures, so a streamgraph
+        is a stacked area drawn around a floating centre and reads as one.
+
+        Parameters
+        ----------
+        series : sequence
+            The per-series value arrays.
+
+        Returns
+        -------
+        PlotType
+            The layer type to emit.
+        """
+        return PlotType.STACKED_AREA if len(series) > 1 else PlotType.AREA

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 from maidr.core.enum import PlotType
+from maidr.core.plot.areaplot import AreaPlot
 from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.boxplot import BoxPlot
 from maidr.core.plot.errorbar import ErrorBarPlot
@@ -49,6 +50,11 @@ class MaidrPlotFactory:
             single_ax = ax[0]
         else:
             single_ax = ax
+
+        if PlotType.AREA == plot_type or PlotType.STACKED_AREA == plot_type:
+            # One class, both types. They differ in how the bands relate, not
+            # in where the numbers are read from.
+            return AreaPlot(single_ax, plot_type, **kwargs)
 
         if PlotType.BAR == plot_type or PlotType.COUNT == plot_type:
             if PlotDetectionUtils.is_mplfinance_bar_plot(**kwargs):

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -1,5 +1,6 @@
 # Import all patches to ensure they are applied
 from . import (  # noqa: F401
+    areaplot,
     barplot,
     boxplot,
     clear,

--- a/maidr/patch/areaplot.py
+++ b/maidr/patch/areaplot.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import wrapt
+from matplotlib.axes import Axes
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.plot.areaplot import AreaPlot
+from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import _draw_quietly
+
+
+def stackplot(wrapped, instance, args, kwargs):
+    """
+    Register an ``Axes.stackplot`` call as a MAIDR area layer.
+
+    The values are taken from the call's own arguments rather than from the
+    polygons it draws, and that is the right way round here even though the
+    rest of this package reads geometry. ``stackplot`` is handed each series'
+    values and accumulates them itself, so the arguments are exactly the
+    per-series magnitudes the schema carries -- while the drawn polygon is a
+    closed outline, running forward along the baseline and back along the top
+    with its endpoints repeated, from which recovering them means undoing both
+    the accumulation and the closure.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``Axes.stackplot``.
+    instance : Any
+        The Axes the method was bound to.
+    args : tuple
+        Positional arguments the caller passed: the shared x, then one array
+        per series.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    list
+        Whatever the wrapped function returned, unchanged.
+    """
+    # Don't proceed if the call is made internally by the patched function.
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    # Set the internal context to avoid cyclic processing.
+    with ContextManager.set_internal_context():
+        collections = _draw_quietly(wrapped, args, kwargs)
+
+    ax = instance if isinstance(instance, Axes) else getattr(instance, "axes", None)
+    if ax is None:
+        return collections
+
+    x, series = _positions_and_series(args, kwargs)
+    if x is None or not series:
+        # `stackplot(y)` with no x, or a call this cannot read. Leaving it
+        # unregistered is what happened before this patch existed, and is
+        # better than describing a shape that was not established.
+        return collections
+
+    FigureManager.create_maidr(
+        ax,
+        AreaPlot.resolve_type(series),
+        x=x,
+        series=series,
+        labels=list(kwargs.get("labels") or []),
+        collections=list(collections or []),
+    )
+
+    return collections
+
+
+def _positions_and_series(args: tuple, kwargs: dict):
+    """
+    Split a ``stackplot`` call into its shared x and its per-series values.
+
+    ``stackplot(x, y1, y2)`` and ``stackplot(x, y)`` with a 2-D ``y`` are both
+    valid and mean the same thing, so the series arrive two ways. There is no
+    keyword form: ``stackplot``'s own ``**kwargs`` are forwarded to
+    ``fill_between``, and a call with no positional series is rejected by
+    matplotlib before it reaches here.
+
+    Parameters
+    ----------
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    tuple
+        The x array and the list of per-series arrays, or ``(None, [])`` when
+        the call is not one this can read.
+    """
+    if not args:
+        return None, []
+
+    x = args[0]
+    rest = list(args[1:])
+
+    if not rest:
+        # `stackplot(x)` alone. Matplotlib rejects it before this is reached
+        # on current versions, and there is nothing to describe either way.
+        return None, []
+
+    if len(rest) == 1 and _is_two_dimensional(rest[0]):
+        # `stackplot(x, y)` with a 2-D y stacks its rows.
+        return x, [row for row in rest[0]]
+
+    return x, rest
+
+
+def _is_two_dimensional(values) -> bool:
+    """
+    Check whether a series argument holds several series rather than one.
+
+    Parameters
+    ----------
+    values : Any
+        A positional argument after the x.
+
+    Returns
+    -------
+    bool
+        True when the argument is a sequence of sequences.
+    """
+    try:
+        first = values[0]
+    except (IndexError, KeyError, TypeError):
+        return False
+
+    return hasattr(first, "__len__") and not isinstance(first, (str, bytes))
+
+
+# Patch matplotlib function.
+wrapt.wrap_function_wrapper(Axes, "stackplot", stackplot)

--- a/maidr/patch/areaplot.py
+++ b/maidr/patch/areaplot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import wrapt
 from matplotlib.axes import Axes
 
@@ -104,16 +105,26 @@ def _positions_and_series(args: tuple, kwargs: dict):
         # on current versions, and there is nothing to describe either way.
         return None, []
 
-    if len(rest) == 1 and _is_two_dimensional(rest[0]):
-        # `stackplot(x, y)` with a 2-D y stacks its rows.
-        return x, [row for row in rest[0]]
+    if len(rest) == 1:
+        rows = _rows_of(rest[0])
+        if rows is not None:
+            # `stackplot(x, y)` with a 2-D y stacks its rows.
+            return x, rows
 
     return x, rest
 
 
-def _is_two_dimensional(values) -> bool:
+def _rows_of(values) -> list | None:
     """
-    Check whether a series argument holds several series rather than one.
+    Split a series argument into rows, when it holds several series.
+
+    Asks numpy rather than indexing or iterating the argument directly,
+    because for a ``DataFrame`` both of those mean the columns. ``values[0]``
+    is the column labelled ``0`` -- absent for named columns, and the wrong
+    axis when present -- and iterating yields the labels themselves rather
+    than any data. Matplotlib reads a ``DataFrame`` here as rows, so a reading
+    that took it for columns would describe a chart nobody drew, and would do
+    so without raising.
 
     Parameters
     ----------
@@ -122,15 +133,20 @@ def _is_two_dimensional(values) -> bool:
 
     Returns
     -------
-    bool
-        True when the argument is a sequence of sequences.
+    list or None
+        One array per series, or None when the argument is a single series.
     """
     try:
-        first = values[0]
-    except (IndexError, KeyError, TypeError):
-        return False
+        array = np.asarray(values)
+    except ValueError:
+        # Ragged input. Matplotlib rejects it too, and it has already done so
+        # by the time this runs, so there is nothing here to describe.
+        return None
 
-    return hasattr(first, "__len__") and not isinstance(first, (str, bytes))
+    if array.ndim != 2:
+        return None
+
+    return list(array)
 
 
 # Patch matplotlib function.

--- a/maidr/patch/highlight.py
+++ b/maidr/patch/highlight.py
@@ -48,3 +48,20 @@ wrapt.wrap_function_wrapper(PathCollection, "draw", tag_elements)
 # one, so wrapping it here installs a subclass-only override: the base class
 # and its other subclasses keep the unwrapped method.
 wrapt.wrap_function_wrapper(PolyQuadMesh, "draw", tag_elements)
+
+# `Axes.stackplot` and `Axes.fill_between` render their bands as
+# `FillBetweenPolyCollection`, which matplotlib 3.10 split out of
+# `PolyCollection` -- so wrapping it is a subclass-only override in exactly the
+# way `PolyQuadMesh` is, and leaves violin bodies and every other
+# `PolyCollection` untouched.
+#
+# Guarded because the class is 3.10 and later, while this package supports
+# 3.8. On an older matplotlib a band keeps the plain `PolyCollection` it always
+# had, and an area layer degrades to no highlight rather than failing to
+# import -- the announcement, which is the reading, is unaffected.
+try:
+    from matplotlib.collections import FillBetweenPolyCollection
+except ImportError:  # pragma: no cover - matplotlib < 3.10
+    pass
+else:
+    wrapt.wrap_function_wrapper(FillBetweenPolyCollection, "draw", tag_elements)

--- a/tests/core/plot/test_areaplot.py
+++ b/tests/core/plot/test_areaplot.py
@@ -1,0 +1,272 @@
+"""Tests for area charts.
+
+``Axes.stackplot`` registered nothing at all before this, so an area chart
+carried no data. It is emitted as an area layer rather than a line one because
+a stacked area draws **two** numbers at each point that a line would conflate:
+the band's height is the series' own value, and its top edge is the running
+total. A reader told one of them has nothing to say which they heard.
+
+The values are read from the caller's arguments rather than from the drawn
+polygons, which is the opposite of how the error bar and point plot layers
+work -- and these tests are written to hold that choice honest, since the
+arguments are only the right source while ``stackplot`` is the thing doing the
+accumulating.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.core.plot.areaplot import AreaPlot  # noqa: E402
+
+
+#: Two series over four years. Every value is distinct and no series' value
+#: equals another's running total, so a reading that took the band's top edge
+#: instead of its height cannot coincide with the right answer.
+X = [2019, 2020, 2021, 2022]
+SUBS = [10, 20, 25, 30]
+SERVICES = [5, 8, 12, 14]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _plots(fig):
+    """
+    Return the MAIDR plots registered for a figure, or an empty list.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to read.
+
+    Returns
+    -------
+    list
+        The registered plots.
+    """
+    maidr_instance = FigureManager.figs.get(fig)
+    return list(maidr_instance._plots) if maidr_instance else []
+
+
+def _schema(fig) -> dict:
+    """
+    Return the layer schema of a figure's only plot.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to read.
+
+    Returns
+    -------
+    dict
+        The MAIDR layer schema.
+    """
+    return _plots(fig)[0].render()
+
+
+def _values(schema: dict, index: int) -> list[float]:
+    """
+    Pull one series' magnitudes out of an emitted schema.
+
+    Parameters
+    ----------
+    schema : dict
+        The layer schema.
+    index : int
+        Which series.
+
+    Returns
+    -------
+    list of float
+        The series' values, in order.
+    """
+    return [point["y"] for point in schema["data"][index]]
+
+
+def test_a_stackplot_registers_at_all():
+    """
+    The gap this closes: nothing was registered for an area chart.
+
+    ``Axes.stackplot`` draws `FillBetweenPolyCollection`s, which no patch
+    intercepted, so the figure carried no layer and the chart was unreadable.
+    """
+    fig, ax = plt.subplots()
+    ax.stackplot(X, SUBS, SERVICES, labels=["Subscriptions", "Services"])
+
+    plots = _plots(fig)
+
+    assert len(plots) == 1
+    assert isinstance(plots[0], AreaPlot)
+    assert plots[0].type == PlotType.STACKED_AREA
+
+
+def test_a_band_carries_its_own_value_not_the_running_total():
+    """
+    The reason this is an area layer rather than a line one.
+
+    The consumer sums the series to reach the running total, so handing it a
+    cumulative number would make the totals grow with the number of series
+    rather than with the data. `stackplot` is given the per-series values and
+    accumulates them itself, which is what makes its arguments the right source
+    and its polygons the wrong one.
+    """
+    fig, ax = plt.subplots()
+    ax.stackplot(X, SUBS, SERVICES, labels=["Subscriptions", "Services"])
+
+    schema = _schema(fig)
+
+    assert _values(schema, 0) == [10, 20, 25, 30]
+    assert _values(schema, 1) == [5, 8, 12, 14]
+    # Not the drawn top edges, which are 15, 28, 37, 44.
+    assert _values(schema, 1) != [15, 28, 37, 44]
+
+
+def test_one_band_is_an_area_and_several_are_stacked():
+    """
+    A single band has nothing stacked on it.
+
+    Announcing a running total equal to the value at every point would be
+    noise, so it reads as the plain area it is.
+    """
+    fig_one, one = plt.subplots()
+    one.stackplot(X, SUBS)
+
+    fig_two, two = plt.subplots()
+    two.stackplot(X, SUBS, SERVICES)
+
+    assert _schema(fig_one)["type"] == PlotType.AREA.value
+    assert _schema(fig_two)["type"] == PlotType.STACKED_AREA.value
+
+
+def test_a_two_dimensional_y_means_the_same_as_several_arrays():
+    """
+    ``stackplot(x, y)`` with a 2-D ``y`` stacks its rows.
+
+    The same chart as ``stackplot(x, y1, y2)``, written the other way, so it
+    has to read the same -- and it is the form a caller with a matrix reaches
+    for.
+    """
+    fig_rows, rows = plt.subplots()
+    rows.stackplot(X, np.array([SUBS, SERVICES]), labels=["a", "b"])
+
+    fig_args, separate = plt.subplots()
+    separate.stackplot(X, SUBS, SERVICES, labels=["a", "b"])
+
+    assert _schema(fig_rows)["data"] == _schema(fig_args)["data"]
+
+
+def test_each_band_is_named_after_its_label():
+    """
+    Without the name a reader hears two sets of numbers with nothing to say
+    which series either belongs to -- what the legend gives a sighted reader.
+    """
+    fig, ax = plt.subplots()
+    ax.stackplot(X, SUBS, SERVICES, labels=["Subscriptions", "Services"])
+
+    schema = _schema(fig)
+
+    assert schema["data"][0][0]["z"] == "Subscriptions"
+    assert schema["data"][1][0]["z"] == "Services"
+
+
+def test_an_unlabelled_chart_emits_no_series_name():
+    """A caller who named nothing gets no invented names."""
+    fig, ax = plt.subplots()
+    ax.stackplot(X, SUBS, SERVICES)
+
+    assert "z" not in _schema(fig)["data"][0][0]
+
+
+def test_a_streamgraph_reads_as_the_stacked_area_it_is():
+    """
+    ``baseline='wiggle'`` floats the stack rather than sitting it on zero.
+
+    That moves where the bands sit on the value axis without changing what any
+    band measures, so the reading -- and the layer type -- are the same. A
+    streamgraph is a stacked area drawn around a moving centre.
+    """
+    fig, ax = plt.subplots()
+    ax.stackplot(X, SUBS, SERVICES, baseline="wiggle", labels=["a", "b"])
+
+    schema = _schema(fig)
+
+    assert schema["type"] == PlotType.STACKED_AREA.value
+    assert _values(schema, 0) == [10, 20, 25, 30]
+
+
+def test_every_band_is_tagged_for_highlighting():
+    """
+    One drawn element per series, in series order.
+
+    The consumer resolves the selector to one element per series and discards
+    the result outright when the count disagrees, so a partial list would
+    silently highlight nothing.
+    """
+    fig, ax = plt.subplots()
+    ax.stackplot(X, SUBS, SERVICES, labels=["a", "b"])
+
+    plot = _plots(fig)[0]
+    schema = plot.render()
+
+    assert plot._support_highlighting is True
+    assert len(plot.elements) == 2
+    assert len(schema["selectors"]) == len(schema["data"])
+
+
+def test_rendering_twice_does_not_double_the_elements():
+    """
+    A layer is rendered more than once -- ``set_id`` renders again when the
+    schema is not yet cached -- and the tagged elements have to stay one per
+    series or the highlight lands on the wrong band.
+    """
+    fig, ax = plt.subplots()
+    ax.stackplot(X, SUBS, SERVICES)
+
+    plot = _plots(fig)[0]
+    plot.render()
+    plot.render()
+
+    assert len(plot.elements) == 2
+
+
+def test_the_axis_labels_travel():
+    """The layer carries the chart's own axis labels, as every layer does."""
+    fig, ax = plt.subplots()
+    ax.stackplot(X, SUBS, SERVICES)
+    ax.set_xlabel("Year")
+    ax.set_ylabel("Revenue")
+
+    axes = _schema(fig)["axes"]
+
+    assert axes["x"]["label"] == "Year"
+    assert axes["y"]["label"] == "Revenue"
+
+
+def test_a_ragged_call_is_refused_rather_than_described():
+    """
+    A series shorter than the x it is drawn against is not a chart.
+
+    Matplotlib rejects it, so this asserts the rejection happens rather than
+    a partial layer being registered from a call that never drew.
+    """
+    fig, ax = plt.subplots()
+
+    with pytest.raises(Exception):
+        ax.stackplot(X, [1, 2])
+
+    assert not _plots(fig)

--- a/tests/core/plot/test_areaplot.py
+++ b/tests/core/plot/test_areaplot.py
@@ -264,6 +264,46 @@ def test_every_band_is_tagged_for_highlighting():
     assert len(schema["selectors"]) == len(schema["data"])
 
 
+def test_the_nth_selector_points_at_the_band_the_nth_series_drew():
+    """
+    Which band is which, asserted rather than assumed.
+
+    The count matching is not the same claim: two selectors and two series
+    pass that test whichever way round they are paired, and a reader whose
+    highlight lands on the neighbouring band is told the wrong task by a
+    chart that reports no error. Everything this layer says about a band --
+    its value, its name, its running total -- is wrong for the band actually
+    lit up.
+
+    Order is checked through geometry rather than through the returned list,
+    because the list is the assumption under test. A stacked band is drawn
+    between the running total below it and the running total including it, so
+    band *i*'s drawn extent is a fact about series 0..i that no other band
+    shares.
+    """
+    fig, ax = plt.subplots()
+    collections = ax.stackplot(X, SUBS, SERVICES, labels=["a", "b"])
+
+    plot = _plots(fig)[0]
+    schema = plot.render()
+    tagged = [element.get_gid() for element in plot.elements]
+
+    # Band 0 runs from the baseline to its own values; band 1 from band 0's
+    # values to the pair's totals.
+    lower = [np.zeros(len(X)), np.array(SUBS, dtype=float)]
+    upper = [np.array(SUBS, dtype=float), np.array(SUBS) + np.array(SERVICES)]
+
+    for index, collection in enumerate(collections):
+        extent = collection.get_paths()[0].get_extents()
+
+        assert extent.y0 == pytest.approx(lower[index].min())
+        assert extent.y1 == pytest.approx(upper[index].max())
+        # The element carrying that geometry is the one the schema names at
+        # the same index, so the selector and the series agree.
+        assert collection.get_gid() == tagged[index]
+        assert collection.get_gid() in schema["selectors"][index]
+
+
 def test_rendering_twice_does_not_double_the_elements():
     """
     A layer is rendered more than once -- ``set_id`` renders again when the
@@ -278,6 +318,26 @@ def test_rendering_twice_does_not_double_the_elements():
     plot.render()
 
     assert len(plot.elements) == 2
+
+
+def test_no_plot_type_is_named_to_a_user_with_an_underscore_in_it():
+    """
+    ``display_name`` exists because the wire value is not the user's word.
+
+    ``_show_fallback`` lists these in one sentence, so a member with no
+    override sits beside "stacked bar" and "dodged bar" reading
+    "stacked_area" -- a schema token shown to someone who wrote
+    ``ax.stackplot``.
+
+    Asserted over every member rather than over the one this branch adds,
+    because the gap is a class of mistake: a new multi-word type is
+    registered in the enum and the override is a separate line to remember.
+    """
+    for plot_type in PlotType:
+        assert "_" not in plot_type.display_name, plot_type.name
+
+    assert PlotType.STACKED_AREA.display_name == "stacked area"
+    assert PlotType.AREA.display_name == "area"
 
 
 def test_the_axis_labels_travel():

--- a/tests/core/plot/test_areaplot.py
+++ b/tests/core/plot/test_areaplot.py
@@ -21,6 +21,7 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
 import pytest  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
@@ -168,6 +169,41 @@ def test_a_two_dimensional_y_means_the_same_as_several_arrays():
     separate.stackplot(X, SUBS, SERVICES, labels=["a", "b"])
 
     assert _schema(fig_rows)["data"] == _schema(fig_args)["data"]
+
+
+@pytest.mark.parametrize(
+    "columns",
+    [
+        pytest.param(None, id="positional-labels"),
+        pytest.param(["a", "b", "c", "d"], id="named-labels"),
+    ],
+)
+def test_a_data_frame_of_series_is_read_by_row_like_matplotlib_reads_it(columns):
+    """
+    A ``DataFrame`` handed to ``stackplot`` is rows, not columns.
+
+    Both of the obvious ways to split one give the columns instead. ``df[0]``
+    is the column *labelled* zero, so it raises for named columns and picks
+    the wrong axis when a column happens to be called that; iterating a frame
+    yields the labels themselves and no data at all. Matplotlib reads the
+    rows, and a description that disagreed with the drawing would be a
+    different chart -- reported without an error either way, which is the
+    reason to pin it.
+
+    Parameterised over both label kinds because the two mistakes fail
+    differently: named columns silently collapse to a single series, and
+    integer ones survive far enough to produce nonsense.
+    """
+    frame = pd.DataFrame([SUBS, SERVICES], columns=columns)
+
+    fig_frame, from_frame = plt.subplots()
+    from_frame.stackplot(X, frame, labels=["a", "b"])
+
+    fig_args, separate = plt.subplots()
+    separate.stackplot(X, SUBS, SERVICES, labels=["a", "b"])
+
+    assert _plots(fig_frame)[0].type == PlotType.STACKED_AREA
+    assert _schema(fig_frame)["data"] == _schema(fig_args)["data"]
 
 
 def test_each_band_is_named_after_its_label():

--- a/tests/core/test_axes_schema.py
+++ b/tests/core/test_axes_schema.py
@@ -115,6 +115,22 @@ class TestMatplotlibCanonicalShape:
         finally:
             plt.close(fig)
 
+    def test_stackplot(self):
+        # A nested-data layer, whose series are lists of points rather than
+        # points -- the canonical axes shape has to hold for that too.
+        fig, ax = plt.subplots()
+        try:
+            ax.stackplot([1, 2, 3], [1.0, 2.0, 3.0], [2.0, 1.0, 4.0])
+            ax.set_xlabel("Year")
+            ax.set_ylabel("Revenue")
+            axes = _first_schema(fig)["axes"]
+
+            _assert_canonical_axes(axes)
+            assert axes["x"]["label"] == "Year"
+            assert axes["y"]["label"] == "Revenue"
+        finally:
+            plt.close(fig)
+
     def test_pointplot(self):
         # The same layer type reached by a different route: seaborn builds the
         # axes itself, so the canonical shape has to survive a chart this


### PR DESCRIPTION
`Axes.stackplot` registered **nothing at all** — no MAIDR layer, so an area chart carried no data and was unreadable. It now emits an `area` or `stacked_area` layer.

Closes the py-maidr side of xability/maidr#788, whose trace shipped in maidr **4.1.0**.

## Why an area layer rather than a line one

A stacked area draws **two** numbers at each point that a line would conflate:

| | what it is |
|---|---|
| band **height** | the series' own value |
| band **top edge** | the running total |

A line layer announces one number per point with nothing to say which of the two it is, and the reader cannot recover the other. The area trace announces the value and reports the total beside it.

## Reading the arguments, not the geometry — and why that's the right way round here

This is the opposite of how `ErrorBarPlot` and `PointPlot` work, so it's worth being explicit. Those read drawn geometry precisely because *the arguments they were given are not the quantity the schema carries* — matplotlib takes an error **offset** while the schema wants an absolute **bound**.

`stackplot` is the other way round. It is handed each series' own values and does the accumulation itself, so its arguments are exactly the per-series magnitudes the consumer needs. Its polygon, meanwhile, is a closed outline:

```
[[2019, 10], [2019, 0], [2020, 0], [2021, 0], [2022, 0],
 [2022, 30], [2022, 30], [2021, 25], [2020, 20], [2019, 10], [2019, 10]]
```

— forward along the baseline, back along the top, endpoints repeated. Recovering the same numbers from that means undoing both the accumulation and the closure, to arrive back at what the caller passed in.

A test asserts the emitted values are `[5, 8, 12, 14]` and **not** `[15, 28, 37, 44]`, the drawn top edges, so a future change to geometry-reading fails rather than looking plausible.

## Behaviours pinned

- **One band is an `area`, several are `stacked_area`.** A single band has nothing stacked on it; a running total equal to its own value at every point is noise.
- **`stackplot(x, y)` with a 2-D `y`** means the same as `stackplot(x, y1, y2)`, asserted by comparing the two schemas directly.
- **`baseline="wiggle"`** — a streamgraph — reads as the stacked area it is. It floats the stack without changing what any band measures. It looks like it should decide the type and does not.
- **Series names** come from `labels=`; an unlabelled chart gets no invented ones.
- **Re-rendering** does not double the tagged elements.

I also removed a `baseline` parameter I'd initially threaded into `resolve_type` and never used — the reasoning lives in the docstring, where it doesn't need a dead argument to carry it.

## Highlighting

Tags `FillBetweenPolyCollection`, which matplotlib 3.10 split out of `PolyCollection`. That makes it a **subclass-only override** in exactly the way `PolyQuadMesh` already is, so violin bodies and every other `PolyCollection` stay untouched — `highlight.py`'s existing comment explains why blanket-wrapping the base would be wrong.

Guarded, because this package supports matplotlib ≥ 3.8 and the class is 3.10+. On an older matplotlib a band keeps the plain `PolyCollection` it always had and the layer degrades to no highlight rather than failing to import.

The selector is withdrawn unless **every** band was tagged — the consumer resolves it to one element per series and discards the result outright on a count mismatch, so a partial list would promise highlighting and silently deliver none. Same rule I applied in #352.

## What is deliberately not here

**`ax.fill_between` with two curves.** `fill_between(x, lo, hi)` draws a band around a line — an uncertainty ribbon — not an area against a baseline. Registering it as `area` would announce the upper edge as "the value", which is the exact conflation this layer type exists to prevent. It stays unregistered, as today.

## One thing worth flagging

Checking whether the pinned runtime knows `area`, I found **`maidr/static/VERSION` is 4.0.0 while npm publishes 4.1.0**, and none of the recently added trace types — `area`, `error_bar`, `gauge`, `waterfall`, `word_cloud`, `dumbbell` — exist in 4.0.0. The CDN path resolves the published version at render time, so the default is fine. The **bundled** path (`use_cdn=False`, or CDN unreachable) serves 4.0.0, whose `TraceFactory` throws `Invalid trace type` on an unknown type.

`bundle_status()` reports `is_behind=True, is_stale=False` — the warning threshold is `STALE_MINOR_GAP = 5`, so one minor behind is silent. That threshold was calibrated for "old but working" drift; a bundle that predates a trace type we now emit is a different failure. `release.yml` refreshes the bundle at release time so released users are unaffected, but it seemed worth writing down rather than leaving for someone to hit.

## Verification actually run

| Step | Result |
|---|---|
| `uv run pytest` | **974 passed** (was 962) |
| `ruff check` on changed files | clean |
| `ruff check` repo-wide | 7 errors, unchanged from `main` (pre-existing `F401`) |

A probe of every call form found one branch I'd written for a keyword-series call (`stackplot(x, Subs=[...])`) that **matplotlib itself rejects** — its `**kwargs` go to `fill_between`, not to series. Dead code for a call that cannot happen; removed rather than tested.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_