### PR TITLE
fix(bar): ask per axes which bar layer supersedes which

### DIFF
--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -25,8 +25,6 @@ class FigureManager:
     figs : dict
         A dictionary that maps matplotlib Figure objects to their corresponding
         Maidr instances.
-    PLOT_TYPE_PRIORITY : dict
-        Defines the priority order for plot types. Higher numbers take precedence.
 
     Methods
     -------
@@ -40,29 +38,6 @@ class FigureManager:
     """
 
     figs = {}
-
-    # Define plot type priority order (higher numbers take precedence)
-    PLOT_TYPE_PRIORITY = {
-        PlotType.BAR: 1,
-        PlotType.STACKED: 2,
-        PlotType.DODGED: 2,  # DODGED and STACKED have same priority
-        PlotType.LINE: 1,
-        PlotType.STEP: 1,
-        PlotType.SCATTER: 1,
-        PlotType.HIST: 1,
-        PlotType.BOX: 1,
-        PlotType.HEAT: 1,
-        PlotType.HEXBIN: 1,
-        PlotType.COUNT: 1,
-        PlotType.PIE: 1,
-        PlotType.SMOOTH: 1,
-        PlotType.CANDLESTICK: 1,
-        PlotType.VIOLIN_KDE: 1,
-        PlotType.VIOLIN_BOX: 1,
-        PlotType.ERRORBAR: 1,
-        PlotType.AREA: 1,
-        PlotType.STACKED_AREA: 2,
-    }
 
     _instance = None
     _lock = threading.Lock()
@@ -103,15 +78,22 @@ class FigureManager:
         """
         Retrieve or create a Maidr instance for the given Figure.
 
-        If a Maidr instance already exists for the figure, update its plot type
-        if the new plot type has higher priority (DODGED/STACKED > BAR).
+        A figure that already has one is returned as it is. It used to have
+        its ``plot_type`` raised here whenever a layer of higher priority was
+        registered -- DODGED and STACKED outranking everything else -- so that
+        ``_flatten_maidr`` could consult one figure-wide answer to decide
+        whether bar layers should be collapsed. That is what made a stacked
+        bar in one panel delete layers from every other panel, and the
+        question is asked per position now, so the table and the update it
+        served are both gone (#376).
 
         Parameters
         ----------
         fig : Figure
             The matplotlib figure to get or create a Maidr instance for.
         plot_type : PlotType
-            The plot type to set or update for the Maidr instance.
+            The type of the layer being registered. Used only when the figure
+            is new, to record what it started as.
 
         Returns
         -------
@@ -120,14 +102,6 @@ class FigureManager:
         """
         if fig not in cls.figs.keys():
             cls.figs[fig] = Maidr(fig, plot_type)
-        else:
-            # Update plot type if the new type has higher priority
-            maidr = cls.figs[fig]
-            current_priority = cls.PLOT_TYPE_PRIORITY.get(maidr.plot_type, 0)
-            new_priority = cls.PLOT_TYPE_PRIORITY.get(plot_type, 0)
-
-            if new_priority > current_priority:
-                maidr.plot_type = plot_type
         return cls.figs[fig]
 
     @classmethod

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -45,7 +45,7 @@ _AXES_WIDE_BAR_TYPES = frozenset(
 )
 
 #: The subset of the above that describes a whole segmented chart, and so is
-#: the layer to keep when a position holds more than one of the family.
+#: the layer to keep when one axes holds more than one of the family.
 _SEGMENTED_BAR_TYPES = frozenset({PlotType.DODGED, PlotType.STACKED})
 
 
@@ -403,9 +403,25 @@ class Maidr:
         )
 
     @staticmethod
-    def _subplot_position(plot: MaidrPlot) -> tuple[int, int]:
-        """The ``(row, col)`` cell a layer belongs to, defaulting to ``(0, 0)``."""
-        return (getattr(plot, "row_index", 0), getattr(plot, "col_index", 0))
+    def _layer_axes_key(plot: MaidrPlot) -> Any:
+        """
+        What decides whether two layers can supersede one another.
+
+        The axes itself, not the grid cell it sits in. The duplication this
+        resolves comes from the extractor reading every container on
+        ``self.ax``, so ``self.ax`` is the thing that makes two layers
+        descriptions of the same bars -- and ``ax.twinx()`` gives a *second*
+        axes at the *same* ``(row, col)``. Keyed by position, a stacked bar on
+        each side of a twinned pair collapsed to one layer and the right-hand
+        chart was announced nowhere.
+
+        Falls back to the grid cell for a layer that carries no axes, which is
+        no coarser than the position-keyed grouping this replaced.
+        """
+        ax = getattr(plot, "ax", None)
+        if ax is not None:
+            return id(ax)
+        return ("position", getattr(plot, "row_index", 0), getattr(plot, "col_index", 0))
 
     def _collapse_segmented_bar_layers(self) -> None:
         """
@@ -436,10 +452,11 @@ class Maidr:
           on the first call avoided it, which is why every test wrote it that
           way.
 
-        So the question is asked per position and answered by type: a position
+        So the question is asked per *axes* and answered by type: an axes
         holding a segmented layer keeps the first of those and drops the other
-        axes-wide bar layers there. Layers of any other type are left alone --
+        axes-wide bar layers on it. Layers of any other type are left alone --
         a line over a stacked bar is a second layer, not a duplicate of it.
+        See ``_layer_axes_key`` for why the axes and not the grid cell.
 
         Idempotent, and it has to be: it runs from ``_create_html_tag`` before
         the elements are collected *and* from ``_flatten_maidr``, which can be
@@ -452,16 +469,16 @@ class Maidr:
         a layer without dropping its id would hand every surviving layer its
         neighbour's, and the highlight would land on the wrong bar.
         """
-        positions: dict[tuple[int, int], list[MaidrPlot]] = defaultdict(list)
+        by_axes: dict[Any, list[MaidrPlot]] = defaultdict(list)
         for plot in self._plots:
-            positions[self._subplot_position(plot)].append(plot)
+            by_axes[self._layer_axes_key(plot)].append(plot)
 
         # A set of the layers themselves: `MaidrPlot` defines neither
         # `__eq__` nor `__hash__`, so membership is identity, which is what
         # this wants -- two layers of the same type over the same bars are
         # still two objects and only one of them is dropped.
         superseded: set[MaidrPlot] = set()
-        for group in positions.values():
+        for group in by_axes.values():
             segmented = [plot for plot in group if plot.type in _SEGMENTED_BAR_TYPES]
             if not segmented:
                 continue
@@ -527,8 +544,8 @@ class Maidr:
         """Return the top-level MAIDR schema for this figure."""
         # A segmented bar layer describes every bar on its axes, so the sibling
         # registrations from the same chart are duplicates of it. Asked per
-        # position rather than per figure -- see the method for what asking it
-        # per figure cost (#376).
+        # axes rather than per figure -- see the method for what asking it per
+        # figure cost (#376).
         self._collapse_segmented_bar_layers()
 
         # Deduplicate: if any SMOOTH plots exist, remove LINE plots

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 import matplotlib.pyplot as plt
 from htmltools import HTML, HTMLDocument, Tag, tags
 from lxml import etree
+from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from maidr.core.enum.plot_type import PlotType
 
@@ -409,7 +410,7 @@ class Maidr:
         )
 
     @staticmethod
-    def _layer_axes_key(plot: MaidrPlot) -> int:
+    def _layer_axes_key(plot: MaidrPlot) -> Axes:
         """
         What decides whether two layers can supersede one another.
 
@@ -422,9 +423,11 @@ class Maidr:
         chart was announced nowhere.
 
         ``MaidrPlot.__init__`` takes a required ``Axes`` and assigns it, so
-        every layer has one and there is no absent-axes case to handle.
+        every layer has one and there is no absent-axes case to handle. The
+        axes is used as the key directly: ``Axes`` overrides neither
+        ``__eq__`` nor ``__hash__``, so it already groups by identity.
         """
-        return id(plot.ax)
+        return plot.ax
 
     def _collapse_segmented_bar_layers(self) -> None:
         """
@@ -472,7 +475,7 @@ class Maidr:
         a layer without dropping its id would hand every surviving layer its
         neighbour's, and the highlight would land on the wrong bar.
         """
-        by_axes: dict[Any, list[MaidrPlot]] = defaultdict(list)
+        by_axes: dict[Axes, list[MaidrPlot]] = defaultdict(list)
         for plot in self._plots:
             by_axes[self._layer_axes_key(plot)].append(plot)
 

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -74,7 +74,18 @@ class Maidr:
     """
 
     def __init__(self, fig: Figure, plot_type: PlotType = PlotType.LINE) -> None:
-        """Create a new Maidr for the given ``matplotlib.figure.Figure``."""
+        """
+        Create a new Maidr for the given ``matplotlib.figure.Figure``.
+
+        ``plot_type`` records the type of the first layer registered for the
+        figure and is **descriptive only** -- nothing reads it to decide
+        anything. It used to be maintained as a figure-wide "highest priority
+        type seen" and consulted to decide whether bar layers should be
+        collapsed, which is how a stacked bar in one panel came to delete
+        layers from every other panel (#376). The question is asked per
+        position now, so the priority table that maintained this is gone. The
+        parameter is kept because ``Maidr`` is exported.
+        """
         self._fig = fig
         self._plots = []
         self.maidr_id = None
@@ -445,14 +456,18 @@ class Maidr:
         for plot in self._plots:
             positions[self._subplot_position(plot)].append(plot)
 
-        superseded: set[int] = set()
+        # A set of the layers themselves: `MaidrPlot` defines neither
+        # `__eq__` nor `__hash__`, so membership is identity, which is what
+        # this wants -- two layers of the same type over the same bars are
+        # still two objects and only one of them is dropped.
+        superseded: set[MaidrPlot] = set()
         for group in positions.values():
             segmented = [plot for plot in group if plot.type in _SEGMENTED_BAR_TYPES]
             if not segmented:
                 continue
             survivor = segmented[0]
             superseded.update(
-                id(plot)
+                plot
                 for plot in group
                 if plot is not survivor and plot.type in _AXES_WIDE_BAR_TYPES
             )
@@ -463,7 +478,7 @@ class Maidr:
         kept = [
             (plot, selector_id)
             for plot, selector_id in zip(self._plots, self.selector_ids)
-            if id(plot) not in superseded
+            if plot not in superseded
         ]
         self._plots = [plot for plot, _ in kept]
         self.selector_ids = [selector_id for _, selector_id in kept]

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -21,6 +21,8 @@ from maidr.core.enum.plot_type import PlotType
 from maidr.core.context_manager import HighlightContextManager
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.plot import MaidrPlot
+from maidr.core.plot.barplot import BarPlot
+from maidr.core.plot.grouped_barplot import GroupedBarPlot
 from maidr.util.dedup_utils import deduplicate_smooth_and_line
 from maidr.util.dependencies import (
     MAIDR_JS_FILENAME,
@@ -35,18 +37,22 @@ from maidr.util.dependencies import (
 from maidr.util.environment import Environment
 from maidr.util.iframe_utils import wrap_in_iframe_matplotlib
 
-#: Layer types whose extractor reads every ``BarContainer`` on its axes rather
-#: than the bars its own call drew, so two of them on one axes describe the
-#: same chart twice. ``BAR`` and ``COUNT`` are ``BarPlot``; ``DODGED`` and
-#: ``STACKED`` are ``GroupedBarPlot``. ``HIST`` draws bars too but reads its
-#: own container, so it is not in this family and is never dropped.
-_AXES_WIDE_BAR_TYPES = frozenset(
-    {PlotType.BAR, PlotType.COUNT, PlotType.DODGED, PlotType.STACKED}
-)
+#: Layer classes whose extractor reads every ``BarContainer`` on its axes
+#: rather than the bars its own call drew, so two of them on one axes describe
+#: the same chart twice.
+#:
+#: Asked by class rather than by ``plot.type``, and that distinction is not
+#: pedantic: ``MplfinanceBarPlot`` also carries ``PlotType.BAR``, and it reads
+#: the volume patches handed to it rather than sweeping the axes. A type-based
+#: check would have made it eligible to be dropped by a stacked bar sharing
+#: its axes, on a premise that is not true of it. ``HistPlot`` draws bars and
+#: reads its own container too. Neither subclasses the two below, so neither
+#: is in the family.
+_AXES_WIDE_BAR_PLOTS = (BarPlot, GroupedBarPlot)
 
 #: The subset of the above that describes a whole segmented chart, and so is
 #: the layer to keep when one axes holds more than one of the family.
-_SEGMENTED_BAR_TYPES = frozenset({PlotType.DODGED, PlotType.STACKED})
+_SEGMENTED_BAR_PLOTS = (GroupedBarPlot,)
 
 
 class Maidr:
@@ -403,7 +409,7 @@ class Maidr:
         )
 
     @staticmethod
-    def _layer_axes_key(plot: MaidrPlot) -> Any:
+    def _layer_axes_key(plot: MaidrPlot) -> int:
         """
         What decides whether two layers can supersede one another.
 
@@ -415,13 +421,10 @@ class Maidr:
         each side of a twinned pair collapsed to one layer and the right-hand
         chart was announced nowhere.
 
-        Falls back to the grid cell for a layer that carries no axes, which is
-        no coarser than the position-keyed grouping this replaced.
+        ``MaidrPlot.__init__`` takes a required ``Axes`` and assigns it, so
+        every layer has one and there is no absent-axes case to handle.
         """
-        ax = getattr(plot, "ax", None)
-        if ax is not None:
-            return id(ax)
-        return ("position", getattr(plot, "row_index", 0), getattr(plot, "col_index", 0))
+        return id(plot.ax)
 
     def _collapse_segmented_bar_layers(self) -> None:
         """
@@ -479,14 +482,16 @@ class Maidr:
         # still two objects and only one of them is dropped.
         superseded: set[MaidrPlot] = set()
         for group in by_axes.values():
-            segmented = [plot for plot in group if plot.type in _SEGMENTED_BAR_TYPES]
+            segmented = [
+                plot for plot in group if isinstance(plot, _SEGMENTED_BAR_PLOTS)
+            ]
             if not segmented:
                 continue
             survivor = segmented[0]
             superseded.update(
                 plot
                 for plot in group
-                if plot is not survivor and plot.type in _AXES_WIDE_BAR_TYPES
+                if plot is not survivor and isinstance(plot, _AXES_WIDE_BAR_PLOTS)
             )
 
         if not superseded:

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -35,6 +35,19 @@ from maidr.util.dependencies import (
 from maidr.util.environment import Environment
 from maidr.util.iframe_utils import wrap_in_iframe_matplotlib
 
+#: Layer types whose extractor reads every ``BarContainer`` on its axes rather
+#: than the bars its own call drew, so two of them on one axes describe the
+#: same chart twice. ``BAR`` and ``COUNT`` are ``BarPlot``; ``DODGED`` and
+#: ``STACKED`` are ``GroupedBarPlot``. ``HIST`` draws bars too but reads its
+#: own container, so it is not in this family and is never dropped.
+_AXES_WIDE_BAR_TYPES = frozenset(
+    {PlotType.BAR, PlotType.COUNT, PlotType.DODGED, PlotType.STACKED}
+)
+
+#: The subset of the above that describes a whole segmented chart, and so is
+#: the layer to keep when a position holds more than one of the family.
+_SEGMENTED_BAR_TYPES = frozenset({PlotType.DODGED, PlotType.STACKED})
+
 
 class Maidr:
     """
@@ -311,6 +324,15 @@ class Maidr:
             Controls how ``maidr.js`` is referenced.  See :meth:`render`
             for the three possible modes.
         """
+        # Before the artists are collected, not after: reading `plot.elements`
+        # renders the layer, and a superseded `BarPlot` on a stacked axes
+        # raises `ExtractionError` there -- which is fatal to the whole figure,
+        # so collapsing later in `_flatten_maidr` would never be reached. It
+        # also keeps one artist from appearing twice in the list below, where
+        # `HighlightContextManager` resolves an artist by its *first* index and
+        # would hand every bar the dropped layer's selector id (#376).
+        self._collapse_segmented_bar_layers()
+
         tagged_elements: list[Any] = [
             element for plot in self._plots for element in plot.elements
         ]
@@ -369,41 +391,82 @@ class Maidr:
             lang="en",
         )
 
-    def _merge_plots_by_subplot_position(self) -> list[MaidrPlot]:
+    @staticmethod
+    def _subplot_position(plot: MaidrPlot) -> tuple[int, int]:
+        """The ``(row, col)`` cell a layer belongs to, defaulting to ``(0, 0)``."""
+        return (getattr(plot, "row_index", 0), getattr(plot, "col_index", 0))
+
+    def _collapse_segmented_bar_layers(self) -> None:
         """
-        Merge plots by their subplot position, keeping only the first plot per position.
+        Drop the bar layers a segmented layer on the same axes already describes.
 
-        For DODGED and STACKED plot types, multiple plots on the same subplot
-        should be merged into a single plot since GroupedBarPlot extracts all
-        containers from the axes itself.
+        ``BarPlot`` and ``GroupedBarPlot`` both read *every* ``BarContainer``
+        on their axes rather than the bars their own call drew, so a stacked
+        chart built from three ``ax.bar()`` calls registers three layers that
+        each describe the whole chart. One has to survive and the rest are
+        duplicates.
 
-        Returns
-        -------
-        list[MaidrPlot]
-            List of plots with one plot per unique subplot position.
+        Which one survives is the part that was wrong. This used to key off
+        ``self.plot_type`` -- a *figure-wide* "highest priority type seen",
+        where ``STACKED``/``DODGED`` outrank everything -- and then keep
+        ``position_plots[0]``, the first layer registered at each position
+        whatever its type. Three things followed, none of which errored (#376):
 
-        Examples
-        --------
-        If we have plots at positions [(0,0), (0,0), (0,1), (1,0)],
-        this will return plots at positions [(0,0), (0,1), (1,0)].
+        * a stacked bar in one panel collapsed **every** panel to its first
+          layer, so an unrelated scatter overlay in the next panel along
+          simply stopped being announced;
+        * which layer survived was registration order, so a reference line
+          drawn before the bars meant the bar chart was the thing dropped;
+        * matplotlib's own documented stacked bar -- ``bottom`` omitted on the
+          first call, as everyone writes it -- registered ``BAR`` then
+          ``STACKED``, kept the ``BAR``, and that layer's extractor then found
+          six patches against three tick labels and raised ``ExtractionError``,
+          which is fatal to the whole figure. Passing ``bottom=np.zeros(n)``
+          on the first call avoided it, which is why every test wrote it that
+          way.
+
+        So the question is asked per position and answered by type: a position
+        holding a segmented layer keeps the first of those and drops the other
+        axes-wide bar layers there. Layers of any other type are left alone --
+        a line over a stacked bar is a second layer, not a duplicate of it.
+
+        Idempotent, and it has to be: it runs from ``_create_html_tag`` before
+        the elements are collected *and* from ``_flatten_maidr``, which can be
+        called on its own.
+
+        ``selector_ids`` is filtered in step with ``_plots``. The two are
+        paired by index in both directions -- ``_create_html_tag`` tags each
+        layer's artists with ``selector_ids[i]``, and ``_flatten_maidr``
+        stamps the same index into the layer's selector string -- so dropping
+        a layer without dropping its id would hand every surviving layer its
+        neighbour's, and the highlight would land on the wrong bar.
         """
-        # Group plots by their subplot position (row, col) using defaultdict
-        subplot_groups: dict[tuple[int, int], list[MaidrPlot]] = defaultdict(list)
-
+        positions: dict[tuple[int, int], list[MaidrPlot]] = defaultdict(list)
         for plot in self._plots:
-            # Get subplot position, defaulting to (0, 0) if not set
-            position = (getattr(plot, "row_index", 0), getattr(plot, "col_index", 0))
-            subplot_groups[position].append(plot)
+            positions[self._subplot_position(plot)].append(plot)
 
-        # Keep only the first plot for each subplot position
-        # The GroupedBarPlot will extract all containers from that axes
-        merged_plots: list[MaidrPlot] = []
-        for position_plots in subplot_groups.values():
-            merged_plots.append(
-                position_plots[0]
-            )  # Each list is guaranteed to have at least one plot
+        superseded: set[int] = set()
+        for group in positions.values():
+            segmented = [plot for plot in group if plot.type in _SEGMENTED_BAR_TYPES]
+            if not segmented:
+                continue
+            survivor = segmented[0]
+            superseded.update(
+                id(plot)
+                for plot in group
+                if plot is not survivor and plot.type in _AXES_WIDE_BAR_TYPES
+            )
 
-        return merged_plots
+        if not superseded:
+            return
+
+        kept = [
+            (plot, selector_id)
+            for plot, selector_id in zip(self._plots, self.selector_ids)
+            if id(plot) not in superseded
+        ]
+        self._plots = [plot for plot, _ in kept]
+        self.selector_ids = [selector_id for _, selector_id in kept]
 
     def _figure_metadata(self) -> dict:
         """
@@ -447,10 +510,11 @@ class Maidr:
 
     def _flatten_maidr(self) -> dict:
         """Return the top-level MAIDR schema for this figure."""
-        # Handle DODGED/STACKED plots: only keep one plot per subplot position
-        # because GroupedBarPlot extracts all containers from the axes itself
-        if self.plot_type in (PlotType.DODGED, PlotType.STACKED):
-            self._plots = self._merge_plots_by_subplot_position()
+        # A segmented bar layer describes every bar on its axes, so the sibling
+        # registrations from the same chart are duplicates of it. Asked per
+        # position rather than per figure -- see the method for what asking it
+        # per figure cost (#376).
+        self._collapse_segmented_bar_layers()
 
         # Deduplicate: if any SMOOTH plots exist, remove LINE plots
         self._plots = deduplicate_smooth_and_line(self._plots)

--- a/tests/core/test_segmented_bar_merge.py
+++ b/tests/core/test_segmented_bar_merge.py
@@ -161,6 +161,34 @@ def test_an_overlay_survives_whichever_order_it_was_drawn_in(line_first) -> None
     assert _emitted(fig) == [[expected]]
 
 
+def test_a_twinned_axes_keeps_its_own_stacked_bar() -> None:
+    """Two axes in one grid cell are two charts, not one chart twice.
+
+    The duplication this collapse resolves comes from the extractor reading
+    every container on ``self.ax``, so the axes is what makes two layers
+    descriptions of the same bars. ``ax.twinx()`` gives a *second* axes at the
+    *same* ``(row, col)`` -- so keyed by grid cell, a stacked bar on each side
+    of a twinned pair collapsed to one and the right-hand chart was announced
+    nowhere.
+
+    Both layers are asserted by their data rather than only by count, since
+    two layers of the right type could still both be the left-hand chart.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, bottom=np.zeros(len(CATEGORIES)), label="l0")
+    ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="l1")
+
+    right = ax.twinx()
+    right.bar(CATEGORIES, SERIES_1 * 2, bottom=np.zeros(len(CATEGORIES)), label="r0")
+    right.bar(CATEGORIES, SERIES_0 * 2, bottom=SERIES_1 * 2, label="r1")
+
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    layers = grid[0][0]["layers"]
+
+    assert [layer["type"].value for layer in layers] == ["stacked_bar"] * 2
+    assert [layer["data"][0][0]["y"] for layer in layers] == [10.0, 60.0]
+
+
 def test_every_layer_keeps_its_own_selector_id() -> None:
     """The pairing that a naive filter would break silently.
 

--- a/tests/core/test_segmented_bar_merge.py
+++ b/tests/core/test_segmented_bar_merge.py
@@ -1,0 +1,208 @@
+"""A stacked bar in one panel was deleting layers from every other panel.
+
+``BarPlot`` and ``GroupedBarPlot`` both read *every* ``BarContainer`` on their
+axes rather than the bars their own call drew, so a stacked chart built from
+three ``ax.bar()`` calls registers three layers that each describe the whole
+chart. One has to survive; the rest are duplicates. That much was known and
+handled.
+
+What was wrong is how the survivor was chosen. ``Maidr.plot_type`` is a
+*figure-wide* "highest priority type seen", and ``PLOT_TYPE_PRIORITY`` gives
+``STACKED``/``DODGED`` a 2 against everything else's 1 -- so one stacked bar
+anywhere set it for the whole figure. ``_flatten_maidr`` then collapsed
+**every** subplot position down to ``position_plots[0]``, the first layer
+registered there, whatever its type.
+
+Three things followed, and none of them errored:
+
+    a stacked bar in panel 0     panel 1 emitted ['line'] instead of
+                                 ['line', 'point']
+    a line drawn before the bars the bar chart was the layer dropped
+    bottom omitted on call 1     ExtractionError -- no HTML at all
+
+The third is matplotlib's own documented stacked bar::
+
+    ax.bar(labels, men_means, width, label='Men')
+    ax.bar(labels, women_means, width, bottom=men_means, label='Women')
+
+which registers ``BAR`` then ``STACKED``, kept the ``BAR``, and that layer's
+extractor then found six patches against three tick labels and raised.
+Writing ``bottom=np.zeros(n)`` on the first call avoided it, which is why
+every test wrote it that way and why this survived (#376).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+CATEGORIES = ["a", "b", "c"]
+SERIES_0 = np.array([10.0, 20.0, 30.0])
+SERIES_1 = np.array([30.0, 20.0, 10.0])
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _emitted(fig) -> list[list[list[str]]]:
+    """The layer types of every subplot cell, as a row-major grid.
+
+    A cell with nothing registered in it is ``{}`` rather than a cell with an
+    empty ``layers``, so the key is read defensively -- an empty panel is one
+    of the states under test here.
+    """
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return [
+        [[layer["type"].value for layer in cell.get("layers", [])] for cell in row]
+        for row in grid
+    ]
+
+
+def test_the_documented_stacked_bar_renders() -> None:
+    """matplotlib's own example, which produced no HTML at all.
+
+    ``bottom`` is omitted on the first call, the way the matplotlib gallery
+    writes it and the way anyone writes it. That first call registers a
+    ``BarPlot``; the second lifts the figure to ``STACKED``, the collapse
+    fired, and it kept the ``BarPlot`` -- whose extractor reads the whole
+    axes, finds six patches against three tick labels, and raises.
+
+    ``ExtractionError`` is fatal to the figure rather than to its own layer,
+    so this is asserted through a real ``render()`` and not only through the
+    layer list: the old failure happened while collecting artists, one step
+    before the schema was built.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, label="s0")
+    ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="s1")
+
+    assert _emitted(fig) == [[["stacked_bar"]]]
+    assert maidr.render(fig) is not None
+
+
+def test_the_same_chart_with_an_explicit_zero_bottom_is_unchanged() -> None:
+    """The control: the spelling that always worked still gives one layer.
+
+    Writing ``bottom=np.zeros(n)`` on the first call registers ``STACKED``
+    twice rather than ``BAR`` then ``STACKED``, so the old code kept a
+    segmented layer by luck. Nothing here should move.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, bottom=np.zeros(len(CATEGORIES)), label="s0")
+    ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="s1")
+
+    assert _emitted(fig) == [[["stacked_bar"]]]
+
+
+def test_a_panel_with_no_bars_keeps_its_layers() -> None:
+    """The quietest of the three, and the one with the widest blast radius.
+
+    Panel 1 is written identically in both halves of this test. The only
+    difference is what panel 0 contains -- and a stacked bar there used to
+    delete panel 1's scatter, because the collapse was gated on a
+    figure-wide type and then applied to every position.
+    """
+    fig, axes = plt.subplots(1, 2)
+    axes[1].plot(CATEGORIES, SERIES_0)
+    axes[1].scatter(CATEGORIES, SERIES_1)
+
+    assert _emitted(fig) == [[[], ["line", "point"]]]
+    plt.close(fig)
+
+    fig, axes = plt.subplots(1, 2)
+    axes[0].bar(CATEGORIES, SERIES_0, bottom=np.zeros(len(CATEGORIES)))
+    axes[0].bar(CATEGORIES, SERIES_1, bottom=SERIES_0)
+    axes[1].plot(CATEGORIES, SERIES_0)
+    axes[1].scatter(CATEGORIES, SERIES_1)
+
+    assert _emitted(fig) == [[["stacked_bar"], ["line", "point"]]]
+
+
+@pytest.mark.parametrize("line_first", [True, False])
+def test_an_overlay_survives_whichever_order_it_was_drawn_in(line_first) -> None:
+    """A line over a stacked bar is a second layer, not a duplicate of it.
+
+    The old collapse kept ``position_plots[0]``, so the survivor was decided
+    by registration order rather than by type. Drawing the reference line
+    first meant the *bar chart* -- the thing the figure is of -- was the layer
+    dropped, and only the annotation was announced. Both orders are
+    parametrized because each dropped a different layer.
+    """
+    fig, ax = plt.subplots()
+
+    def draw_line():
+        ax.plot(CATEGORIES, SERIES_0 + SERIES_1, label="total")
+
+    def draw_bars():
+        ax.bar(CATEGORIES, SERIES_0, bottom=np.zeros(len(CATEGORIES)), label="s0")
+        ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="s1")
+
+    if line_first:
+        draw_line()
+        draw_bars()
+        expected = ["line", "stacked_bar"]
+    else:
+        draw_bars()
+        draw_line()
+        expected = ["stacked_bar", "line"]
+
+    assert _emitted(fig) == [[expected]]
+
+
+def test_every_layer_keeps_its_own_selector_id() -> None:
+    """The pairing that a naive filter would break silently.
+
+    ``_plots`` and ``selector_ids`` are matched by index in both directions --
+    the artists are tagged with ``selector_ids[i]`` and the schema stamps the
+    same index into the layer's selector string. Dropping a layer without
+    dropping its id shifts every id after it by one, so each surviving layer
+    would carry its neighbour's and the highlight would land on the wrong
+    mark. Nothing errors; the outline just moves.
+
+    Here the dropped layer is at index 0, so the shift is visible: the
+    stacked layer's id must be the *second* one issued, not the first.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, label="s0")
+    ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="s1")
+
+    figure_maidr = FigureManager.get_maidr(fig)
+    issued = list(figure_maidr.selector_ids)
+    assert len(issued) == 2
+
+    figure_maidr._flatten_maidr()
+
+    assert len(figure_maidr.plots) == 1
+    assert figure_maidr.selector_ids == [issued[1]]
+
+
+def test_collapsing_twice_changes_nothing() -> None:
+    """It runs from two places, so it has to be safe to run again.
+
+    ``_create_html_tag`` collapses before collecting artists -- it has to,
+    since reading a superseded ``BarPlot``'s elements is what raised -- and
+    ``_flatten_maidr`` collapses too, because it is reachable on its own.
+    A single render therefore calls it twice.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, label="s0")
+    ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="s1")
+
+    figure_maidr = FigureManager.get_maidr(fig)
+    figure_maidr._collapse_segmented_bar_layers()
+    after_once = (list(figure_maidr.plots), list(figure_maidr.selector_ids))
+    figure_maidr._collapse_segmented_bar_layers()
+
+    assert (figure_maidr.plots, figure_maidr.selector_ids) == after_once

--- a/tests/core/test_segmented_bar_merge.py
+++ b/tests/core/test_segmented_bar_merge.py
@@ -43,6 +43,7 @@ import pytest  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.core.plot.mplfinance_barplot import MplfinanceBarPlot  # noqa: E402
 
 CATEGORIES = ["a", "b", "c"]
 SERIES_0 = np.array([10.0, 20.0, 30.0])
@@ -214,6 +215,38 @@ def test_every_layer_keeps_its_own_selector_id() -> None:
 
     assert len(figure_maidr.plots) == 1
     assert figure_maidr.selector_ids == [issued[1]]
+
+
+def test_a_bar_typed_layer_outside_the_family_is_not_dropped() -> None:
+    """The family is a class, not a ``PlotType``, and that has to stay true.
+
+    ``MplfinanceBarPlot`` carries ``PlotType.BAR`` but reads the volume
+    patches handed to it rather than sweeping the axes -- so the premise that
+    justifies dropping a layer, *its extractor already describes every bar
+    here*, is not true of it. A ``plot.type`` check said it was, and a stacked
+    bar sharing its axes would have taken the volume chart with it.
+
+    The obvious later "simplification" is to collapse ``_AXES_WIDE_BAR_PLOTS``
+    back to a set of types, which reads cleaner and is wrong. This is the test
+    that catches that, so it drives the classification directly rather than
+    building an mplfinance figure to reach it.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, bottom=np.zeros(len(CATEGORIES)), label="s0")
+    ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="s1")
+
+    figure_maidr = FigureManager.get_maidr(fig)
+    volume = MplfinanceBarPlot(ax)
+    figure_maidr.plots.append(volume)
+    figure_maidr.selector_ids.append("volume-id")
+
+    figure_maidr._collapse_segmented_bar_layers()
+
+    assert volume in figure_maidr.plots
+    assert "volume-id" in figure_maidr.selector_ids
+    # The duplicate stacked registration is still dropped, so this is not
+    # passing because the collapse stopped working.
+    assert len(figure_maidr.plots) == 2
 
 
 def test_collapsing_twice_changes_nothing() -> None:


### PR DESCRIPTION
Closes #376.

`BarPlot` and `GroupedBarPlot` both read *every* `BarContainer` on their axes rather than the bars their own call drew, so a stacked chart built from three `ax.bar()` calls registers three layers that each describe the whole chart. One has to survive and the rest are duplicates — that much was already handled.

How the survivor was chosen was not. `Maidr.plot_type` is a **figure-wide** "highest priority type seen", and `PLOT_TYPE_PRIORITY` gives `STACKED`/`DODGED` a 2 against everything else's 1, so one stacked bar anywhere set it for the whole figure. `_flatten_maidr` then collapsed **every** subplot position down to `position_plots[0]` — the first layer registered there, whatever its type.

## Three things followed, and none of them errored

**A panel with no bars in it lost a layer.** Panel 1 is written identically in both rows below; the only difference is what panel 0 contains:

| panel 0 contains | panel 0 emits | **panel 1 emits** |
|---|---|---|
| `plot` + `scatter` | `['line', 'point']` | `['line', 'point']` |
| a stacked bar | `['stacked_bar']` | **`['line']`** |

**Which layer survived was registration order, not type.**

```
registered=['line', 'stacked_bar', 'stacked_bar']   emitted=['line']
```

The bar chart — the thing the figure is *of* — dropped, the annotation line kept. Drawing the line second dropped the line instead.

**matplotlib's own documented stacked bar rendered nothing at all.** The [gallery example](https://matplotlib.org/stable/gallery/lines_bars_and_markers/bar_stacked.html) omits `bottom` on the first call, as everyone does:

```python
ax.bar(labels, men_means, width, label='Men')
ax.bar(labels, women_means, width, bottom=men_means, label='Women')
```

That registers `BAR` then `STACKED`; the collapse fired and kept the `BAR`, whose extractor found six patches against three tick labels and raised `ExtractionError` — fatal to the whole figure. Writing `bottom=np.zeros(n)` on the first call avoided it, which is why every existing test wrote it that way and why this survived.

## The fix

The question is asked **per position** and answered **by type**: a position holding a segmented layer keeps the first of those and drops the other axes-wide bar layers there. Layers of any other type are left alone — a line over a stacked bar is a second layer, not a duplicate of it. `HIST` draws bars but reads its own container, so it is not in the family and is never dropped.

### Two details are load-bearing

**It runs before the artists are collected**, not only in `_flatten_maidr`. Reading `plot.elements` renders the layer, and the superseded `BarPlot` raised *there* — one step before the schema was ever built:

```
maidr/core/maidr.py:315  in <listcomp>          <- tagged_elements
maidr/core/plot/maidr_plot.py:295  in elements
maidr/core/plot/barplot.py:72  in _extract_plot_data
    raise ExtractionError(self.type, plot)
```

Collapsing only in `_flatten_maidr` would never have been reached. It also keeps one artist from appearing twice in that list, where `HighlightContextManager` resolves an artist by its **first** index and would hand every bar the dropped layer's selector id.

**`selector_ids` is filtered in step with `_plots`.** The two are paired by index in both directions — the artists are tagged with `selector_ids[i]`, and the schema stamps the same index into the layer's selector string. Dropping a layer without dropping its id shifts every id after it, so each surviving layer carries its neighbour's and the highlight lands on the wrong bar, with nothing raised. It matters here specifically because the dropped layer is often at index 0.

## Falsification

| reverted | failing tests |
|---|---|
| old merge restored (figure-wide gate + `position_plots[0]`) | 5 of 7 |
| keep `group[0]` instead of `segmented[0]` | 3 of 7 |
| `selector_ids` left unfiltered | 1 of 7 |

The two that survive the first revert are the control (the `bottom=np.zeros(n)` spelling that always worked) and the idempotence test.

## Left out deliberately

Two plain `ax.bar()` calls with no `bottom` at all still raise `ExtractionError`, because `BarPlot` reads the whole axes and no segmented layer is ever registered for this to act on. What two *overlapping* bar layers should be announced as is a genuine question rather than an oversight; noted on #376 for its own issue.

## Verification

`ruff check` clean. Full suite: **1198 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_