### PR TITLE
feat(area): read a baseline-to-curve fill_between as an area chart

### DIFF
--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -736,6 +736,38 @@ ax.legend(loc="upper left")
 plt.show() #<<
 ```
 
+`ax.fill_between()` reads as an area too, when it draws one: `fill_between(x,
+y)` fills from zero up to a curve, which is the same chart a single
+`stackplot` band draws. `ax.fill_betweenx()` is the same picture turned over
+and reads the same way.
+
+```{python}
+#| fig-alt: Filled area chart of monthly rainfall
+
+import matplotlib.pyplot as plt
+
+import maidr #<<
+
+months = list(range(1, 13))
+rainfall = [78, 62, 71, 55, 48, 39, 31, 35, 52, 74, 89, 84]
+
+fig, ax = plt.subplots(figsize=(8, 4))
+ax.fill_between(months, rainfall, alpha=0.6, label="Rainfall") #<<
+
+ax.set_title("Monthly Rainfall")
+ax.set_xlabel("Month")
+ax.set_ylabel("Rainfall (mm)")
+
+plt.show() #<<
+```
+
+A band drawn **between two curves** — `fill_between(x, lower, upper)`, the
+usual way to shade a confidence interval — is a different chart, and maidr
+does not read it as an area. Its content is the gap between the edges rather
+than the height of either, so announcing it as an area would report the upper
+edge as a magnitude and drop the lower one. Those charts render as a static
+image for now; see [issue #339](https://github.com/xability/py-maidr/issues/339).
+
 ### Point Plot
 
 `sns.pointplot()` is the same reading from the other direction: it estimates a

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -79,6 +79,8 @@ We currently support the following data visualization libraries in Python:, and 
 
 * Hexbin plot (`ax.hexbin()`) having one x (numerical) and one y (numerical) axis and a z axis carrying what the fill encodes — each hexagon's count by default, the reduction of `C` when one is given, or the count's interval when `bins` is a number. Read as a lattice of counted cells, one row at a time; because hexagons tessellate by offsetting alternate rows, each bin is announced by its centre rather than by a column index.
 
+* Filled area plot (`ax.stackplot()`, `ax.fill_between()`, `ax.fill_betweenx()`) having one x (numerical) and one y (numerical) axis. A band drawn from the baseline to a curve reads as an area; several stacked bands read as a stacked area, with each band's own value announced alongside the running total. A band drawn *between two curves* is not read as an area, since its content is the gap rather than either edge.
+
 * Scatter plot having one x (numerical) and one y (numerical) axis.
 
 * Regression plot having one x (numerical) and one y (numerical) axis with scatter points and fitted regression line.

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -6,6 +6,7 @@ from . import (  # noqa: F401
     clear,
     colorbar,
     errorbar,
+    fillbetween,
     heatmap,
     hexbin,
     highlight,

--- a/maidr/patch/fillbetween.py
+++ b/maidr/patch/fillbetween.py
@@ -50,7 +50,51 @@ def _baseline_is_zero(wrapped, args: tuple, kwargs: dict, name: str) -> bool:
         values = np.asarray(other, dtype=float)
     except (TypeError, ValueError):
         return False
-    return values.ndim == 0 and values == 0
+    # An array of zeros is the same chart as the default, spelled out. Only
+    # a *non-zero* edge changes what the heights are measured from.
+    return bool(values.size > 0 and np.all(values == 0))
+
+
+def _fills_the_whole_range(wrapped, args: tuple, kwargs: dict) -> bool:
+    """
+    Whether the fill covers every position, rather than a masked subset.
+
+    ``where=`` fills only where the mask holds, leaving the chart blank
+    elsewhere -- ``fill_between(x, y, where=y > 0)`` draws three separate
+    bands out of an eight-point series, and matplotlib returns three paths
+    for it rather than one.
+
+    An area layer is one continuous series, so announcing the masked call as
+    one would report every position as filled, gaps included: a complete,
+    confident description of a chart that was not drawn. Which is the same
+    thing declining the two-curve form avoids, so it is declined the same
+    way.
+
+    A mask that holds everywhere is not a mask. It draws the single band the
+    default draws, and reads as one.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original function, used for its parameter order.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    bool
+        True when no mask was given, or the mask holds at every position.
+    """
+    where = _argument("where", wrapped, args, kwargs)
+    if where is None:
+        return True
+    try:
+        mask = np.asarray(where, dtype=bool)
+    except (TypeError, ValueError):
+        return False
+    return bool(mask.size > 0 and np.all(mask))
 
 
 def _magnitudes(wrapped, args: tuple, kwargs: dict, position: str, value: str):
@@ -146,6 +190,9 @@ def _fill(wrapped, instance, args, kwargs, position: str, value: str, other: str
         collection = _draw_quietly(wrapped, args, kwargs)
 
     if not _baseline_is_zero(wrapped, args, kwargs, other):
+        return collection
+
+    if not _fills_the_whole_range(wrapped, args, kwargs):
         return collection
 
     positions, values = _magnitudes(wrapped, args, kwargs, position, value)

--- a/maidr/patch/fillbetween.py
+++ b/maidr/patch/fillbetween.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import numpy as np
+import wrapt
+from matplotlib.axes import Axes
+from matplotlib.collections import Collection
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.patch.common import _argument, _draw_quietly
+
+
+def _baseline_is_zero(wrapped, args: tuple, kwargs: dict, name: str) -> bool:
+    """
+    Whether the band runs from the value axis' zero to a single curve.
+
+    ``fill_between(x, y1)`` fills from zero up to ``y1``. That is an area
+    chart, and it measures exactly what a one-series ``stackplot`` band
+    measures -- a magnitude per position, from a baseline the reader can
+    assume.
+
+    Anything else is a band between two curves, which is a different claim.
+    ``fill_between(x, lo, hi)`` draws the *gap*, and its content is the
+    distance between the two edges rather than the height of either; read as
+    an area it would announce ``hi`` as a magnitude and drop ``lo`` entirely.
+    A constant second edge is the same problem in miniature: the heights are
+    measured from somewhere the announcement would not mention.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``fill_between`` or ``fill_betweenx``, used for its
+        parameter order.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+    name : str
+        ``"y2"`` for ``fill_between``, ``"x2"`` for ``fill_betweenx``.
+
+    Returns
+    -------
+    bool
+        True when the second edge is absent or an explicit zero.
+    """
+    other = _argument(name, wrapped, args, kwargs)
+    if other is None:
+        return True
+    try:
+        values = np.asarray(other, dtype=float)
+    except (TypeError, ValueError):
+        return False
+    return values.ndim == 0 and values == 0
+
+
+def _magnitudes(wrapped, args: tuple, kwargs: dict, position: str, value: str):
+    """
+    Read the positions and the one curve a filled area is drawn from.
+
+    Taken from the call's own arguments rather than from the polygon, the
+    same way ``stackplot`` reads its series and for the same reason: the drawn
+    artist is a closed outline, running forward along the curve and back along
+    the baseline with its endpoints repeated, so recovering the series from it
+    means undoing the closure.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original function, used for its parameter order.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+    position : str
+        The parameter naming the shared axis: ``"x"`` or ``"y"``.
+    value : str
+        The parameter naming the curve: ``"y1"`` or ``"x1"``.
+
+    Returns
+    -------
+    tuple
+        The positions and the values, or ``(None, None)`` when either is
+        missing or they do not line up.
+    """
+    positions = _argument(position, wrapped, args, kwargs)
+    values = _argument(value, wrapped, args, kwargs)
+    if positions is None or values is None:
+        return None, None
+
+    positions = np.atleast_1d(np.asarray(positions, dtype=object))
+    values = np.atleast_1d(np.asarray(values))
+    if len(positions) != len(values):
+        # A scalar `y1` broadcast against the positions is a horizontal band,
+        # not a series. Nothing here can describe it, and pairing the two
+        # lists by index would silently describe a one-point chart.
+        return None, None
+
+    return positions, values
+
+
+def _fill(wrapped, instance, args, kwargs, position: str, value: str, other: str):
+    """
+    Draw a patched fill call and register the area it produced, when it is one.
+
+    Only the baseline-to-curve form is registered. The two-curve form draws an
+    interval, whose content is the gap rather than either edge, and MAIDR has
+    no reading for it that would not invent an estimate the chart never drew
+    -- so it is left unregistered and the figure keeps its static image, as it
+    did before this patch existed (#339).
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``fill_between`` or ``fill_betweenx``.
+    instance : Any
+        The Axes the method was bound to.
+    args : tuple
+        Positional arguments the caller passed.
+    kwargs : dict
+        Keyword arguments the caller passed.
+    position : str
+        The parameter naming the shared axis.
+    value : str
+        The parameter naming the curve.
+    other : str
+        The parameter naming the second edge.
+
+    Returns
+    -------
+    matplotlib.collections.Collection
+        Whatever the wrapped function returned, unchanged.
+    """
+    # Don't proceed if the call is made internally by the patched function.
+    #
+    # `stackplot` draws its bands through here and reads them itself, but it
+    # is not what this guard catches: every band it draws carries two explicit
+    # edges (`fill_between(x, stack[i], stack[i + 1])`), so the baseline test
+    # below declines them all anyway. Kept as the convention every patch in
+    # this package follows, and because "the caller happens to pass two edges"
+    # is a property of matplotlib's `stackplot` rather than a rule about
+    # nested draws.
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        collection = _draw_quietly(wrapped, args, kwargs)
+
+    if not _baseline_is_zero(wrapped, args, kwargs, other):
+        return collection
+
+    positions, values = _magnitudes(wrapped, args, kwargs, position, value)
+    if positions is None:
+        return collection
+
+    ax = instance if isinstance(instance, Axes) else getattr(instance, "axes", None)
+    if ax is None:
+        return collection
+
+    from maidr.core.figure_manager import FigureManager
+
+    FigureManager.create_maidr(
+        ax,
+        PlotType.AREA,
+        x=positions,
+        series=[values],
+        labels=[kwargs["label"]] if isinstance(kwargs.get("label"), str) else [],
+        collections=[collection],
+    )
+
+    return collection
+
+
+def fill_between(wrapped, instance, args, kwargs) -> Collection:
+    """Register an ``Axes.fill_between`` call as a MAIDR area layer."""
+    return _fill(wrapped, instance, args, kwargs, "x", "y1", "y2")
+
+
+def fill_betweenx(wrapped, instance, args, kwargs) -> Collection:
+    """
+    Register an ``Axes.fill_betweenx`` call as a MAIDR area layer.
+
+    The same chart with the axes exchanged: the shared axis is ``y`` and the
+    magnitude runs along ``x``. Emitted as an area either way, since what a
+    band measures does not change with which way it is drawn.
+    """
+    return _fill(wrapped, instance, args, kwargs, "y", "x1", "x2")
+
+
+# Patch matplotlib functions. `AreaPlot` is reached through the factory, so
+# both land as the same layer type a one-series `stackplot` produces.
+wrapt.wrap_function_wrapper(Axes, "fill_between", fill_between)
+wrapt.wrap_function_wrapper(Axes, "fill_betweenx", fill_betweenx)

--- a/tests/core/test_fill_between.py
+++ b/tests/core/test_fill_between.py
@@ -1,0 +1,230 @@
+"""A filled band from the baseline is an area chart; a band between two is not.
+
+``Axes.fill_between`` was unregistered entirely, so a filled area chart drew
+and read as a static image. ``stackplot`` already emitted an area layer for
+the same picture (#356), which made the gap arbitrary from a reader's side:
+the same chart read or did not depending on which function drew it.
+
+The part that needed deciding rather than writing is that ``fill_between``
+draws two different charts.
+
+``fill_between(x, y1)`` fills from zero up to a curve. That is an area chart,
+and it measures what a one-series ``stackplot`` band measures -- a magnitude
+per position, from a baseline the reader can assume.
+
+``fill_between(x, lo, hi)`` draws the **gap**. Its content is the distance
+between the edges, not the height of either, so read as an area it would
+announce ``hi`` as a magnitude and drop ``lo`` without saying so. The honest
+reading is an estimate and its interval, and there is no estimate on the
+chart -- inventing the midpoint would put a number in the reader's ear that
+nothing drew. So it stays unregistered, and the figure keeps the static image
+it had, rather than gaining a confident description of a different chart
+(#339).
+
+That decision is what these pin. The registration is the easy half.
+"""
+
+from __future__ import annotations
+
+import json
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+X = np.arange(5)
+Y = np.array([1.0, 3.0, 2.0, 5.0, 4.0])
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _layers(fig) -> list:
+    """The plot types registered for a figure, or an empty list."""
+    try:
+        return [plot.type for plot in FigureManager.get_maidr(fig).plots]
+    except KeyError:
+        return []
+
+
+def _layer(fig) -> dict:
+    """The one emitted layer's schema, as JSON round-trips it."""
+    schema = json.loads(json.dumps(FigureManager.get_maidr(fig)._flatten_maidr()))
+    return schema["subplots"][0][0]["layers"][0]
+
+
+def test_a_band_from_the_baseline_is_an_area():
+    """The registration, and the values it carries.
+
+    Read against the arguments the caller passed rather than against the
+    drawn polygon: `fill_between` closes its outline, running forward along
+    the curve and back along the baseline with the endpoints repeated, so a
+    reading taken from the artist would have to undo the closure first.
+    """
+    fig, ax = plt.subplots()
+    ax.set_xlabel("t")
+    ax.set_ylabel("v")
+    ax.fill_between(X, Y)
+
+    assert _layers(fig) == [PlotType.AREA]
+
+    layer = _layer(fig)
+    assert layer["type"] == "area"
+    assert layer["axes"]["x"]["label"] == "t"
+    assert layer["axes"]["y"]["label"] == "v"
+
+    points = layer["data"][0]
+    assert [point["x"] for point in points] == X.tolist()
+    assert [point["y"] for point in points] == Y.tolist()
+
+
+def test_an_explicit_zero_baseline_is_the_same_chart():
+    """``y2=0`` is what the default already means, written out."""
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y, 0)
+
+    assert _layers(fig) == [PlotType.AREA]
+    assert [point["y"] for point in _layer(fig)["data"][0]] == Y.tolist()
+
+
+def test_a_band_between_two_curves_is_declined():
+    """The decision, not an oversight.
+
+    Its content is the gap. Announced as an area, ``hi`` becomes a magnitude
+    and ``lo`` disappears -- a complete, confident description of a chart
+    nobody drew. The alternative reading needs an estimate the chart does not
+    carry.
+    """
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y - 1, Y + 1)
+
+    assert _layers(fig) == []
+
+
+def test_a_constant_second_edge_is_declined_too():
+    """The same problem in miniature, and the one a zero-check alone misses.
+
+    ``fill_between(x, y, 2)`` measures heights from two, and an area layer
+    would announce them as though measured from zero. Nothing in the reading
+    would mention the baseline it actually used.
+    """
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y, 2)
+
+    assert _layers(fig) == []
+
+
+def test_a_line_keeps_its_band_unannounced_rather_than_misannounced():
+    """The common idiom, and what it still costs.
+
+    A line with a confidence ribbon is the case a reader loses most from,
+    and it is deliberately not fixed here: the band is an interval around
+    the line, which is an `error_bar` reading rather than an area one, and
+    matching a band to a line is a heuristic worth settling before writing.
+
+    What is pinned is that it does not silently gain a *wrong* layer in the
+    meantime -- the figure reads as the line it always did.
+    """
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+    ax.fill_between(X, Y - 1, Y + 1, alpha=0.3)
+
+    assert _layers(fig) == [PlotType.LINE]
+
+
+def test_fill_betweenx_is_the_same_chart_turned_over():
+    """The shared axis is y and the magnitude runs along x.
+
+    What a band measures does not change with which way it is drawn, so it
+    is the same layer type -- and the arguments have to be read from their
+    own parameter names rather than by position, since `x1` sits where `y1`
+    does.
+    """
+    fig, ax = plt.subplots()
+    ax.fill_betweenx(X, Y)
+
+    assert _layers(fig) == [PlotType.AREA]
+
+    points = _layer(fig)["data"][0]
+    assert [point["x"] for point in points] == X.tolist()
+    assert [point["y"] for point in points] == Y.tolist()
+
+
+def test_a_stackplot_still_reads_as_a_stack():
+    """The thing most at risk: `stackplot` draws its bands through here.
+
+    It calls `fill_between` once per band and reads the series itself, so a
+    stacked chart could gain one area layer per band on top of its stack --
+    every band described twice, once as its own value and once as a running
+    total.
+
+    Two things stop that, and it is worth being exact about which does the
+    work, because the obvious answer is not the one that fires. The recursion
+    guard would catch it, but never gets the chance: `stackplot` draws every
+    band with two explicit edges (`fill_between(x, stack[i], stack[i + 1])`),
+    so the baseline test declines them first. Removing the guard alone leaves
+    this passing.
+
+    Asserted on the outcome for that reason. It is the outcome that matters,
+    and pinning it to one mechanism would make the test a description of
+    matplotlib's `stackplot` rather than of this package.
+    """
+    fig, ax = plt.subplots()
+    ax.stackplot(X, Y, Y + 1)
+
+    assert _layers(fig) == [PlotType.STACKED_AREA]
+    assert len(_layer(fig)["data"]) == 2
+
+
+def test_a_scalar_curve_is_declined():
+    """`fill_between(x, 3)` is a horizontal band, not a series.
+
+    Matplotlib broadcasts the scalar across the positions. Pairing the two
+    by index would describe a one-point chart out of a five-point one, and
+    the count is the only thing that would have looked wrong.
+    """
+    fig, ax = plt.subplots()
+    ax.fill_between(X, 3)
+
+    assert _layers(fig) == []
+
+
+def test_the_band_is_tagged_for_highlighting():
+    """A selector per band, resolving to the drawn polygon.
+
+    `AreaPlot` addresses its bands by the artist's own gid, which is
+    assigned during extraction because the schema is built before the draw
+    that would otherwise stamp one.
+    """
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y)
+
+    layer = _layer(fig)
+    assert len(layer["selectors"]) == 1
+    assert "maidr-" in layer["selectors"][0]
+
+
+def test_a_label_is_carried_onto_the_points():
+    """`label=` is what a legend would show, and names the series.
+
+    Only when it is a string: matplotlib accepts other objects and renders
+    them through `str()`, which is a decision about display rather than a
+    name the reader should be handed.
+    """
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y, label="rainfall")
+
+    assert all(point["z"] == "rainfall" for point in _layer(fig)["data"][0])

--- a/tests/core/test_fill_between.py
+++ b/tests/core/test_fill_between.py
@@ -145,6 +145,64 @@ def test_a_line_keeps_its_band_unannounced_rather_than_misannounced():
     assert _layers(fig) == [PlotType.LINE]
 
 
+def test_a_masked_fill_is_declined():
+    """``where=`` draws several bands, and an area layer is one series.
+
+    ``fill_between(x, y, where=y > 0)`` fills only where the mask holds and
+    leaves the chart blank elsewhere -- matplotlib returns three paths for
+    the eight-point series below, against one for the unmasked call.
+
+    Announced as an area it would report every position as filled, gaps
+    included. That is the same thing declining the two-curve form avoids,
+    so it is declined the same way rather than described partially: a reader
+    walking left to right would otherwise cross a gap without being told
+    there was one.
+    """
+    signed = np.array([1.0, 3.0, -2.0, 5.0, -4.0, 2.0, 6.0, 1.0])
+    positions = np.arange(len(signed))
+
+    fig, ax = plt.subplots()
+    ax.fill_between(positions, signed, where=signed > 0)
+
+    assert _layers(fig) == []
+
+
+def test_a_mask_that_holds_everywhere_is_not_a_mask():
+    """It draws the single band the default draws, and reads as one.
+
+    Declining on the presence of the argument rather than on what it says
+    would refuse a chart that is identical to one already accepted.
+    """
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y, where=np.ones_like(Y, dtype=bool))
+
+    assert _layers(fig) == [PlotType.AREA]
+    assert [point["y"] for point in _layer(fig)["data"][0]] == Y.tolist()
+
+
+def test_an_array_of_zeros_is_the_default_spelled_out():
+    """``fill_between(x, y, np.zeros_like(x))`` is the same chart as omitting it.
+
+    Only a *non-zero* edge changes what the heights are measured from, so
+    testing for a scalar zero alone would decline a chart identical to one
+    already accepted.
+    """
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y, np.zeros_like(X, dtype=float))
+
+    assert _layers(fig) == [PlotType.AREA]
+    assert [point["y"] for point in _layer(fig)["data"][0]] == Y.tolist()
+
+
+def test_the_pyplot_entry_point_is_covered_too():
+    """``plt.fill_between`` reaches the same bound method through ``gca()``."""
+    fig = plt.figure()
+    fig.add_subplot()
+    plt.fill_between(X, Y)
+
+    assert _layers(fig) == [PlotType.AREA]
+
+
 def test_fill_betweenx_is_the_same_chart_turned_over():
     """The shared axis is y and the magnitude runs along x.
 


### PR DESCRIPTION
Part of #339.

`Axes.fill_between` was unregistered, so a filled area chart drew and read as a static image. `ax.stackplot()` already emitted an area layer for the same picture (#356), which made the gap arbitrary from a reader's side: **the same chart read or did not depending on which function drew it.**

```
                            before              after
fill_between(x, y)          not registered      area
fill_between(x, y, 0)       not registered      area
fill_betweenx(y, x)         not registered      area
fill_between(x, lo, hi)     not registered      not registered   (deliberate)
fill_between(x, y, 2)       not registered      not registered   (deliberate)
stackplot(x, y1, y2)        stacked_area        stacked_area
```

## The part that needed deciding rather than writing

`fill_between` draws two different charts, and only one of them is an area.

**`fill_between(x, y1)` fills from zero up to a curve.** That measures exactly what a one-series `stackplot` band measures — a magnitude per position, from a baseline the reader can assume. Registered.

**`fill_between(x, lo, hi)` draws the gap.** Its content is the distance between the edges, not the height of either. Read as an area it would announce `hi` as a magnitude and drop `lo` without saying so — a complete, confident description of a chart nobody drew. The honest reading is an estimate and its interval, and there is no estimate on the chart; the midpoint would be a number nothing drew. So it is left unregistered and the figure keeps the static image it had.

A **constant second edge** (`fill_between(x, y, 2)`) is the same problem in miniature: heights measured from somewhere the announcement would not mention. Declined too, and it is the case a bare zero-check would have let through.

## Why the arguments and not the artist

The same reason `stackplot`'s patch reads its series from the call: the drawn artist is a closed outline, running forward along the curve and back along the baseline with the endpoints repeated, so recovering the series from it means undoing the closure first.

`fill_betweenx` is the same chart turned over — the shared axis is `y` and the magnitude runs along `x` — which is why the arguments are read by parameter name rather than by position, since `x1` sits where `y1` does.

## Tests

Ten cases. Each mechanism reverted, with a named test failing:

| reverted | fails |
| --- | --- |
| baseline check | `a_band_between_two_curves_is_declined`, `a_constant_second_edge_is_declined_too`, `a_line_keeps_its_band_unannounced_rather_than_misannounced` |
| position/value length check | `a_scalar_curve_is_declined` |

**One thing worth flagging, because I wrote the test's rationale wrong first.** `test_a_stackplot_still_reads_as_a_stack` originally claimed the recursion guard was what stopped a stacked chart gaining an area layer per band. Removing the guard fails nothing: `stackplot` draws every band with two explicit edges (`fill_between(x, stack[i], stack[i + 1])`), so the baseline test declines them first and the guard never gets the chance. The test now asserts the outcome and says which mechanism actually fires — pinning it to the guard would have made it a description of matplotlib's `stackplot` rather than of this package. The guard stays as the convention every patch here follows.

| | |
| --- | --- |
| Python 3.11 / matplotlib 3.10.9 | 1155 passed |
| Python 3.9 / matplotlib 3.9.4 | the new file's 10 passed |
| lint | clean |

Docs updated: the supported-plots list, and an `Area Plot` example that also states plainly which bands are *not* read and links to #339.

## What stays open on #339

The band-around-a-line case — `ax.plot(...)` plus `ax.fill_between(x, y-e, y+e)`, the usual confidence ribbon. That is an `error_bar` reading (`{x, y, yMin, yMax}`, with `y` from the line), not an area one, and matching a band to a line is a heuristic: the line may be drawn after the band, there may be several, and the x may not line up. It should fail toward declining rather than toward guessing an estimate, and that is worth settling before writing. Analysis is on the issue.

What this PR does guarantee in the meantime is that such a figure does not silently gain a *wrong* layer — it reads as the line it always did.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_