### PR TITLE
fix(colorbar): a colorbar is a legend, not a second chart

### DIFF
--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -4,6 +4,7 @@ from . import (  # noqa: F401
     barplot,
     boxplot,
     clear,
+    colorbar,
     errorbar,
     heatmap,
     hexbin,

--- a/maidr/patch/colorbar.py
+++ b/maidr/patch/colorbar.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any
+
+import wrapt
+from matplotlib.colorbar import Colorbar
+
+from maidr.core.context_manager import ContextManager
+
+
+def draw_quietly(wrapped, _, args, kwargs) -> Any:
+    """
+    Draw a colorbar without registering it as a chart of its own.
+
+    A colorbar paints its gradient onto its own axes through the very entry
+    points the heatmap patch wraps, so MAIDR was registering it as a second
+    ``heat`` layer. It is not a chart: it is the legend for the one beside it,
+    and the values it carries are already the ``z`` axis of that layer.
+
+    Two things went wrong, and the second is the one a user notices.
+
+    A phantom layer, first -- a reader handed a second "heatmap" to page
+    through that the figure does not contain. And then the render **died**:
+    extraction reaches the colorbar's outline, a ``LineCollection`` where a
+    mappable is expected, and raises. An ``ExtractionError`` is not confined
+    to its own layer; it takes the whole figure with it, so a chart that would
+    have read perfectly well produced nothing at all (#369).
+
+    Every route -- ``Figure.colorbar``, ``plt.colorbar``, an explicitly
+    supplied ``cax`` -- goes through ``Colorbar._draw_all``, which is why the
+    guard lives here rather than on a test for "is this axes a colorbar".
+    Attribute-sniffing would also have been wrong on the timing:
+    ``ax._colorbar`` is not assigned until after the draw that registers the
+    layer.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``Colorbar._draw_all``.
+    _ : Any
+        The ``Colorbar`` wrapt bound the method to. Unused, and named for that.
+    args : tuple
+        Positional arguments matplotlib passed.
+    kwargs : dict
+        Keyword arguments matplotlib passed.
+
+    Returns
+    -------
+    Any
+        Whatever the wrapped method returned, unchanged.
+    """
+    with ContextManager.set_internal_context():
+        return wrapped(*args, **kwargs)
+
+
+# `_draw_all` is private, so a rename upstream must degrade to the previous
+# behaviour rather than stop the package importing. That is a phantom layer
+# and a broken render, which is bad -- but a package that cannot be imported
+# is worse, and the failure would be caught by the tests that pin this rather
+# than by a user.
+try:
+    wrapt.wrap_function_wrapper(Colorbar, "_draw_all", draw_quietly)
+except AttributeError:  # pragma: no cover - matplotlib renamed the method
+    pass

--- a/maidr/patch/colorbar.py
+++ b/maidr/patch/colorbar.py
@@ -8,9 +8,13 @@ from matplotlib.colorbar import Colorbar
 from maidr.core.context_manager import ContextManager
 
 
-def draw_quietly(wrapped, _, args, kwargs) -> Any:
+def _suppress_registration(wrapped, _, args, kwargs) -> Any:
     """
     Draw a colorbar without registering it as a chart of its own.
+
+    Named apart from ``common._draw_quietly``, which is a different helper
+    doing a different job -- that one suppresses *warnings* around a
+    plotting call, and nearly every other patch module uses it.
 
     A colorbar paints its gradient onto its own axes through the very entry
     points the heatmap patch wraps, so MAIDR was registering it as a second
@@ -59,6 +63,6 @@ def draw_quietly(wrapped, _, args, kwargs) -> Any:
 # is worse, and the failure would be caught by the tests that pin this rather
 # than by a user.
 try:
-    wrapt.wrap_function_wrapper(Colorbar, "_draw_all", draw_quietly)
+    wrapt.wrap_function_wrapper(Colorbar, "_draw_all", _suppress_registration)
 except AttributeError:  # pragma: no cover - matplotlib renamed the method
     pass

--- a/tests/core/test_colorbar_is_not_a_chart.py
+++ b/tests/core/test_colorbar_is_not_a_chart.py
@@ -1,0 +1,165 @@
+"""A colorbar is a legend, and must not be read as a second chart.
+
+A colorbar paints its gradient onto its own axes through the same entry
+points the heatmap patch wraps, so MAIDR registered it as a ``heat`` layer of
+its own. Two things followed, and the second is the one a user notices:
+
+* a phantom layer -- a reader handed a second "heatmap" to page through that
+  the figure does not contain;
+* the render **died**. Extraction reaches the colorbar's outline, a
+  ``LineCollection`` where a mappable is expected, and raises
+  ``ExtractionError`` -- which is not confined to its own layer. It takes the
+  whole figure with it, so a chart that would have read perfectly well
+  produced nothing at all (#369).
+
+Not specific to heatmaps: the fault is in what the colorbar's own draw
+registers, so every plot type that wants a colour scale was affected.
+
+Hidden this long because ``sns.heatmap()`` creates its colorbar *inside* the
+patched call, where the recursion guard already suppressed it, and every
+worked example in the documentation happens to take that path. Only a caller
+writing ``fig.colorbar(...)`` themselves hit it.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _layers(fig) -> list:
+    """The plot types registered for a figure, or an empty list."""
+    try:
+        return [plot.type for plot in FigureManager.get_maidr(fig).plots]
+    except KeyError:
+        return []
+
+
+def _mappables():
+    """One chart per plot type that carries a colour scale."""
+    rng = np.random.default_rng(20260814)
+
+    def mesh(ax):
+        return ax.pcolormesh(np.arange(12).reshape(3, 4))
+
+    def scatter(ax):
+        return ax.scatter(
+            rng.normal(size=20), rng.normal(size=20), c=rng.normal(size=20)
+        )
+
+    def hexbin(ax):
+        return ax.hexbin(rng.normal(size=80), rng.normal(size=80), gridsize=3)
+
+    return [
+        ("pcolormesh", mesh, PlotType.HEAT),
+        ("scatter", scatter, PlotType.SCATTER),
+        ("hexbin", hexbin, PlotType.HEXBIN),
+    ]
+
+
+@pytest.mark.parametrize("name,draw,expected", _mappables())
+def test_a_colorbar_adds_no_layer_of_its_own(name, draw, expected) -> None:
+    """The chart is registered once, and the colorbar is not a second chart.
+
+    Asserted across three plot types because the fault was never about
+    heatmaps -- it was about what the colorbar's own draw registers, which is
+    the same whatever it is a legend for. ``pcolormesh`` came out as
+    ``['heat', 'heat']``, and the duplicate was the legend.
+    """
+    fig, ax = plt.subplots()
+    fig.colorbar(draw(ax), ax=ax, label="Legend")
+
+    assert _layers(fig) == [expected]
+
+
+@pytest.mark.parametrize("name,draw,expected", _mappables())
+def test_a_figure_with_a_colorbar_still_renders(name, draw, expected) -> None:
+    """The half a user notices, and the reason this is a crash not a wart.
+
+    ``ExtractionError`` is fatal to the render rather than to the layer that
+    raised it, so one unreadable phantom layer left the caller with no chart
+    at all -- not a degraded one, none.
+    """
+    fig, ax = plt.subplots()
+    fig.colorbar(draw(ax), ax=ax, label="Legend")
+
+    schema = FigureManager.get_maidr(fig)._flatten_maidr()
+
+    layers = schema["subplots"][0][0]["layers"]
+    assert len(layers) == 1
+    assert layers[0]["type"] == expected.value
+
+
+def test_an_explicitly_placed_colorbar_is_covered_too() -> None:
+    """``cax=`` is the other common idiom, and takes a different route in.
+
+    ``Figure.colorbar`` steals space from the parent axes when given ``ax=``
+    and skips that when handed a ``cax``, so the two paths diverge well before
+    the draw. They converge at ``Colorbar._draw_all``, which is where the
+    guard sits -- a test for "is this axes a colorbar" would have had to cover
+    both, and would have been wrong about the timing anyway, since
+    ``ax._colorbar`` is not assigned until after the draw that registers the
+    layer.
+    """
+    fig, ax = plt.subplots()
+    cax = fig.add_axes((0.92, 0.1, 0.02, 0.8))
+    fig.colorbar(ax.pcolormesh(np.arange(12).reshape(3, 4)), cax=cax)
+
+    assert _layers(fig) == [PlotType.HEAT]
+
+
+def test_the_chart_a_colorbar_belongs_to_is_unchanged() -> None:
+    """Suppressing the legend must not suppress anything the chart says.
+
+    The guard runs the colorbar's draw inside the recursion context, which is
+    the same mechanism that stops a patched function registering the calls it
+    makes internally. Scoped to the draw, so what the chart itself emitted
+    beforehand is untouched -- asserted rather than assumed, because a context
+    that leaked would silently swallow every layer after the first colorbar.
+    """
+    values = np.arange(12).reshape(3, 4)
+
+    without = plt.figure()
+    ax = without.add_subplot()
+    ax.pcolormesh(values)
+    bare = FigureManager.get_maidr(without)._flatten_maidr()
+
+    with_bar = plt.figure()
+    ax = with_bar.add_subplot()
+    with_bar.colorbar(ax.pcolormesh(values), ax=ax, label="Legend")
+    legended = FigureManager.get_maidr(with_bar)._flatten_maidr()
+
+    assert legended["subplots"][0][0]["layers"][0]["data"] == (
+        bare["subplots"][0][0]["layers"][0]["data"]
+    )
+
+
+def test_a_chart_drawn_after_a_colorbar_still_registers() -> None:
+    """The context has to end with the draw, not outlive it.
+
+    A guard that leaked would take the next chart with it, and the symptom --
+    a figure quietly missing a layer -- looks nothing like a colorbar problem.
+    """
+    fig, ax = plt.subplots()
+    fig.colorbar(ax.pcolormesh(np.arange(12).reshape(3, 4)), ax=ax)
+
+    second = fig.add_subplot(2, 1, 2)
+    second.scatter([1, 2, 3], [1, 2, 3])
+
+    assert _layers(fig) == [PlotType.HEAT, PlotType.SCATTER]

--- a/tests/core/test_colorbar_is_not_a_chart.py
+++ b/tests/core/test_colorbar_is_not_a_chart.py
@@ -124,6 +124,20 @@ def test_an_explicitly_placed_colorbar_is_covered_too() -> None:
     assert _layers(fig) == [PlotType.HEAT]
 
 
+def test_the_pyplot_level_colorbar_is_covered_too() -> None:
+    """The third route in, and the last one not pinned by a test.
+
+    ``plt.colorbar`` reaches the same ``Colorbar._draw_all`` as the two above,
+    which is the argument for putting the guard there -- but an argument is
+    not a test, and this is the one route where a reader would reasonably
+    wonder whether the reasoning holds.
+    """
+    fig, ax = plt.subplots()
+    plt.colorbar(ax.pcolormesh(np.arange(12).reshape(3, 4)), ax=ax)
+
+    assert _layers(fig) == [PlotType.HEAT]
+
+
 def test_the_chart_a_colorbar_belongs_to_is_unchanged() -> None:
     """Suppressing the legend must not suppress anything the chart says.
 


### PR DESCRIPTION
Closes #369.

A colorbar paints its gradient onto its own axes through the same entry points the heatmap patch wraps, so MAIDR registered it as a `heat` layer of its own. Two things followed, and the second is the one a user notices.

A **phantom layer**, first — a reader handed a second "heatmap" to page through that the figure does not contain.

And then the **render died**. Extraction reaches the colorbar's outline, a `LineCollection` where a mappable is expected, and raises `ExtractionError` — which is not confined to the layer that raised it. It takes the whole figure with it, so a chart that would have read perfectly well produced nothing at all.

## Not a heatmap problem

The fault is in what the colorbar's own draw registers, which is the same whatever it is a legend for. Before:

| the user's chart | layers registered | `render()` |
| --- | --- | --- |
| `ax.pcolormesh(...)` | `['heat', 'heat']` | `ExtractionError` |
| `ax.scatter(..., c=...)` | `['point', 'heat']` | `ExtractionError` |
| `ax.hexbin(...)` | `['hexbin', 'heat']` | `ExtractionError` |

So any chart wanting a colour scale — most charts that use colour to carry a third variable — could not be rendered at all, as long as the caller wrote the colorbar rather than letting seaborn do it.

That last clause is why this stayed hidden. `sns.heatmap()` creates its colorbar *inside* the patched call, where the recursion guard already suppressed it, and the documented heatmap example reaches for the existing one (`heatmap.collections[0].colorbar`) rather than making a new one. Every worked example in the docs happens to take the path that works. It turned up while I was writing the hexbin example for #368, which needed a colorbar and crashed.

## Where the guard goes, and why not where it looks like it should

`Colorbar._draw_all`, run inside the same recursion context every patched function already uses for the calls it makes internally.

The obvious alternative — test whether the target axes belongs to a colorbar — is wrong twice over. It would have to cover two routes that diverge well before the draw (`Figure.colorbar` steals space from the parent axes when given `ax=` and skips that entirely when handed a `cax`), and the attribute it would read is not set yet:

```
registered heat   | axes._colorbar set: False | _colorbar_info set: False
registered heat   | axes._colorbar set: False | _colorbar_info set: True
```

`ax._colorbar` is assigned *after* the draw that registers the layer. Measured, not assumed. Every route converges at `_draw_all`, which is why the guard sits there.

`_draw_all` is private, so the wrap is guarded: an upstream rename degrades to today's behaviour rather than stopping the package importing, and the tests below would catch it.

## Tests

Nine cases in `tests/core/test_colorbar_is_not_a_chart.py`, all nine failing with the guard removed.

The two that matter most are the pair: *no layer is added* and *the figure still renders*. The first alone would have passed on a fix that stopped registering the layer but left something else broken; the second is what a user actually experiences.

Two more guard the mechanism rather than the symptom, because the failure mode of a leaking context is silent and looks nothing like a colorbar bug:

- `test_the_chart_a_colorbar_belongs_to_is_unchanged` — the layer's data is byte-identical to the same chart drawn without a colorbar, so suppressing the legend suppressed nothing the chart says.
- `test_a_chart_drawn_after_a_colorbar_still_registers` — a second chart added afterwards is still picked up, so the context ends with the draw rather than outliving it.

And `test_an_explicitly_placed_colorbar_is_covered_too` pins the `cax=` route, which is the one an axes-attribute test would most plausibly have missed.

| | |
| --- | --- |
| Python 3.11 / matplotlib 3.10.9 | 1144 passed |
| Python 3.9 / matplotlib 3.9.4 | the new file's 9 passed |
| guard removed | 9 failed |
| lint | clean |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_