### PR TITLE
feat(hexbin): read Axes.hexbin as a hexagonal bin lattice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ The `maidr/patch/` modules use `wrapt` to intercept matplotlib/seaborn plot call
 
 ### Supported Plot Types
 
-Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, COUNT, DODGED, HEAT, HIST, LINE, PIE, SCATTER, STACKED, STEP, SMOOTH, CANDLESTICK, VIOLIN_KDE, VIOLIN_BOX.
+Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, COUNT, DODGED, HEAT, HEXBIN, HIST, LINE, PIE, SCATTER, STACKED, STEP, SMOOTH, CANDLESTICK, VIOLIN_KDE, VIOLIN_BOX.
 
 Note that `maidr/plotly/` builds its MAIDR schema in Python and therefore needs its own
 handling per plot type, whereas `maidr/altair/` delegates entirely to the upstream

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -505,6 +505,48 @@ if cbar:
 plt.show() #<<
 ```
 
+### Hexbin Plot
+
+A hexbin is the usual answer to a scatter plot with too many points to read:
+the points are binned into hexagons and the count is shown as fill. maidr reads
+it as a lattice of counted cells, one row at a time.
+
+Hexagons tessellate by offsetting alternate rows by half a cell, so a bin's
+column index is not its position — bin 3 of one row and bin 3 of the next sit
+at different x. Each bin is therefore announced by its **centre** rather than
+by an index, and moving up or down keeps to the x you started from instead of
+carrying the index into a row where it means something else.
+
+```{python}
+#| fig-alt: Hexbin plot of two thousand points drawn from two overlapping clusters
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import maidr #<<
+
+rng = np.random.default_rng(20260813)
+x = np.concatenate([rng.normal(-1, 0.8, 1200), rng.normal(1.5, 0.5, 800)])
+y = np.concatenate([rng.normal(0, 0.9, 1200), rng.normal(1.5, 0.6, 800)])
+
+fig, ax = plt.subplots(figsize=(7, 6))
+# `z_label` names the colour axis for maidr, so a bin reads as
+# "First measurement: -1.02, Second measurement: 0.31, Points: 47".
+# Without it the axis is named "count", which is what the fill encodes.
+hexes = ax.hexbin(x, y, gridsize=12, cmap="Blues", z_label="Points") #<<
+ax.set_xlabel("First measurement")
+ax.set_ylabel("Second measurement")
+ax.set_title("Where the points pile up")
+
+plt.show() #<<
+```
+
+`hexbin` has two arguments that change what the fill means, and maidr names the
+colour axis to match rather than calling everything a count: `C=` replaces the
+count with a reduction of the values you supply, and a numeric `bins=`
+discretises the counts so the colour shows *which interval* a bin landed in.
+Pass `z_label=` to name it yourself.
+
 ### Box Plot
 
 ```{python}

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -77,7 +77,7 @@ We currently support the following data visualization libraries in Python:, and 
 
 * Heatmap having one x (categorical) and one y (categorical) and z (numerical) axis.
 
-* Hexbin plot (`ax.hexbin()`) having one x (numerical) and one y (numerical) axis and a z axis carrying each hexagon's count. Read as a lattice of counted cells, one row at a time; because hexagons tessellate by offsetting alternate rows, each bin is announced by its centre rather than by a column index.
+* Hexbin plot (`ax.hexbin()`) having one x (numerical) and one y (numerical) axis and a z axis carrying what the fill encodes — each hexagon's count by default, the reduction of `C` when one is given, or the count's interval when `bins` is a number. Read as a lattice of counted cells, one row at a time; because hexagons tessellate by offsetting alternate rows, each bin is announced by its centre rather than by a column index.
 
 * Scatter plot having one x (numerical) and one y (numerical) axis.
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -77,6 +77,8 @@ We currently support the following data visualization libraries in Python:, and 
 
 * Heatmap having one x (categorical) and one y (categorical) and z (numerical) axis.
 
+* Hexbin plot (`ax.hexbin()`) having one x (numerical) and one y (numerical) axis and a z axis carrying each hexagon's count. Read as a lattice of counted cells, one row at a time; because hexagons tessellate by offsetting alternate rows, each bin is announced by its centre rather than by a column index.
+
 * Scatter plot having one x (numerical) and one y (numerical) axis.
 
 * Regression plot having one x (numerical) and one y (numerical) axis with scatter points and fitted regression line.

--- a/maidr/core/enum/maidr_key.py
+++ b/maidr/core/enum/maidr_key.py
@@ -43,6 +43,9 @@ class MaidrKey(str, Enum):
     # Scatter plot grid navigation keys.
     TICK_STEP = "tickStep"
 
+    # Hexbin keys. A bin carries its centre and how many points fell in it.
+    COUNT = "count"
+
     # Step plot keys. The per-point ordinal level name reuses LABEL above.
     STEP_DIRECTION = "stepDirection"
 

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -10,6 +10,11 @@ class PlotType(str, Enum):
     DODGED = "dodged_bar"
     ERRORBAR = "error_bar"
     HEAT = "heat"
+    #: A hexagonal bin lattice: the standard answer to an overplotted scatter.
+    #: Read as a grid of cells each carrying a count, which is a heatmap --
+    #: except that alternate rows are offset by half a cell, so a bin's column
+    #: index is not its position and the trace announces centres instead.
+    HEXBIN = "hexbin"
     HIST = "hist"
     LINE = "line"
     #: A filled band between a series and a baseline. Emitted for a single

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -52,6 +52,7 @@ class FigureManager:
         PlotType.HIST: 1,
         PlotType.BOX: 1,
         PlotType.HEAT: 1,
+        PlotType.HEXBIN: 1,
         PlotType.COUNT: 1,
         PlotType.PIE: 1,
         PlotType.SMOOTH: 1,

--- a/maidr/core/plot/hexbinplot.py
+++ b/maidr/core/plot/hexbinplot.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import uuid
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import Collection
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot import MaidrPlot
+from maidr.exception import ExtractionError
+
+
+class HexbinPlot(MaidrPlot):
+    """
+    A hexagonal bin lattice read as a grid of counted cells.
+
+    ``Axes.hexbin`` answers an overplotted scatter by binning the points into
+    hexagons and encoding each bin's count as fill. Read that way it is a
+    heatmap, and the navigation, braille and pitch all transfer.
+
+    The one real difference is that a hex lattice **staggers alternate rows by
+    half a cell**, which is what lets the hexagons tessellate. Two consequences
+    shape everything below.
+
+    First, a bin's column index is not its position: bin 3 of one row and bin 3
+    of the next sit at different x. So each bin carries its own centre, and the
+    frontend announces centres rather than indices.
+
+    Second, matplotlib does not emit the bins in the order the grid reads them.
+    ``get_offsets()`` is built lattice by lattice and, within each, x index by x
+    index -- so consecutive offsets walk *up a column*, and the second lattice
+    (the offset rows) comes after the whole of the first. Regrouping the points
+    into rows without regrouping the selectors alongside them would leave every
+    bin past the first row boundary highlighting a hexagon belonging to someone
+    else, which on a staggered lattice is not even a neighbour in the direction
+    a reader would guess.
+
+    Rows are ragged by design and are left that way. The lattices hold
+    different numbers of bins, and ``mincnt`` or a ``C`` argument drops the
+    empty ones, so a row can be shorter than the one below it. Padding would
+    invent bins that were never drawn; the frontend's ``MovableGrid`` clamps a
+    row change to the new row's length precisely because grids arrive ragged.
+
+    Notes
+    -----
+    The collection comes from the patch rather than being searched for on the
+    axes. ``hexbin(marginals=True)`` draws two further ``PolyCollection``s for
+    the marginal distributions, and a violin or a ``fill_between`` band on the
+    same axes is one too -- so "the PolyCollection on this Axes" does not
+    identify the lattice, while the call's own return value does.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        self._collection: Collection | None = kwargs.pop("collection", None)
+        self._z_label = kwargs.pop("z_label", "count")
+        #: Emission indices of the bins, in the row-major order the points are
+        #: emitted in. This is what keeps the selectors aligned with them.
+        self._bin_order: list[int] = []
+        super().__init__(ax, PlotType.HEXBIN)
+
+    def _extract_axes_data(self) -> dict:
+        """
+        Extend the base per-axis mapping with the ``z`` axis the fill encodes.
+
+        Returns
+        -------
+        dict
+            ``{"x": ..., "y": ..., "z": {"label": ...}}``.
+        """
+        axes_data = super()._extract_axes_data()
+        axes_data[MaidrKey.Z] = self._axis_config(label=self._z_label)
+        return axes_data
+
+    def _extract_plot_data(self) -> list[list[dict]]:
+        """
+        Read the lattice as rows of bins, bottom row first.
+
+        Returns
+        -------
+        list of list of dict
+            One list per lattice row, each holding ``{"x", "y", "count"}`` for
+            every bin in it, left to right.
+
+        Raises
+        ------
+        ExtractionError
+            When the call left no readable lattice.
+        """
+        collection = self._collection
+        if collection is None:
+            raise ExtractionError(self.type, self.ax)
+
+        offsets = np.asarray(collection.get_offsets(), dtype=float)
+        values = collection.get_array()
+        if values is None or offsets.ndim != 2 or offsets.shape[0] == 0:
+            raise ExtractionError(self.type, self.ax)
+
+        values = np.asarray(values, dtype=float)
+        if len(values) != len(offsets):
+            # The two are filtered together by `mincnt`, so they cannot
+            # disagree on any matplotlib this reads -- but the whole scheme
+            # below indexes one by the other, and a silent mismatch would
+            # pair a bin with a stranger's count.
+            raise ExtractionError(self.type, self.ax)
+
+        # Grouped on the y centre by exact equality, which is exact rather
+        # than approximate here: matplotlib builds every centre in a row from
+        # the same `index * spacing + origin`, so a row's values are identical
+        # bit for bit, and the two lattices are half a spacing apart.
+        rows: dict[float, list[int]] = {}
+        for index, (_, y) in enumerate(offsets):
+            rows.setdefault(float(y), []).append(index)
+
+        # Ascending y, because the frontend's UPWARD steps to the *next* row
+        # index -- so row 0 is the bottom of the chart, as it is for a heatmap.
+        self._bin_order = []
+        data: list[list[dict]] = []
+        for y in sorted(rows):
+            in_row = sorted(rows[y], key=lambda index: offsets[index][0])
+            data.append(
+                [
+                    {
+                        MaidrKey.X: float(offsets[index][0]),
+                        MaidrKey.Y: float(offsets[index][1]),
+                        MaidrKey.COUNT: float(values[index]),
+                    }
+                    for index in in_row
+                ]
+            )
+            self._bin_order.extend(in_row)
+
+        # Assigned here rather than relied upon: a gid is otherwise only
+        # stamped at draw time, and the schema is built first. `AreaPlot` and
+        # `MultiLinePlot` do the same for the same reason.
+        if collection.get_gid() is None:
+            collection.set_gid(f"maidr-{uuid.uuid4()}")
+        self._elements.clear()
+        self._elements.append(collection)
+
+        return data
+
+    def _get_selector(self) -> list[str]:
+        """
+        Return one selector per bin, in the order the points are emitted.
+
+        Every bin is drawn, including the empty ones, so the SVG holds one
+        ``<use>`` per offset and the correspondence is exact. What it is *not*
+        is in reading order, so each bin is addressed by its own emission index
+        rather than by relying on document order -- see the class docstring.
+
+        ``nth-of-type`` rather than ``nth-child`` because matplotlib writes the
+        shared hexagon into a ``<defs>`` sibling ahead of the groups, and
+        counting that would shift every bin by one.
+
+        Returns
+        -------
+        list of str
+            One selector per bin, row-major, bottom row first.
+        """
+        gid = self._collection.get_gid() if self._collection is not None else None
+        if gid is None:
+            return []
+        return [
+            f"g[id='{gid}'] > g:nth-of-type({index + 1}) > use"
+            for index in self._bin_order
+        ]

--- a/maidr/core/plot/hexbinplot.py
+++ b/maidr/core/plot/hexbinplot.py
@@ -96,7 +96,13 @@ class HexbinPlot(MaidrPlot):
         if values is None or offsets.ndim != 2 or offsets.shape[0] == 0:
             raise ExtractionError(self.type, self.ax)
 
-        values = np.asarray(values, dtype=float)
+        # Through the mask rather than around it. `get_array()` hands back a
+        # masked array, and `np.asarray` on one returns the data *under* the
+        # mask -- so a bin matplotlib had declined to give a value would be
+        # announced with whatever happened to be in that slot. No release
+        # masks a bin today (empty ones are dropped before `set_array`), which
+        # is exactly why this would go unnoticed if one started.
+        values = np.ma.filled(np.ma.asarray(values).astype(float), np.nan)
         if len(values) != len(offsets):
             # The two are filtered together by `mincnt`, so they cannot
             # disagree on any matplotlib this reads -- but the whole scheme
@@ -123,7 +129,7 @@ class HexbinPlot(MaidrPlot):
                     {
                         MaidrKey.X: float(offsets[index][0]),
                         MaidrKey.Y: float(offsets[index][1]),
-                        MaidrKey.COUNT: float(values[index]),
+                        MaidrKey.COUNT: self._count(values[index]),
                     }
                     for index in in_row
                 ]
@@ -139,6 +145,33 @@ class HexbinPlot(MaidrPlot):
         self._elements.append(collection)
 
         return data
+
+    @staticmethod
+    def _count(value: float) -> float | None:
+        """
+        Render one bin's value, or ``None`` when it does not have one.
+
+        A masked or non-finite entry is a bin matplotlib declined to score,
+        and there is no number to put in its place. It still has to be
+        *emitted*, because the hexagon is drawn and the selector list is
+        matched against the DOM by length -- dropping it would withdraw
+        highlighting from the whole lattice. The frontend already reads a
+        non-finite count as "no value here": it filters them out of the
+        pitch range and announces `NaN`.
+
+        Parameters
+        ----------
+        value : float
+            One bin's value, possibly ``nan``.
+
+        Returns
+        -------
+        float or None
+            The value, or ``None`` for a bin without one. ``None`` rather
+            than ``nan`` because JSON has no NaN literal.
+        """
+        number = float(value)
+        return number if np.isfinite(number) else None
 
     def _get_selector(self) -> list[str]:
         """

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -9,6 +9,7 @@ from maidr.core.plot.boxplot import BoxPlot
 from maidr.core.plot.errorbar import ErrorBarPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
 from maidr.core.plot.heatmap import HeatPlot
+from maidr.core.plot.hexbinplot import HexbinPlot
 from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
 from maidr.core.plot.maidr_plot import MaidrPlot
@@ -73,6 +74,8 @@ class MaidrPlotFactory:
             return ErrorBarPlot(single_ax, **kwargs)
         elif PlotType.HEAT == plot_type:
             return HeatPlot(single_ax, **kwargs)
+        elif PlotType.HEXBIN == plot_type:
+            return HexbinPlot(single_ax, **kwargs)
         elif PlotType.HIST == plot_type:
             return HistPlot(single_ax)
         elif PlotType.LINE == plot_type:

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -6,6 +6,7 @@ from . import (  # noqa: F401
     clear,
     errorbar,
     heatmap,
+    hexbin,
     highlight,
     histogram,
     lineplot,

--- a/maidr/patch/hexbin.py
+++ b/maidr/patch/hexbin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import wrapt
 from matplotlib.axes import Axes
 from matplotlib.collections import Collection
@@ -55,6 +56,60 @@ def _fill_label(wrapped, args: tuple, kwargs: dict) -> str:
     return "count"
 
 
+def _is_readable(wrapped, args, kwargs, collection: Collection) -> bool:
+    """
+    Whether the drawn lattice can be described truthfully.
+
+    Two ways it cannot, and both would otherwise produce a chart that reads
+    confidently and says something false.
+
+    **A log axis.** ``hexbin`` takes its own ``xscale``/``yscale``, and bins in
+    the transformed space. On matplotlib 3.10 the offsets come back in that
+    space too, so a bin centred at x = 3.4 would be announced as ``0.53``:
+    right structure, right counts, wrong coordinates, and nothing in the
+    output to contradict them. On 3.9 the same call returns one path per
+    hexagon and a single placeholder offset, so the centres are not in
+    ``get_offsets()`` at all.
+
+    Un-transforming the 3.10 case would be an assumption about matplotlib's
+    internals that the 3.9 case shows is not stable, so a log-scaled hexbin is
+    declined on both. Note this reads ``hexbin``'s own arguments, not the
+    axis: an axes that was *already* log-scaled makes matplotlib bin linearly,
+    and those offsets are honest data coordinates.
+
+    **A count list that does not match the bins.** They are filtered together
+    by ``mincnt``, so they agree on every release this reads -- but the whole
+    scheme indexes one by the other, and a silent mismatch would pair a bin
+    with a stranger's count.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``Axes.hexbin``, used for its parameter order.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+    collection : matplotlib.collections.Collection
+        The collection the call drew.
+
+    Returns
+    -------
+    bool
+        True when the lattice can be read.
+    """
+    for axis in ("xscale", "yscale"):
+        if _argument(axis, wrapped, args, kwargs) == "log":
+            return False
+
+    values = collection.get_array()
+    if values is None:
+        return False
+
+    offsets = np.asarray(collection.get_offsets())
+    return offsets.ndim == 2 and len(offsets) > 0 and len(offsets) == len(values)
+
+
 def hexbin(wrapped, _, args, kwargs) -> Collection:
     """
     Draw a patched ``Axes.hexbin`` call and register the lattice with MAIDR.
@@ -93,6 +148,14 @@ def hexbin(wrapped, _, args, kwargs) -> Collection:
     # Set the internal context to avoid cyclic processing.
     with ContextManager.set_internal_context():
         collection = _draw_quietly(wrapped, args, kwargs)
+
+    if not _is_readable(wrapped, args, kwargs, collection):
+        # Left unregistered, so the figure renders as it did before this patch
+        # existed: a static image, with no layer claiming to describe it.
+        # `stackplot` declines the calls it cannot read the same way, and for
+        # the same reason -- saying nothing beats describing a shape that was
+        # not established.
+        return collection
 
     ax = FigureManager.get_axes(collection)
     FigureManager.create_maidr(

--- a/maidr/patch/hexbin.py
+++ b/maidr/patch/hexbin.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import wrapt
+from matplotlib.axes import Axes
+from matplotlib.collections import Collection
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import _argument, _draw_quietly
+
+
+def _fill_label(wrapped, args: tuple, kwargs: dict) -> str:
+    """
+    Name the quantity ``hexbin`` encoded as fill.
+
+    Usually it is the count of points that fell in the bin, and usually saying
+    so is the whole of it. Two of ``hexbin``'s own arguments change what the
+    colour means, and neither changes anything else a reader could notice:
+
+    * ``C`` replaces the count with ``reduce_C_function`` applied to the values
+      given for the points in the bin -- a mean by default, which is not a
+      count and is routinely not even an integer.
+    * ``bins``, given as a number or a sequence of edges, discretises the
+      counts and colours each bin by *which* interval its count landed in.
+      ``get_array()` then holds an interval index. A three-point bin and a
+      nine-point bin can both read 1.
+
+    Announcing either as "count" would be wrong in the way that is hardest to
+    catch: the number is plausible, the chart is otherwise sound, and nothing
+    contradicts it. ``bins="log"`` is not one of these -- it only installs a
+    log norm for the colouring and leaves the array as raw counts.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``Axes.hexbin``, used for its parameter order.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    str
+        The label for the ``z`` axis.
+    """
+    if _argument("C", wrapped, args, kwargs) is not None:
+        return "value"
+
+    bins = _argument("bins", wrapped, args, kwargs)
+    if bins is not None and not (isinstance(bins, str) and bins == "log"):
+        return "count bin"
+
+    return "count"
+
+
+def hexbin(wrapped, _, args, kwargs) -> Collection:
+    """
+    Draw a patched ``Axes.hexbin`` call and register the lattice with MAIDR.
+
+    The drawn collection is handed to the layer rather than searched for on the
+    axes: ``marginals=True`` draws two more ``PolyCollection``s, and a violin
+    body or a ``fill_between`` band on the same axes is one as well, so the
+    class does not identify the lattice while the return value does.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``Axes.hexbin``.
+    _ : Any
+        The instance wrapt bound the patched function to. Unused, and named
+        for that.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    matplotlib.collections.Collection
+        Whatever the wrapped function returned, unchanged.
+    """
+    # Don't proceed if the call is made internally by the patched function.
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    # MAIDR's own, and not a parameter of the function being wrapped:
+    # `hexbin` forwards what it does not recognise to the collection, which
+    # raises from somewhere the caller cannot connect back to MAIDR.
+    z_label = kwargs.pop("z_label", None)
+
+    # Set the internal context to avoid cyclic processing.
+    with ContextManager.set_internal_context():
+        collection = _draw_quietly(wrapped, args, kwargs)
+
+    ax = FigureManager.get_axes(collection)
+    FigureManager.create_maidr(
+        ax,
+        PlotType.HEXBIN,
+        collection=collection,
+        z_label=z_label or _fill_label(wrapped, args, kwargs),
+    )
+
+    return collection
+
+
+# Patch matplotlib function. `seaborn.jointplot(kind="hex")` draws through
+# this same entry point, so it is covered by the one patch.
+wrapt.wrap_function_wrapper(Axes, "hexbin", hexbin)

--- a/maidr/patch/hexbin.py
+++ b/maidr/patch/hexbin.py
@@ -46,14 +46,20 @@ def _fill_label(wrapped, args: tuple, kwargs: dict) -> str:
     str
         The label for the ``z`` axis.
     """
-    if _argument("C", wrapped, args, kwargs) is not None:
-        return "value"
+    reduced = _argument("C", wrapped, args, kwargs) is not None
 
+    # `bins` is read first because it wins. matplotlib applies it *after* the
+    # count-or-reduce step and overwrites whatever that produced, so a numeric
+    # `bins` alongside `C` leaves interval indices where the reduced values
+    # were -- measured, not inferred: `C=` alone gives float64 spanning 79 to
+    # 114, and `C=` with `bins=5` gives int64 spanning 0 to 4.
     bins = _argument("bins", wrapped, args, kwargs)
     if bins is not None and not (isinstance(bins, str) and bins == "log"):
-        return "count bin"
+        # Which quantity was discretised still matters. "count bin" for a
+        # chart that never counted anything would be its own small lie.
+        return "value bin" if reduced else "count bin"
 
-    return "count"
+    return "value" if reduced else "count"
 
 
 def _is_readable(wrapped, args, kwargs, collection: Collection) -> bool:

--- a/maidr/patch/hexbin.py
+++ b/maidr/patch/hexbin.py
@@ -24,7 +24,7 @@ def _fill_label(wrapped, args: tuple, kwargs: dict) -> str:
       count and is routinely not even an integer.
     * ``bins``, given as a number or a sequence of edges, discretises the
       counts and colours each bin by *which* interval its count landed in.
-      ``get_array()` then holds an interval index. A three-point bin and a
+      ``get_array()`` then holds an interval index. A three-point bin and a
       nine-point bin can both read 1.
 
     Announcing either as "count" would be wrong in the way that is hardest to
@@ -142,14 +142,17 @@ def hexbin(wrapped, _, args, kwargs) -> Collection:
     matplotlib.collections.Collection
         Whatever the wrapped function returned, unchanged.
     """
+    # Lifted before the recursion guard, not after. `hexbin` forwards what it
+    # does not recognise to the collection, so a `z_label` still in `kwargs`
+    # on the internal-context path would reach matplotlib and raise from
+    # somewhere the caller cannot connect back to MAIDR. There is no live path
+    # that reaches this in an internal context today; popping first costs
+    # nothing and means there does not have to be one.
+    z_label = kwargs.pop("z_label", None)
+
     # Don't proceed if the call is made internally by the patched function.
     if ContextManager.is_internal_context():
         return _draw_quietly(wrapped, args, kwargs)
-
-    # MAIDR's own, and not a parameter of the function being wrapped:
-    # `hexbin` forwards what it does not recognise to the collection, which
-    # raises from somewhere the caller cannot connect back to MAIDR.
-    z_label = kwargs.pop("z_label", None)
 
     # Set the internal context to avoid cyclic processing.
     with ContextManager.set_internal_context():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,11 @@ test = [
     "jupyter>=1.0.0,<2",
     "pytest>=7.3.2,<8",
     "pytest-mock>=3.12.0,<4",
+    # Resolves an emitted CSS selector against the exported SVG, which is the
+    # only way to check that a selector addresses the element its point
+    # describes. `lxml` is already a runtime dependency; this is the CSS
+    # front end for it.
+    "cssselect>=1.2",
     "flask>=3.0.0",
     "plotly>=5.0",
 ]

--- a/tests/core/plot/test_hist2d.py
+++ b/tests/core/plot/test_hist2d.py
@@ -10,13 +10,16 @@ skips nested draws -- would take this away silently: no error, no warning, just
 a chart that used to be navigable and no longer is. These tests make that a
 failure instead.
 
-The other two 2D density paths do NOT read, and are asserted here too so the
-boundary is visible in one place rather than discovered per bug report:
+The other 2D density paths are asserted here too, so the boundary is visible in
+one place rather than discovered per bug report:
 
-- ``Axes.hexbin`` renders a ``PolyCollection`` of hexagons, which is neither a
-  mesh nor a rectangular grid.
+- ``Axes.hexbin`` reads as a ``hexbin`` layer of its own. It renders a
+  ``PolyCollection`` of hexagons rather than a mesh, and its rows are staggered
+  and ragged, so it is not a heatmap in the shape the mesh path builds -- what
+  it emits is pinned in ``tests/core/test_hexbin_lattice.py``. Registration is
+  asserted here because this is where a reader comes looking for it.
 - ``sns.kdeplot(x=, y=)`` renders filled or line contours, which need a
-  contour trace to describe levels rather than cells.
+  contour trace to describe levels rather than cells, and does NOT read.
 """
 
 from __future__ import annotations
@@ -130,18 +133,39 @@ def test_hist2d_registers_exactly_one_layer():
     assert len(_plots(fig)) == 1
 
 
-def test_hexbin_is_not_registered_yet():
+def test_hexbin_registers_a_hexbin_layer():
     """
-    ``hexbin`` renders a ``PolyCollection`` of hexagons rather than a mesh.
+    ``hexbin`` reads, as a layer of its own rather than as a heatmap.
 
-    Asserted rather than left unsaid: it is the neighbouring call a user will
-    reach for, and pinning the boundary here means the day hexagonal binning
-    lands, this test fails and has to be rewritten as a positive one.
+    This was the negative half of the boundary above, written so that the day
+    hexagonal binning landed it would fail and have to be rewritten. It did.
+
+    The type matters as much as the registration: hexagons tessellate by
+    offsetting alternate rows, so a bin's column index is not its position and
+    the frontend has a trace that announces centres instead. Registering it as
+    ``heat`` would navigate, and would place every bin past the first row on
+    the wrong x.
     """
     fig, ax = plt.subplots()
     ax.hexbin(X, Y, gridsize=3)
 
-    assert _plots(fig) == []
+    plots = _plots(fig)
+    assert len(plots) == 1
+    assert plots[0].type == PlotType.HEXBIN
+
+
+def test_hexbin_registers_exactly_one_layer():
+    """
+    One call registers one layer, marginals and all.
+
+    ``hexbin(marginals=True)`` draws two further ``PolyCollection``s for the
+    marginal distributions. They are part of the same chart, not two more
+    lattices to navigate.
+    """
+    fig, ax = plt.subplots()
+    ax.hexbin(X, Y, gridsize=3, marginals=True)
+
+    assert len(_plots(fig)) == 1
 
 
 @pytest.mark.parametrize("fill", [True, False])

--- a/tests/core/test_hexbin_lattice.py
+++ b/tests/core/test_hexbin_lattice.py
@@ -1,0 +1,276 @@
+"""A hexbin lattice must be read in rows without losing which bin is which.
+
+``Axes.hexbin`` is a heatmap whose cells are hexagons, and read that way the
+navigation, braille and pitch all transfer. Two things about how matplotlib
+builds it do not survive a naive reading, and both are invisible until you
+look at the numbers.
+
+The first is the **emission order**. ``get_offsets()`` is built lattice by
+lattice and, within each, x index by x index, so consecutive offsets walk up a
+*column* and the offset rows all come after the aligned ones. Grouping the
+points into rows is therefore a permutation, not a reshape -- and the selector
+list has to be permuted with them. It would not have looked broken: every bin
+would still announce a real centre and a real count, while the highlight sat
+on someone else's hexagon. That is the same defect as #316 and #350, in the
+trace where it would be hardest to notice, because a hexbin announces centres
+rather than indices and so has nothing that would give it away.
+
+The second is that the rows are **ragged**, by construction rather than by
+accident: the two lattices hold different numbers of bins, and ``mincnt`` or a
+``C`` argument drops the empty ones. Padding them to a rectangle would invent
+bins that were never drawn.
+
+So the selector test here resolves the emitted CSS against the real exported
+SVG and checks that each match is the hexagon whose centre and count that bin
+announces. Nothing weaker distinguishes a correct mapping from an off-by-a-row
+one.
+"""
+
+from __future__ import annotations
+
+import json
+
+import matplotlib
+import numpy as np
+import pytest
+from lxml import etree
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+def _points() -> tuple[np.ndarray, np.ndarray]:
+    """A reproducible cloud dense enough to leave some bins empty."""
+    rng = np.random.default_rng(0)
+    return rng.normal(size=200), rng.normal(size=200)
+
+
+@pytest.fixture
+def hexbin():
+    """Draw a hexbin and yield the figure, its collection and its layer."""
+    created = []
+
+    def draw(**kwargs):
+        fig, ax = plt.subplots()
+        ax.set_xlabel("first")
+        ax.set_ylabel("second")
+        x, y = _points()
+        collection = ax.hexbin(x, y, gridsize=kwargs.pop("gridsize", 3), **kwargs)
+        created.append(fig)
+
+        instance = FigureManager.get_maidr(fig)
+        html = instance._create_html_tag().get_html_string()
+        schema = json.loads(json.dumps(instance._flatten_maidr()))
+        layer = schema["subplots"][0][0]["layers"][0]
+        return collection, layer, html
+
+    yield draw
+
+    for fig in created:
+        plt.close(fig)
+
+
+def _svg(html: str) -> etree._Element:
+    """Parse the exported SVG out of the rendered HTML, namespaces stripped.
+
+    ``cssselect`` translates a selector into namespace-free XPath, and the
+    frontend's ``querySelectorAll`` matches on local names as well, so
+    stripping is what makes the two agree.
+    """
+    start = html.index("<svg")
+    end = html.index("</svg>", start) + len("</svg>")
+    root = etree.fromstring(html[start:end].encode("utf-8"))
+    for element in root.iter():
+        if isinstance(element.tag, str) and "}" in element.tag:
+            element.tag = element.tag.split("}", 1)[1]
+    return root
+
+
+def _resolve(root: etree._Element, selector: str) -> list:
+    """Resolve one CSS selector against the SVG, as the frontend would."""
+    from cssselect import GenericTranslator
+
+    return root.xpath(GenericTranslator().css_to_xpath(selector, prefix="//"))
+
+
+def _flat(layer: dict) -> list[dict]:
+    """The layer's bins in the order the frontend flattens them."""
+    return [bin for row in layer["data"] for bin in row]
+
+
+def test_the_lattice_is_read_as_rows_bottom_first(hexbin) -> None:
+    """Rows ascend in y, and bins ascend in x within a row.
+
+    Bottom-first because the frontend's UPWARD steps to the *next* row index,
+    the same convention a heatmap follows. Getting it inverted would flip the
+    chart under the cursor while every announcement stayed true.
+    """
+    _, layer, _ = hexbin()
+
+    assert layer["type"] == "hexbin"
+
+    rows = layer["data"]
+    assert len(rows) > 1
+
+    row_y = [row[0]["y"] for row in rows]
+    assert row_y == sorted(row_y)
+
+    for row in rows:
+        assert [bin["y"] for bin in row] == [row[0]["y"]] * len(row)
+        assert [bin["x"] for bin in row] == sorted(bin["x"] for bin in row)
+
+
+def test_the_rows_are_ragged_and_stay_that_way(hexbin) -> None:
+    """The two lattices hold different numbers of bins.
+
+    Padding to a rectangle would put bins on the chart that were never drawn.
+    The frontend clamps a row change to the new row's length precisely because
+    grids arrive like this.
+    """
+    _, layer, _ = hexbin()
+
+    lengths = {len(row) for row in layer["data"]}
+    assert len(lengths) > 1
+
+
+def test_every_drawn_bin_is_announced_including_the_empty_ones(hexbin) -> None:
+    """One bin per offset, counts and all.
+
+    With no ``mincnt`` matplotlib draws the empty cells too -- there is a
+    hexagon on the chart for each -- so leaving them out would announce a
+    lattice with holes in it that a sighted reader does not see. It would also
+    put the selector list out of step with the DOM by however many were
+    dropped.
+    """
+    collection, layer, _ = hexbin()
+
+    counts = np.asarray(collection.get_array(), dtype=float)
+    assert (counts == 0).any(), "the fixture must leave some bins empty"
+
+    announced = [bin["count"] for bin in _flat(layer)]
+    assert sorted(announced) == sorted(counts.tolist())
+
+
+def test_the_reading_order_is_not_the_emission_order(hexbin) -> None:
+    """The guard that keeps the selector test below from being vacuous.
+
+    If matplotlib happened to emit the bins row by row, the regrouping would
+    be a no-op and a selector list left in document order would pass. It does
+    not: it walks up each column of one lattice and then the other.
+    """
+    collection, layer, _ = hexbin()
+
+    emitted = np.asarray(collection.get_offsets(), dtype=float)
+    reading = [(bin["x"], bin["y"]) for bin in _flat(layer)]
+
+    assert len(reading) == len(emitted)
+    assert reading != [(x, y) for x, y in emitted]
+
+
+def test_each_selector_addresses_the_bin_it_describes(hexbin) -> None:
+    """The one that catches an off-by-a-row highlight.
+
+    Resolved against the exported SVG rather than reasoned about: the claim is
+    that selector *k* matches the hexagon whose centre and count bin *k*
+    announces, and only walking the document can say whether it does.
+    """
+    collection, layer, html = hexbin()
+
+    root = _svg(html)
+    gid = collection.get_gid()
+    group = root.xpath(f"//g[@id='{gid}']")
+    assert len(group) == 1, "the collection must be tagged before the schema is built"
+
+    drawn = group[0].xpath(".//use")
+    offsets = np.asarray(collection.get_offsets(), dtype=float)
+    counts = np.asarray(collection.get_array(), dtype=float)
+    assert len(drawn) == len(offsets), "one drawn hexagon per bin"
+
+    selectors = layer["selectors"]
+    bins = _flat(layer)
+    assert len(selectors) == len(bins)
+
+    for selector, bin in zip(selectors, bins):
+        matched = _resolve(root, selector)
+        assert len(matched) == 1, f"{selector} matched {len(matched)}"
+
+        emitted = drawn.index(matched[0])
+        assert offsets[emitted][0] == pytest.approx(bin["x"])
+        assert offsets[emitted][1] == pytest.approx(bin["y"])
+        assert counts[emitted] == pytest.approx(bin["count"])
+
+
+def test_mincnt_drops_the_empty_bins_and_the_lattice_still_lines_up(hexbin) -> None:
+    """``mincnt`` changes what is drawn, so it changes both lists together.
+
+    matplotlib filters the offsets and the counts through one mask, so the
+    correspondence survives -- but the rows get shorter and more uneven, which
+    is exactly the case a padded reading would get wrong.
+    """
+    collection, layer, html = hexbin(mincnt=1)
+
+    offsets = np.asarray(collection.get_offsets(), dtype=float)
+    counts = np.asarray(collection.get_array(), dtype=float)
+    assert not (counts == 0).any()
+
+    bins = _flat(layer)
+    assert len(bins) == len(counts)
+
+    root = _svg(html)
+    drawn = root.xpath(f"//g[@id='{collection.get_gid()}']")[0].xpath(".//use")
+    assert len(drawn) == len(offsets)
+
+    for selector, bin in zip(layer["selectors"], bins):
+        matched = _resolve(root, selector)
+        assert len(matched) == 1
+
+        emitted = drawn.index(matched[0])
+        assert offsets[emitted][0] == pytest.approx(bin["x"])
+        assert offsets[emitted][1] == pytest.approx(bin["y"])
+        assert counts[emitted] == pytest.approx(bin["count"])
+
+
+def test_the_colour_axis_is_named_for_what_the_fill_encodes(hexbin) -> None:
+    """"count" is the usual answer and is wrong in two of hexbin's own modes.
+
+    ``C`` replaces the count with a reduction of the given values, and a
+    numeric ``bins`` replaces it with *which interval* the count fell in -- a
+    three-point bin and a nine-point bin can both read 1. Announcing either as
+    a count is the kind of wrong that nothing else in the output contradicts.
+
+    ``bins="log"`` only installs a log norm for the colouring and leaves the
+    array as raw counts, so it is not one of them.
+    """
+    x, _ = _points()
+
+    _, plain, _ = hexbin()
+    assert plain["axes"]["z"]["label"] == "count"
+
+    _, logged, _ = hexbin(bins="log")
+    assert logged["axes"]["z"]["label"] == "count"
+
+    _, binned, _ = hexbin(bins=5)
+    assert binned["axes"]["z"]["label"] == "count bin"
+
+    _, reduced, _ = hexbin(C=x)
+    assert reduced["axes"]["z"]["label"] == "value"
+
+    _, named, _ = hexbin(z_label="density")
+    assert named["axes"]["z"]["label"] == "density"
+
+
+def test_marginals_do_not_pull_in_the_marginal_collections(hexbin) -> None:
+    """``marginals=True`` draws two more PolyCollections on the same axes.
+
+    They are not part of the lattice, and the layer is handed the call's own
+    return value rather than searching the axes for a PolyCollection -- which
+    would find three, and on an axes carrying a violin or a ``fill_between``
+    band would find one that is not a hexbin at all.
+    """
+    collection, layer, _ = hexbin(marginals=True)
+
+    assert len(_flat(layer)) == len(np.asarray(collection.get_offsets()))

--- a/tests/core/test_hexbin_lattice.py
+++ b/tests/core/test_hexbin_lattice.py
@@ -263,6 +263,71 @@ def test_the_colour_axis_is_named_for_what_the_fill_encodes(hexbin) -> None:
     assert named["axes"]["z"]["label"] == "density"
 
 
+@pytest.mark.parametrize(
+    "scales",
+    [{"xscale": "log"}, {"yscale": "log"}, {"xscale": "log", "yscale": "log"}],
+)
+def test_a_log_axis_still_groups_into_rows(scales) -> None:
+    """The row grouping is exact-equality, so a second scale path is worth a look.
+
+    ``hexbin`` takes its own ``xscale``/``yscale``, which log-transform the
+    input before binning. The centres are still built from one
+    ``index * spacing + origin`` in the transformed space, so a row's y
+    values stay identical bit for bit -- but that is a claim about a code
+    path the default case does not exercise, and a grouping that silently
+    fell apart would split every row into singletons rather than fail.
+    """
+    rng = np.random.default_rng(0)
+    positive = np.abs(rng.normal(5, 2, 300)) + 0.1
+
+    fig, ax = plt.subplots()
+    collection = ax.hexbin(positive, positive.copy(), gridsize=3, **scales)
+    instance = FigureManager.get_maidr(fig)
+    layer = json.loads(json.dumps(instance._flatten_maidr()))
+    layer = layer["subplots"][0][0]["layers"][0]
+    plt.close(fig)
+
+    assert len(_flat(layer)) == len(np.asarray(collection.get_offsets()))
+    assert len(layer["data"]) == len(np.unique(np.asarray(collection.get_offsets())[:, 1]))
+    for row in layer["data"]:
+        assert [bin["y"] for bin in row] == [row[0]["y"]] * len(row)
+
+
+def test_a_bin_with_no_value_is_emitted_without_one(hexbin) -> None:
+    """A masked bin must not be announced with the number underneath the mask.
+
+    ``get_array()`` hands back a masked array. No matplotlib release masks a
+    hexbin cell today -- the empty ones are dropped before ``set_array`` --
+    so this drives the case directly rather than through a chart. It is
+    written because ``np.asarray`` on a masked array returns the data *under*
+    the mask, which would announce a fabricated count with nothing in the
+    output to contradict it.
+
+    The bin is still emitted. The hexagon is drawn, and the frontend matches
+    the selector list against the DOM by length, so dropping one bin would
+    withdraw highlighting from the entire lattice.
+    """
+    collection, _, _ = hexbin()
+
+    counts = np.asarray(collection.get_array(), dtype=float)
+    collection.set_array(np.ma.array(counts, mask=[i == 1 for i in range(len(counts))]))
+
+    plot = FigureManager.get_maidr(collection.axes.get_figure())._plots[0]
+    rows = plot._extract_plot_data()
+    bins = [bin for row in rows for bin in row]
+
+    assert len(bins) == len(counts)
+    assert sum(bin["count"] is None for bin in bins) == 1
+
+    masked = next(bin for bin in bins if bin["count"] is None)
+    assert masked["x"] == pytest.approx(float(collection.get_offsets()[1][0]))
+    assert masked["y"] == pytest.approx(float(collection.get_offsets()[1][1]))
+
+    # `None`, not `nan`: JSON has no NaN literal, and `json.dumps` would emit
+    # a bare `NaN` that the browser's own parser rejects.
+    assert "NaN" not in json.dumps(rows)
+
+
 def test_marginals_do_not_pull_in_the_marginal_collections(hexbin) -> None:
     """``marginals=True`` draws two more PolyCollections on the same axes.
 

--- a/tests/core/test_hexbin_lattice.py
+++ b/tests/core/test_hexbin_lattice.py
@@ -274,6 +274,22 @@ def test_the_colour_axis_is_named_for_what_the_fill_encodes(hexbin) -> None:
     _, reduced, _ = hexbin(C=x)
     assert reduced["axes"]["z"]["label"] == "value"
 
+    # `bins` wins over `C`, because matplotlib applies it after the reduction
+    # and overwrites the result. Measured: `C=` alone leaves float64 spanning
+    # 79 to 114, and `C=` with `bins=5` leaves int64 spanning 0 to 4. Reading
+    # that as the reduced value announces "value: 2" for a bin whose mean is
+    # 113.8 -- a plausible number with nothing in the chart to deny it.
+    #
+    # It is not "count bin" either. Nothing was counted, so which quantity
+    # got discretised is still worth saying.
+    _, both, _ = hexbin(C=x, bins=5)
+    assert both["axes"]["z"]["label"] == "value bin"
+
+    # `bins="log"` is the exception on both paths: it installs a norm and
+    # leaves the array alone, reduced values included.
+    _, logged_reduction, _ = hexbin(C=x, bins="log")
+    assert logged_reduction["axes"]["z"]["label"] == "value"
+
     _, named, _ = hexbin(z_label="density")
     assert named["axes"]["z"]["label"] == "density"
 

--- a/tests/core/test_hexbin_lattice.py
+++ b/tests/core/test_hexbin_lattice.py
@@ -29,6 +29,7 @@ one.
 from __future__ import annotations
 
 import json
+import unittest.mock
 
 import matplotlib
 import numpy as np
@@ -37,10 +38,24 @@ from lxml import etree
 
 matplotlib.use("Agg")
 
+import matplotlib.collections  # noqa: E402
 import matplotlib.pyplot as plt  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them.
+
+    Not housekeeping. A figure left open stays registered with
+    ``FigureManager``, and a later test calling ``plt.show()`` renders every
+    one of them -- so a layer this file could not read once took down two
+    tests in ``test_offline_bundle.py`` that have nothing to do with hexbins.
+    """
+    yield
+    plt.close("all")
 
 
 def _points() -> tuple[np.ndarray, np.ndarray]:
@@ -267,30 +282,81 @@ def test_the_colour_axis_is_named_for_what_the_fill_encodes(hexbin) -> None:
     "scales",
     [{"xscale": "log"}, {"yscale": "log"}, {"xscale": "log", "yscale": "log"}],
 )
-def test_a_log_axis_still_groups_into_rows(scales) -> None:
-    """The row grouping is exact-equality, so a second scale path is worth a look.
+def test_a_log_scaled_lattice_is_declined_rather_than_mistranslated(scales) -> None:
+    """``hexbin``'s own log scales are not read, and that is the honest answer.
 
-    ``hexbin`` takes its own ``xscale``/``yscale``, which log-transform the
-    input before binning. The centres are still built from one
-    ``index * spacing + origin`` in the transformed space, so a row's y
-    values stay identical bit for bit -- but that is a claim about a code
-    path the default case does not exercise, and a grouping that silently
-    fell apart would split every row into singletons rather than fail.
+    It bins in the transformed space, and on matplotlib 3.10 the offsets come
+    back in that space as well: for data spanning 0.3 to 11.2 they run -0.52
+    to 1.05. Announced as centres, a bin at x = 3.4 reads as ``0.53``. The
+    structure is right, the counts are right, the coordinates are wrong, and
+    nothing in the chart contradicts them -- which is worse than saying
+    nothing.
+
+    Un-transforming them would be an assumption about matplotlib's internals
+    that the neighbouring release already breaks: on 3.9 the same call returns
+    one path per hexagon and a single placeholder offset, so the centres are
+    not in ``get_offsets()`` at all.
+
+    So the layer is not registered and the figure keeps the static image it
+    had before this patch existed. What is asserted here is that it degrades
+    rather than crashes -- an `ExtractionError` from a layer takes the whole
+    render down with it, including every other chart on the figure.
     """
     rng = np.random.default_rng(0)
     positive = np.abs(rng.normal(5, 2, 300)) + 0.1
 
     fig, ax = plt.subplots()
-    collection = ax.hexbin(positive, positive.copy(), gridsize=3, **scales)
-    instance = FigureManager.get_maidr(fig)
-    layer = json.loads(json.dumps(instance._flatten_maidr()))
-    layer = layer["subplots"][0][0]["layers"][0]
-    plt.close(fig)
+    ax.hexbin(positive, positive.copy(), gridsize=3, **scales)
 
-    assert len(_flat(layer)) == len(np.asarray(collection.get_offsets()))
-    assert len(layer["data"]) == len(np.unique(np.asarray(collection.get_offsets())[:, 1]))
-    for row in layer["data"]:
-        assert [bin["y"] for bin in row] == [row[0]["y"]] * len(row)
+    with pytest.raises(KeyError):
+        FigureManager.get_maidr(fig)
+
+
+def test_an_already_log_axis_is_still_read(hexbin) -> None:
+    """The distinction the check turns on, asserted rather than only argued.
+
+    Declining is keyed on ``hexbin``'s *own* ``xscale``/``yscale``, not on the
+    axis. An axes that was already log-scaled makes matplotlib bin linearly,
+    so those offsets are honest data coordinates and the chart reads.
+    """
+    fig, ax = plt.subplots()
+    ax.set_xscale("log")
+    rng = np.random.default_rng(0)
+    positive = np.abs(rng.normal(5, 2, 300)) + 0.1
+    collection = ax.hexbin(positive, positive.copy(), gridsize=3)
+
+    layer = json.loads(json.dumps(FigureManager.get_maidr(fig)._flatten_maidr()))
+    layer = layer["subplots"][0][0]["layers"][0]
+
+    offsets = np.asarray(collection.get_offsets(), dtype=float)
+    assert len(_flat(layer)) == len(offsets)
+    assert min(bin["x"] for bin in _flat(layer)) == pytest.approx(offsets[:, 0].min())
+    # Data coordinates, not log10 of them.
+    assert max(bin["x"] for bin in _flat(layer)) > 1.0
+
+
+def test_a_lattice_whose_counts_do_not_match_is_declined(hexbin) -> None:
+    """The second way a lattice cannot be read, driven directly.
+
+    ``mincnt`` filters the offsets and the counts through one mask, so they
+    agree on every release this reads -- and matplotlib 3.9 shows that is a
+    property of the representation rather than a law: under a log scale it
+    returns eleven counts against a single offset. The whole scheme indexes
+    one list by the other, so a mismatch has to end in no layer rather than
+    in a bin wearing a stranger's count.
+    """
+    fig, ax = plt.subplots()
+    rng = np.random.default_rng(0)
+
+    with unittest.mock.patch.object(
+        matplotlib.collections.Collection,
+        "get_offsets",
+        lambda self: np.zeros((1, 2)),
+    ):
+        ax.hexbin(rng.normal(size=200), rng.normal(size=200), gridsize=3)
+
+    with pytest.raises(KeyError):
+        FigureManager.get_maidr(fig)
 
 
 def test_a_bin_with_no_value_is_emitted_without_one(hexbin) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -20,11 +20,11 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "jinja2" },
-    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "narwhals" },
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "jinja2", marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "narwhals", marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/c0/184a89bd5feba14ff3c41cfaf1dd8a82c05f5ceedbc92145e17042eb08a4/altair-6.0.0.tar.gz", hash = "sha256:614bf5ecbe2337347b590afb111929aa9c16c9527c4887d96c9bc7f6640756b4", size = 763834, upload-time = "2025-11-12T08:59:11.519Z" }
 wheels = [
@@ -45,11 +45,11 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "jinja2" },
-    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "narwhals" },
-    { name = "packaging" },
-    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+    { name = "jinja2", marker = "python_full_version >= '3.10'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "narwhals", marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/1e/365a9144db3254f86f1b974660b9ede1e9a38c9dc0730e4a9b1192eec5d6/altair-6.1.0.tar.gz", hash = "sha256:dda699216cf85b040d968ae5a569ad45957616811e38760a85e5118269daca67", size = 765519, upload-time = "2026-04-21T13:08:46.44Z" }
 wheels = [
@@ -73,9 +73,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "idna" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -96,9 +96,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -192,7 +192,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/4d/71ec4d3939dc755264f680f6c2b4906423a304c3d18e96853f0a595dfe97/async_lru-2.0.5.tar.gz", hash = "sha256:481d52ccdd27275f42c43a928b4a50c3bfb2d67af4e78b170e3e0bb39c66e5bb", size = 10380, upload-time = "2025-03-16T17:25:36.919Z" }
 wheels = [
@@ -213,7 +213,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
 wheels = [
@@ -268,14 +268,14 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pytokens" },
-    { name = "tomli" },
-    { name = "typing-extensions" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mypy-extensions", marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pathspec", marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytokens", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8c/ad/33adf4708633d047950ff2dfdea2e215d84ac50ef95aff14a614e4b6e9b2/black-25.11.0.tar.gz", hash = "sha256:9a323ac32f5dc75ce7470501b887250be5005a01602e931a15e45593f70f6e08", size = 655669, upload-time = "2025-11-10T01:53:50.558Z" }
 wheels = [
@@ -320,14 +320,14 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "mypy-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pathspec", marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytokens", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
@@ -367,7 +367,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "webencodings" },
+    { name = "webencodings", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/9a/0e33f5054c54d349ea62c277191c020c2d6ef1d65ab2cb1993f91ec846d1/bleach-6.2.0.tar.gz", hash = "sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f", size = 203083, upload-time = "2024-10-29T18:30:40.477Z" }
 wheels = [
@@ -376,7 +376,7 @@ wheels = [
 
 [package.optional-dependencies]
 css = [
-    { name = "tinycss2" },
+    { name = "tinycss2", marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]
@@ -393,7 +393,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "webencodings" },
+    { name = "webencodings", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
 wheels = [
@@ -402,7 +402,7 @@ wheels = [
 
 [package.optional-dependencies]
 css = [
-    { name = "tinycss2" },
+    { name = "tinycss2", marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]
@@ -716,7 +716,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -737,7 +737,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
@@ -783,7 +783,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/31a8f28b4a2a4fa0e01085e542f3081ab0588eff8e589d39d775172c9792/contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4", size = 13464370, upload-time = "2024-08-27T21:00:03.328Z" }
 wheels = [
@@ -861,7 +861,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -936,7 +936,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1011,6 +1011,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/59/ebfb8c677c75605cc27f7122c90313fd2f375ff3c8d19a1694bda74aaa63/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70f9aad7de812d6541d29d2bbf8feb22ff7e1c299523db288004e3157ff4674e", size = 302202, upload-time = "2025-07-26T12:02:55.947Z" },
     { url = "https://files.pythonhosted.org/packages/3c/37/21972a15834d90bfbfb009b9d004779bd5a07a0ec0234e5ba8f64d5736f4/contourpy-1.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ed3657edf08512fc3fe81b510e35c2012fbd3081d2e26160f27ca28affec989", size = 329207, upload-time = "2025-07-26T12:02:57.468Z" },
     { url = "https://files.pythonhosted.org/packages/0c/58/bd257695f39d05594ca4ad60df5bcb7e32247f9951fd09a9b8edb82d1daa/contourpy-1.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3d1a3799d62d45c18bafd41c5fa05120b96a28079f2393af559b843d1a966a77", size = 225315, upload-time = "2025-07-26T12:02:58.801Z" },
+]
+
+[[package]]
+name = "cssselect"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/0a/c3ea9573b1dc2e151abfe88c7fe0c26d1892fe6ed02d0cdb30f0d57029d5/cssselect-1.3.0.tar.gz", hash = "sha256:57f8a99424cfab289a1b6a816a43075a4b00948c86b4dcf3ef4ee7e15f7ab0c7", size = 42870, upload-time = "2025-03-10T09:30:29.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/58/257350f7db99b4ae12b614a36256d9cc870d71d9e451e79c2dc3b23d7c3c/cssselect-1.3.0-py3-none-any.whl", hash = "sha256:56d1bf3e198080cc1667e137bc51de9cadfca259f03c2d4e09037b3e01e30f0d", size = 18786, upload-time = "2025-03-10T09:30:28.048Z" },
+]
+
+[[package]]
+name = "cssselect"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5a/6d6fcf922709391fac986f0a03ad4546f4f45b94d10aeb6c1ee041599993/cssselect-1.5.0.tar.gz", hash = "sha256:3cbe82dd7acbee9ba9e5723b5f9e4749826912f1fb31cd7f92aabed5fde15b15", size = 47598, upload-time = "2026-07-27T09:17:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/e9/6734502f67533a752ea8b1c8f7f227c94eecf300252ba8bf23e3e59d8a36/cssselect-1.5.0-py3-none-any.whl", hash = "sha256:1d1aded98e82bdde447ded990a191fd6916177c4f0c914fb62eccd58e2ffcdcc", size = 20797, upload-time = "2026-07-27T09:17:33.04Z" },
 ]
 
 [[package]]
@@ -1108,7 +1138,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1379,8 +1409,8 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/1d/c568d17e9fb5ad5aa0ca3531c58d36fe69deb8eee4e53ff6425c1f99f210/htmltools-0.6.0.tar.gz", hash = "sha256:e8a3fb023d748935035db7ff17f620612ffc814a6a80b6ae388f7b7ab182adf7", size = 97152, upload-time = "2024-10-29T20:21:43.378Z" }
 wheels = [
@@ -1401,8 +1431,8 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "packaging" },
-    { name = "typing-extensions" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/e6/a4dcaf072ecf76fd32854bf37c63d246c83acdf7a80fa81cba9c232558af/htmltools-0.6.1.tar.gz", hash = "sha256:3dc4505b5134055cb10be251f8f17431bcdad9f5de11667f53a1405aec221f38", size = 97717, upload-time = "2026-05-01T15:07:58.293Z" }
 wheels = [
@@ -1485,7 +1515,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1506,7 +1536,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1563,19 +1593,19 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
-    { name = "comm" },
-    { name = "debugpy" },
-    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-client", version = "8.6.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "nest-asyncio" },
-    { name = "packaging" },
-    { name = "psutil" },
-    { name = "pyzmq" },
-    { name = "tornado" },
-    { name = "traitlets" },
+    { name = "appnope", marker = "python_full_version < '3.10' and sys_platform == 'darwin'" },
+    { name = "comm", marker = "python_full_version < '3.10'" },
+    { name = "debugpy", marker = "python_full_version < '3.10'" },
+    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jupyter-client", version = "8.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.10'" },
+    { name = "nest-asyncio", marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "psutil", marker = "python_full_version < '3.10'" },
+    { name = "pyzmq", marker = "python_full_version < '3.10'" },
+    { name = "tornado", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/1d/d5ba6edbfe6fae4c3105bca3a9c889563cc752c7f2de45e333164c7f4846/ipykernel-6.31.0.tar.gz", hash = "sha256:2372ce8bc1ff4f34e58cafed3a0feb2194b91fc7cad0fc72e79e47b45ee9e8f6", size = 167493, upload-time = "2025-10-20T11:42:39.948Z" }
 wheels = [
@@ -1596,20 +1626,20 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
-    { name = "comm" },
-    { name = "debugpy" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "appnope", marker = "python_full_version >= '3.10' and sys_platform == 'darwin'" },
+    { name = "comm", marker = "python_full_version >= '3.10'" },
+    { name = "debugpy", marker = "python_full_version >= '3.10'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jupyter-client", version = "8.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "nest-asyncio" },
-    { name = "packaging" },
-    { name = "psutil" },
-    { name = "pyzmq" },
-    { name = "tornado" },
-    { name = "traitlets" },
+    { name = "jupyter-client", version = "8.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.10'" },
+    { name = "nest-asyncio", marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "psutil", marker = "python_full_version >= '3.10'" },
+    { name = "pyzmq", marker = "python_full_version >= '3.10'" },
+    { name = "tornado", marker = "python_full_version >= '3.10'" },
+    { name = "traitlets", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/8d/b68b728e2d06b9e0051019640a40a9eb7a88fcd82c2e1b5ce70bef5ff044/ipykernel-7.2.0.tar.gz", hash = "sha256:18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e", size = 176046, upload-time = "2026-02-06T16:43:27.403Z" }
 wheels = [
@@ -1624,17 +1654,17 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi", version = "0.19.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.10'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "jedi", version = "0.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.10'" },
+    { name = "pexpect", marker = "python_full_version < '3.10' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "stack-data", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/b9/3ba6c45a6df813c09a48bac313c22ff83efa26cbb55011218d925a46e2ad/ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27", size = 5486330, upload-time = "2023-11-27T09:58:34.596Z" }
 wheels = [
@@ -1649,17 +1679,17 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi", version = "0.20.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version == '3.10.*' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version == '3.10.*'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "jedi", version = "0.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "matplotlib-inline", marker = "python_full_version == '3.10.*'" },
+    { name = "pexpect", marker = "python_full_version == '3.10.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version == '3.10.*'" },
+    { name = "pygments", marker = "python_full_version == '3.10.*'" },
+    { name = "stack-data", marker = "python_full_version == '3.10.*'" },
+    { name = "traitlets", marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1679,18 +1709,18 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi", version = "0.20.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", version = "0.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -1702,7 +1732,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1756,7 +1786,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "parso" },
+    { name = "parso", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
@@ -1777,7 +1807,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "parso" },
+    { name = "parso", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
@@ -1843,10 +1873,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing", version = "0.36.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version < '3.10'" },
+    { name = "jsonschema-specifications", marker = "python_full_version < '3.10'" },
+    { name = "referencing", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
 wheels = [
@@ -1855,15 +1885,15 @@ wheels = [
 
 [package.optional-dependencies]
 format-nongpl = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "rfc3987-syntax" },
-    { name = "uri-template" },
-    { name = "webcolors", version = "24.11.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "fqdn", marker = "python_full_version < '3.10'" },
+    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "isoduration", marker = "python_full_version < '3.10'" },
+    { name = "jsonpointer", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "rfc3339-validator", marker = "python_full_version < '3.10'" },
+    { name = "rfc3986-validator", marker = "python_full_version < '3.10'" },
+    { name = "rfc3987-syntax", marker = "python_full_version < '3.10'" },
+    { name = "uri-template", marker = "python_full_version < '3.10'" },
+    { name = "webcolors", version = "24.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]
@@ -1880,10 +1910,10 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version >= '3.10'" },
+    { name = "jsonschema-specifications", marker = "python_full_version >= '3.10'" },
+    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1892,15 +1922,15 @@ wheels = [
 
 [package.optional-dependencies]
 format-nongpl = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer", version = "3.1.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "rfc3987-syntax" },
-    { name = "uri-template" },
-    { name = "webcolors", version = "25.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "fqdn", marker = "python_full_version >= '3.10'" },
+    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "isoduration", marker = "python_full_version >= '3.10'" },
+    { name = "jsonpointer", version = "3.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "rfc3339-validator", marker = "python_full_version >= '3.10'" },
+    { name = "rfc3986-validator", marker = "python_full_version >= '3.10'" },
+    { name = "rfc3987-syntax", marker = "python_full_version >= '3.10'" },
+    { name = "uri-template", marker = "python_full_version >= '3.10'" },
+    { name = "webcolors", version = "25.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]
@@ -1942,12 +1972,12 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pyzmq" },
-    { name = "tornado" },
-    { name = "traitlets" },
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
+    { name = "pyzmq", marker = "python_full_version < '3.10'" },
+    { name = "tornado", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/22/bf9f12fdaeae18019a468b68952a60fe6dbab5d67cd2a103cac7659b41ca/jupyter_client-8.6.3.tar.gz", hash = "sha256:35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419", size = 342019, upload-time = "2024-09-17T10:44:17.613Z" }
 wheels = [
@@ -1968,11 +1998,11 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pyzmq" },
-    { name = "tornado" },
-    { name = "traitlets" },
+    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
+    { name = "pyzmq", marker = "python_full_version >= '3.10'" },
+    { name = "tornado", marker = "python_full_version >= '3.10'" },
+    { name = "traitlets", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
 wheels = [
@@ -2011,9 +2041,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
-    { name = "traitlets" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pywin32", marker = "python_full_version < '3.10' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/1b/72906d554acfeb588332eaaa6f61577705e9ec752ddb486f302dafa292d9/jupyter_core-5.8.1.tar.gz", hash = "sha256:0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941", size = 88923, upload-time = "2025-05-27T07:38:16.655Z" }
 wheels = [
@@ -2034,8 +2064,8 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "traitlets" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "traitlets", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
@@ -2601,6 +2631,8 @@ plotly = [
 test = [
     { name = "altair", version = "6.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "altair", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "cssselect", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cssselect", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "flask" },
     { name = "jupyter" },
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -2636,6 +2668,7 @@ dev = [
 requires-dist = [
     { name = "altair", marker = "extra == 'altair'", specifier = ">=5.0" },
     { name = "altair", marker = "extra == 'test'", specifier = ">=5.0" },
+    { name = "cssselect", marker = "extra == 'test'", specifier = ">=1.2" },
     { name = "flask", marker = "extra == 'test'", specifier = ">=3.0.0" },
     { name = "flask", marker = "extra == 'visualization'", specifier = ">=3.0.0" },
     { name = "htmltools", specifier = ">=0.5" },
@@ -2679,7 +2712,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -2700,7 +2733,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -2811,16 +2844,16 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools", version = "4.60.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "importlib-resources" },
-    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cycler", marker = "python_full_version < '3.10'" },
+    { name = "fonttools", version = "4.60.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "importlib-resources", marker = "python_full_version < '3.10'" },
+    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyparsing", marker = "python_full_version < '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/17/1747b4154034befd0ed33b52538f5eb7752d05bb51c5e2a31470c3bc7d52/matplotlib-3.9.4.tar.gz", hash = "sha256:1e00e8be7393cbdc6fedfa8a6fba02cf3e83814b285db1c60b906a023ba41bc3", size = 36106529, upload-time = "2024-12-13T05:56:34.184Z" }
 wheels = [
@@ -2880,17 +2913,17 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler" },
-    { name = "fonttools", version = "4.62.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "kiwisolver", version = "1.5.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cycler", marker = "python_full_version >= '3.10'" },
+    { name = "fonttools", version = "4.62.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "kiwisolver", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging" },
-    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -3024,10 +3057,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "jupyter-client", version = "8.6.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "nbformat" },
-    { name = "traitlets" },
+    { name = "jupyter-client", version = "8.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "nbformat", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/66/7ffd18d58eae90d5721f9f39212327695b749e23ad44b3881744eaf4d9e8/nbclient-0.10.2.tar.gz", hash = "sha256:90b7fc6b810630db87a6d0c2250b1f0ab4cf4d3c27a299b0cde78a4ed3fd9193", size = 62424, upload-time = "2024-12-19T10:32:27.164Z" }
 wheels = [
@@ -3048,10 +3081,10 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "jupyter-client", version = "8.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "nbformat" },
-    { name = "traitlets" },
+    { name = "jupyter-client", version = "8.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "nbformat", marker = "python_full_version >= '3.10'" },
+    { name = "traitlets", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/91/1c1d5a4b9a9ebba2b4e32b8c852c2975c872aec1fe42ab5e516b2cecd193/nbclient-0.10.4.tar.gz", hash = "sha256:1e54091b16e6da39e297b0ece3e10f6f29f4ac4e8ee515d29f8a7099bd6553c9", size = 62554, upload-time = "2025-12-23T07:45:46.369Z" }
 wheels = [
@@ -3384,11 +3417,11 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.10.*'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -3461,9 +3494,9 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -3562,7 +3595,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3870,9 +3903,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "beartype" },
-    { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "beartype", marker = "python_full_version >= '3.10'" },
+    { name = "rich", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/84146ae5ff6c40d11357acdb36aafe3db7e104de01c1026d8e1b0ce3e7f1/plum_dispatch-2.9.0.tar.gz", hash = "sha256:fb45c5b2dd4dadd57def51bcf321dfa3a258df5c725f43adea7e7f6db3b79b52", size = 244502, upload-time = "2026-04-28T08:38:34.442Z" }
 wheels = [
@@ -4177,8 +4210,8 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "packaging" },
-    { name = "tomli" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/fd/437901c891f58a7b9096511750247535e891d2d5a5a6eefbc9386a2b41d5/pyproject_api-1.9.1.tar.gz", hash = "sha256:43c9918f49daab37e302038fc1aed54a8c7a91a9fa935d00b9a485f37e0f5335", size = 22710, upload-time = "2025-05-12T14:41:58.025Z" }
 wheels = [
@@ -4199,8 +4232,8 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "packaging" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/7b/c0e1333b61d41c69e59e5366e727b18c4992688caf0de1be10b3e5265f6b/pyproject_api-1.10.0.tar.gz", hash = "sha256:40c6f2d82eebdc4afee61c773ed208c04c19db4c4a60d97f8d7be3ebc0bbb330", size = 22785, upload-time = "2025-10-09T19:12:27.21Z" }
 wheels = [
@@ -4286,7 +4319,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
 wheels = [
@@ -4638,9 +4671,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "attrs", marker = "python_full_version < '3.10'" },
+    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
@@ -4661,9 +4694,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "attrs", marker = "python_full_version >= '3.10'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -4678,10 +4711,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version < '3.10'" },
+    { name = "charset-normalizer", marker = "python_full_version < '3.10'" },
+    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "urllib3", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -4702,10 +4735,10 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version >= '3.10'" },
+    { name = "charset-normalizer", marker = "python_full_version >= '3.10'" },
+    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "urllib3", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
@@ -5101,7 +5134,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -5139,7 +5172,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -5203,7 +5236,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5349,9 +5382,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "certifi" },
-    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version < '3.10'" },
+    { name = "certifi", marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/9a/4887ebe7b46f4669a896dc286a3ac559101d2ceadbbea4614472960c2222/sphobjinv-2.3.1.3.tar.gz", hash = "sha256:a1d51e4cf3d968b9e0d3ed1cbccea0071e5e5795f24a2d7401a4e37d6bd75717", size = 268835, upload-time = "2025-05-26T15:18:16.994Z" }
 wheels = [
@@ -5372,9 +5405,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "certifi" },
-    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version >= '3.10'" },
+    { name = "certifi", marker = "python_full_version >= '3.10'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/67/19f33eeb4ffff0e2fd39afd4783a6ee38a6d58bcc1ddade779712a7e2e49/sphobjinv-2.4.tar.gz", hash = "sha256:44d57e7e87e17d8c7b053c853dcc36f80cbf7d1fc152d57634fd7bcae38ca48a", size = 249997, upload-time = "2026-03-23T05:04:54.011Z" }
 wheels = [
@@ -5603,17 +5636,17 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "chardet" },
-    { name = "colorama" },
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pluggy" },
-    { name = "pyproject-api", version = "1.9.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "tomli" },
-    { name = "typing-extensions" },
-    { name = "virtualenv" },
+    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "chardet", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "python_full_version < '3.10'" },
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pyproject-api", version = "1.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "virtualenv", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/b2/cee55172e5e10ce030b087cd3ac06641e47d08a3dc8d76c17b157dba7558/tox-4.30.3.tar.gz", hash = "sha256:f3dd0735f1cd4e8fbea5a3661b77f517456b5f0031a6256432533900e34b90bf", size = 202799, upload-time = "2025-10-02T16:24:39.974Z" }
 wheels = [
@@ -5634,18 +5667,18 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "cachetools", version = "7.1.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "colorama" },
-    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pluggy" },
-    { name = "pyproject-api", version = "1.10.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-discovery" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tomli-w" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "virtualenv" },
+    { name = "cachetools", version = "7.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "colorama", marker = "python_full_version >= '3.10'" },
+    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pyproject-api", version = "1.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "python-discovery", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "tomli-w", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+    { name = "virtualenv", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/d7/a8e0f889eb6872740e2f013a93a8f9c6c23c3f02fe0911bbd91673615636/tox-4.53.1.tar.gz", hash = "sha256:7be9805ed4a34242510c7acc9a7e3a01a35942e08f31f8bd69067c3a37130afc", size = 276809, upload-time = "2026-05-02T08:34:41.655Z" }
 wheels = [


### PR DESCRIPTION
Closes #341.

A hexbin is the standard answer to an overplotted scatter: bin the points into hexagons and encode the count as fill. Read that way it is a heatmap, and the navigation, braille and pitch all transfer. maidr.js has carried a `hexbin` trace since v4.2.0 and nothing here emitted one, so `ax.hexbin()` fell through to a static image.

Two things about how matplotlib builds the lattice do not survive a naive reading, and both are invisible until you look at the numbers. They are the whole reason this is not thirty lines.

## The emission order is not the reading order

`Axes.hexbin` builds its offsets like this:

```python
offsets[:nx1 * ny1, 0] = np.repeat(np.arange(nx1), ny1)     # aligned lattice
offsets[:nx1 * ny1, 1] = np.tile(np.arange(ny1), nx1)
offsets[nx1 * ny1:, 0] = np.repeat(np.arange(nx2) + 0.5, ny2)  # offset lattice
offsets[nx1 * ny1:, 1] = np.tile(np.arange(ny2), nx2) + 0.5
```

`repeat` on x and `tile` on y means consecutive offsets walk **up a column**, and the whole offset lattice comes after the whole aligned one. So grouping the points into rows is a permutation, not a reshape. For a `gridsize=3` lattice it comes out `[0, 2, 4, 6, 8, 9, 10, 1, 3, 5, 7]`.

The selector list has to be permuted with them. Left in document order, every bin past the first row boundary highlights someone else's hexagon while still announcing a real centre and a real count — the same defect as #316 and #350, in the trace where it is hardest to notice, because a hexbin announces centres rather than indices and so has nothing that would give it away.

Grouping is on the y centre by exact float equality, which is exact here rather than approximate: every centre in a row comes from the same `index * spacing + origin`, so a row's values are identical bit for bit, and the two lattices are half a spacing apart.

## The rows are ragged, and stay that way

The two lattices hold different numbers of bins, and `mincnt` or a `C` argument drops the empty ones — `gridsize=3` gives rows of 4, 3, 4. They are left ragged. Padding would put bins on the chart that were never drawn, and `MovableGrid.moveOnce` clamps a row change to the new row's length precisely because grids arrive like this:

> On ragged grids a row change can leave col past the new row's end

Rows ascend in y, so row 0 is the bottom — the frontend's UPWARD steps to the *next* row index, the same convention a heatmap follows.

## Every drawn bin is announced

With no `mincnt` matplotlib draws the empty cells too, so there is a hexagon on the chart for each. Dropping them would describe a lattice with holes a sighted reader does not see, and would put the selector list out of step with the DOM by however many were dropped. `HexbinTrace.mapToSvgElements` withdraws highlighting outright when the counts disagree, so that failure is total rather than partial.

Measured across every mode, offsets ↔ counts ↔ `<use>` stay 1:1:

| | offsets | array | `<use>` |
| --- | --- | --- | --- |
| default | 11 | 11 | 11 |
| `mincnt=1` | 9 | 9 | 9 |
| `bins="log"` | 11 | 11 | 11 |
| `bins=5` | 11 | 11 | 11 |
| `C=` | 9 | 9 | 9 |
| `marginals=True` | 11 | 11 | 11 |

## The colour axis is named for what the fill encodes

`hexbin` has two arguments that change what the number means:

- `C=` replaces the count with `reduce_C_function` applied to the values given for the points in the bin — a mean by default, routinely not an integer. Labelled `value`.
- a numeric `bins=` discretises the counts and colours each bin by *which interval* its count landed in. `get_array()` then holds an interval index: a three-point bin and a nine-point bin can both read 1. Labelled `count bin`.

Announcing either as a count would be wrong in the way that is hardest to catch — plausible number, sound chart, nothing contradicting it. `bins="log"` is **not** one of these: it only installs a log norm and leaves the array as raw counts, which I checked in the source rather than assumed. `z_label=` overrides all three.

## The collection comes from the patch

Rather than being searched for on the axes. `marginals=True` draws two further `PolyCollection`s, and a violin body or a `fill_between` band on the same axes is one as well, so the class does not identify the lattice while the call's return value does. The gid is assigned during extraction, as `AreaPlot` and `MultiLinePlot` already do, because a gid is otherwise only stamped at draw time and the schema is built first.

## Tests

Eight cases in `tests/core/test_hexbin_lattice.py`. The one that matters resolves the **emitted CSS against the real exported SVG** and checks each match is the hexagon whose centre and count that bin announces — nothing weaker distinguishes a correct mapping from an off-by-a-row one. `cssselect` is added to the `test` extra for it, alongside the `lxml` already used to build the SVG.

There is an explicit anti-vacuity guard: `test_the_reading_order_is_not_the_emission_order` fails if matplotlib ever starts emitting row by row, at which point the selector test would pass without proving anything.

Each mechanism was reverted and the named test confirmed to fail:

| reverted | fails |
| --- | --- |
| selectors left in document order | `each_selector_addresses_the_bin_it_describes`, `mincnt_...still_lines_up` |
| rows in descending y | `the_lattice_is_read_as_rows_bottom_first` |
| z label always `count` | `the_colour_axis_is_named_for_what_the_fill_encodes` |

`test_hexbin_is_not_registered_yet` in `test_hist2d.py` was written to fail on this day and be rewritten as a positive one. Done, along with the module docstring that drew the boundary.

Full suite: 1129 passed. Lint clean on every touched path.

## One thing found and not fixed here

While writing the docs example I hit a crash that has nothing to do with hexbin: a user-written `fig.colorbar(...)` registers a spurious `heat` layer and then **breaks `render()` outright** with an `ExtractionError`. It reproduces on `pcolormesh` and `scatter` with all hexbin code removed, so it predates this. Filed separately rather than folded in; the docs example simply does not call `fig.colorbar`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_