### PR TITLE
fix(seaborn): a colour probe is not a chart

### DIFF
--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -15,10 +15,10 @@ from . import (  # noqa: F401
     pieplot,
     pointplot,
     scatterplot,
-    seaborn_probe,
     regplot,
     kdeplot,
     candlestick,
     mplfinance,
     violinplot,
+    seaborn_probe,
 )

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -15,6 +15,7 @@ from . import (  # noqa: F401
     pieplot,
     pointplot,
     scatterplot,
+    seaborn_probe,
     regplot,
     kdeplot,
     candlestick,

--- a/maidr/patch/seaborn_probe.py
+++ b/maidr/patch/seaborn_probe.py
@@ -1,0 +1,113 @@
+"""Keep seaborn's colour probe from registering as a chart.
+
+``seaborn.utils._default_color`` resolves a default colour by *drawing* a
+throwaway artist, reading its face colour, and removing it again. Every
+branch ends in ``scout.remove()``::
+
+    elif method.__name__ == "fill_between":
+        kws = normalize_kwargs(kws, mpl.collections.PolyCollection)
+        scout = method([], [], **kws)
+        facecolor = scout.get_facecolor()
+        color = to_rgb(facecolor[0])
+        scout.remove()
+
+It is a probe, never a chart. But it draws through ``Axes.fill_between``,
+``Axes.plot``, ``Axes.scatter`` and ``Axes.bar`` -- all of which MAIDR
+patches -- and it runs *before* any seaborn-level patch has set a recursion
+context, so nothing suppressed it (#373).
+"""
+
+from __future__ import annotations
+
+import sys
+import warnings
+from typing import Any
+
+import wrapt
+
+from maidr.core.context_manager import ContextManager
+
+
+def _suppress_registration(wrapped, _, args, kwargs) -> Any:
+    """
+    Resolve a default colour without registering the artist it drew.
+
+    A layer from the probe describes a fill of two empty arrays. It has no
+    elements on the chart, so it announces a region that is not drawn and
+    highlights nothing -- the same shape of defect as #369, where a colorbar
+    registered as a second heatmap.
+
+    Suppressing the whole function rather than teaching each patch to decline
+    an empty call is the honest scope. ``fill_between`` could be taught to
+    refuse ``([], [])``, and that would fix the one branch and leave the
+    hazard: the probe also drives ``plot``, ``scatter`` and ``bar``, and the
+    next patch added to any of them reintroduces it somewhere new. The probe
+    is the thing that should be quiet, not each artist it happens to draw.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        The original ``seaborn.utils._default_color``.
+    _ : Any
+        Unused -- the function is module-level, so wrapt binds nothing.
+    args : tuple
+        Positional arguments seaborn passed.
+    kwargs : dict
+        Keyword arguments seaborn passed.
+
+    Returns
+    -------
+    Any
+        The resolved colour, unchanged.
+    """
+    with ContextManager.set_internal_context():
+        return wrapped(*args, **kwargs)
+
+
+def _patch_default_color() -> None:
+    """
+    Wrap the probe at every seaborn module that holds a reference to it.
+
+    ``_default_color`` is not a re-export like the plotting functions
+    ``wrap_seaborn`` handles -- it is a private helper pulled into three
+    modules by name::
+
+        from .utils import _default_color   # categorical, distributions,
+                                            # relational
+
+    so its ``__module__`` names one binding out of four and the call sites
+    take the other three. Sweeping the loaded ``seaborn`` modules covers
+    every binding without a hard-coded table, and stays correct if seaborn
+    switches to a qualified ``utils._default_color(...)`` call, since
+    ``seaborn.utils`` is in the sweep too.
+
+    The identity check is what makes the sweep safe: a name that no longer
+    resolves to the same object is left alone rather than wrapped by guess.
+    Importing ``seaborn.utils`` runs ``seaborn/__init__.py``, which imports
+    every module that binds the probe, so they are all in ``sys.modules`` by
+    the time the sweep runs.
+    """
+    import seaborn.utils
+
+    original = getattr(seaborn.utils, "_default_color", None)
+    if original is None:  # pragma: no cover - seaborn renamed the helper
+        warnings.warn(
+            "maidr: seaborn.utils._default_color is gone, so the colour probe "
+            "is no longer suppressed. If seaborn still resolves default "
+            "colours by drawing a throwaway artist, that artist will be "
+            "registered as a chart of its own.",
+            stacklevel=2,
+        )
+        return
+
+    for module in list(sys.modules.values()):
+        name = getattr(module, "__name__", "")
+        if name != "seaborn" and not name.startswith("seaborn."):
+            continue
+        if getattr(module, "_default_color", None) is original:
+            wrapt.wrap_function_wrapper(
+                module, "_default_color", _suppress_registration
+            )
+
+
+_patch_default_color()

--- a/maidr/patch/seaborn_probe.py
+++ b/maidr/patch/seaborn_probe.py
@@ -83,14 +83,20 @@ def _patch_default_color() -> None:
 
     The identity check is what makes the sweep safe: a name that no longer
     resolves to the same object is left alone rather than wrapped by guess.
-    Importing ``seaborn.utils`` runs ``seaborn/__init__.py``, which imports
-    every module that binds the probe, so they are all in ``sys.modules`` by
-    the time the sweep runs.
+
+    The sweep is a snapshot of ``sys.modules`` taken once, at ``import
+    maidr``, and it assumes ``seaborn/__init__.py`` has already pulled in
+    every module that binds the probe -- which it has, since it does
+    ``from .categorical import *`` and the same for the other two. A seaborn
+    that imported its submodules lazily would leave a binding unwrapped and
+    say nothing, so the assumption is asserted rather than trusted:
+    ``test_the_known_call_sites_are_covered`` indexes ``sys.modules`` by name
+    and raises ``KeyError`` the moment one of them is no longer loaded.
     """
     import seaborn.utils
 
     original = getattr(seaborn.utils, "_default_color", None)
-    if original is None:  # pragma: no cover - seaborn renamed the helper
+    if original is None:
         warnings.warn(
             "maidr: seaborn.utils._default_color is gone, so the colour probe "
             "is no longer suppressed. If seaborn still resolves default "

--- a/tests/core/test_seaborn_color_probe.py
+++ b/tests/core/test_seaborn_color_probe.py
@@ -1,0 +1,204 @@
+"""A colour probe is not a chart, and MAIDR was registering it as one.
+
+``seaborn.utils._default_color`` resolves a default colour by *drawing* a
+throwaway artist, reading its face colour, and removing it again. Every
+branch ends in ``scout.remove()``::
+
+    elif method.__name__ == "fill_between":
+        kws = normalize_kwargs(kws, mpl.collections.PolyCollection)
+        scout = method([], [], **kws)
+        facecolor = scout.get_facecolor()
+        color = to_rgb(facecolor[0])
+        scout.remove()
+
+It draws through ``Axes.fill_between``, ``Axes.plot``, ``Axes.scatter`` and
+``Axes.bar`` -- all patched -- and it runs *before* any seaborn-level patch
+has set a recursion context, so nothing suppressed it. Since #339 taught
+MAIDR to read ``fill_between`` as an area chart, the probe registered a
+layer describing a fill of two empty arrays (#373).
+
+Measured across seaborn, before and after:
+
+    rugplot     ExtractionError -> renders     (the probe's empty layer was
+                                                fatal to the whole figure)
+    ecdfplot    line            -> step        (same data, wrong chart)
+    stripplot   4 layers        -> 3           (one per group, and one more)
+    boxenplot   area, line, ... -> line, ...
+
+The `ecdfplot` row is the one worth reading twice. The layer count was
+already right and the numbers were already right; the probe simply got
+registered first and its ``ax.plot([], [])`` carried no ``drawstyle``, so
+the shared line pass settled on ``line``. An ECDF announced as a line chart
+rather than a step chart, with nothing in the output to catch.
+
+The `rugplot` row is the #369 shape exactly: the phantom layer did not just
+add noise, it raised ``ExtractionError`` when its data was read, and that is
+fatal to the whole render rather than to its own layer. A scatter with a rug
+over it -- which is how ``rugplot`` is actually used -- produced no HTML at
+all.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import matplotlib
+import numpy as np
+import pandas as pd
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+#: The modules that pull the probe in by name, plus the one that defines it.
+CALL_SITES = [
+    "seaborn.utils",
+    "seaborn.categorical",
+    "seaborn.distributions",
+    "seaborn.relational",
+]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Three groups and a numeric column, enough for a categorical plot."""
+    rng = np.random.default_rng(20260814)
+    return pd.DataFrame(
+        {"group": list("abc") * 8, "value": rng.normal(size=24)}
+    )
+
+
+def _is_wrapped(function) -> bool:
+    """Whether wrapt has a wrapper installed on this object."""
+    return type(function).__name__ == "FunctionWrapper"
+
+
+def _layers(fig) -> list:
+    """The plot types registered for a figure, or an empty list."""
+    try:
+        return [plot.type for plot in FigureManager.get_maidr(fig).plots]
+    except KeyError:
+        return []
+
+
+def test_no_seaborn_module_holds_an_unwrapped_probe() -> None:
+    """The binding, swept rather than listed.
+
+    ``_default_color`` is a private helper imported by name into three
+    modules, so ``__module__`` names one binding out of four and the call
+    sites take the other three. This is the check that fails if seaborn adds
+    a fourth importer -- which a hard-coded table would not notice, and which
+    nothing downstream would report, since the symptom is a phantom layer in
+    one function nobody thought to re-measure.
+    """
+    unwrapped = [
+        name
+        for name, module in sys.modules.items()
+        if (name == "seaborn" or name.startswith("seaborn."))
+        and getattr(module, "_default_color", None) is not None
+        and not _is_wrapped(module._default_color)
+    ]
+
+    assert unwrapped == [], f"unwrapped probe bindings: {unwrapped}"
+
+
+@pytest.mark.parametrize("module_name", CALL_SITES)
+def test_the_known_call_sites_are_covered(module_name) -> None:
+    """The sweep found the modules it was written for.
+
+    The test above passes vacuously if the sweep wrapped *nothing*, so the
+    four bindings that exist today are named here as well.
+    """
+    module = sys.modules[module_name]
+
+    assert _is_wrapped(module._default_color)
+
+
+def test_a_rug_over_a_scatter_renders() -> None:
+    """The phantom layer was fatal, not merely noisy.
+
+    ``rugplot`` draws its ticks as a ``LineCollection`` MAIDR does not read,
+    so the only layer it registered was the probe -- and reading that layer's
+    data raised ``ExtractionError``, which takes the whole figure with it
+    rather than just its own layer. A scatter that would have read perfectly
+    well produced nothing at all.
+    """
+    frame = _frame()
+    fig, ax = plt.subplots()
+
+    sns.scatterplot(data=frame, x="value", y="value", ax=ax)
+    sns.rugplot(data=frame, x="value", ax=ax)
+
+    assert _layers(fig) == [PlotType.SCATTER]
+
+    # The render itself, because the layer list alone would not have caught
+    # it: extraction is where the old failure happened.
+    html = maidr.render(fig)
+    assert html is not None
+
+
+def test_an_ecdf_is_announced_as_a_step() -> None:
+    """Right data, right layer count, wrong chart.
+
+    The probe registered first, and its ``ax.plot([], [])`` carried no
+    ``drawstyle``, so the shared line pass settled on ``line`` for a curve
+    that is drawn ``steps-post``. Nothing about the reading looked wrong --
+    which is what makes it worth a test rather than a comment.
+    """
+    fig, ax = plt.subplots()
+    sns.ecdfplot(data=_frame(), x="value", ax=ax)
+
+    assert _layers(fig) == [PlotType.STEP]
+
+
+def test_a_strip_plot_registers_one_layer_per_group() -> None:
+    """Three groups, three layers. It was four.
+
+    ``_default_color`` probes through ``ax.scatter`` here, so the extra layer
+    carried the *point* type -- indistinguishable from a real one in the
+    layer list, and a fourth series to page through that the chart does not
+    have.
+    """
+    fig, ax = plt.subplots()
+    sns.stripplot(data=_frame(), x="group", y="value", ax=ax)
+
+    assert _layers(fig) == [PlotType.SCATTER] * 3
+
+
+def test_a_boxen_plot_carries_no_phantom_area() -> None:
+    """The reproduction from the issue.
+
+    ``boxenplot`` is not a supported plot type and this does not make it one:
+    what it registers is still not a boxen plot. But the leading ``area`` was
+    a fill of two empty arrays, and it is gone.
+    """
+    fig, ax = plt.subplots()
+    sns.boxenplot(data=_frame(), x="group", y="value", ax=ax)
+
+    assert PlotType.AREA not in _layers(fig)
+
+
+def test_a_real_fill_between_is_untouched() -> None:
+    """The control, and the thing that would be worst to break.
+
+    Suppression is scoped to the probe's extent, so a fill a user actually
+    asked for still registers. Without this, "no phantom areas" would be
+    satisfiable by reading no areas at all.
+    """
+    fig, ax = plt.subplots()
+    x = np.linspace(0, 10, 50)
+    ax.fill_between(x, np.sin(x) + 2)
+
+    assert _layers(fig) == [PlotType.AREA]

--- a/tests/core/test_seaborn_color_probe.py
+++ b/tests/core/test_seaborn_color_probe.py
@@ -55,6 +55,7 @@ import seaborn as sns  # noqa: E402
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.patch.seaborn_probe import _patch_default_color  # noqa: E402
 
 #: The modules that pull the probe in by name, plus the one that defines it.
 CALL_SITES = [
@@ -124,6 +125,26 @@ def test_the_known_call_sites_are_covered(module_name) -> None:
     module = sys.modules[module_name]
 
     assert _is_wrapped(module._default_color)
+
+
+def test_a_renamed_probe_warns(monkeypatch) -> None:
+    """The one branch that cannot wrap anything, driven rather than assumed.
+
+    If seaborn renames or drops ``_default_color`` there is nothing to
+    suppress, and the phantom layer comes back with no other signal -- so the
+    branch says so. Exercised by deleting the attribute, since it is
+    unreachable on any seaborn this has been measured against.
+
+    Safe to re-run ``_patch_default_color`` here: with the attribute gone it
+    returns after warning, so nothing is double-wrapped, and ``monkeypatch``
+    puts the probe back.
+    """
+    import seaborn.utils
+
+    monkeypatch.delattr(seaborn.utils, "_default_color")
+
+    with pytest.warns(UserWarning, match="_default_color is gone"):
+        _patch_default_color()
 
 
 def test_a_rug_over_a_scatter_renders() -> None:


### PR DESCRIPTION
Closes #373.

`seaborn.utils._default_color` resolves a default colour by *drawing* a throwaway artist, reading its face colour, and removing it again. Every branch ends in `scout.remove()`:

```python
elif method.__name__ == "fill_between":
    kws = normalize_kwargs(kws, mpl.collections.PolyCollection)
    scout = method([], [], **kws)
    facecolor = scout.get_facecolor()
    color = to_rgb(facecolor[0])
    scout.remove()
```

It is a probe, never a chart. But it draws through `Axes.fill_between`, `Axes.plot`, `Axes.scatter` and `Axes.bar` — all patched — and it runs *before* any seaborn-level patch has set a recursion context, so nothing suppressed it. Since #339 taught MAIDR to read `fill_between` as an area chart, the probe started registering a layer describing a fill of two empty arrays.

## Measured, before → after

| | before | after |
|---|---|---|
| `rugplot` | **`ExtractionError`** | renders |
| `ecdfplot` | `line` | `step` |
| `stripplot` (3 groups) | 4 layers | 3 |
| `boxenplot` | `area, line, point, point, point` | `line, point, point, point` |

**`rugplot` is the #369 shape exactly.** Its ticks are a `LineCollection` MAIDR does not read, so the probe's layer was the *only* one registered — and reading its data raised `ExtractionError`, which is fatal to the whole render rather than to its own layer. A scatter with a rug over it, which is how `rugplot` is actually used, produced no HTML at all:

```
                                before                      after
scatter + rugplot overlay       ExtractionError             OK (19573 bytes)
rugplot alone                   ExtractionError             KeyError: no MAIDR found
```

Standalone `rugplot` is still not a supported chart, and now says so through the ordinary "no MAIDR found for figure" path instead of a data-extraction crash.

**`ecdfplot` is the one worth reading twice.** The layer count was already right and the numbers were already right — same `x: -Infinity, y: 0.0` first point before and after. The probe simply registered first, and its `ax.plot([], [])` carried no `drawstyle`, so the shared line pass settled on `line` for a curve drawn `steps-post`. An ECDF announced as a line chart, with nothing in the output to catch.

## Why suppress the function rather than teach `fill_between` to decline

`fill_between` could be taught to refuse `([], [])`. That fixes one branch and leaves the hazard: the probe also drives `plot`, `scatter` and `bar`, and the next patch added to any of them reintroduces this somewhere new. The probe is the thing that should be quiet, not each artist it happens to draw. Same reasoning as #370, which suppressed `Colorbar._draw_all` rather than testing "is this axes a colorbar".

## Why a sweep rather than `__module__`

`_default_color` is not a re-export like the plotting functions `wrap_seaborn` handles — it is a private helper pulled into three modules by name:

```
_default_color   __module__=seaborn.utils
                 bindings=['seaborn.categorical', 'seaborn.distributions',
                           'seaborn.relational', 'seaborn.utils']
```

So `__module__` names one binding out of four and the call sites take the other three. Sweeping the loaded `seaborn` modules covers every binding without a hard-coded table, and stays correct if seaborn switches to a qualified `utils._default_color(...)` call, since `seaborn.utils` is in the sweep too. The identity check is what makes it safe: a name that no longer resolves to the same object is left alone rather than wrapped by guess.

`test_no_seaborn_module_holds_an_unwrapped_probe` asserts the sweep left nothing behind, which is the check that fails if seaborn adds a fourth importer — a hard-coded table would not notice, and nothing downstream would report it.

## Falsification

Reverting the patch fails **9 of the 10** new assertions. The one that survives is `test_a_real_fill_between_is_untouched` — the control, asserting a fill a user actually asked for still reads as an area. Without it, "no phantom areas" would be satisfiable by reading no areas at all.

## Verification

`ruff check` clean. Full suite: **1190 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_