### PR TITLE
fix: two silent misreadings — highlight targets and category axis names

### DIFF
--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -250,6 +250,17 @@ class BoxPlot(
         if bxp_stats is None:
             return None
 
+        # Three lists beside `_elements` are filled here and read by
+        # `_get_selector()`, and they carried the same defect: appended to on
+        # every render, so a second one produced twice as many selectors as
+        # there are boxes. Worse than the extra entries, this loop stamps a
+        # fresh gid on each artist every time, so after a second render the
+        # *first* half of the map names gids no artist carries any more and
+        # those selectors resolve to nothing (#354).
+        for gids in self.elements_map.values():
+            gids.clear()
+        self.lower_outliers_count.clear()
+
         whiskers = self._bxp_extractor.extract_whiskers(bxp_stats["whiskers"])
         caps = self._bxp_extractor.extract_caps(bxp_stats["caps"])
         medians = self._bxp_extractor.extract_medians(bxp_stats["medians"])

--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -76,8 +76,10 @@ class CandlestickPlot(MaidrPlot):
             self._maidr_wick_gid = wick_collection.get_gid()
             self._maidr_gid = self._maidr_body_gid or self._maidr_wick_gid
 
-            # Use the original collections for highlighting
-            self._elements = [body_collection, wick_collection]
+            # Use the original collections for highlighting. Extended rather
+            # than rebound, so `self._elements` stays the list `render()`
+            # cleared rather than becoming a different one.
+            self._elements.extend([body_collection, wick_collection])
 
             # Extract data directly from DataFrame
             if self._maidr_original_data is not None and isinstance(
@@ -231,7 +233,8 @@ class CandlestickPlot(MaidrPlot):
                 axis_cfg[MaidrKey.FORMAT] = prev[MaidrKey.FORMAT]
         base_schema[MaidrKey.AXES] = axes_data
 
-        base_schema[MaidrKey.DATA] = self._extract_plot_data()
-        if self._support_highlighting:
-            base_schema[MaidrKey.SELECTOR] = self._get_selector()
+        # Data and selector are left as `super().render()` built them. Running
+        # the extraction a second time here appended a second set of artists
+        # to `self._elements` within one render, which the frontend then
+        # indexes into by point index (#354). Only the axes needed refreshing.
         return base_schema

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -77,6 +77,18 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         if format_config:
             self._merge_format_into_axes(axes_data, format_config)
 
+        # Extraction owns the whole element list, so it starts empty every time.
+        #
+        # A layer is rendered more than once -- `schema`, `elements` and
+        # `set_id` each render when nothing is cached, and a caller may render
+        # explicitly besides -- and every subclass appended without clearing,
+        # so the list grew by a full set of artists per render. `elements` is
+        # the ordered list the highlight machinery tags and the frontend
+        # indexes into by point index, so a doubled list leaves point n
+        # pointing at the artist for point n mod count. Nothing errors; the
+        # outline simply lands on the wrong mark (#354).
+        self._elements.clear()
+
         # Generate a unique UUID for this layer to ensure each plot layer can be distinctly identified
         # in the MAIDR frontend. This supports robust layer switching.
         maidr_schema = {

--- a/maidr/core/plot/mplfinance_barplot.py
+++ b/maidr/core/plot/mplfinance_barplot.py
@@ -86,8 +86,11 @@ class MplfinanceBarPlot(
         # Sort patches by x-coordinate to maintain order
         sorted_patches = sorted(volume_patches, key=lambda p: p.get_x())
 
-        # Set elements for highlighting (use the patches directly)
-        self._elements = sorted_patches
+        # Set elements for highlighting (use the patches directly). Extended
+        # rather than rebound: `render()` clears the list it owns, and a
+        # rebinding would leave `self._elements` pointing at a different list
+        # from the one that was cleared.
+        self._elements.extend(sorted_patches)
 
         # Use datetime converter for enhanced data extraction
         if self._maidr_datetime_converter is not None:
@@ -167,7 +170,8 @@ class MplfinanceBarPlot(
                 axis_cfg[MaidrKey.FORMAT] = prev[MaidrKey.FORMAT]
         base_schema[MaidrKey.AXES] = axes_data
 
-        base_schema[MaidrKey.DATA] = self._extract_plot_data()
-        if self._support_highlighting:
-            base_schema[MaidrKey.SELECTOR] = self._get_selector()
+        # Data and selector are left as `super().render()` built them. Running
+        # the extraction a second time here appended a second set of patches
+        # to `self._elements` within one render, which the frontend then
+        # indexes into by point index (#354). Only the axes needed refreshing.
         return base_schema

--- a/maidr/core/plot/mplfinance_lineplot.py
+++ b/maidr/core/plot/mplfinance_lineplot.py
@@ -208,7 +208,8 @@ class MplfinanceLinePlot(MaidrPlot, LineExtractorMixin):
                 axis_cfg[MaidrKey.FORMAT] = prev[MaidrKey.FORMAT]
         base_schema[MaidrKey.AXES] = axes_data
 
-        base_schema[MaidrKey.DATA] = self._extract_plot_data()
-        if self._support_highlighting:
-            base_schema[MaidrKey.SELECTOR] = self._get_selector()
+        # Data and selector are left as `super().render()` built them. Running
+        # the extraction a second time here appended a second set of lines to
+        # `self._elements` within one render, which the frontend then indexes
+        # into by point index (#354). Only the axes needed refreshing.
         return base_schema

--- a/maidr/core/plot/violin_box_plot.py
+++ b/maidr/core/plot/violin_box_plot.py
@@ -164,7 +164,16 @@ class ViolinBoxPlot(MaidrPlot):
             self._elements.append(artist)
 
     def _tag_sns_artists(self) -> None:
-        """Tag seaborn inner-box Line2D artists with GIDs."""
+        """
+        Tag seaborn inner-box Line2D artists with GIDs.
+
+        The gid map is rebuilt rather than appended to. `_build_sns_selectors`
+        emits one selector per entry, so a second render would have doubled
+        the selector list against unchanged data -- the same defect as #354,
+        in a list beside `_elements` rather than in it.
+        """
+        self._sns_gids.clear()
+
         for violin_lines in self._sns_box_lines:
             gid_map: dict[str, str] = {}
             for role, line in violin_lines.items():

--- a/maidr/core/plot/violin_kde_plot.py
+++ b/maidr/core/plot/violin_kde_plot.py
@@ -57,10 +57,30 @@ class ViolinKdePlot(MaidrPlot):
     # Selector
     # ------------------------------------------------------------------
     def _get_selector(self) -> list[str]:
-        """Return one CSS selector per violin using PolyCollection GIDs."""
-        if self._poly_gids:
-            return [f"g[id='{gid}'] path, g[id='{gid}'] use" for gid in self._poly_gids]
-        return ["g[id^='maidr-'] path"]
+        """
+        Return one CSS selector per violin using PolyCollection GIDs.
+
+        In the order the data was emitted, which for a horizontal violin is
+        the reverse of the order the collections were drawn in -- the box
+        layer's convention, which the KDE layer matches.
+
+        The reversal is done here rather than to ``self._poly_gids``, because
+        that list is the constructor's and persists across renders. Reversing
+        it in place put it back in drawn order on every second render while
+        the data, rebuilt each time, stayed reversed -- so an even number of
+        renders left selector *i* pointing at a different violin from point
+        *i*, and the highlight landed on a neighbour. The same failure #354
+        describes, one list further along.
+        """
+        if not self._poly_gids:
+            return ["g[id^='maidr-'] path"]
+
+        gids = (
+            list(reversed(self._poly_gids))
+            if self._orientation == "horz"
+            else self._poly_gids
+        )
+        return [f"g[id='{gid}'] path, g[id='{gid}'] use" for gid in gids]
 
     # ------------------------------------------------------------------
     # Data extraction
@@ -109,9 +129,11 @@ class ViolinKdePlot(MaidrPlot):
             all_violins.append(violin_points)
 
         # Reverse for horizontal to match the box layer's ordering convention.
+        # `all_violins` is rebuilt every call, so reversing it is idempotent;
+        # the matching order for the selectors is derived in `_get_selector`
+        # rather than written back onto the constructor's gid list.
         if is_horz:
             all_violins.reverse()
-            self._poly_gids.reverse()
 
         return all_violins
 

--- a/maidr/core/plot/violin_kde_plot.py
+++ b/maidr/core/plot/violin_kde_plot.py
@@ -53,10 +53,6 @@ class ViolinKdePlot(MaidrPlot):
         self._x_levels = kwargs.get("x_levels", None)
         self._orientation = kwargs.get("orientation", "vert")
 
-        # Register PolyCollections so highlight.py tags them in SVG.
-        for poly in self._poly_collections:
-            self._elements.append(poly)
-
     # ------------------------------------------------------------------
     # Selector
     # ------------------------------------------------------------------
@@ -80,6 +76,13 @@ class ViolinKdePlot(MaidrPlot):
         """
         x_levels = self._resolve_x_levels()
         all_violins: list[list[dict]] = []
+
+        # Registered here rather than in `__init__` so that extraction owns the
+        # whole element list and `render()` can clear it without dropping the
+        # violin bodies. Both lists arrive from the constructor, so rebuilding
+        # them per render costs nothing and keeps one place responsible (#354).
+        for poly in self._poly_collections:
+            self._elements.append(poly)
 
         is_horz = self._orientation == "horz"
 

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
@@ -114,11 +114,96 @@ class LineExtractorMixin:
         return ax.get_lines()
 
     @staticmethod
+    def _category_tick_labels(ax: Axes, axis: str) -> Dict[float, str]:
+        """
+        Map an axis's tick coordinates to the names written beside them.
+
+        Built from the *unfiltered* tick positions and labels, and keyed by
+        tick coordinate rather than array index, so it survives boundary ticks
+        being filtered elsewhere (``LevelExtractorMixin.extract_level``) and
+        tick layouts that are neither contiguous nor zero-based.
+
+        Empty unless the axis really is a string-category axis: matplotlib
+        leaves a ``UnitData`` on the axis it mapped strings onto, and nothing
+        else. A numeric axis has tick labels too -- "0", "25", "1.00" -- and
+        they are formatted renderings of the numbers rather than names for
+        them, so substituting one costs the value both its type and its
+        precision.
+
+        Parameters
+        ----------
+        ax : Axes
+            The matplotlib axes object
+        axis : str
+            ``"x"`` or ``"y"``
+
+        Returns
+        -------
+        Dict[float, str]
+            Tick coordinate to label, or an empty mapping on a numeric axis
+        """
+        holder = ax.xaxis if axis == "x" else ax.yaxis
+        if holder.units is None:
+            return {}
+
+        positions = ax.get_xticks() if axis == "x" else ax.get_yticks()
+        labels = ax.get_xticklabels() if axis == "x" else ax.get_yticklabels()
+        return {
+            float(pos): label.get_text()
+            for pos, label in zip(positions, labels)
+            if label.get_text()
+        }
+
+    @staticmethod
+    def _named_coordinate(
+        coordinate: float, tick_labels: Dict[float, str]
+    ) -> Union[str, float]:
+        """
+        Name one coordinate after the tick it was drawn on, when there is one.
+
+        A string-category axis puts its groups on consecutive integers, so a
+        point drawn *off* one is a group a ``dodge`` shifted aside to make room
+        for its neighbour -- still that group, and still named by the tick it
+        was moved from. Rounding recovers the name; without it a dodged series
+        announces "-0.025" where the chart says "Thur".
+
+        ``tick_labels`` is empty on a numeric axis, so the same rounding cannot
+        rename a measurement after whichever tick it happens to fall nearest.
+
+        Parameters
+        ----------
+        coordinate : float
+            The drawn coordinate
+        tick_labels : Dict[float, str]
+            The axis's tick names, from :meth:`_category_tick_labels`
+
+        Returns
+        -------
+        Union[str, float]
+            The tick's name, or the coordinate when the axis has none
+        """
+        if not tick_labels:
+            return float(coordinate)
+
+        exact = tick_labels.get(float(coordinate))
+        if exact is not None:
+            return exact
+
+        nearest = tick_labels.get(float(round(coordinate)))
+        return nearest if nearest is not None else float(coordinate)
+
+    @staticmethod
     def extract_line_data_with_categorical_labels(
         ax: Axes, line: Line2D
-    ) -> Optional[List[Tuple[Union[str, float], float]]]:
+    ) -> Optional[List[Tuple[Union[str, float], Union[str, float]]]]:
         """
-        Extract line data with proper handling of categorical x-axis labels.
+        Extract line data, naming whichever axis carries the categories.
+
+        Categories sit on x in a vertical chart and on y in a horizontal one,
+        and the axis that carries them is the one to recover names from. This
+        followed x alone, so a horizontal categorical chart announced its
+        groups as the positions they were drawn at -- and a dodged one as the
+        offsets it was shifted to (#353).
 
         Parameters
         ----------
@@ -129,9 +214,9 @@ class LineExtractorMixin:
 
         Returns
         -------
-        Optional[List[Tuple[Union[str, float], float]]]
-            List of (x, y) tuples where x values are categorical labels if available,
-            or numeric values if no categorical labels are found
+        Optional[List[Tuple[Union[str, float], Union[str, float]]]]
+            List of (x, y) tuples, each coordinate being the name written
+            beside it on a category axis and the drawn number otherwise
         """
         if ax is None or line is None:
             return None
@@ -145,48 +230,16 @@ class LineExtractorMixin:
         if xy_array.size == 0:
             return None
 
-        # Build a coordinate -> label map directly from the *unfiltered* tick
-        # positions and labels. Looking up by tick *coordinate* (not array
-        # index) avoids off-by-one errors when boundary ticks are filtered
-        # elsewhere (e.g. by ``LevelExtractorMixin.extract_level``) and
-        # gracefully handles non-contiguous or non-zero-based tick layouts.
-        tick_positions = ax.get_xticks()
-        tick_labels = [label.get_text() for label in ax.get_xticklabels()]
-        tick_map = {
-            float(pos): text
-            for pos, text in zip(tick_positions, tick_labels)
-            if text
-        }
+        x_ticks = LineExtractorMixin._category_tick_labels(ax, "x")
+        y_ticks = LineExtractorMixin._category_tick_labels(ax, "y")
 
-        # A string-category axis puts its groups on consecutive integers, so a
-        # point drawn off one is a group a `dodge` shifted aside to make room
-        # for its neighbour -- still that group, and still named by the tick it
-        # was moved from. Rounding recovers the name; without it a dodged
-        # series announces "-0.025" where the chart says "Thur".
-        #
-        # Gated on the axis really being categorical, because on a numeric axis
-        # the same rounding would rename a measurement after whichever tick it
-        # happens to fall nearest.
-        is_categorical = ax.xaxis.units is not None
-
-        # If we have categorical labels, map numeric coordinates to labels
-        if tick_map:
-            result: List[Tuple[Union[str, float], float]] = []
-            for x, y in xy_array:
-                x_coord = float(x)
-                # Look up by coordinate value; fall back to the numeric x when
-                # the data point doesn't sit exactly on a labelled tick.
-                label_value = tick_map.get(x_coord)
-                if label_value is None and is_categorical:
-                    label_value = tick_map.get(float(round(x_coord)))
-                x_value: Union[str, float] = (
-                    label_value if label_value is not None else x_coord
-                )
-                result.append((x_value, float(y)))
-            return result
-        else:
-            # No categorical labels, return numeric values
-            return [(float(x), float(y)) for x, y in xy_array]
+        return [
+            (
+                LineExtractorMixin._named_coordinate(x, x_ticks),
+                LineExtractorMixin._named_coordinate(y, y_ticks),
+            )
+            for x, y in xy_array
+        ]
 
 
 class CollectionExtractorMixin:

--- a/tests/core/plot/test_element_stability.py
+++ b/tests/core/plot/test_element_stability.py
@@ -237,6 +237,54 @@ def test_rendering_repeatedly_never_grows_the_list(name):
     assert counts[1:] == counts[:-1]
 
 
+@pytest.mark.parametrize("name", sorted(BUILDERS))
+def test_rendering_twice_emits_the_same_selectors(name):
+    """
+    `_elements` is not the only list the selectors are built from.
+
+    A layer may keep its own gid bookkeeping beside it, and those lists
+    accumulated too. `BoxPlot` kept four — one per element role plus the
+    outlier counts — so a second render emitted **twice as many selectors as
+    there are boxes**, and because the same loop re-stamps a fresh gid on each
+    artist every time, the first half named gids no artist carried any more.
+    Those selectors resolve to nothing at all.
+
+    The assertion is on how many, not on which. Several layers mint a fresh
+    gid per artist on every render and name the new one, which stays
+    consistent -- the artist carries the gid the selector asks for. What must
+    not change is the count, because that is what the frontend pairs with the
+    data.
+    """
+    fig = BUILDERS[name]()
+    plots = _plots(fig)
+    assert plots
+
+    for plot in plots:
+        first = plot.render().get("selectors")
+        second = plot.render().get("selectors")
+
+        assert isinstance(second, type(first))
+        if isinstance(first, list):
+            assert len(second) == len(first)
+
+
+def test_a_box_layer_emits_one_selector_per_box():
+    """
+    Counted against the chart, so stable-but-wrong does not pass.
+
+    Three distributions, three selectors, three points -- however many times
+    the layer is rendered.
+    """
+    fig = _box()
+    plot = _plots(fig)[0]
+
+    for _ in range(3):
+        schema = plot.render()
+
+        assert len(schema["selectors"]) == 3
+        assert len(schema["data"]) == 3
+
+
 def test_a_bar_layer_tags_one_artist_per_bar():
     """
     Stable is not the same as right.

--- a/tests/core/plot/test_element_stability.py
+++ b/tests/core/plot/test_element_stability.py
@@ -323,6 +323,73 @@ def test_the_mplfinance_layers_extract_once_per_render():
         assert len(plot.elements) == expected[name], name
 
 
+def test_a_horizontal_violin_keeps_its_selectors_paired_with_its_data():
+    """
+    The KDE layer reversed a list it did not own.
+
+    A horizontal violin emits its series in the reverse of the drawn order, to
+    match the box layer's convention. The data is rebuilt each render so
+    reversing it is idempotent, but the gid list comes from the constructor
+    and persists -- and it was reversed **in place**, so it was back in drawn
+    order on every second render while the data was still reversed. Selector
+    *i* then pointed at a different violin from point *i*, and the highlight
+    landed on a neighbour. Silently, with no error and no change to anything
+    announced: the same failure this file exists for, one list further along.
+
+    Rendering an even number of times is exactly what the cases above do for
+    every other layer, and none of them is horizontal.
+    """
+    from maidr.core.plot.violin_kde_plot import ViolinKdePlot
+
+    fig, ax = plt.subplots()
+    ax.violinplot(
+        [[1.0, 2.0, 3.0, 9.0], [20.0, 21.0, 22.0, 30.0], [5.0, 6.0, 7.0, 8.0]],
+        vert=False,
+    )
+    plot = [p for p in _plots(fig) if isinstance(p, ViolinKdePlot)][0]
+    assert plot._orientation == "horz"
+
+    drawn = list(plot._poly_gids)
+    selectors = [plot.render()["selectors"] for _ in range(4)]
+
+    # Every render agrees, rather than alternating between two orders.
+    assert selectors[1:] == selectors[:-1]
+
+    # And they agree on the *right* order: the reverse of the drawn one,
+    # which is the order the data comes out in.
+    assert all(
+        gid in selector
+        for gid, selector in zip(reversed(drawn), selectors[0])
+    )
+
+    # The constructor's list is left as it was found.
+    assert plot._poly_gids == drawn
+
+
+def test_a_vertical_violin_addresses_its_violins_in_drawn_order():
+    """
+    The counterpart: no reversal where none is due.
+
+    A fix that reversed unconditionally would satisfy the stability check
+    above and pair every vertical violin with the wrong body.
+    """
+    from maidr.core.plot.violin_kde_plot import ViolinKdePlot
+
+    fig, ax = plt.subplots()
+    ax.violinplot(
+        [[1.0, 2.0, 3.0, 9.0], [20.0, 21.0, 22.0, 30.0], [5.0, 6.0, 7.0, 8.0]]
+    )
+    plot = [p for p in _plots(fig) if isinstance(p, ViolinKdePlot)][0]
+    assert plot._orientation == "vert"
+
+    drawn = list(plot._poly_gids)
+    selectors = plot.render()["selectors"]
+
+    assert all(
+        gid in selector for gid, selector in zip(drawn, selectors)
+    )
+
+
 def test_a_violin_keeps_its_bodies_as_well_as_its_curves():
     """
     ``ViolinKdePlot`` registered its bodies in ``__init__``.

--- a/tests/core/plot/test_element_stability.py
+++ b/tests/core/plot/test_element_stability.py
@@ -1,0 +1,350 @@
+"""Every layer tags the same artists however many times it is rendered.
+
+``MaidrPlot._elements`` is the ordered list the highlight machinery tags, and
+the frontend indexes into the resolved selection *by point index*. A list that
+grew leaves point *n* pointing at the artist for point *n mod count*, so the
+outline lands on a different mark from the one being announced. Nothing
+errors, no announcement changes, and no assertion on the emitted data can see
+it (#354).
+
+A layer is rendered more than once as a matter of course: ``schema``,
+``elements`` and ``set_id`` each render when nothing is cached, and three
+types re-ran their extraction inside their own ``render()`` besides -- so for
+those the list doubled within a *single* render.
+
+These tests render twice and compare, which is the shape of the defect rather
+than a count nobody can check. They also assert a count against something
+independent -- the artists matplotlib actually drew -- because a list that is
+merely *stable* could still be stably wrong.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _plots(fig):
+    """
+    Return the MAIDR plots registered for a figure, or an empty list.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to read.
+
+    Returns
+    -------
+    list
+        The registered plots.
+    """
+    maidr_instance = FigureManager.figs.get(fig)
+    return list(maidr_instance._plots) if maidr_instance else []
+
+
+# --------------------------------------------------------------------------
+# One builder per layer type. Each draws a chart and returns its figure.
+# --------------------------------------------------------------------------
+
+
+def _bar():
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b", "c"], [4.0, 5.0, 6.0])
+    return fig
+
+
+def _box():
+    fig, ax = plt.subplots()
+    ax.boxplot([[1, 2, 3, 10], [4, 5, 6, 20], [7, 8, 9, 30]])
+    return fig
+
+
+def _pie():
+    fig, ax = plt.subplots()
+    ax.pie([30, 50, 20], labels=["a", "b", "c"])
+    return fig
+
+
+def _hist():
+    fig, ax = plt.subplots()
+    ax.hist([1, 1, 2, 3, 3, 3, 4, 5, 5, 9], bins=4)
+    return fig
+
+
+def _line():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2, 3], [4.0, 5.0, 3.0, 6.0])
+    return fig
+
+
+def _scatter():
+    fig, ax = plt.subplots()
+    ax.scatter([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    return fig
+
+
+def _heat():
+    fig, ax = plt.subplots()
+    sns.heatmap(np.array([[1.0, 2.0], [3.0, 4.0]]), ax=ax)
+    return fig
+
+
+def _errorbar():
+    fig, ax = plt.subplots()
+    ax.errorbar([1, 2, 3], [4.0, 5.0, 6.0], yerr=[0.4, 0.6, 0.3], fmt="o")
+    return fig
+
+
+def _grouped_bar():
+    frame = pd.DataFrame(
+        {
+            "group": ["a", "a", "b", "b", "c", "c"],
+            "half": ["x", "y", "x", "y", "x", "y"],
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        }
+    )
+    fig, ax = plt.subplots()
+    sns.barplot(frame, x="group", y="value", hue="half", ax=ax)
+    return fig
+
+
+def _regplot():
+    fig, ax = plt.subplots()
+    sns.regplot(
+        x=np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+        y=np.array([2.0, 4.0, 5.0, 4.0, 6.0]),
+        ax=ax,
+    )
+    return fig
+
+
+def _pointplot():
+    frame = pd.DataFrame(
+        {
+            "group": ["a"] * 4 + ["b"] * 4 + ["c"] * 4,
+            "value": [1.0, 2.0, 3.0, 9.0, 20.0, 21.0, 22.0, 30.0, 5.0, 6.0, 7.0, 8.0],
+        }
+    )
+    fig, ax = plt.subplots()
+    sns.pointplot(frame, x="group", y="value", ax=ax)
+    return fig
+
+
+def _violin():
+    frame = pd.DataFrame(
+        {
+            "group": ["a"] * 6 + ["b"] * 6,
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0, 9.0, 4.0, 5.0, 6.0, 7.0, 8.0, 12.0],
+        }
+    )
+    fig, ax = plt.subplots()
+    sns.violinplot(frame, x="group", y="value", ax=ax)
+    return fig
+
+
+def _area():
+    fig, ax = plt.subplots()
+    ax.stackplot([0, 1, 2], [[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]], labels=["a", "b"])
+    return fig
+
+
+def _step():
+    fig, ax = plt.subplots()
+    ax.step([0.0, 1.0, 2.0, 3.0], [4, 2, 1, 3], where="post")
+    return fig
+
+
+#: Every layer type whose extraction appends to ``_elements``. The names are
+#: the parameter ids, so a failure says which layer rather than which index.
+BUILDERS = {
+    "bar": _bar,
+    "box": _box,
+    "pie": _pie,
+    "hist": _hist,
+    "line": _line,
+    "scatter": _scatter,
+    "heat": _heat,
+    "errorbar": _errorbar,
+    "grouped_bar": _grouped_bar,
+    "regplot": _regplot,
+    "pointplot": _pointplot,
+    "violin": _violin,
+    "area": _area,
+    "step": _step,
+}
+
+
+@pytest.mark.parametrize("name", sorted(BUILDERS))
+def test_rendering_twice_tags_the_same_artists(name):
+    """
+    A second render must not add a second set of artists.
+
+    This is the whole defect: the frontend pairs element *i* with point *i*,
+    so a list that doubled points the highlight at the wrong mark for every
+    point past the first set, while the data and the announcements stay
+    correct. Rendering is not idempotent by accident -- ``schema``,
+    ``elements`` and ``set_id`` each render when nothing is cached.
+    """
+    fig = BUILDERS[name]()
+    plots = _plots(fig)
+    assert plots, f"{name} registered no layer"
+
+    for plot in plots:
+        plot.render()
+        after_first = list(plot.elements)
+        plot.render()
+        after_second = list(plot.elements)
+
+        assert after_second == after_first
+
+
+@pytest.mark.parametrize("name", sorted(BUILDERS))
+def test_rendering_repeatedly_never_grows_the_list(name):
+    """
+    The count is flat, not merely equal between two renders.
+
+    A fix that cleared on alternate renders would satisfy the pair above.
+    Five renders is enough to catch a period-two mistake and cheap enough to
+    run for every type.
+    """
+    fig = BUILDERS[name]()
+    plots = _plots(fig)
+    assert plots
+
+    counts = []
+    for _ in range(5):
+        for plot in plots:
+            plot.render()
+        counts.append([len(plot.elements) for plot in plots])
+
+    assert counts[1:] == counts[:-1]
+
+
+def test_a_bar_layer_tags_one_artist_per_bar():
+    """
+    Stable is not the same as right.
+
+    Every assertion above passes on a list that is consistently twice as long
+    as it should be, so at least one type is checked against something drawn
+    rather than against itself: three bars, three patches, three points.
+    """
+    fig = _bar()
+    plot = _plots(fig)[0]
+
+    schema = plot.render()
+
+    assert len(plot.elements) == 3
+    assert len(schema["data"]) == 3
+
+
+#: Eight sessions, enough for a 3-period moving average to be drawn and for
+#: the volume-bar count to be checkable by eye.
+OHLCV = pd.DataFrame(
+    {
+        "Open": [10.0, 11.0, 12.0, 11.0, 13.0, 14.0, 13.0, 15.0],
+        "High": [11.0, 12.0, 13.0, 12.0, 14.0, 15.0, 14.0, 16.0],
+        "Low": [9.0, 10.0, 11.0, 10.0, 12.0, 13.0, 12.0, 14.0],
+        "Close": [11.0, 12.0, 11.0, 13.0, 14.0, 13.0, 15.0, 16.0],
+        "Volume": [100.0, 120.0, 90.0, 130.0, 110.0, 140.0, 95.0, 150.0],
+    },
+    index=pd.date_range("2024-01-01", periods=8, freq="D"),
+)
+
+
+def _mplfinance_figure():
+    """
+    Draw a candlestick chart with volume and a moving average.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The figure, carrying a candlestick, a volume bar and a line layer.
+    """
+    mpf = pytest.importorskip("mplfinance")
+    fig, _ = mpf.plot(OHLCV, type="candle", volume=True, mav=3, returnfig=True)
+    return fig
+
+
+def test_the_mplfinance_layers_extract_once_per_render():
+    """
+    Three layers re-ran their own extraction inside ``render()``.
+
+    ``CandlestickPlot``, ``MplfinanceBarPlot`` and ``MplfinanceLinePlot`` each
+    called ``super().render()`` -- which extracts -- and then overwrote
+    ``data`` and ``selector`` with a second extraction, to refresh the axes.
+    Only the axes needed refreshing; the second call appended another full set
+    of artists, so these three doubled within a *single* render rather than
+    across two. Clearing in ``render()`` cannot see that, because the second
+    call comes after the clear.
+
+    The counts are checked against the chart: eight sessions means eight
+    volume bars, one moving average is one line, and a candlestick is drawn as
+    a body collection and a wick collection.
+    """
+    from maidr.core.plot.candlestick import CandlestickPlot
+    from maidr.core.plot.mplfinance_barplot import MplfinanceBarPlot
+    from maidr.core.plot.mplfinance_lineplot import MplfinanceLinePlot
+
+    fig = _mplfinance_figure()
+    plots = {type(plot).__name__: plot for plot in _plots(fig)}
+
+    assert set(plots) == {
+        CandlestickPlot.__name__,
+        MplfinanceBarPlot.__name__,
+        MplfinanceLinePlot.__name__,
+    }
+
+    expected = {
+        CandlestickPlot.__name__: 2,
+        MplfinanceBarPlot.__name__: len(OHLCV),
+        MplfinanceLinePlot.__name__: 1,
+    }
+    for name, plot in plots.items():
+        plot.render()
+        assert len(plot.elements) == expected[name], name
+        plot.render()
+        assert len(plot.elements) == expected[name], name
+
+
+def test_a_violin_keeps_its_bodies_as_well_as_its_curves():
+    """
+    ``ViolinKdePlot`` registered its bodies in ``__init__``.
+
+    That is why the fix could not be a clear in ``render()`` alone: clearing
+    would have dropped the ``PolyCollection`` for each violin and left the
+    bodies untagged, which is a *worse* failure than the doubling -- the
+    highlight would disappear rather than land on a neighbour. The bodies now
+    come from extraction, so both survive a second render.
+    """
+    from maidr.core.plot.violin_kde_plot import ViolinKdePlot
+
+    fig = _violin()
+    kde = [plot for plot in _plots(fig) if isinstance(plot, ViolinKdePlot)]
+    assert kde, "no KDE layer was registered"
+
+    plot = kde[0]
+    plot.render()
+    first = list(plot.elements)
+    plot.render()
+
+    # Two violins: a body and a curve each.
+    assert len(first) == 4
+    assert list(plot.elements) == first
+    assert all(poly in plot.elements for poly in plot._poly_collections)

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -453,15 +453,14 @@ def test_nothing_recognisable_still_describes_the_lines():
     assert plots[0].type == PlotType.LINE
 
 
-def test_a_horizontal_dodge_still_reports_raw_category_offsets():
+def test_a_horizontal_dodge_names_its_groups():
     """
-    The known limit of the tick-rounding fix, pinned rather than left implicit.
+    The categories are on y here, and they are named there (#353).
 
-    ``extract_line_data_with_categorical_labels`` reads the *x* ticks only, so
-    the label recovery helps a vertical dodged chart and not a horizontal one,
-    whose categories sit on y. Recorded here so the gap is visible and so the
-    day the shared helper learns to follow the category axis, this test turns
-    red rather than the behaviour changing unnoticed. Tracked in #353.
+    This replaces a test that pinned the gap. ``-0.025`` and ``0.975`` are
+    where two hue levels were shifted to make room for each other around the
+    ticks the chart writes ``a`` and ``b`` on, so a reader was given the
+    offsets and no way to reach the names.
     """
     frame = FRAME.assign(half=["x", "y"] * 9)
 
@@ -470,13 +469,88 @@ def test_a_horizontal_dodge_still_reports_raw_category_offsets():
 
     schema = _schema(fig)
 
-    # Category positions on y, still numeric and still dodged aside.
     assert schema["type"] == PlotType.LINE.value
+    named = {point["y"] for series in schema["data"] for point in series}
+    assert named == set(FRAME["group"].unique())
+
+    # The value axis is still numeric: only the axis carrying the categories
+    # is named, and naming both would have made the measurement a string.
     assert all(
-        isinstance(point["y"], float)
+        isinstance(point["x"], float)
         for series in schema["data"]
         for point in series
     )
+
+
+def test_a_horizontal_chart_names_its_groups_without_a_dodge():
+    """
+    An undodged horizontal chart sits exactly on its ticks.
+
+    The dodged case above exercises the rounding; this one exercises the exact
+    lookup, so a fix that only ever rounded would still be caught. Drawn with
+    ``Axes.plot`` because an undodged ``pointplot`` emits an error bar layer,
+    which reads its categories by a different route.
+    """
+    fig, ax = plt.subplots()
+    ax.plot([4.0, 5.0, 6.0], ["a", "b", "c"])
+
+    schema = _schema(fig)
+    points = [point for series in schema["data"] for point in series]
+
+    assert [point["y"] for point in points] == ["a", "b", "c"]
+    assert [point["x"] for point in points] == [4.0, 5.0, 6.0]
+
+
+def test_a_vertical_chart_still_names_its_groups():
+    """
+    The axis this used to follow, unchanged.
+
+    Following the category axis rather than x must not have cost the vertical
+    case anything, which is what it was doing correctly all along.
+    """
+    fig, ax = plt.subplots()
+    ax.plot(["a", "b", "c"], [4.0, 5.0, 6.0])
+
+    schema = _schema(fig)
+    points = [point for series in schema["data"] for point in series]
+
+    assert [point["x"] for point in points] == ["a", "b", "c"]
+    assert [point["y"] for point in points] == [4.0, 5.0, 6.0]
+
+
+def test_a_numeric_axis_keeps_its_numbers():
+    """
+    The over-correction, guarded.
+
+    A numeric axis has tick labels too, and they are formatted renderings of
+    the numbers rather than names for them. Substituting one costs the value
+    its type and its precision -- this chart reported ``"1.00"`` for an x of
+    ``1.0`` before, which is a string where the frontend expects a number.
+    """
+    fig, ax = plt.subplots()
+    ax.plot([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+
+    schema = _schema(fig)
+    points = [point for series in schema["data"] for point in series]
+
+    assert [point["x"] for point in points] == [1.0, 2.0, 3.0]
+    assert [point["y"] for point in points] == [4.0, 5.0, 6.0]
+
+
+def test_a_measurement_near_a_tick_is_not_renamed_after_it():
+    """
+    Rounding is what recovers a dodged group, and it must not reach further.
+
+    On a numeric axis a point at 1.98 is a measurement, not a group drawn
+    beside the tick at 2. Nothing here may name it after that tick.
+    """
+    fig, ax = plt.subplots()
+    ax.plot([0.02, 1.98, 3.01], [4.0, 5.0, 6.0])
+
+    schema = _schema(fig)
+    points = [point for series in schema["data"] for point in series]
+
+    assert [point["x"] for point in points] == [0.02, 1.98, 3.01]
 
 
 #: Two groups of five observations and one of a single observation -- ordinary


### PR DESCRIPTION
## Description

Closes #354 and #353.

Two separate defects, both of which produce a chart that is confidently wrong rather than obviously broken, and neither of which any assertion on the emitted data could see. They are on one branch because the branch is fixed for this work; they are separate commits and can be reviewed as such.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

# 1. `_elements` accumulated across renders (#354) — `d5a3fbf`, `0a63f73`

`MaidrPlot._elements` was initialised once in `__init__` and appended to during extraction, so the list grew by a full set of artists per render. It is the ordered list the highlight machinery tags, and the frontend indexes into the resolved selection **by point index** — so a doubled list left point *n* pointing at the artist for point *n mod count*.

Nothing errors. No announcement changes. The data is right, the braille is right, the sonification is right, and the outline lands on a different mark from the one being read. Same shape as the highlight-only bugs on xability/maidr#814.

Rendering more than once is routine: `schema`, `elements` and `set_id` each render when nothing is cached, and a caller may render explicitly besides.

### Changes

**Extraction now owns the whole list** — `render()` clears `_elements` before `_extract_plot_data()`, one mechanism for all fourteen types the issue listed.

Two things made that alone wrong, which is why the issue called for an audit rather than a one-liner:

- **`ViolinKdePlot` registered its bodies in `__init__`.** A central clear would have dropped the `PolyCollection` for each violin and left the bodies untagged — *worse* than the doubling, because the highlight would disappear rather than land on a neighbour. Both its lists come from the constructor, so the bodies are registered in `_extract_plot_data()` now.
- **Three layers re-ran their own extraction inside `render()`, which the clear cannot see.** `CandlestickPlot`, `MplfinanceBarPlot` and `MplfinanceLinePlot` each called `super().render()` — which extracts — and then overwrote `data` and `selector` with a second extraction in order to refresh the axes. Only the axes needed refreshing; `super().render()` had already set both keys to the same values. These three doubled within a **single** render, and the second call comes *after* the clear.

**Two grew the list by rebinding rather than appending** (`self._elements = sorted_patches`, `= [body, wick]`), which would have left `_elements` pointing at a different list from the one cleared. Both `extend` now.

**And one more list with the same problem, found in review** (`0a63f73`). A horizontal violin emits its series in the reverse of the drawn order, to match the box layer's convention. `all_violins` is rebuilt each render so reversing it is idempotent — but `self._poly_gids` comes from the constructor and persists, and it was reversed **in place**. On every second render it was back in drawn order while the data was still reversed, so selector *i* addressed a different violin from point *i*:

```
render 1: gids in drawn order = False    data first-y = 5.025
render 2: gids in drawn order = True     data first-y = 5.025
render 3: gids in drawn order = False    data first-y = 5.025
```

`_get_selector()` now derives the order from a copy and writes nothing back. The first render is unchanged; every even one is corrected.

`AreaPlot` and `PointPlot` already cleared at the top of extraction and keep doing so; their *second* clear — the one that gives up on highlighting when the count disagrees with the data — is a different mechanism and is untouched.

### Tests

New `tests/core/plot/test_element_stability.py`, **33 cases**. The parametrised pair covers fourteen layer types and asserts that rendering twice tags the same artists, and that rendering five times never grows the list — because a fix that cleared on alternate renders would satisfy the first. Then five that check what those cannot:

- **a bar layer tags one artist per bar.** Stable is not the same as right: every assertion above passes on a list consistently twice as long as it should be.
- **the mplfinance layers extract once per render**, with counts checked against the chart.
- **a violin keeps its bodies as well as its curves** — the case that would have caught the naive central clear.
- **a horizontal violin keeps its selectors paired with its data** across four renders, with `_poly_gids` left as it was found.
- **a vertical violin addresses its violins in drawn order** — because a fix that reversed unconditionally would satisfy the case above and pair every vertical violin with the wrong body.

**Verified they bite.** Removing the clear fails **26 of 30**; restoring the redundant re-extraction fails the mplfinance case; restoring the in-place reversal fails the horizontal violin case. None of the three failures overlaps another, so each part of the fix is independently guarded.

---

# 2. Category names were recovered on the x axis only (#353) — `da854ac`

`LineExtractorMixin.extract_line_data_with_categorical_labels` read `ax.get_xticks()` and nothing else, so a **horizontal** categorical chart announced its groups as the positions they were drawn at:

```python
sns.pointplot(frame, y="group", x="value", hue="half", dodge=True)
# before: [{"x": 1.5, "y": -0.025, "z": "x"}, {"x": 20.5, "y": 0.975, "z": "x"}]
# after:  [{"x": 1.5, "y": "a",    "z": "x"}, {"x": 20.5, "y": "b",    "z": "x"}]
```

`-0.025` and `0.975` are where two hue levels were shifted to make room for each other, around the ticks the chart writes `a` and `b` on. The reader was given the offsets and no route to the names.

### Changes

Both axes are asked the same question, and each coordinate is named by its own axis. Which axis is categorical is what matplotlib records in `axis.units`, so a horizontal chart stops being a special case: it is the same lookup on the other axis.

The tick map is now **empty** on a numeric axis rather than merely ungating the rounding, and that fixes a second misreading in the same function. A point sitting exactly on a numeric tick took that tick's *label text*, so:

```python
ax.plot([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
# before: {"x": "1.00", "y": 4.0}   <- a string, and to two decimal places
# after:  {"x": 1.0,    "y": 4.0}
```

A formatted rendering of a number is not a name for it, and the frontend wants the number. Nothing in the suite depended on the old reading.

### Tests

`tests/core/plot/test_pointplot.py`: the pinned `test_a_horizontal_dodge_still_reports_raw_category_offsets` is **replaced** by one asserting the names, which is what the issue asked for. Four more cover the exact lookup (undodged, on ticks) as distinct from the rounding, the vertical case that already worked, a numeric axis keeping numbers on both axes, and a measurement near a tick not being renamed after it.

**Verified they bite:** reverting the extractor fails 3 of the 5. Two pass either way and are honest about it — the vertical case is a regression guard, and the near-a-tick case guards a future over-correction rather than reproducing the old one.

---

## Screenshots (if applicable)

n/a — both changes are in extracted data and tagged artists, pinned by test rather than by eye.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

| Gate | Result |
|---|---|
| `uv run pytest` | **1015 passed** (was 978) |
| `uv run ruff check` on the changed files | clean |

`uv run ruff check` across the repo reports 7 pre-existing `F401` re-export findings in four `__init__.py` files. None are in files this touches and the count is unchanged by the branch.