### PR TITLE
fix(plotly): run the shared line-series pass once per render

### DIFF
--- a/maidr/plotly/multiline.py
+++ b/maidr/plotly/multiline.py
@@ -73,8 +73,9 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         """
         # Positions filtered by the same predicate that filters the data, so
         # series *i* always addresses the element series *i* is drawn as --
-        # see `_line_series_with_positions`.
-        _, drawn_positions = self._line_series_with_positions(
+        # see `_line_series_with_positions`. The pass is shared with
+        # `_extract_plot_data` rather than repeated: see `_drawn_line_series`.
+        _, drawn_positions = self._drawn_line_series(
             self._traces, self._scatter_positions
         )
         return self._scatter_line_selectors(self._traces, drawn_positions)
@@ -85,7 +86,5 @@ class PlotlyMultiLinePlot(PlotlyPlot):
         Each inner list contains ``{x, y}`` dicts for one line, with an
         optional ``z`` key set to the trace name.
         """
-        lines, _ = self._line_series_with_positions(
-            self._traces, self._scatter_positions
-        )
+        lines, _ = self._drawn_line_series(self._traces, self._scatter_positions)
         return lines

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -253,7 +253,16 @@ class PlotlyPlot(ABC):
 
         Cached against the two lists by identity rather than unconditionally,
         so a caller passing different traces gets an answer for those traces
-        instead of the previous ones.
+        instead of the previous ones. Identity rather than equality because a
+        layer always hands over the same two objects it stored in ``__init__``,
+        so the check is free where it matters and never walks the points to
+        decide whether to walk the points.
+
+        One entry, deliberately — not a memoizer. It exists so that the two
+        halves of a single ``render()`` share one pass, and a layer only ever
+        asks about one pair. Alternating between two pairs would recompute
+        every time, correctly; if that ever becomes a real call pattern, this
+        wants replacing rather than widening.
 
         Parameters
         ----------

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -51,6 +51,10 @@ class PlotlyPlot(ABC):
         self.row_index: int = 0
         self.col_index: int = 0
         self._schema: dict = {}
+        # Set by `_drawn_line_series`; see it for why the pass is cached.
+        self._line_series_cache: (
+            tuple[list[dict], list[int], tuple[list[list[dict]], list[int]]] | None
+        ) = None
 
     @staticmethod
     def _to_native(val: Any) -> Any:
@@ -227,6 +231,50 @@ class PlotlyPlot(ABC):
                 drawn_positions.append(position)
 
         return series_list, drawn_positions
+
+    def _drawn_line_series(
+        self, traces: list[dict], positions: list[int]
+    ) -> tuple[list[list[dict]], list[int]]:
+        """
+        Return ``_line_series_with_positions``, run once per layer.
+
+        ``render()`` asks for the data and the selector as two separate steps,
+        and both answers come out of the same pass. Running it a second time
+        for the second caller is not merely wasteful — it assumes the pass can
+        be repeated, and it cannot: ``as_list`` materialises a trace array with
+        ``list(value)``, so a one-shot iterable is spent by the first walk and
+        reads as empty on the second. The layer then reports its series and no
+        selector at all, which is the silent no-highlight this pairing exists
+        to prevent.
+
+        ``Figure.to_dict()`` hands back lists, numpy arrays and typed-array
+        specs, never an iterator, so the export path does not reach that. A
+        caller constructing a layer directly does.
+
+        Cached against the two lists by identity rather than unconditionally,
+        so a caller passing different traces gets an answer for those traces
+        instead of the previous ones.
+
+        Parameters
+        ----------
+        traces : list of dict
+            The traces this layer covers, in series order.
+        positions : list of int
+            Each trace's zero-based position among the subplot's
+            scatter-family traces, in the same order.
+
+        Returns
+        -------
+        tuple of (list of list of dict, list of int)
+            The non-empty series and the positions they were drawn at.
+        """
+        cached = self._line_series_cache
+        if cached is not None and cached[0] is traces and cached[1] is positions:
+            return cached[2]
+
+        drawn = self._line_series_with_positions(traces, positions)
+        self._line_series_cache = (traces, positions, drawn)
+        return drawn
 
     @staticmethod
     def _validate_scatter_positions(positions: list[int], trace_count: int) -> None:

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -89,8 +89,9 @@ class PlotlyStepPlot(PlotlyPlot):
         """
         # Positions filtered by the same predicate that filters the data, so
         # series *i* always addresses the element series *i* is drawn as --
-        # see `_line_series_with_positions`.
-        _, drawn_positions = self._line_series_with_positions(
+        # see `_line_series_with_positions`. The pass is shared with
+        # `_extract_plot_data` rather than repeated: see `_drawn_line_series`.
+        _, drawn_positions = self._drawn_line_series(
             self._traces, self._scatter_positions
         )
         return self._scatter_line_selectors(self._traces, drawn_positions)
@@ -147,7 +148,5 @@ class PlotlyStepPlot(PlotlyPlot):
             ``{x, y}`` per point, with ``z`` set to the trace name when it has
             one. Empty series are dropped, matching ``PlotlyMultiLinePlot``.
         """
-        series, _ = self._line_series_with_positions(
-            self._traces, self._scatter_positions
-        )
+        series, _ = self._drawn_line_series(self._traces, self._scatter_positions)
         return series

--- a/tests/plotly/test_plotly_line_series_pass.py
+++ b/tests/plotly/test_plotly_line_series_pass.py
@@ -1,0 +1,166 @@
+"""``data`` and ``selector`` come out of one pass, so it must run only once.
+
+``PlotlyStepPlot`` and ``PlotlyMultiLinePlot`` filter their series and their
+positions by the same predicate, in ``_line_series_with_positions``, so that
+series *i* always addresses the element series *i* is drawn as (#316).
+``render()`` then asks for the two halves separately -- ``_extract_plot_data()``
+and ``_get_selector()`` -- and each was calling that pass for itself.
+
+Repeating it assumes it can be repeated. ``as_list`` materialises a trace array
+with ``list(value)``, so a one-shot iterable is spent by the first walk and
+reads as empty on the second: the layer reports its series and then no selector
+at all. That is the silent no-highlight the pairing exists to prevent, arrived
+at from the other direction.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.plotly.multiline import PlotlyMultiLinePlot
+from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.step import PlotlyStepPlot
+
+plotly = pytest.importorskip("plotly")
+
+
+def _step(x, y, name: str) -> dict:
+    """
+    Build a staircase trace.
+
+    Parameters
+    ----------
+    x, y : Any
+        Sample coordinates, in any shape ``as_list`` accepts.
+    name : str
+        Trace name.
+
+    Returns
+    -------
+    dict
+        A scatter trace whose ``line.shape`` makes plotly draw risers.
+    """
+    return {
+        "type": "scatter",
+        "mode": "lines",
+        "x": x,
+        "y": y,
+        "line": {"shape": "hv"},
+        "name": name,
+    }
+
+
+def _line(x, y, name: str) -> dict:
+    """
+    Build a plain line trace.
+
+    Parameters
+    ----------
+    x, y : Any
+        Sample coordinates, in any shape ``as_list`` accepts.
+    name : str
+        Trace name.
+
+    Returns
+    -------
+    dict
+        A scatter/lines trace dict.
+    """
+    return {"type": "scatter", "mode": "lines", "x": x, "y": y, "name": name}
+
+
+#: Both classes share the pass, so every case runs against both.
+CLASSES = [
+    pytest.param(PlotlyStepPlot, _step, id="step"),
+    pytest.param(PlotlyMultiLinePlot, _line, id="multiline"),
+]
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_a_one_shot_trace_array_keeps_its_selectors(plot_class, make) -> None:
+    """An iterator is spent by the first walk, so the second must not happen.
+
+    ``Figure.to_dict()`` hands back lists, numpy arrays and typed-array specs,
+    never an iterator, so the export path does not reach this. A caller
+    constructing a layer directly does, and ``as_list`` accepts it -- the
+    array simply comes out empty the second time, and with it every selector.
+    """
+    traces = [
+        make(iter([0, 1]), iter([1, 2]), "a"),
+        make(iter([0, 1]), iter([2, 1]), "b"),
+    ]
+
+    schema = plot_class(traces, {}, scatter_positions=[0, 1]).schema
+
+    assert len(schema[MaidrKey.DATA]) == 2
+    assert len(schema[MaidrKey.SELECTOR]) == 2
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_the_pass_runs_once_per_render(plot_class, make, mocker) -> None:
+    """One render, one walk of the points.
+
+    Asserted on the call count rather than on timing: the pass allocates a
+    dict per point of every trace, so running it twice doubles the cost of
+    exporting a figure, and a count says so without a benchmark's noise.
+    """
+    spy = mocker.spy(PlotlyPlot, "_line_series_with_positions")
+    traces = [make([0, 1], [1, 2], "a"), make([0, 1], [2, 1], "b")]
+
+    plot_class(traces, {}, scatter_positions=[0, 1]).schema
+
+    assert spy.call_count == 1
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_a_second_layer_is_not_served_the_first_one_s_answer(
+    plot_class, make
+) -> None:
+    """The cache is per layer, and keyed on the lists it was built from.
+
+    Each layer is its own instance, so this could not go wrong today -- which
+    is the point: it pins that the cache stays scoped to what it was computed
+    for rather than becoming a class-level one later.
+    """
+    first = plot_class([make([0, 1], [1, 2], "a")], {}, scatter_positions=[0])
+    second = plot_class([make([0, 1, 2], [5, 6, 7], "b")], {}, scatter_positions=[4])
+
+    assert len(first.schema[MaidrKey.DATA][0]) == 2
+    assert len(second.schema[MaidrKey.DATA][0]) == 3
+    assert "nth-child(1)" in first.schema[MaidrKey.SELECTOR][0]
+    assert "nth-child(5)" in second.schema[MaidrKey.SELECTOR][0]
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_different_traces_are_not_answered_from_the_cache(plot_class, make) -> None:
+    """Passing other lists recomputes rather than returning the stored pair.
+
+    The cache holds one entry and matches it by the identity of both lists, so
+    this is what keeps a helper that looks reusable actually reusable.
+    """
+    layer = plot_class([make([0, 1], [1, 2], "a")], {}, scatter_positions=[0])
+    layer.schema
+
+    other_traces = [make([0, 1, 2], [9, 9, 9], "b")]
+    series, positions = layer._drawn_line_series(other_traces, [7])
+
+    assert len(series[0]) == 3
+    assert positions == [7]
+
+
+@pytest.mark.parametrize(("plot_class", "make"), CLASSES)
+def test_rendering_twice_gives_the_same_answer(plot_class, make) -> None:
+    """A cached pass must not make the second render differ from the first.
+
+    ``Maidr`` re-renders a figure whenever it is shown again, and a cache that
+    served a stale or half-consumed answer would surface exactly there.
+    """
+    traces = [make([0, 1], [1, 2], "a"), make([], [], "empty"), make([2], [3], "c")]
+    layer = plot_class(traces, {}, scatter_positions=[0, 1, 2])
+
+    first = layer.render()
+    second = layer.render()
+
+    assert first[MaidrKey.DATA] == second[MaidrKey.DATA]
+    assert first[MaidrKey.SELECTOR] == second[MaidrKey.SELECTOR]


### PR DESCRIPTION
# Pull Request

## Description

#350 gave `PlotlyStepPlot` and `PlotlyMultiLinePlot` one predicate for both `data` and `selector`, so series *i* always addresses the element series *i* is drawn as (#316). `render()` then asks for the two halves separately, and each half was calling that pass for itself — so the pass that exists to be shared ran twice.

The review on #350 raised this as a performance point, and it is one. But repeating the pass also **assumes it can be repeated**, and it cannot: `as_list` materialises a trace array with `list(value)`, so a one-shot iterable is spent by the first walk and reads as empty on the second. The layer reports its series, then reports no selector at all — the same silent no-highlight the pairing was written to prevent, reached from the other side.

## Related Issues

Closes #361. Follows up the review on #350; #316 is the bug that pairing exists to fix.

## Changes Made

**`maidr/plotly/plotly_plot.py`** — `_drawn_line_series(traces, positions)` wraps `_line_series_with_positions` and caches its answer on the layer, keyed by the **identity** of the two lists it was built from. Whichever of `_extract_plot_data` / `_get_selector` runs first computes the pass; the other reads it.

The reviewer on #350 pointed at the `PlotlyBoxPlot` idiom — stash the result on `self` during `_extract_plot_data` for `_get_selector` to read afterwards — as the established pattern here, and it is. Keying on the inputs instead does the same work without depending on `render()` calling data before selector, and recomputes rather than answering for lists it was not built from.

**`maidr/plotly/step.py`, `maidr/plotly/multiline.py`** — both call sites go through it.

**`tests/plotly/test_plotly_line_series_pass.py`** — new, both classes parametrized:

| Case | Pins |
| --- | --- |
| `a_one_shot_trace_array_keeps_its_selectors` | the regression: data **and** selectors survive an iterator |
| `the_pass_runs_once_per_render` | one render, one call — a count, not a benchmark |
| `a_second_layer_is_not_served_the_first_one_s_answer` | the cache stays scoped to its layer |
| `different_traces_are_not_answered_from_the_cache` | passing other lists recomputes |
| `rendering_twice_gives_the_same_answer` | a cached pass does not make render 2 differ from render 1 |

## Verification

**The regression is from #350, not pre-existing.** Before it, `_get_selector` read `self._scatter_positions` directly and never touched the trace arrays. Run against `0faa7fc~1` and against `0faa7fc`:

```
pre-#350  -> data: 2  selectors: ['… nth-child(1) path.js-line', '… nth-child(2) path.js-line']
post-#350 -> data: 2  selectors: None
with this -> data: 2  selectors: 2                      (both classes)
```

**The new tests fail without the change** — 6 of 10 on the current `main` source, including both `a_one_shot_trace_array_keeps_its_selectors` cases and both `the_pass_runs_once_per_render` cases.

**Measured, not asserted.** 50 series × 10,000 points, `PlotlyMultiLinePlot.render()`, median of five runs:

| | median render |
| --- | --- |
| `main` | 1.859 s |
| this branch | 0.923 s |

Exactly the 2× a doubled walk predicts — the pass allocates a dict per point.

**Suite:** `uv run pytest -q` → **1067 passed**. `ruff check maidr/plotly tests/plotly` → clean.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**How reachable the iterator case is, stated plainly.** `Figure.to_dict()` returns lists, numpy arrays and typed-array specs, never an iterator, so the export path does not hit it. A caller constructing a layer directly does, and `as_list` accepts an arbitrary iterable by design. So it is narrow — but it is the kind of narrow that is invisible when it happens, and closing it costs nothing beyond the fix the performance point already asked for.

**Not addressed here:** the reviewer's second point on #350, that `PlotlyStepPlot._get_selector` and `PlotlyMultiLinePlot._get_selector` now have identical bodies. They do, but their docstrings carry different information — the step one explains why a staircase resolves to the same `path.js-line` a plain line does, and why a lone step trace is still `nth-child`-scoped — and folding the bodies into a base method would have to drop or merge that. It is pre-existing duplication of a three-line call, and separable from this.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_