### PR TITLE
fix(deps): never resolve the CDN version on an event loop

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -297,7 +297,14 @@ One exception is worth knowing about: **Altair** charts always load `maidr.js` f
 ::: {.callout-note}
 ## Shiny and other async servers
 
-`render_maidr` calls into the synchronous render path, so the one-time lookup happens on the event loop and blocks it for up to `MAIDR_CDN_TIMEOUT`. Set `MAIDR_CDN_VERSION=bundled` at startup for Shiny apps to avoid that entirely.
+**No lookup happens on an event loop.** `render_maidr` calls into the synchronous render path, so the one-time lookup used to land on the loop and block it — every concurrent session queued behind one slow request. py-maidr now answers from the bundled version instead whenever a lookup would have to be made from a thread running a loop, which needs no request and is still an immutable URL.
+
+You give up picking up a release newer than your wheel, automatically, in an async app. Two ways to get it back:
+
+- `maidr.set_cdn_version("3.74.0")` at startup, if you know which version you want.
+- Call `maidr.get_cdn_version()` once from synchronous code at startup. That resolves and caches, and every async render then uses the resolved version — the request is paid for once, by your startup, not by a render.
+
+The same caching means this is not "async gets a different answer forever": after any resolution anywhere in the process, the loop and the main thread agree. It also means `warn_if_bundle_is_stale()` stays quiet in an app that never resolves, since it reads only an already-completed lookup.
 :::
 
 `bundle_status()` is the one deliberate exception: it resolves even when pinned, because "how does my bundle compare to what's published?" has no answer otherwise. Pass `resolve=False` if you need it silent.

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -26,6 +26,7 @@ grows large enough to matter.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import math
@@ -357,9 +358,11 @@ def get_cdn_version() -> str:
 
     1. An explicit pin from :func:`set_cdn_version`.
     2. The ``MAIDR_CDN_VERSION`` environment variable.
-    3. The ``latest`` dist-tag resolved over the network (once per
+    3. The version this wheel ships, when resolving would block an event
+       loop — see :func:`_resolution_would_block`, and the note below.
+    4. The ``latest`` dist-tag resolved over the network (once per
        process, then cached).
-    4. The literal string ``"latest"`` when the lookup fails, which
+    5. The literal string ``"latest"`` when the lookup fails, which
        reproduces the library's historical behaviour.
 
     Returns
@@ -369,7 +372,7 @@ def get_cdn_version() -> str:
 
     Notes
     -----
-    Step 4 is what makes this safe to call from a render path: an
+    Step 5 is what makes this safe to call from a render path: an
     unreachable, blocked, or malformed resolver degrades to ``"latest"``
     rather than raising.  That guarantee rests on
     :func:`_fetch_latest_version` honouring its own "never raises"
@@ -384,10 +387,38 @@ def get_cdn_version() -> str:
     A ``KeyboardInterrupt`` is treated differently: it is not cached, so
     interrupting one render does not leave the rest of the process
     emitting ``@latest``.
+
+    Step 3 is the one that depends on where it is called from, and it is
+    a deliberate trade.  ``maidr.render()`` is synchronous and Shiny calls
+    it from ``render_maidr.render()``, which is ``async`` — so under the
+    default the first figure in an app performed a blocking ``urlopen`` on
+    the event loop, stalling every concurrent session behind it (#296).
+    The bundled version is a real published one, so the URL resolves and
+    is immutable; what is given up is picking up a release newer than the
+    wheel, automatically, in an async process.
+
+    That is the trade the docs already recommended making by hand:
+    ``MAIDR_CDN_VERSION=bundled`` was the advice for Shiny apps, and this
+    makes the default do it in exactly the context the advice was for.
+    Two things follow that are worth knowing rather than discovering:
+
+    * :func:`warn_if_bundle_is_stale` reads only an already-completed
+      lookup, so a process that never resolves never hears it.
+    * Calling this once from synchronous code at start-up caches the
+      answer, after which every async render uses the resolved version --
+      which is how an app that wants the newer release gets it without
+      any render paying for the request.
+
+    Synchronous callers are unaffected, including threads: they still
+    resolve once per process and queue on ``_fetch_lock`` while the first
+    of them does.  That queueing is not fixed here; it is the event loop
+    specifically that must not be made to wait.
     """
     pin = _version_pin()
     if pin is not None:
         return pin
+    if _resolution_would_block():
+        return _offline_version()
     return _resolve_latest_version() or LATEST_TAG
 
 
@@ -446,6 +477,75 @@ def _cached_resolution() -> str | None:
     """Return the resolved version if a lookup has completed, else ``None``."""
     attempted, value = _resolution_state()
     return value if attempted else None
+
+
+def _offline_version() -> str:
+    """Return the best version available without making a request.
+
+    The order is the same question asked three ways, cheapest first: what
+    did the caller ask for, what did an earlier lookup establish, and what
+    shipped in this wheel.  Only when none of those is usable does this
+    fall back to :data:`LATEST_TAG`, the mutable dist-tag this module
+    exists to stop emitting.
+
+    Both offline callers read it from here rather than each spelling it
+    out, because when they disagreed the result was one page loading two
+    different builds of ``maidr.js`` -- an iframe on the pinned version
+    and its host on the bundled one.
+
+    Returns
+    -------
+    str
+        A concrete version, or ``latest`` when there is no better answer.
+    """
+    pin = _version_pin()
+    if pin is not None:
+        return pin
+
+    resolved = _cached_resolution()
+    if resolved is not None and _is_valid_version(resolved):
+        return resolved
+
+    bundled = maidr_js_version()
+    if _is_valid_version(bundled) and bundled != _UNKNOWN_VERSION:
+        return bundled
+
+    return LATEST_TAG
+
+
+def _resolution_would_block() -> bool:
+    """Report whether resolving now would stall an event loop.
+
+    ``_resolve_latest_version`` makes a blocking ``urlopen`` call, holding
+    ``_fetch_lock`` across it.  On a thread running an event loop -- which
+    is where ``maidr.render()`` is called from in a Shiny app, through
+    ``render_maidr.render()`` -- that stalls every other session in the
+    process for up to :data:`MAIDR_CDN_TIMEOUT`, and that budget is only
+    approximate: ``urlopen``'s timeout applies per socket operation and
+    does not reliably cover ``getaddrinfo``, so a broken resolver can
+    exceed it (#296).
+
+    A lookup that has already completed costs nothing, so it is not
+    blocking and this says so -- which is what makes the answer stable
+    rather than context-dependent after the first resolution anywhere in
+    the process.  Resolving once from synchronous code at start-up is
+    therefore the way to have an async app serve the resolved version.
+
+    Returns
+    -------
+    bool
+        ``True`` only when a lookup would have to be performed *and* this
+        thread is running an event loop.
+    """
+    attempted, _ = _resolution_state()
+    if attempted:
+        return False
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
 
 
 def unresolved_cdn_url(filename: str) -> str:
@@ -548,28 +648,16 @@ def bundled_cdn_url(filename: str) -> str:
         A jsDelivr URL at the bundled version, or at ``latest`` when that
         version is unknown.
     """
-    # A pin is the caller's own answer to "which version?", and reading
-    # it costs nothing -- no request is involved either way.  Without
-    # this, a pinned session emitted the *bundled* version here while
-    # every iframe emitted the pinned one, so one page loaded two
-    # different builds of maidr.js: exactly the split the next paragraph
-    # exists to avoid, and a contradiction of what set_cdn_version
-    # documents. A LATEST_TAG pin lands here too and yields the ``@latest``
-    # URL, which is what that pin asks for and what the render paths emit.
-    pin = _version_pin()
-    if pin is not None:
-        return _CDN_URL_TEMPLATE.format(version=pin, filename=filename)
-
-    # Then a version an earlier lookup already established.  It also costs
-    # nothing, and it keeps these tags on the same version the iframes
-    # load, rather than leaving two copies of maidr.js in one page.
-    resolved = _cached_resolution()
-    if resolved is not None and _is_valid_version(resolved):
-        return _CDN_URL_TEMPLATE.format(version=resolved, filename=filename)
-    bundled = maidr_js_version()
-    if _is_valid_version(bundled) and bundled != _UNKNOWN_VERSION:
-        return _CDN_URL_TEMPLATE.format(version=bundled, filename=filename)
-    return _unresolved_cdn_url(filename)
+    # A pin first, then a version an earlier lookup already established,
+    # then the bundled one -- see `_offline_version`, which is the same
+    # order `get_cdn_version` falls back to on an event loop, written once
+    # so the two cannot answer differently. When they did, a pinned
+    # session emitted the *bundled* version here while every iframe
+    # emitted the pinned one, and one page loaded two builds of maidr.js.
+    #
+    # A LATEST_TAG pin lands there too and yields the ``@latest`` URL,
+    # which is what that pin asks for and what the render paths emit.
+    return _CDN_URL_TEMPLATE.format(version=_offline_version(), filename=filename)
 
 
 def maidr_js_cdn_url() -> str:

--- a/tests/core/test_cdn_event_loop.py
+++ b/tests/core/test_cdn_event_loop.py
@@ -1,0 +1,193 @@
+"""Resolving the CDN version must not stall an event loop.
+
+``maidr.render()`` is synchronous, and Shiny calls it from
+``render_maidr.render()``, which is ``async``. Under the default the first
+figure in an app therefore performed a blocking ``urlopen`` **on the event
+loop** -- up to ``MAIDR_CDN_TIMEOUT``, and that budget is only approximate
+because ``urlopen``'s timeout applies per socket operation and does not
+reliably cover ``getaddrinfo``. Every concurrent session queued behind it on
+``_fetch_lock`` (#296).
+
+The fix is to answer from the bundled version instead when a lookup would have
+to be made on a loop. What these pin is that the request is not made -- asserted
+on the call count rather than on elapsed time, because a timing assertion on CI
+measures the runner's load as much as the code.
+
+They also pin the two things that keep the answer from being merely
+context-dependent: an explicit pin still wins, and a lookup that has already
+completed anywhere in the process is used, so an app that resolves once from
+synchronous code at start-up serves the resolved version from then on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+
+import pytest
+
+from maidr.util import dependencies
+
+
+class _FakeResponse(io.BytesIO):
+    """Minimal ``urlopen`` stand-in supporting the ``with`` protocol."""
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+
+@pytest.fixture
+def requests(monkeypatch):
+    """Record every registry request, answering each with version 9.9.9.
+
+    Yields the list of requested URLs, so a test can say "no request was
+    made" as a fact about the network rather than about the clock.
+    """
+    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+    dependencies.set_cdn_version(None)
+    dependencies.reset_cdn_version_cache()
+
+    calls: list[str] = []
+
+    def fake_urlopen(request, timeout=None):
+        calls.append(request.full_url)
+        return _FakeResponse(json.dumps({"version": "9.9.9"}).encode("utf-8"))
+
+    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    yield calls
+
+    dependencies.set_cdn_version(None)
+    dependencies.reset_cdn_version_cache()
+
+
+def in_loop(call):
+    """Run ``call`` on a fresh event loop and return its result."""
+
+    async def main():
+        return call()
+
+    return asyncio.run(main())
+
+
+def test_a_render_on_an_event_loop_makes_no_request(requests) -> None:
+    """The reported bug: the loop must not be made to wait.
+
+    Asserting the request count rather than the duration. A stalled loop is
+    what the user experiences, but the *cause* is the round trip, and that is
+    the thing a test can state without measuring a shared CI runner.
+    """
+    version = in_loop(dependencies.get_cdn_version)
+
+    assert requests == []
+    assert version == dependencies.maidr_js_version()
+
+
+def test_a_synchronous_render_still_resolves(requests) -> None:
+    """The control. Nothing outside an event loop changes."""
+    version = dependencies.get_cdn_version()
+
+    assert len(requests) == 1
+    assert version == "9.9.9"
+
+
+def test_the_version_emitted_on_a_loop_is_concrete(requests) -> None:
+    """Bundled, not ``latest``.
+
+    ``@latest`` is the mutable dist-tag this whole module exists to stop
+    emitting -- jsDelivr serves it with a seven-day ``max-age``, so a browser
+    can replay a week-old bundle. Declining to resolve must not quietly
+    reintroduce it.
+    """
+    url = in_loop(dependencies.maidr_js_cdn_url)
+
+    assert requests == []
+    assert f"maidr@{dependencies.LATEST_TAG}/" not in url
+    assert f"maidr@{dependencies.maidr_js_version()}/" in url
+
+
+def test_an_explicit_pin_still_wins_on_a_loop(requests) -> None:
+    """A pin is the caller's own answer and costs no request either way."""
+    dependencies.set_cdn_version("3.74.0")
+
+    assert in_loop(dependencies.get_cdn_version) == "3.74.0"
+    assert requests == []
+
+
+def test_a_completed_lookup_is_used_on_a_loop(requests) -> None:
+    """Resolve once from synchronous code and every async render benefits.
+
+    This is what keeps the behaviour from being context-dependent for the
+    life of the process: after any resolution anywhere, the loop and the
+    main thread agree. It is also the supported way for an async app to
+    serve a release newer than its wheel.
+    """
+    assert dependencies.get_cdn_version() == "9.9.9"
+
+    assert in_loop(dependencies.get_cdn_version) == "9.9.9"
+    assert len(requests) == 1
+
+
+def test_a_cached_failure_is_not_retried_on_a_loop(monkeypatch, requests) -> None:
+    """A failed lookup stays failed, and stays cheap.
+
+    An offline notebook must not stall on a doomed request for every figure,
+    and the loop must not either. The answer is ``latest`` here rather than
+    the bundled version, which is what a failed lookup has always produced --
+    this path is unchanged and is pinned so it stays that way.
+    """
+    monkeypatch.setattr(dependencies, "_fetch_latest_version", lambda budget: None)
+
+    assert dependencies.get_cdn_version() == dependencies.LATEST_TAG
+
+    assert in_loop(dependencies.get_cdn_version) == dependencies.LATEST_TAG
+    assert requests == []
+
+
+def test_two_concurrent_renders_on_one_loop_both_return(requests) -> None:
+    """No pile-up, because there is nothing to pile up behind.
+
+    Concurrent first-renders used to queue on ``_fetch_lock`` while the first
+    of them made the request, so a slow resolver cost every session the same
+    stall rather than costing one of them.
+    """
+
+    async def main():
+        return await asyncio.gather(
+            asyncio.to_thread(lambda: None),
+            *[asyncio.sleep(0, dependencies.get_cdn_version()) for _ in range(4)],
+        )
+
+    results = asyncio.run(main())
+
+    assert requests == []
+    assert set(results[1:]) == {dependencies.maidr_js_version()}
+
+
+def test_bundled_cdn_url_still_prefers_a_pin_then_a_lookup(requests) -> None:
+    """The offline URL builder shares the fallback order, so it cannot drift.
+
+    Both it and `get_cdn_version`'s event-loop branch answer "which version,
+    without asking?" and they used to spell that out separately. When they
+    disagreed, a pinned session emitted the bundled version here while every
+    iframe emitted the pinned one, and one page loaded two builds of
+    ``maidr.js``.
+    """
+    dependencies.set_cdn_version("3.74.0")
+    assert "maidr@3.74.0/" in dependencies.bundled_cdn_url(
+        dependencies.MAIDR_JS_FILENAME
+    )
+
+    dependencies.set_cdn_version(None)
+    assert dependencies.get_cdn_version() == "9.9.9"
+    assert "maidr@9.9.9/" in dependencies.bundled_cdn_url(
+        dependencies.MAIDR_JS_FILENAME
+    )
+
+    dependencies.reset_cdn_version_cache()
+    assert f"maidr@{dependencies.maidr_js_version()}/" in dependencies.bundled_cdn_url(
+        dependencies.MAIDR_JS_FILENAME
+    )

--- a/tests/core/test_cdn_event_loop.py
+++ b/tests/core/test_cdn_event_loop.py
@@ -147,24 +147,32 @@ def test_a_cached_failure_is_not_retried_on_a_loop(monkeypatch, requests) -> Non
     assert requests == []
 
 
-def test_two_concurrent_renders_on_one_loop_both_return(requests) -> None:
+def test_interleaved_renders_on_one_loop_all_return(requests) -> None:
     """No pile-up, because there is nothing to pile up behind.
 
     Concurrent first-renders used to queue on ``_fetch_lock`` while the first
     of them made the request, so a slow resolver cost every session the same
     stall rather than costing one of them.
+
+    Each call yields to the loop before asking, so the four are interleaved by
+    the scheduler rather than run to completion in turn -- which is the shape
+    a Shiny app's sessions arrive in. Written as ``await asyncio.sleep(0)``
+    inside each coroutine rather than as an argument to it: an argument is
+    evaluated when the coroutine is *created*, so all four calls would happen
+    before ``gather`` ever scheduled anything.
     """
 
+    async def one_render():
+        await asyncio.sleep(0)
+        return dependencies.get_cdn_version()
+
     async def main():
-        return await asyncio.gather(
-            asyncio.to_thread(lambda: None),
-            *[asyncio.sleep(0, dependencies.get_cdn_version()) for _ in range(4)],
-        )
+        return await asyncio.gather(*[one_render() for _ in range(4)])
 
     results = asyncio.run(main())
 
     assert requests == []
-    assert set(results[1:]) == {dependencies.maidr_js_version()}
+    assert set(results) == {dependencies.maidr_js_version()}
 
 
 def test_bundled_cdn_url_still_prefers_a_pin_then_a_lookup(requests) -> None:


### PR DESCRIPTION
# Pull Request

## Description

`maidr.render()` is synchronous and Shiny calls it from `render_maidr.render()`, which is `async` — so under the default `use_cdn="auto"` the first figure in an app performed a blocking `urlopen` **on the event loop**, and every concurrent session queued behind it while it ran.

`get_cdn_version()` now answers from the bundled version when a lookup would have to be made from a thread running a loop.

## Related Issues

Closes #296. Follows up #291; interacts with #295.

## Changes Made

### `maidr/util/dependencies.py`

- **`_resolution_would_block()`** — true only when a lookup would have to be *performed* **and** this thread is running a loop. `asyncio.get_running_loop()` raises `RuntimeError` when there is none, so the check is cheap.
- **`get_cdn_version()`** — a new step 3 between the pin and the lookup.
- **`_offline_version()`** — the pin → cached-lookup → bundled → `latest` order, written once. `bundled_cdn_url()` spelled the same thing out separately; its own comment records what happened when the two disagreed (*"one page loaded two different builds of maidr.js"* — an iframe on the pinned version, its host on the bundled one). Both read it now.

### Which of the issue's three options this is, and why

The issue offered three and folded none in, because "all three trade determinism for responsiveness in some way."

This is **option 1**, and the reason to prefer it is that its context-dependence is bounded in a way the other two are not:

| | never blocks the loop | output independent of timing | output independent of context |
| --- | --- | --- | --- |
| skip when a loop is running | ✅ | ✅ | after the first resolution anywhere |
| non-blocking lock acquire | partly — the winner still blocks | ❌ | ❌ |
| resolve in a background thread | ✅ | ❌ | ❌ |

A completed lookup is *not* blocking, so it is used on the loop like anywhere else. That means the "async is different" window is one process-wide first resolution, not forever — and calling `get_cdn_version()` once from synchronous code at start-up closes it deliberately. Options 2 and 3 both make the emitted URL depend on which session won a race, which is a worse thing to debug than "this app serves its bundled version."

### The trade, stated plainly

An async app no longer picks up a release newer than its wheel automatically. That is the trade `docs/index.qmd` **already recommended making by hand** — `MAIDR_CDN_VERSION=bundled` was the advice for Shiny apps — so this makes the default do it in exactly the context the advice was written for. The docs now say the lookup cannot happen there, and give the two ways to get the newer release back.

One consequence worth knowing rather than discovering: `warn_if_bundle_is_stale()` reads only an already-completed lookup (`bundle_status(resolve=False)`), so a process that never resolves never hears it. Said in the docs and the docstring.

### One correction to the issue

> `_resolve_latest_version()` holds `_resolution_lock` across the network call

It holds **`_fetch_lock`**; `_resolution_lock` is explicitly released before the call, with a comment saying why ("the offline paths read that lock, so holding it here would make a stalled lookup block a render that promised to make no request at all"). The consequence the issue describes — concurrent first-renders queueing — is real and is `_fetch_lock`'s.

**Not fixed, and not claimed to be:** synchronous threads still queue on `_fetch_lock` while the first of them resolves. It is the event loop specifically that must not be made to wait.

## Verification

Measured against a stubbed 3-second resolver:

```
bundled wheel version: 4.1.0
sync                       -> '9.9.9' in 3.00s
async                      -> '4.1.0' in 0.00s
async, second call         -> '4.1.0' in 0.00s
async after a sync resolve -> '9.9.9' in 0.00s
async with an explicit pin -> '1.2.3'
```

`tests/core/test_cdn_event_loop.py` asserts these on the **request count**, not on elapsed time — a stalled loop is what the user experiences, but the round trip is the cause, and it is the thing a test can state without measuring a shared CI runner.

| Case | Pins |
| --- | --- |
| `a_render_on_an_event_loop_makes_no_request` | the bug |
| `a_synchronous_render_still_resolves` | the control |
| `the_version_emitted_on_a_loop_is_concrete` | declining to resolve must not reintroduce `@latest` |
| `an_explicit_pin_still_wins_on_a_loop` | a pin is the caller's own answer |
| `a_completed_lookup_is_used_on_a_loop` | the window is one resolution, not forever |
| `a_cached_failure_is_not_retried_on_a_loop` | the failure path is unchanged |
| `two_concurrent_renders_on_one_loop_both_return` | no pile-up |
| `bundled_cdn_url_still_prefers_a_pin_then_a_lookup` | the shared fallback order after the refactor |

**3 of 8 fail on `main`** without the change.

**Suite:** `uv run pytest -q` → **1075 passed**. `ruff check maidr/util tests/core` → clean.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`asyncio.get_running_loop()` is per-thread, which is what makes this correct rather than merely convenient: a render dispatched to a worker thread by `asyncio.to_thread` has no running loop on that thread and resolves normally, which is right — it is not the loop's thread and cannot stall it.

This does not close #295 ("consider falling back to the bundled version, not `@latest`, when resolution fails"). That is a different question — what to do when a lookup *was* made and failed — and this change deliberately leaves that path exactly as it was.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_