### PR TITLE
fix(deps): stop emitting @latest on the failure path, and warn on a mistyped pin

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -319,6 +319,14 @@ maidr.set_cdn_version("latest")   # skip resolution, emit the mutable @latest UR
 maidr.set_cdn_version(None)       # back to resolving automatically
 ```
 
+::: {.callout-note}
+## A mistyped pin warns; a mistyped environment variable does not
+
+`maidr.set_cdn_version("3.74")` — a missing patch component — raises a `FutureWarning` and is then ignored, so URLs resolve as if no pin had been set. A future major release will raise `ValueError` there instead.
+
+`MAIDR_CDN_VERSION=3.74` stays quiet apart from a log line. The asymmetry is deliberate: an explicit function call with a bad argument is the caller's mistake and worth interrupting them over, while an environment variable is ambient configuration that a CI image or a container base may have set without them, and crashing on it would be hostile.
+:::
+
 ::: {.callout-warning}
 ## These settings are process-wide, not per-session
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -284,7 +284,9 @@ This matters because the CDN serves the mutable `maidr@latest` URL with a seven-
 :::: {.callout-note}
 ## This performs one network request
 
-Resolving the version makes a single outbound HTTPS request, the first time a CDN URL is built for a *rendered plot*. It is cached for the rest of the process and falls back to the `@latest` URL if it fails — so a blocked or slow network costs you a one-time delay, never an error.
+Resolving the version makes a single outbound HTTPS request, the first time a CDN URL is built for a *rendered plot*. It is cached for the rest of the process and falls back to **the version bundled in your wheel** if it fails — so a blocked or slow network costs you a one-time delay, never an error, and never the mutable `@latest` URL whose seven-day cache lifetime this resolution exists to avoid.
+
+The trade is that a network hiccup pins that page to the version you installed rather than the current one. That is the quieter failure: the bundled version is a real published release, and it is the same copy py-maidr would serve with `use_cdn=False`.
 
 `import maidr` makes no request, even in a notebook: `init_notebook()` pins its tags to the version bundled in the wheel, which needs no lookup and is still immutable.
 

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -390,6 +390,26 @@ def set_cdn_version(version: str | None) -> None:
     Takes precedence over the ``MAIDR_CDN_VERSION`` environment variable.
     A value that is neither a recognised tag nor a valid semver is
     ignored (with a warning) in favour of the normal resolution path.
+
+    Warns
+    -----
+    FutureWarning
+        When ``version`` is unusable.  Today the pin is ignored and the
+        next URL resolves normally; a future major release will raise
+        :class:`ValueError` instead.
+
+        The leniency is right for ``MAIDR_CDN_VERSION`` -- ambient
+        configuration may be set by something outside the caller's
+        control, and crashing on it would be hostile.  It is wrong here:
+        this is an explicit call with a bad argument, which is the
+        textbook case for ``ValueError``, and the caller currently gets no
+        return value, no exception, and a *log* line they may never see.
+        So a typo does nothing, visibly (#294).
+
+        Raising outright would break a script that has been quietly
+        mistyping its pin and rendering fine, so it goes through a
+        deprecation the way :func:`bundled_css_path` did.  The warning is
+        the behaviour change; the raise is the next major's.
     """
     global _cdn_version_override
     # A blank string is treated as ``None`` rather than as a malformed
@@ -400,7 +420,25 @@ def set_cdn_version(version: str | None) -> None:
         _cdn_version_override = None
         reset_cdn_version_cache()
         return
-    _cdn_version_override = str(version).strip()
+
+    candidate = str(version).strip()
+    # Checked here as well as on every URL build, because the two
+    # answer different questions. `_normalise_version_pin` asks "can I
+    # use this?" every time it needs a URL, and logs. This asks "did the
+    # caller just make a mistake?", once, at the point they made it --
+    # which is the only moment a stack trace points anywhere useful.
+    if _normalise_version_pin(candidate) is None:
+        warnings.warn(
+            f"maidr.set_cdn_version({version!r}) was given something that is "
+            f"neither a semver such as '3.74.0' nor {BUNDLED_TAG!r} or "
+            f"{LATEST_TAG!r}. The pin is ignored and URLs resolve as if it "
+            "had not been set. A future major release will raise ValueError "
+            "here instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
+    _cdn_version_override = candidate
 
 
 def get_cdn_version() -> str:

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -509,7 +509,22 @@ def get_cdn_version() -> str:
         return pin
     if _resolution_would_block():
         return _offline_version()
-    return _resolve_latest_version() or LATEST_TAG
+    # A lookup that failed falls back to the bundled version, not to
+    # `@latest`.  `@latest` is the mutable dist-tag whose seven-day
+    # `Cache-Control` is the whole of #290 -- so degrading to it meant the
+    # fix stopped applying in precisely the case it was meant to survive,
+    # and an offline browser could still replay a week-old build (#295).
+    #
+    # The bundled version is a real published one, immutable, and is the
+    # copy this wheel would have served anyway had the CDN been declined.
+    # What it costs is that a network hiccup pins the page to a possibly
+    # older release -- quieter, but staler. That trade was argued the
+    # other way when this fallback was written, on the grounds that
+    # `@latest` is byte-for-byte what users had before version resolution
+    # existed and so nobody ends up worse off. Three other paths have
+    # since moved to the bundled answer, and being the last one left
+    # emitting the mutable tag is not a place worth defending.
+    return _resolve_latest_version() or _offline_version()
 
 
 def _version_pin() -> str | None:

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -22,6 +22,15 @@ drift behind upstream between releases — and a render that falls back to
 it silently runs older code.  :func:`bundle_status` reports that drift and
 :func:`warn_if_bundle_is_stale` surfaces it once per process when the gap
 grows large enough to matter.
+
+Version distance is the coarse signal, not the answer.  What a user
+actually wants to know is whether the bundle can draw the chart they are
+emitting, and :func:`warn_if_bundle_cannot_render` answers that directly
+by reading the installed file — no network, so unlike the staleness
+warning it reaches the offline and pinned users whose bundle is what runs.
+Keep the two apart when changing either: "you are drifting" and "this
+chart will not draw" are different claims, and the second is the one worth
+acting on.
 """
 
 from __future__ import annotations
@@ -1258,6 +1267,25 @@ def _fetch_latest_version(budget: float) -> str | None:
 #: Minor-version gap at which the bundled fallback stops being "a release
 #: or two behind" and starts being a copy users should know about.  The
 #: bug report that prompted this check cited a gap of 8.
+#:
+#: Picked without the release histories, then measured against them (#292).
+#: The question that decides it is not how fast upstream ships, it is how
+#: many minors accumulate between the py-maidr releases that refresh the
+#: bundle.  Over the seventeen cycles from 2026-01-31 to 2026-08-10:
+#:
+#:     median 1   mean 1.7   min 0   max 7
+#:     cycles reaching 3+:  6/17  (35%)
+#:     cycles reaching 5+:  1/17  (6%)
+#:     cycles reaching 8+:  0/17  (0%)
+#:
+#: So 5 fires on the one cycle in seventeen where the bundle genuinely
+#: fell behind -- a 68-day gap with nothing released -- and stays quiet
+#: otherwise.  3 would fire on a third of all cycles, which is how a
+#: warning becomes noise; 8 would not have fired even on that one.
+#:
+#: Recompute the *cycle* table, not upstream's cadence, if this is ever
+#: revisited: upstream shipping faster only matters here to the extent it
+#: outruns py-maidr's releases.
 STALE_MINOR_GAP = 5
 
 #: Set to ``0`` / ``false`` / ``off`` to silence the staleness warning.

--- a/tests/core/test_broken_bundle_version.py
+++ b/tests/core/test_broken_bundle_version.py
@@ -104,13 +104,19 @@ def test_a_failed_lookup_stays_quiet(monkeypatch, caplog, no_pin) -> None:
     An offline notebook falls back to the bundled version on every figure,
     and that is working as documented. Warning here as well would make the
     broken-install message indistinguishable from ordinary life on a train.
+
+    Since #295 the failed lookup routes through `_offline_version` rather
+    than straight to `latest`, so it now passes *through* the code that
+    warns -- which is why this asserts the silence rather than assuming
+    it. The warning is about the broken install, not about being offline,
+    and a healthy bundle is what keeps it quiet here.
     """
     monkeypatch.setattr(dependencies, "_fetch_latest_version", lambda budget: None)
 
     with caplog.at_level(logging.WARNING):
         version = dependencies.get_cdn_version()
 
-    assert version == dependencies.LATEST_TAG
+    assert version == dependencies.maidr_js_version()
     assert "maidr.js version" not in caplog.text
 
 

--- a/tests/core/test_cdn_event_loop.py
+++ b/tests/core/test_cdn_event_loop.py
@@ -135,15 +135,17 @@ def test_a_cached_failure_is_not_retried_on_a_loop(monkeypatch, requests) -> Non
     """A failed lookup stays failed, and stays cheap.
 
     An offline notebook must not stall on a doomed request for every figure,
-    and the loop must not either. The answer is ``latest`` here rather than
-    the bundled version, which is what a failed lookup has always produced --
-    this path is unchanged and is pinned so it stays that way.
+    and the loop must not either. Both answer with the bundled version --
+    the loop because it declines to look, the main thread because its
+    lookup failed and #295 made that fall back the same way. The two
+    agreeing is the point: after any resolution attempt, context stops
+    mattering.
     """
     monkeypatch.setattr(dependencies, "_fetch_latest_version", lambda budget: None)
 
-    assert dependencies.get_cdn_version() == dependencies.LATEST_TAG
+    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
 
-    assert in_loop(dependencies.get_cdn_version) == dependencies.LATEST_TAG
+    assert in_loop(dependencies.get_cdn_version) == dependencies.maidr_js_version()
     assert requests == []
 
 

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -341,8 +341,14 @@ def test_validator_and_comparator_share_one_grammar():
         )
 
 
+@pytest.mark.filterwarnings("ignore:maidr.set_cdn_version:FutureWarning")
 def test_invalid_pin_logs_once_not_once_per_render(resolvable, caplog):
-    """A typo'd pin must not log two lines for every figure rendered."""
+    """A typo'd pin must not log two lines for every figure rendered.
+
+    About the per-render log, not about the one-off deprecation the call
+    itself now raises -- `test_invalid_pin_never_reaches_the_url` covers
+    that, and asserting both here would confuse which is being counted.
+    """
     maidr.set_cdn_version("3.74")  # missing patch component
 
     with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
@@ -354,6 +360,7 @@ def test_invalid_pin_logs_once_not_once_per_render(resolvable, caplog):
     assert len(complaints) == 1, f"logged {len(complaints)} times, expected 1"
 
 
+@pytest.mark.filterwarnings("ignore:maidr.set_cdn_version:FutureWarning")
 def test_a_second_bad_pin_still_warns(resolvable, caplog):
     """Deduplication is per value, so a new mistake stays audible."""
 
@@ -367,8 +374,14 @@ def test_a_second_bad_pin_still_warns(resolvable, caplog):
     assert len(complaints) == 2
 
 
+@pytest.mark.filterwarnings("ignore:maidr.set_cdn_version:FutureWarning")
 def test_warned_keys_stays_bounded(resolvable):
-    """Many distinct bad pins must not grow the dedup set without bound."""
+    """Many distinct bad pins must not grow the dedup set without bound.
+
+    The deprecation from `set_cdn_version` is filtered rather than
+    asserted: the subject here is the *log* dedup set, and every one of
+    these several hundred calls raises the same deprecation.
+    """
     for i in range(dependencies._MAX_WARNED_KEYS * 3):
         maidr.set_cdn_version(f"bad-{i}")
         dependencies.maidr_js_cdn_url()
@@ -388,8 +401,14 @@ def test_warned_keys_stays_bounded(resolvable):
     ],
 )
 def test_invalid_pin_never_reaches_the_url(hostile, resolvable):
-    """A bad pin is ignored rather than spliced into the CDN URL."""
-    maidr.set_cdn_version(hostile)
+    """A bad pin is ignored rather than spliced into the CDN URL.
+
+    And it says so at the call, which is what #294 asked for: these are
+    the values a caller most needs telling about, and the log line they
+    used to get is invisible unless logging is configured.
+    """
+    with pytest.warns(FutureWarning, match="set_cdn_version"):
+        maidr.set_cdn_version(hostile)
     url = dependencies.maidr_js_cdn_url()
 
     assert hostile not in url

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -492,8 +492,16 @@ def test_falls_back_to_npm_registry_when_jsdelivr_fails(monkeypatch):
     assert len(calls) == 2
 
 
-def test_offline_falls_back_to_latest_tag(monkeypatch):
-    """No network: the URL degrades to the historical ``@latest`` form."""
+def test_offline_falls_back_to_the_bundled_version(monkeypatch):
+    """No network: the URL degrades to the version this wheel ships.
+
+    Not to ``@latest``, which was the historical form. That is the mutable
+    dist-tag whose seven-day ``Cache-Control`` is the whole of #290, so
+    degrading to it meant the fix stopped applying in precisely the case
+    it had to survive -- an offline browser could still replay a week-old
+    build (#295). The bundled version is immutable and is the copy this
+    wheel would have served anyway.
+    """
     monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
     dependencies.set_cdn_version(None)
     calls: list[str] = []
@@ -504,7 +512,10 @@ def test_offline_falls_back_to_latest_tag(monkeypatch):
 
     monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
 
-    assert dependencies.maidr_js_cdn_url() == dependencies.MAIDR_JS_CDN_URL
+    assert dependencies.maidr_js_cdn_url() == (
+        "https://cdn.jsdelivr.net/npm/maidr@"
+        f"{dependencies.maidr_js_version()}/dist/maidr.js"
+    )
     # Failure is cached too, so an offline session does not stall on a
     # doomed request for every figure it renders.
     dependencies.maidr_js_cdn_url()
@@ -528,7 +539,7 @@ def test_non_object_resolver_response_is_unusable(monkeypatch):
 
     monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == dependencies.LATEST_TAG
+    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
 
 
 def test_malformed_resolver_response_falls_back(monkeypatch):
@@ -539,7 +550,7 @@ def test_malformed_resolver_response_falls_back(monkeypatch):
         return _FakeResponse(b"<!DOCTYPE html><html>error</html>")
 
     monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
-    assert dependencies.get_cdn_version() == "latest"
+    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
 
 
 def test_hostile_resolver_version_is_rejected(monkeypatch):
@@ -552,7 +563,7 @@ def test_hostile_resolver_version_is_rejected(monkeypatch):
 
     monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == "latest"
+    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
     assert "evil" not in dependencies.maidr_js_cdn_url()
 
 
@@ -588,7 +599,7 @@ def test_timeout_is_a_total_budget_across_endpoints(monkeypatch):
 
     monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == "latest"
+    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
 
     assert len(seen) == len(dependencies._RESOLVER_ENDPOINTS)
     # Each attempt gets only what is left of the budget, so the timeouts
@@ -612,7 +623,7 @@ def test_budget_exhaustion_skips_remaining_endpoints(monkeypatch):
 
     monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == "latest"
+    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
     assert len(calls) == 1, "second endpoint should be skipped once spent"
 
 
@@ -984,8 +995,9 @@ def test_non_oserror_from_urlopen_does_not_escape(bar_plot, monkeypatch):
 
     monkeypatch.setattr(dependencies, "urlopen", blocked)
 
-    # Degrades to @latest rather than raising, and caches the failure.
-    assert dependencies.get_cdn_version() == dependencies.LATEST_TAG
+    # Degrades to the bundled version rather than raising, and caches
+    # the failure.
+    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
     maidr.render(bar_plot, use_cdn="auto")
 
 
@@ -1347,3 +1359,48 @@ def test_freshness_workflow_imports_resolve():
     status = maidr.bundle_status(resolve=False)
     for attribute in ("bundled", "published", "is_stale", "is_behind"):
         assert hasattr(status, attribute)
+
+
+def test_a_failed_lookup_never_emits_the_mutable_tag(monkeypatch):
+    """The point of #295, asserted on the URL rather than on the version.
+
+    ``@latest`` carries a seven-day ``Cache-Control``, which is the whole
+    of #290. Degrading to it when the lookup failed meant the fix stopped
+    applying in exactly the case it was written to survive: an offline
+    browser could still be handed a week-old build.
+
+    Every path is checked, not just the one that regressed, because the
+    version is spliced in three places and a fallback that fixed one of
+    them would look fixed.
+    """
+    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+    dependencies.set_cdn_version(None)
+    monkeypatch.setattr(
+        dependencies, "urlopen", lambda *_a, **_k: (_ for _ in ()).throw(OSError())
+    )
+
+    bundled = dependencies.maidr_js_version()
+    urls = [
+        dependencies.maidr_js_cdn_url(),
+        dependencies.cdn_url(dependencies.MAIDR_MATH_CSS_FILENAME),
+        dependencies.bundled_cdn_url(dependencies.MAIDR_JS_FILENAME),
+    ]
+
+    for url in urls:
+        assert f"maidr@{dependencies.LATEST_TAG}/" not in url, url
+        assert f"maidr@{bundled}/" in url, url
+
+
+def test_an_explicit_latest_pin_still_gets_the_mutable_tag(monkeypatch):
+    """Asking for ``latest`` is not a failure, and still means ``latest``.
+
+    The fallback moved; the pin did not. Someone who writes
+    ``MAIDR_CDN_VERSION=latest`` is deliberately opting out of resolution
+    and asking for the mutable tag, and #295 must not take that away --
+    it is the documented way to keep the CDN without the lookup.
+    """
+    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, "latest")
+    dependencies.set_cdn_version(None)
+
+    assert dependencies.get_cdn_version() == dependencies.LATEST_TAG
+    assert dependencies.maidr_js_cdn_url() == dependencies.MAIDR_JS_CDN_URL

--- a/tests/core/test_pin_validation.py
+++ b/tests/core/test_pin_validation.py
@@ -1,0 +1,152 @@
+"""A typo in ``set_cdn_version()`` must not do nothing, quietly.
+
+``maidr.set_cdn_version("3.74")`` -- a missing patch component -- logged a
+line and was otherwise ignored: the next URL resolved exactly as if no pin
+had been set. The caller got no return value, no exception, and a *log* line
+they may never see, because logging is not configured by default (#294).
+
+The leniency is right for ``MAIDR_CDN_VERSION``. Ambient configuration may be
+set by something outside the caller's control -- a CI image, a container
+base, a colleague's shell profile -- and crashing on it would be hostile. It
+is wrong for an explicit call with a bad argument.
+
+These pin the asymmetry as much as the warning, because the asymmetry is the
+part someone reading only one half will think is a bug.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import maidr
+from maidr.util import dependencies
+
+
+@pytest.fixture(autouse=True)
+def clean():
+    """No pin, no cached lookup, and a fresh log-dedup set."""
+    dependencies.set_cdn_version(None)
+    dependencies.reset_cdn_version_cache()
+    dependencies._warned_keys.clear()
+    yield
+    dependencies.set_cdn_version(None)
+    dependencies.reset_cdn_version_cache()
+
+
+#: Values that are neither a semver nor a recognised tag. The last four are
+#: the hostile ones from `test_cdn_version.py`; a caller typing those has a
+#: bigger problem than a typo, and should still be told.
+UNUSABLE = [
+    "3.74",
+    "not-a-version",
+    "v",
+    "../../../evil",
+    "3.74.0 && rm -rf /",
+    "https://evil.example.com/x.js",
+    "latest?cb=1",
+]
+
+USABLE = ["3.74.0", "v3.74.0", "  3.74.0  ", "bundled", "latest", "LATEST"]
+
+
+@pytest.mark.parametrize("value", UNUSABLE)
+def test_an_unusable_pin_says_so_at_the_call(value) -> None:
+    """The warning names the call, not a module three frames down.
+
+    `stacklevel=2` so the location Python attributes it to is the line the
+    caller wrote. A deprecation pointing into `dependencies.py` tells them
+    the library has a problem rather than that they do.
+    """
+    with pytest.warns(FutureWarning, match=r"set_cdn_version"):
+        maidr.set_cdn_version(value)
+
+
+@pytest.mark.parametrize("value", UNUSABLE)
+def test_an_unusable_pin_is_still_ignored_for_now(value) -> None:
+    """Today's behaviour is unchanged: warn, then resolve as if unpinned.
+
+    Raising outright would break a script that has been quietly mistyping
+    its pin and rendering fine. The warning is this release's change; the
+    raise is a future major's, and the message says so.
+    """
+    with pytest.warns(FutureWarning, match="will raise ValueError"):
+        maidr.set_cdn_version(value)
+
+    assert dependencies._version_pin() is None
+
+
+@pytest.mark.parametrize("value", USABLE)
+def test_a_usable_pin_is_silent(value) -> None:
+    """The overwhelmingly common case says nothing.
+
+    Including the tags and the shapes a caller reasonably writes -- a
+    ``v`` prefix, because that is how releases are spelled, and
+    surrounding space, because that is what a copy-paste brings with it.
+    """
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        maidr.set_cdn_version(value)
+
+    assert [r for r in records if issubclass(r.category, FutureWarning)] == []
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_clearing_the_pin_is_silent(value, monkeypatch) -> None:
+    """Clearing is not a mistake.
+
+    A blank string is treated as ``None`` rather than as a malformed pin,
+    which is a decision that predates this and would look like an
+    oversight if the deprecation started shouting about it.
+
+    The environment variable is removed for the duration: the suite's
+    autouse fixture sets it, and with it in place a cleared override
+    correctly falls through to it -- so asserting on the *pin* rather
+    than on the override would be measuring the fixture.
+    """
+    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        maidr.set_cdn_version(value)
+
+    assert [r for r in records if issubclass(r.category, FutureWarning)] == []
+    assert dependencies._version_pin() is None
+
+
+def test_the_environment_variable_stays_lenient(monkeypatch) -> None:
+    """The asymmetry, asserted rather than only documented.
+
+    ``MAIDR_CDN_VERSION`` is ambient configuration. Someone whose CI image
+    sets it wrongly should get a chart and a log line, not a warning they
+    cannot act on from inside their own code -- and certainly not, later,
+    an exception.
+    """
+    dependencies.set_cdn_version(None)
+    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, "3.74")
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        resolved = dependencies._version_pin()
+
+    assert resolved is None
+    assert [r for r in records if issubclass(r.category, FutureWarning)] == []
+
+
+def test_the_warning_is_a_futurewarning_not_a_deprecationwarning() -> None:
+    """Category chosen for the audience, as elsewhere in this module.
+
+    ``DeprecationWarning`` is silenced by default outside ``__main__``, so
+    a call from inside a Shiny app or an imported module would never see
+    it -- and would meet the eventual ``ValueError`` as a breakage rather
+    than as a warning, which is the one thing a deprecation exists to
+    prevent. Same reasoning as `_warn_placeholder_css`.
+    """
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        maidr.set_cdn_version("3.74")
+
+    categories = {r.category for r in records}
+    assert FutureWarning in categories
+    assert DeprecationWarning not in categories

--- a/tests/core/test_resolver_outcome.py
+++ b/tests/core/test_resolver_outcome.py
@@ -228,7 +228,7 @@ def test_a_reset_discards_the_verdict_with_the_lookup(monkeypatch, clean) -> Non
 
 
 def test_the_render_path_is_unchanged_by_any_of_it(monkeypatch, clean) -> None:
-    """A failed lookup still degrades to ``latest`` rather than raising.
+    """A failed lookup still degrades rather than raising.
 
     The reason the outcome is a separate accessor rather than a widened
     ``BundleStatus``: nothing on the render path has to know about it, and
@@ -239,5 +239,5 @@ def test_the_render_path_is_unchanged_by_any_of_it(monkeypatch, clean) -> None:
         lambda request, timeout=None: (_ for _ in ()).throw(TimeoutError()),
     )
 
-    assert dependencies.get_cdn_version() == dependencies.LATEST_TAG
+    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
     assert dependencies.bundle_status(resolve=False).published is None


### PR DESCRIPTION
# Pull Request

Three follow-ups from #291. Separate commits; read them that way.

## Related Issues

Closes #295. Closes #292. Closes #294 in part — see the note at the end, which I have **not** decided alone.

---

## 1 — a failed lookup emitted the mutable tag (#295)

`@latest` carries a seven-day `Cache-Control`, which is the whole of #290. Degrading to it when the lookup failed meant **the fix stopped applying in exactly the case it was written to survive**: an offline browser could still be handed a week-old build.

It now falls back to the bundled version — a real published release, immutable, and the same copy py-maidr would serve with `use_cdn=False`. The cost is that a network hiccup pins that page to the version you installed rather than the current one: quieter, but staler.

That trade was argued the other way when the fallback was written, on the grounds that `@latest` is byte-for-byte what users had before version resolution existed, so nobody ends up worse off. **Three other paths have since moved to the bundled answer** — notebook tags and `bundled_cdn_url()` via `_offline_version()` (#366), and a render on an event loop (#363) — and being the last one still emitting the mutable tag is not a place worth defending.

**An explicit `latest` pin is untouched.** Asking for the mutable tag is not a failure, and `MAIDR_CDN_VERSION=latest` remains the documented way to keep the CDN without the lookup. There is a case asserting exactly that, because it is the thing this change could plausibly have broken.

### On the ten tests that pinned the old behaviour

Each is updated in place, not deleted. Several had the fallback only *incidentally* — `test_timeout_is_a_total_budget_across_endpoints`, `test_budget_exhaustion_skips_remaining_endpoints`, `test_non_oserror_from_urlopen_does_not_escape` are about the budget, endpoint skipping and a blocked socket respectively, and merely happened to assert the resulting version. Those keep their subject; only the version assertion moves.

`test_offline_falls_back_to_latest_tag` is renamed, since its name was the claim.

---

## 2 — `set_cdn_version("3.74")` did nothing, quietly (#294)

A missing patch component logged a line and was otherwise ignored. The caller got no return value, no exception, and a **log** line they may never see, because logging is not configured by default.

It now raises a `FutureWarning` at the call, pointing at the caller's own line via `stacklevel=2`, and says a future major will raise `ValueError` instead. **Not raising today** — that would break a script quietly mistyping its pin and rendering fine, which is exactly the caller this is trying to reach. Same deprecation shape as the placeholder-CSS accessors in #334, and `FutureWarning` for the same reason: `DeprecationWarning` is silenced outside `__main__`, so a call from inside a Shiny app would never see it.

**The asymmetry is documented**, as the issue asked. `MAIDR_CDN_VERSION` stays lenient — ambient configuration a CI image may have set without the caller, where crashing would be hostile.

---

## 3 — `STALE_MINOR_GAP = 5`, measured (#292)

Picked without the release histories. It survives them, but the deciding number is not the one the issue reaches for first.

Upstream ships a minor every 5.1 days (median, 33 minors over 197 days). On its own that settles nothing. What settles it is **how many minors accumulate between the py-maidr releases that refresh the bundle**, over seventeen cycles:

```
median 1   mean 1.7   min 0   max 7
cycles reaching 3+:  6/17  (35%)
cycles reaching 5+:  1/17  (6%)
cycles reaching 8+:  0/17  (0%)
```

The one cycle reaching 5 is the 68-day gap with nothing released — exactly what the warning is for. So the worry (*"upstream ships 8 minors per cycle, so 5 fires routinely"*) does not happen. **3 would fire on a third of all cycles**, which is how a warning becomes noise.

On the issue's alternative — age instead of version distance — the docstring records why distance stays: both are proxies for *can this bundle draw my chart*, and since #358 `warn_if_bundle_cannot_render()` answers that directly, from the installed file, with no network.

---

## Verification

```
uv run pytest -q                                    1120 passed
tests/core/test_pin_validation.py against main        15 failed
test_a_failed_lookup_never_emits_the_mutable_tag      fails on main
uv run pytest -W error::FutureWarning               1120 passed  (no strays)
ruff check maidr/util tests/core                    All checks passed
```

The `-W error::FutureWarning` run matters: item 2 adds a warning to a call several existing tests make deliberately, and a run that merely *tolerates* it would not show whether it escapes somewhere it should not.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**#295 was closed by accident, by me.** #363's description contained the sentence *"This does not close #295"*, and GitHub's linked-issue parser read `close #295` inside it. A line written to say the issue was out of scope is what marked it done. Reopened, and noted there.

**#294's second item is left for you.** That issue's comment proposes renaming `get_cdn_version()` → `resolve_cdn_version()` with a deprecated alias, because `get_` reads like a cheap accessor over network I/O. It offers that and "document the I/O more loudly" as equal options, with no stated preference — and **#363 changed the premise**: `get_cdn_version()` no longer resolves on a thread running an event loop, so the name misleads less than it did, and `resolve_cdn_version` would newly mislead in the other direction for exactly the async callers the rename was meant to protect. A 50/50 call about a public symbol is yours rather than mine.

**Why `fix` and not `fix!`.** Item 1 changes what a URL says on a path users cannot easily observe, which is the reason #295 asked for it to be its own change rather than slipped into a review. It is not breaking: both the old and new URLs load a working `maidr.js`, and an explicit `latest` pin still gets `@latest`.