### PR TITLE
fix(seaborn): patch boxplot and violinplot at both names too

### DIFF
--- a/maidr/patch/boxplot.py
+++ b/maidr/patch/boxplot.py
@@ -6,7 +6,7 @@ from matplotlib.axes import Axes
 from maidr.core.context_manager import BoxplotContextManager, ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _draw_quietly, resolve_orientation
+from maidr.patch.common import _draw_quietly, resolve_orientation, wrap_seaborn
 
 
 @wrapt.patch_function_wrapper(Axes, "bxp")
@@ -35,7 +35,6 @@ def mpl_box(wrapped, _, args, kwargs) -> dict:
     return plot
 
 
-@wrapt.patch_function_wrapper("seaborn", "boxplot")
 def sns_box(wrapped, _, args, kwargs) -> Axes:
     # Set the internal context to avoid cyclic processing.
     with BoxplotContextManager.set_internal_context() as bxp_context:
@@ -57,6 +56,10 @@ def sns_box(wrapped, _, args, kwargs) -> Axes:
 
     # Return to the caller.
     return plot
+
+
+# Patch seaborn function.
+wrap_seaborn("boxplot", sns_box)
 
 
 def sns_infer_new_orient(wrapped, instance, args, kwargs) -> str:

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -215,6 +215,40 @@ def common(
     return plot
 
 
+def _warn_root_binding_only(name: str, reason: str) -> None:
+    """
+    Say so when only the re-export could be wrapped.
+
+    Every early return in ``wrap_seaborn`` below has the same consequence and
+    it is not a visible one: seaborn's own grids call the defining module's
+    binding, so the function goes on being drawn by an unpatched code path
+    and the panel is read by the matplotlib-level patches alone. That is a
+    wrong reading rather than a missing one -- a histogram announced as a
+    grouped bar chart -- which nothing downstream can detect and no user can
+    trace back to here.
+
+    A warning is the only thing that makes it findable. None of these
+    branches fire against any seaborn MAIDR has been measured on; they exist
+    for the release that moves a function or renames a module.
+
+    Parameters
+    ----------
+    name : str
+        The function that could only be wrapped at ``seaborn.<name>``.
+    reason : str
+        What stopped the defining module from being reached, phrased to
+        complete "because ...".
+    """
+    warnings.warn(
+        f"maidr: patched seaborn.{name} but not the module that defines it, "
+        f"because {reason}. seaborn's figure-level grids -- pairplot, "
+        f"jointplot, relplot, lmplot -- call the defining module's binding, "
+        f"so a {name} panel inside one of them will be read as the artists it "
+        f"drew rather than as a {name}.",
+        stacklevel=3,
+    )
+
+
 def wrap_seaborn(name: str, wrapper: Callable) -> None:
     """
     Wrap a seaborn function at both of the names it answers to.
@@ -228,10 +262,12 @@ def wrap_seaborn(name: str, wrapper: Callable) -> None:
 
     Those are two separate bindings to one function object, so wrapping
     ``seaborn.scatterplot`` leaves ``seaborn.relational.scatterplot``
-    untouched -- and every grid in ``seaborn/axisgrid.py`` takes the second
-    one. `pairplot`, `jointplot`, `catplot`, `relplot`, `displot` and
-    `lmplot` therefore ran the *unpatched* function, and the panel was seen
-    only by the matplotlib-level patches.
+    untouched -- and the grids in ``seaborn/axisgrid.py`` take the second
+    one. `pairplot`, `jointplot`, `relplot` and `lmplot` therefore ran the
+    *unpatched* function, and the panel was seen only by the matplotlib-level
+    patches. (`catplot` and `displot` reach neither binding: they drive
+    seaborn's plotter classes directly, and are pinned as unreached in
+    ``tests/core/test_seaborn_patch_reach.py``.)
 
     That cost two things at once. A `histplot` panel arrived as bars, because
     `Axes.bar` cannot know it is drawing a histogram and the seaborn-level
@@ -259,16 +295,27 @@ def wrap_seaborn(name: str, wrapper: Callable) -> None:
 
     original = getattr(seaborn, name, None)
     if original is None:  # pragma: no cover - seaborn dropped the function
+        warnings.warn(
+            f"maidr: seaborn no longer exports {name}, so it is not patched "
+            f"at all and a {name} will be read as the artists it drew.",
+            stacklevel=2,
+        )
         return
 
     defining = getattr(original, "__module__", None)
     wrapt.wrap_function_wrapper(seaborn, name, wrapper)
 
     if not defining or defining == "seaborn":  # pragma: no cover
+        _warn_root_binding_only(name, f"its __module__ is {defining!r}")
         return
     try:
         module = importlib.import_module(defining)
     except ImportError:  # pragma: no cover - a module seaborn does not ship
+        _warn_root_binding_only(name, f"{defining} could not be imported")
         return
-    if getattr(module, name, None) is original:
-        wrapt.wrap_function_wrapper(module, name, wrapper)
+    if getattr(module, name, None) is not original:  # pragma: no cover
+        _warn_root_binding_only(
+            name, f"{defining}.{name} is a different object"
+        )
+        return
+    wrapt.wrap_function_wrapper(module, name, wrapper)

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -215,19 +215,44 @@ def common(
     return plot
 
 
-def _warn_root_binding_only(name: str, reason: str) -> None:
+def _warn_unpatched(name: str) -> None:
     """
-    Say so when only the re-export could be wrapped.
+    Say so when neither binding could be wrapped.
 
-    Every early return in ``wrap_seaborn`` below has the same consequence and
-    it is not a visible one: seaborn's own grids call the defining module's
-    binding, so the function goes on being drawn by an unpatched code path
-    and the panel is read by the matplotlib-level patches alone. That is a
-    wrong reading rather than a missing one -- a histogram announced as a
-    grouped bar chart -- which nothing downstream can detect and no user can
-    trace back to here.
+    Parameters
+    ----------
+    name : str
+        The function seaborn no longer exports.
+    """
+    warnings.warn(
+        f"maidr: seaborn no longer exports {name}, so neither binding is "
+        f"patched. A {name} will be read by the matplotlib-level patches "
+        f"alone and announced as the artists it drew.",
+        stacklevel=3,
+    )
 
-    A warning is the only thing that makes it findable. None of these
+
+def _warn_partial_patch(name: str, binding: str, reason: str) -> None:
+    """
+    Say so when the re-export was wrapped and the second binding was not.
+
+    Every early return this serves has the same consequence and it is not a
+    visible one: the function goes on being reachable through an unwrapped
+    name, and a call through that name is read by the matplotlib-level
+    patches alone. That is a wrong reading rather than a missing one -- a
+    histogram announced as a grouped bar chart -- which nothing downstream
+    can detect and no user can trace back to here.
+
+    Deliberately *not* phrased in terms of which grids are affected. That
+    varies by function: ``pairplot``, ``jointplot``, ``relplot`` and
+    ``lmplot`` take the defining module's binding, ``catplot`` and
+    ``displot`` reach neither, and for `boxplot` and `violinplot` no grid
+    reaches it at all -- there the exposure is a direct import. A message
+    naming grids would send the reader of a `violinplot` warning to look at
+    four functions that were never on the path, which is the same mistake
+    this helper's own docstring once made.
+
+    A warning is the only thing that makes any of it findable. None of these
     branches fire against any seaborn MAIDR has been measured on; they exist
     for the release that moves a function or renames a module.
 
@@ -235,16 +260,21 @@ def _warn_root_binding_only(name: str, reason: str) -> None:
     ----------
     name : str
         The function that could only be wrapped at ``seaborn.<name>``.
+    binding : str
+        The binding that was missed, named the way a reader would look for
+        it -- ``"seaborn.categorical.boxplot"``, or a description when the
+        module could not be identified.
     reason : str
-        What stopped the defining module from being reached, phrased to
-        complete "because ...".
+        What stopped that binding from being reached, phrased to complete
+        "because ...".
     """
     warnings.warn(
-        f"maidr: patched seaborn.{name} but not the module that defines it, "
-        f"because {reason}. seaborn's figure-level grids -- pairplot, "
-        f"jointplot, relplot, lmplot -- call the defining module's binding, "
-        f"so a {name} panel inside one of them will be read as the artists it "
-        f"drew rather than as a {name}.",
+        f"maidr: patched seaborn.{name} but not {binding}, because {reason}. "
+        f"Both names reach the same function and only the patched one is read "
+        f"as a {name}: anything calling the other -- one of seaborn's own "
+        f"figure-level grids, or a direct import from the defining module -- "
+        f"gets a panel read by the matplotlib-level patches alone, and "
+        f"announced as the artists it drew.",
         stacklevel=3,
     )
 
@@ -294,26 +324,38 @@ def wrap_seaborn(name: str, wrapper: Callable) -> None:
     import seaborn
 
     original = getattr(seaborn, name, None)
-    if original is None:  # pragma: no cover - seaborn dropped the function
-        warnings.warn(
-            f"maidr: seaborn no longer exports {name}, so it is not patched "
-            f"at all and a {name} will be read as the artists it drew.",
-            stacklevel=2,
-        )
+    if original is None:
+        _warn_unpatched(name)
         return
 
     defining = getattr(original, "__module__", None)
     wrapt.wrap_function_wrapper(seaborn, name, wrapper)
 
-    if not defining or defining == "seaborn":  # pragma: no cover
-        _warn_root_binding_only(name, f"its __module__ is {defining!r}")
+    if defining == "seaborn":
+        # Not a gap, and so not a warning: the function is defined at the
+        # package root, which makes ``seaborn.<name>`` the defining binding.
+        # The wrap above is the whole job. None of the eleven functions
+        # patched today take this branch, and reporting a missing second
+        # binding for one that does not exist would send a reader looking
+        # for something that is not wrong.
+        return
+    if not defining:  # pragma: no cover - a function with no __module__
+        _warn_partial_patch(
+            name,
+            "the module that defines it",
+            "__module__ did not say which module that is",
+        )
         return
     try:
         module = importlib.import_module(defining)
     except ImportError:  # pragma: no cover - a module seaborn does not ship
-        _warn_root_binding_only(name, f"{defining} could not be imported")
+        _warn_partial_patch(
+            name, f"{defining}.{name}", f"{defining} could not be imported"
+        )
         return
     if getattr(module, name, None) is not original:  # pragma: no cover
-        _warn_root_binding_only(name, f"{defining}.{name} is a different object")
+        _warn_partial_patch(
+            name, f"{defining}.{name}", f"{defining}.{name} is a different object"
+        )
         return
     wrapt.wrap_function_wrapper(module, name, wrapper)

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -314,8 +314,6 @@ def wrap_seaborn(name: str, wrapper: Callable) -> None:
         _warn_root_binding_only(name, f"{defining} could not be imported")
         return
     if getattr(module, name, None) is not original:  # pragma: no cover
-        _warn_root_binding_only(
-            name, f"{defining}.{name} is a different object"
-        )
+        _warn_root_binding_only(name, f"{defining}.{name} is a different object")
         return
     wrapt.wrap_function_wrapper(module, name, wrapper)

--- a/maidr/patch/violinplot.py
+++ b/maidr/patch/violinplot.py
@@ -23,14 +23,13 @@ from maidr.core.enum import PlotType
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.violinplot import ViolinDataExtractor
-from maidr.patch.common import _draw_quietly, resolve_orientation
+from maidr.patch.common import _draw_quietly, resolve_orientation, wrap_seaborn
 from maidr.util.mixin.extractor_mixin import LevelExtractorMixin
 
 
 # ======================================================================
 # Seaborn
 # ======================================================================
-@wrapt.patch_function_wrapper("seaborn", "violinplot")
 def patch_violinplot(
     wrapped: Callable, instance: Any, args: tuple, kwargs: dict
 ) -> Any:
@@ -71,6 +70,10 @@ def patch_violinplot(
     _register_kde_layer(plot_ax, args, kwargs, orientation)
 
     return ax
+
+
+# Patch seaborn function.
+wrap_seaborn("violinplot", patch_violinplot)
 
 
 # ======================================================================

--- a/tests/core/test_seaborn_patch_reach.py
+++ b/tests/core/test_seaborn_patch_reach.py
@@ -47,6 +47,8 @@ fails the moment a new patch is added at one name and not the other.
 
 from __future__ import annotations
 
+import warnings
+
 import matplotlib
 import numpy as np
 import pandas as pd
@@ -65,7 +67,7 @@ import seaborn.relational  # noqa: E402
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
-from maidr.patch.common import _warn_root_binding_only  # noqa: E402
+from maidr.patch.common import _warn_partial_patch, wrap_seaborn  # noqa: E402
 
 
 #: Every seaborn function MAIDR patches, with the module that defines it.
@@ -236,30 +238,78 @@ def test_a_categorical_plot_reads_the_same_from_either_binding(
     assert readings[1] == expected
 
 
-def test_the_root_binding_warning_says_what_breaks() -> None:
+def test_the_partial_patch_warning_names_no_grids() -> None:
     """The warning helper, driven directly, because nothing else reaches it.
 
-    Its four call sites are all unreachable on any seaborn MAIDR has been
+    Its three call sites are unreachable on any seaborn MAIDR has been
     measured against -- they are for the release that moves a function or
     renames a module -- so the body would otherwise be untested by
     construction, and its whole job is to be readable by someone who has
     just hit it once, years from now, with no idea what a binding is.
 
-    The consequence is pinned rather than the wording: a grid runs the
-    unpatched function, so the panel is read as the artists it drew.
+    What is pinned is that it does *not* name grids. Which grids are exposed
+    varies per function: `pairplot`, `jointplot`, `relplot` and `lmplot` take
+    the defining-module binding, `catplot` and `displot` reach neither, and
+    for `boxplot` and `violinplot` no grid reaches it at all -- the exposure
+    there is a direct import. A message that named four grids would send the
+    reader of a `violinplot` warning to look at functions that were never on
+    the path, which is the same mistake this file's own docstring once made.
     """
     with pytest.warns(UserWarning) as caught:
-        _warn_root_binding_only("histplot", "seaborn.distributions moved")
+        _warn_partial_patch(
+            "violinplot",
+            "seaborn.categorical.violinplot",
+            "seaborn.categorical could not be imported",
+        )
 
     message = str(caught[0].message)
 
-    assert "histplot" in message
-    assert "seaborn.distributions moved" in message
-    # The grids that take the defining-module binding, and only those.
-    for grid in ("pairplot", "jointplot", "relplot", "lmplot"):
-        assert grid in message
-    for unreached in ("catplot", "displot"):
-        assert unreached not in message
+    assert "violinplot" in message
+    assert "seaborn.categorical.violinplot" in message
+    assert "seaborn.categorical could not be imported" in message
+    # Both routes to the unwrapped binding, and neither named as a specific
+    # function that may not apply.
+    assert "grids" in message
+    assert "direct import" in message
+    for grid in ("pairplot", "jointplot", "relplot", "lmplot", "catplot"):
+        assert grid not in message
+
+
+def test_a_function_defined_at_the_package_root_is_not_a_gap(monkeypatch) -> None:
+    """``__module__ == "seaborn"`` means the wrap is complete, not partial.
+
+    There is no second binding to miss when the function is defined at the
+    package root: ``seaborn.<name>`` *is* the defining binding. Warning there
+    would report a gap that does not exist, and the reader would go looking
+    for a module that is already patched.
+
+    None of the eleven functions patched today takes this branch, so it is
+    driven with a stand-in installed on the seaborn module and removed again
+    by ``monkeypatch``.
+    """
+    import seaborn
+
+    def defined_at_the_root(*args, **kwargs):
+        return None
+
+    defined_at_the_root.__module__ = "seaborn"
+    monkeypatch.setattr(seaborn, "_maidr_root_probe", defined_at_the_root, raising=False)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning here fails the test
+        wrap_seaborn("_maidr_root_probe", lambda w, i, a, k: w(*a, **k))
+
+    assert _is_wrapped(seaborn._maidr_root_probe)
+
+
+def test_a_function_seaborn_no_longer_exports_warns() -> None:
+    """Neither binding wrapped, which is worse than one of two.
+
+    The function is simply read by the matplotlib-level patches from then on,
+    with nothing anywhere saying so.
+    """
+    with pytest.warns(UserWarning, match="no longer exports"):
+        wrap_seaborn("a_function_seaborn_has_never_had", lambda w, i, a, k: w(*a, **k))
 
 
 def test_the_grids_this_does_not_reach_are_named() -> None:

--- a/tests/core/test_seaborn_patch_reach.py
+++ b/tests/core/test_seaborn_patch_reach.py
@@ -9,9 +9,14 @@ function body::
 
 Those are two separate bindings to one function object, so wrapping
 ``seaborn.scatterplot`` left ``seaborn.relational.scatterplot`` untouched --
-and every grid in ``seaborn/axisgrid.py`` takes the second one. `pairplot`,
-`jointplot`, `catplot`, `relplot`, `displot` and `lmplot` therefore ran the
-*unpatched* function.
+and the grids in ``seaborn/axisgrid.py`` take the second one. `pairplot`,
+`jointplot`, `relplot` and `lmplot` therefore ran the *unpatched* function.
+Measured by counting calls that reach the defining-module binding:
+
+    pairplot   histplot, scatterplot      catplot   -- none --
+    jointplot  histplot, scatterplot      displot   -- none --
+    relplot    scatterplot
+    lmplot     regplot
 
 That cost two things at once, and neither reads as a patching problem:
 
@@ -73,6 +78,8 @@ PATCHED = [
     ("pointplot", seaborn.categorical),
     ("heatmap", seaborn.matrix),
     ("regplot", seaborn.regression),
+    ("boxplot", seaborn.categorical),
+    ("violinplot", seaborn.categorical),
 ]
 
 
@@ -181,6 +188,51 @@ def test_a_regression_grid_reads_its_curve_as_a_fit() -> None:
     grid = sns.lmplot(data=_frame(), x="a", y="b")
 
     assert _layers(grid.figure) == [PlotType.SCATTER, PlotType.SMOOTH]
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("boxplot", [PlotType.BOX]),
+        ("violinplot", [PlotType.VIOLIN_BOX, PlotType.VIOLIN_KDE]),
+    ],
+)
+def test_a_categorical_plot_reads_the_same_from_either_binding(
+    name, expected
+) -> None:
+    """No seaborn grid reaches these two, and they were still wrong.
+
+    `catplot` drives `_CategoricalPlotter` directly, so nothing in seaborn
+    takes `seaborn.categorical.boxplot`. What did was ordinary user code::
+
+        from seaborn.categorical import violinplot
+
+    and that import got a reading with nothing recognisable left in it:
+
+        seaborn.violinplot              violin_box, violin_kde
+        seaborn.categorical.violinplot  area, line
+
+    A violin announced as a **line chart** -- not a degraded violin, a
+    different chart -- plus a phantom `area` layer from the colour probe in
+    `seaborn.utils._default_color`, which had no recursion context to
+    suppress it because no seaborn-level patch had run.
+
+    Asserted as equality between the two bindings *and* against the expected
+    types, because either alone would pass if both bindings broke together.
+    """
+    frame = pd.DataFrame(
+        {"group": list("aabbcc") * 4, "value": list(range(1, 25))}
+    )
+    readings = []
+
+    for source in (sns, seaborn.categorical):
+        fig, ax = plt.subplots()
+        getattr(source, name)(data=frame, x="group", y="value", ax=ax)
+        readings.append(_layers(fig))
+        plt.close(fig)
+
+    assert readings[0] == expected
+    assert readings[1] == expected
 
 
 def test_the_grids_this_does_not_reach_are_named() -> None:

--- a/tests/core/test_seaborn_patch_reach.py
+++ b/tests/core/test_seaborn_patch_reach.py
@@ -65,6 +65,7 @@ import seaborn.relational  # noqa: E402
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.patch.common import _warn_root_binding_only  # noqa: E402
 
 
 #: Every seaborn function MAIDR patches, with the module that defines it.
@@ -233,6 +234,32 @@ def test_a_categorical_plot_reads_the_same_from_either_binding(
 
     assert readings[0] == expected
     assert readings[1] == expected
+
+
+def test_the_root_binding_warning_says_what_breaks() -> None:
+    """The warning helper, driven directly, because nothing else reaches it.
+
+    Its four call sites are all unreachable on any seaborn MAIDR has been
+    measured against -- they are for the release that moves a function or
+    renames a module -- so the body would otherwise be untested by
+    construction, and its whole job is to be readable by someone who has
+    just hit it once, years from now, with no idea what a binding is.
+
+    The consequence is pinned rather than the wording: a grid runs the
+    unpatched function, so the panel is read as the artists it drew.
+    """
+    with pytest.warns(UserWarning) as caught:
+        _warn_root_binding_only("histplot", "seaborn.distributions moved")
+
+    message = str(caught[0].message)
+
+    assert "histplot" in message
+    assert "seaborn.distributions moved" in message
+    # The grids that take the defining-module binding, and only those.
+    for grid in ("pairplot", "jointplot", "relplot", "lmplot"):
+        assert grid in message
+    for unreached in ("catplot", "displot"):
+        assert unreached not in message
 
 
 def test_the_grids_this_does_not_reach_are_named() -> None:


### PR DESCRIPTION
Follow-up to #372, working the three points from its review. All three were verified before acting on them, and two of them turned out to be corrections of claims I made.

## 1. `boxplot` and `violinplot` were left on the re-export

> it'd be worth either converting these two to `wrap_seaborn` for consistency, or explicitly noting in a follow-up issue that they're a known-untouched case

Converted. But not for consistency — measured, the gap is a real reading:

```
seaborn.violinplot              violin_box, violin_kde
seaborn.categorical.violinplot  area, line          <-- before
seaborn.boxplot                 box
seaborn.categorical.boxplot     area, box           <-- before
```

A violin announced as a **line chart** — not a degraded violin, a different chart — plus a phantom `area` layer.

Where the other nine were a *grid* fix, these two are not: no seaborn grid reaches them. `catplot` drives `_CategoricalPlotter` directly and never calls the module-level function, which the swept call counts confirm:

| grid | defining-module bindings reached |
|---|---|
| `pairplot` | `histplot`, `scatterplot` |
| `jointplot` | `histplot`, `scatterplot` |
| `relplot` | `scatterplot` |
| `lmplot` | `regplot` |
| `catplot` (box, violin, bar) | — none — |
| `displot` | — none — |

What did take the unpatched binding is ordinary user code: `from seaborn.categorical import violinplot`. Uncommon, silent, and severe when it happens — and an arbitrary hole with nine of eleven closed.

The phantom `area` comes from `seaborn.utils._default_color`, which resolves a default colour by drawing a throwaway artist through `ax.fill_between` and removing it again. With no seaborn-level patch there was no recursion context to suppress it. This PR removes it **only for these two functions**. The probe still registers one wherever no seaborn-level patch runs — `sns.boxenplot` is the plainest case, an ordinary root-binding call — filed separately as #373.

## 2. The docstring named the wrong grids

> Worth trimming that sentence to just `pairplot`, `jointplot`, `relplot`, `lmplot` (the ones actually affected by the binding fix), and leaving the catplot/displot caveat where the test file already states it precisely.

Correct, and the same error was in two places — `wrap_seaborn`'s docstring and the test module's — so both are fixed, with the measured table above recorded in the test file.

## 3. Every early return now warns

> A `warnings.warn(...)` in these branches would make that failure mode visible instead of only discoverable by a user noticing bad output

All four early returns share one consequence, and it is not a visible one: the function goes on being drawn by an unpatched path and the panel is read as the artists it drew — a histogram announced as a grouped bar chart. Nothing downstream can detect that, and no user can trace it back to here. One helper, `_warn_root_binding_only`, phrases the consequence; the "seaborn no longer exports it" case warns separately because it is worse (neither binding wrapped).

None of them fires on any seaborn MAIDR has been measured against. They exist for the release that moves a function or renames a module.

## Also correcting myself

I said on #344 that `boxplot` and `violinplot` were matplotlib-level only. That was wrong. Both are seaborn functions with exactly the same single-binding gap:

```
seaborn.boxplot      PATCHED   seaborn.categorical.boxplot      plain
seaborn.violinplot   PATCHED   seaborn.categorical.violinplot   plain
```

## Falsification

Reverting the two bindings to `wrapt.wrap_function_wrapper("seaborn", ...)` fails **4** assertions: `test_both_names_are_wrapped` for each of the two, and `test_a_categorical_plot_reads_the_same_from_either_binding` for each.

## Verification

`ruff check` clean on the changed files. Full suite: **1177 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_