### PR TITLE
fix(seaborn): patch each function at both names it answers to

### DIFF
--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -7,7 +7,7 @@ from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
 
 from maidr.core.enum import MaidrKey, PlotType
-from maidr.patch.common import common
+from maidr.patch.common import common, wrap_seaborn
 from maidr.util.mixin import LevelExtractorMixin
 
 
@@ -289,5 +289,5 @@ wrapt.wrap_function_wrapper(Axes, "bar", bar)
 wrapt.wrap_function_wrapper(Axes, "barh", bar)
 
 # Patch seaborn functions.
-wrapt.wrap_function_wrapper("seaborn", "barplot", sns_bar)
-wrapt.wrap_function_wrapper("seaborn", "countplot", sns_bar)
+wrap_seaborn("barplot", sns_bar)
+wrap_seaborn("countplot", sns_bar)

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -5,6 +5,8 @@ import threading
 import warnings
 from typing import Any, Callable
 
+import wrapt
+
 from matplotlib.axes import Axes
 
 from maidr.core.context_manager import ContextManager
@@ -211,3 +213,62 @@ def common(
     FigureManager.create_maidr(ax, plot_type, **kwargs)
 
     return plot
+
+
+def wrap_seaborn(name: str, wrapper: Callable) -> None:
+    """
+    Wrap a seaborn function at both of the names it answers to.
+
+    seaborn re-exports its plotting functions from the package root, and its
+    own figure-level functions import them from the *defining* module inside
+    the function body::
+
+        from .relational import scatterplot   # Avoid circular import
+        from .distributions import histplot, kdeplot
+
+    Those are two separate bindings to one function object, so wrapping
+    ``seaborn.scatterplot`` leaves ``seaborn.relational.scatterplot``
+    untouched -- and every grid in ``seaborn/axisgrid.py`` takes the second
+    one. `pairplot`, `jointplot`, `catplot`, `relplot`, `displot` and
+    `lmplot` therefore ran the *unpatched* function, and the panel was seen
+    only by the matplotlib-level patches.
+
+    That cost two things at once. A `histplot` panel arrived as bars, because
+    `Axes.bar` cannot know it is drawing a histogram and the seaborn-level
+    patch that would have known never ran. And every panel registered twice:
+    `seaborn.utils._default_color` draws a throwaway artist to resolve a
+    default colour and removes it again, and with no seaborn-level patch
+    there was no recursion context to suppress it, so the probe registered as
+    a chart of its own (#344).
+
+    The defining module is located through ``__module__`` rather than a table
+    of names, so a function seaborn moves does not quietly stop being
+    patched -- and the identity check means a name that no longer resolves to
+    the same object is left alone rather than wrapped by guess.
+
+    Parameters
+    ----------
+    name : str
+        The function's name, the same at both bindings.
+    wrapper : Callable
+        The wrapt-style wrapper to install.
+    """
+    import importlib
+
+    import seaborn
+
+    original = getattr(seaborn, name, None)
+    if original is None:  # pragma: no cover - seaborn dropped the function
+        return
+
+    defining = getattr(original, "__module__", None)
+    wrapt.wrap_function_wrapper(seaborn, name, wrapper)
+
+    if not defining or defining == "seaborn":  # pragma: no cover
+        return
+    try:
+        module = importlib.import_module(defining)
+    except ImportError:  # pragma: no cover - a module seaborn does not ship
+        return
+    if getattr(module, name, None) is original:
+        wrapt.wrap_function_wrapper(module, name, wrapper)

--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -12,7 +12,7 @@ from matplotlib.image import AxesImage
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _draw_quietly
+from maidr.patch.common import _draw_quietly, wrap_seaborn
 
 
 def _declares_fmt(wrapped: Callable) -> bool:
@@ -130,4 +130,4 @@ wrapt.wrap_function_wrapper(Axes, "pcolormesh", heat)
 wrapt.wrap_function_wrapper(Axes, "pcolor", heat)
 
 # Patch seaborn function.
-wrapt.wrap_function_wrapper("seaborn", "heatmap", heat)
+wrap_seaborn("heatmap", heat)

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -12,7 +12,7 @@ import uuid
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _draw_quietly, common
+from maidr.patch.common import _draw_quietly, common, wrap_seaborn
 
 
 @wrapt.patch_function_wrapper(Axes, "hist")
@@ -43,7 +43,6 @@ def mpl_hist(
     return n, bins, plot
 
 
-@wrapt.patch_function_wrapper("seaborn", "histplot")
 def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     """
     Patch seaborn.histplot to register HIST and (if kde=True) SMOOTH layers for MAIDR.
@@ -69,3 +68,7 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
                         dict(kwargs, regression_line=line),
                     )
     return ax
+
+
+# Patch seaborn function at both names it answers to; see `wrap_seaborn`.
+wrap_seaborn("histplot", sns_hist)

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import wrapt
 import uuid
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 from matplotlib.collections import PolyCollection
 from maidr.core.enum import PlotType
-from maidr.patch.common import _draw_quietly, common
+from maidr.patch.common import _draw_quietly, common, wrap_seaborn
 from maidr.core.context_manager import ContextManager
 from maidr.util.svg_utils import unique_lines_by_xy
 
@@ -60,4 +59,4 @@ def kde(wrapped, instance, args, kwargs) -> Axes | Line2D | PolyCollection:
 
 
 # Patch seaborn kdeplot
-wrapt.wrap_function_wrapper("seaborn", "kdeplot", kde)
+wrap_seaborn("kdeplot", kde)

--- a/maidr/patch/lineplot.py
+++ b/maidr/patch/lineplot.py
@@ -5,7 +5,7 @@ from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 
 from maidr.core.enum import PlotType
-from maidr.patch.common import _draw_quietly, common
+from maidr.patch.common import _draw_quietly, common, wrap_seaborn
 from maidr.core.context_manager import ContextManager
 from maidr.core.figure_manager import FigureManager
 from maidr.util.step_utils import is_step_axes
@@ -58,4 +58,4 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
 wrapt.wrap_function_wrapper(Axes, "plot", line)
 
 # Patch seaborn function.
-wrapt.wrap_function_wrapper("seaborn", "lineplot", line)
+wrap_seaborn("lineplot", line)

--- a/maidr/patch/pointplot.py
+++ b/maidr/patch/pointplot.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 import matplotlib.pyplot as plt
 import numpy as np
-import wrapt
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _draw_quietly
+from maidr.patch.common import _draw_quietly, wrap_seaborn
 
 # The marker seaborn leaves on the lines it draws the intervals with. The
 # estimate line carries a real one -- `"o"` by default, and the empty string
@@ -249,4 +248,4 @@ def _pairs_up(estimates: list[Line2D], intervals: list[Line2D]) -> bool:
 
 
 # Patch seaborn function.
-wrapt.wrap_function_wrapper("seaborn", "pointplot", point)
+wrap_seaborn("pointplot", point)

--- a/maidr/patch/regplot.py
+++ b/maidr/patch/regplot.py
@@ -4,7 +4,7 @@ import wrapt
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 from maidr.core.enum import PlotType
-from maidr.patch.common import _draw_quietly, common
+from maidr.patch.common import _draw_quietly, common, wrap_seaborn
 from maidr.core.context_manager import ContextManager
 import uuid
 from maidr.core.enum.smooth_keywords import SMOOTH_KEYWORDS
@@ -84,6 +84,6 @@ def patched_plot(wrapped, instance, args, kwargs):
 
 
 # Patch seaborn function.
-wrapt.wrap_function_wrapper("seaborn", "regplot", regplot)
+wrap_seaborn("regplot", regplot)
 # Patch matplotlib Axes.plot for smooth line detection/registration
 wrapt.wrap_function_wrapper(Axes, "plot", patched_plot)

--- a/maidr/patch/scatterplot.py
+++ b/maidr/patch/scatterplot.py
@@ -5,7 +5,7 @@ from matplotlib.axes import Axes
 from matplotlib.collections import PathCollection
 
 from maidr.core.enum import PlotType
-from maidr.patch.common import common
+from maidr.patch.common import common, wrap_seaborn
 
 
 def scatter(wrapped, instance, args, kwargs) -> Axes | PathCollection:
@@ -16,4 +16,4 @@ def scatter(wrapped, instance, args, kwargs) -> Axes | PathCollection:
 wrapt.wrap_function_wrapper(Axes, "scatter", scatter)
 
 # Patch seaborn function.
-wrapt.wrap_function_wrapper("seaborn", "scatterplot", scatter)
+wrap_seaborn("scatterplot", scatter)

--- a/tests/core/test_seaborn_patch_reach.py
+++ b/tests/core/test_seaborn_patch_reach.py
@@ -1,0 +1,207 @@
+"""A seaborn function has two names, and MAIDR was patching one of them.
+
+seaborn re-exports its plotting functions from the package root, and its own
+figure-level functions import them from the **defining module**, inside the
+function body::
+
+    from .relational import scatterplot   # Avoid circular import
+    from .distributions import histplot, kdeplot
+
+Those are two separate bindings to one function object, so wrapping
+``seaborn.scatterplot`` left ``seaborn.relational.scatterplot`` untouched --
+and every grid in ``seaborn/axisgrid.py`` takes the second one. `pairplot`,
+`jointplot`, `catplot`, `relplot`, `displot` and `lmplot` therefore ran the
+*unpatched* function.
+
+That cost two things at once, and neither reads as a patching problem:
+
+* a `histplot` panel arrived as **bars**, because `Axes.bar` cannot know it is
+  drawing a histogram and the seaborn-level patch that would have known never
+  ran;
+* every panel registered **twice**. `seaborn.utils._default_color` draws a
+  throwaway artist to resolve a default colour and removes it again, and with
+  no seaborn-level patch there was no recursion context to suppress it, so the
+  probe registered as a chart of its own (#344).
+
+Measured on a two-variable `pairplot`, which draws four panels::
+
+    before   bar, dodged_bar, bar, dodged_bar, point, point, point, point
+    after    hist, hist, point, point
+
+Three grids change: `pairplot`, `jointplot` and `lmplot`. `relplot` was
+already right. `displot` and `catplot` are **not** fixed by this -- they drive
+seaborn's plotter classes directly rather than importing the module-level
+functions -- and are pinned at the foot of this file so the boundary is
+visible rather than discovered.
+
+The failure was invisible from a direct call -- `sns.histplot(ax=ax)` has
+always given `hist` -- which is why it survived this long. So the first test
+below asserts the *binding*, not the behaviour: it is the only thing that
+fails the moment a new patch is added at one name and not the other.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import seaborn as sns  # noqa: E402
+import seaborn.categorical  # noqa: E402
+import seaborn.distributions  # noqa: E402
+import seaborn.matrix  # noqa: E402
+import seaborn.regression  # noqa: E402
+import seaborn.relational  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+#: Every seaborn function MAIDR patches, with the module that defines it.
+PATCHED = [
+    ("scatterplot", seaborn.relational),
+    ("lineplot", seaborn.relational),
+    ("histplot", seaborn.distributions),
+    ("kdeplot", seaborn.distributions),
+    ("barplot", seaborn.categorical),
+    ("countplot", seaborn.categorical),
+    ("pointplot", seaborn.categorical),
+    ("heatmap", seaborn.matrix),
+    ("regplot", seaborn.regression),
+]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Two numeric columns, enough for a 2x2 grid."""
+    rng = np.random.default_rng(20260814)
+    return pd.DataFrame({"a": rng.normal(size=60), "b": rng.normal(size=60)})
+
+
+def _is_wrapped(function) -> bool:
+    """Whether wrapt has a wrapper installed on this object."""
+    return type(function).__name__ == "FunctionWrapper"
+
+
+def _layers(fig) -> list:
+    """The plot types registered for a figure, or an empty list."""
+    try:
+        return [plot.type for plot in FigureManager.get_maidr(fig).plots]
+    except KeyError:
+        return []
+
+
+@pytest.mark.parametrize("name,module", PATCHED)
+def test_both_names_are_wrapped(name, module) -> None:
+    """The binding, asserted directly, because the behaviour hides it.
+
+    Everything else in this file goes through a grid, which is a long way
+    from the line that installs a patch. This is the check that fails the
+    moment a tenth function is patched at the re-export and not at its
+    defining module -- and that mistake is silent everywhere else, since a
+    direct call keeps working.
+    """
+    assert _is_wrapped(getattr(sns, name)), f"seaborn.{name} is unwrapped"
+    assert _is_wrapped(
+        getattr(module, name)
+    ), f"{module.__name__}.{name} is unwrapped"
+
+
+def test_a_pairplot_reads_one_layer_per_panel() -> None:
+    """Four panels, four layers, and the diagonal is a histogram.
+
+    Before, this was eight layers: every panel twice, with the diagonal
+    arriving as `bar` plus `dodged_bar` because only the matplotlib-level
+    patches saw it.
+    """
+    grid = sns.pairplot(_frame())
+
+    assert _layers(grid.figure) == [
+        PlotType.HIST,
+        PlotType.HIST,
+        PlotType.SCATTER,
+        PlotType.SCATTER,
+    ]
+
+
+def test_a_jointplot_marginal_is_a_histogram() -> None:
+    """The central panel and its two marginals, each once.
+
+    The marginals were `dodged_bar`, which is a chart with groups in it --
+    a reader would have been told a distribution was a grouped bar chart.
+    """
+    grid = sns.jointplot(data=_frame(), x="a", y="b")
+
+    assert _layers(grid.figure) == [
+        PlotType.SCATTER,
+        PlotType.HIST,
+        PlotType.HIST,
+    ]
+
+
+def test_a_direct_call_is_unchanged() -> None:
+    """The control, and what made this invisible.
+
+    Calling the same functions with an explicit axes has always been right,
+    because the top-level name is the one a user reaches for. Nothing here
+    should move.
+    """
+    frame = _frame()
+
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", ax=ax)
+    assert _layers(fig) == [PlotType.HIST]
+
+    fig, ax = plt.subplots()
+    sns.scatterplot(data=frame, x="a", y="b", ax=ax)
+    assert _layers(fig) == [PlotType.SCATTER]
+
+
+def test_a_regression_grid_reads_its_curve_as_a_fit() -> None:
+    """`lmplot` gained more than a layer count: its curve changed meaning.
+
+    It was `point` plus **`line`** -- the fitted curve announced as though it
+    were the data. `smooth` is the type for a computed fit, and it is what a
+    direct `sns.regplot()` has always emitted. Unlooked-for when this change
+    was written, and the clearest illustration of what running the unpatched
+    function costs: the layer count was already right, so nothing about the
+    old reading looked wrong.
+    """
+    grid = sns.lmplot(data=_frame(), x="a", y="b")
+
+    assert _layers(grid.figure) == [PlotType.SCATTER, PlotType.SMOOTH]
+
+
+def test_the_grids_this_does_not_reach_are_named() -> None:
+    """The boundary, asserted rather than left to be discovered per bug report.
+
+    `displot` and `catplot` do not import the module-level functions at all --
+    they drive `_DistributionPlotter` and `_CategoricalPlotter` directly -- so
+    patching the defining module does not touch them. They are still read only
+    by the matplotlib-level patches, and still wrong: a distribution arrives as
+    a grouped bar chart.
+
+    Pinned here so that the day either is fixed, this test fails and has to be
+    rewritten, the way `test_hist2d.py` pinned `hexbin` before #368.
+    """
+    frame = _frame()
+    frame["group"] = ["x", "y"] * 30
+
+    # A histogram, announced as a grouped bar chart.
+    assert _layers(sns.displot(data=frame, x="a").figure) == [PlotType.DODGED]
+
+    # Bars plus the error-bar lines, neither read as what it is.
+    assert _layers(
+        sns.catplot(data=frame, x="group", y="a", kind="bar").figure
+    ) == [PlotType.DODGED, PlotType.LINE]


### PR DESCRIPTION
Closes #344.

seaborn re-exports its plotting functions from the package root, and its own figure-level functions import them from the **defining module**, inside the function body:

```python
from .relational import scatterplot   # Avoid circular import
from .distributions import histplot, kdeplot
```

Those are two separate bindings to one function object. MAIDR patched only the re-export:

```
seaborn.scatterplot                PATCHED
seaborn.relational.scatterplot     plain
seaborn.histplot                   PATCHED
seaborn.distributions.histplot     plain
```

So every grid in `seaborn/axisgrid.py` ran the **unpatched** function.

## What that cost

Two things at once, and neither reads as a patching problem.

A `histplot` panel arrived as **bars** — `Axes.bar` cannot know it is drawing a histogram, and the seaborn-level patch that would have known never ran. And every panel registered **twice**: `seaborn.utils._default_color` draws a throwaway artist to find out what colour the axes would give it and then removes it, and with no seaborn-level patch there was no recursion context to suppress it, so the probe registered as a chart of its own. Same family as #369, where a colorbar's gradient became a second heatmap.

Measured before and after:

| | before | after |
| --- | --- | --- |
| `pairplot` (2 vars) | `bar, dodged_bar, bar, dodged_bar, point ×4` | `hist, hist, point, point` |
| `jointplot` | `point, dodged_bar, dodged_bar` | `point, hist, hist` |
| `lmplot` | `point, `**`line`** | `point, `**`smooth`** |
| `relplot` (scatter / line) | `point` / `line` | unchanged — already right |

**`lmplot` was unlooked-for, and is the clearest illustration of the cost.** Its layer count was already right, so nothing about the reading looked wrong — while the fitted curve was announced as though it were the data. `smooth` is the type for a computed fit, and what a direct `sns.regplot()` has always emitted.

## The change

One helper, `wrap_seaborn(name, wrapper)`, used at all nine patch sites. It finds the defining module through `__module__` rather than a hard-coded table, so a function seaborn moves does not quietly stop being patched, and checks identity before wrapping so a name that no longer resolves to the same object is left alone rather than wrapped by guess.

`histogram.py`'s decorator form (`@wrapt.patch_function_wrapper("seaborn", "histplot")`) becomes a plain function plus a `wrap_seaborn` call, so all nine sites read the same way.

Named `wrap_seaborn` rather than `patch_seaborn` because `boxplot.py` already has a module-local `patch_seaborn()` doing something else — the same confusable-name trap review flagged on #370.

## What this does **not** reach

`displot` and `catplot` drive `_DistributionPlotter` and `_CategoricalPlotter` directly rather than importing the module-level functions, so patching the defining module does not touch them. They are still read only by the matplotlib-level patches, and still wrong — a distribution arrives as a grouped bar chart.

That boundary is asserted by `test_the_grids_this_does_not_reach_are_named`, so the day either is fixed the test fails and has to be rewritten, the way `test_hist2d.py` pinned `hexbin` before #368.

## Tests

Fourteen cases. The first is the one that matters most for the future:

**`test_both_names_are_wrapped`** asserts the *binding*, parametrised over all nine functions. Everything else goes through a grid, which is a long way from the line that installs a patch — and the mistake this fixes is silent everywhere else, because a direct call keeps working. That parametrised case is what fails the moment a tenth function is patched at one name and not the other.

Removing the defining-module wrap fails 12 of the 14.

| | |
| --- | --- |
| Python 3.11 / matplotlib 3.10.9 | 1173 passed |
| Python 3.9 / matplotlib 3.9.4 | the new file's 14 passed |
| lint | clean on every touched path |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_