### PR TITLE
fix(bar): read the bars this call drew, not every bar on the axes

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -37,9 +37,13 @@ from maidr.util.dependencies import (
 from maidr.util.environment import Environment
 from maidr.util.iframe_utils import wrap_in_iframe_matplotlib
 
-#: Layer classes whose extractor reads every ``BarContainer`` on its axes
-#: rather than the bars its own call drew, so two of them on one axes describe
-#: the same chart twice.
+#: Layer classes a segmented bar layer on the same axes can supersede.
+#:
+#: ``GroupedBarPlot`` reads every ``BarContainer`` on its axes, so it already
+#: describes whatever a ``BarPlot`` beside it would -- whether that ``BarPlot``
+#: swept the axes too (the seaborn path) or narrowed to the one container its
+#: own ``ax.bar()`` call drew (the matplotlib path, since #380). Either way the
+#: segmented layer covers it, which is what makes it superseded.
 #:
 #: Asked by class rather than by ``plot.type``, and that distinction is not
 #: pedantic: ``MplfinanceBarPlot`` also carries ``PlotType.BAR``, and it reads
@@ -433,11 +437,12 @@ class Maidr:
         """
         The bar layers a segmented layer on the same axes already describes.
 
-        ``BarPlot`` and ``GroupedBarPlot`` both read *every* ``BarContainer``
-        on their axes rather than the bars their own call drew, so a stacked
-        chart built from three ``ax.bar()`` calls registers three layers that
-        each describe the whole chart. The first segmented one survives; the
-        other axes-wide bar layers on that axes are duplicates of it.
+        ``GroupedBarPlot`` reads *every* ``BarContainer`` on its axes, so a
+        stacked chart built from three ``ax.bar()`` calls registers three
+        layers that each describe the whole chart. The first survives; the
+        rest are duplicates, and so is any ``BarPlot`` beside them -- whose
+        bars, whether it swept the axes or narrowed to its own call's
+        container, the segmented layer already covers.
 
         Layers of any other kind are left alone -- a line over a stacked bar
         is a second layer, not a duplicate of it.
@@ -536,11 +541,10 @@ class Maidr:
         """
         Drop every layer another layer on the same axes already describes.
 
-        ``BarPlot`` and ``GroupedBarPlot`` both read *every* ``BarContainer``
-        on their axes rather than the bars their own call drew, so a stacked
-        chart built from three ``ax.bar()`` calls registers three layers that
-        each describe the whole chart. One has to survive and the rest are
-        duplicates.
+        ``GroupedBarPlot`` reads *every* ``BarContainer`` on its axes, so a
+        stacked chart built from three ``ax.bar()`` calls registers three
+        layers that each describe the whole chart. One has to survive and the
+        rest are duplicates.
 
         Which one survives is the part that was wrong. This used to key off
         ``self.plot_type`` -- a *figure-wide* "highest priority type seen",

--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -13,6 +13,16 @@ from maidr.util.mixin import (
 )
 
 
+#: The keyword ``Axes.bar`` hands its own ``BarContainer`` to this layer
+#: under. Named once and imported at both ends rather than spelled twice:
+#: ``kwargs.get`` falls back to sweeping the axes on a mismatch, so a typo
+#: would not raise -- it would quietly restore the behaviour #380 removed.
+#:
+#: Lives here rather than beside ``common.drawn_as`` because ``maidr.patch``
+#: imports ``maidr.core`` and not the other way about.
+DRAWN_BARS = "_maidr_bars"
+
+
 class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMergerMixin):
     def __init__(self, ax: Axes, **kwargs) -> None:
         super().__init__(ax, PlotType.BAR)
@@ -20,7 +30,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         # The container this layer's own call drew, when the patch could say.
         # `None` falls back to sweeping the axes, which is what seaborn needs:
         # it draws one layer as several containers, one per hue group.
-        self._own_bars = kwargs.get("_maidr_bars", None)
+        self._own_bars = kwargs.get(DRAWN_BARS, None)
 
     @property
     def _is_horizontal(self) -> bool:
@@ -88,7 +98,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
 
         return [{"x": x, "y": y} for x, y in combined_data]
 
-    def _own_containers(self) -> list[BarContainer]:
+    def _own_containers(self) -> list[BarContainer] | None:
         """
         The containers this layer describes.
 
@@ -105,8 +115,10 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
 
         Returns
         -------
-        list of BarContainer
-            One or more containers, in the order the axes holds them.
+        list of BarContainer, optional
+            One or more containers, in the order the axes holds them. ``None``
+            when the axes holds no container list at all, which the caller
+            already treats as nothing to extract.
         """
         if self._own_bars is not None:
             return [self._own_bars]

--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -14,9 +14,13 @@ from maidr.util.mixin import (
 
 
 class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMergerMixin):
-    def __init__(self, ax: Axes) -> None:
+    def __init__(self, ax: Axes, **kwargs) -> None:
         super().__init__(ax, PlotType.BAR)
         self._orientation = "vert"
+        # The container this layer's own call drew, when the patch could say.
+        # `None` falls back to sweeping the axes, which is what seaborn needs:
+        # it draws one layer as several containers, one per hue group.
+        self._own_bars = kwargs.get("_maidr_bars", None)
 
     @property
     def _is_horizontal(self) -> bool:
@@ -63,7 +67,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         return DictMergerMixin.merge_dict(base_schema, bar_orientation)
 
     def _extract_plot_data(self) -> list:
-        plot = self.extract_container(self.ax, BarContainer, include_all=True)
+        plot = self._own_containers()
         self._orientation = self._extract_orientation(plot)
         levels = self.extract_level(self.ax, self._level_key)
 
@@ -83,6 +87,30 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
             raise ExtractionError(self.type, plot)
 
         return [{"x": x, "y": y} for x, y in combined_data]
+
+    def _own_containers(self) -> list[BarContainer]:
+        """
+        The containers this layer describes.
+
+        The containers its own call drew when the patch could name them, and
+        every ``BarContainer`` on the axes otherwise.
+
+        The sweep is not a fallback in the apologetic sense -- seaborn draws
+        one bar layer as several containers, one per hue group, and registers
+        it from a seaborn-level patch where no single container is the answer.
+        What the sweep cannot do is tell one ``ax.bar()`` call's bars from
+        another's, so two overlaid calls each found both containers' patches,
+        failed the count check against one axis' worth of tick labels, and
+        raised ``ExtractionError`` -- fatal to the whole figure (#380).
+
+        Returns
+        -------
+        list of BarContainer
+            One or more containers, in the order the axes holds them.
+        """
+        if self._own_bars is not None:
+            return [self._own_bars]
+        return self.extract_container(self.ax, BarContainer, include_all=True)
 
     def _extract_bar_container_data(
         self, plot: list[BarContainer] | None, levels: list[str] | None

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -61,7 +61,7 @@ class MaidrPlotFactory:
             if PlotDetectionUtils.is_mplfinance_bar_plot(**kwargs):
                 return MplfinanceBarPlot(single_ax, **kwargs)
             else:
-                return BarPlot(single_ax)
+                return BarPlot(single_ax, **kwargs)
         elif PlotType.BOX == plot_type:
             return BoxPlot(single_ax, **kwargs)
         elif PlotType.ERRORBAR == plot_type:

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -7,6 +7,7 @@ from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
 
 from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot.barplot import DRAWN_BARS
 from maidr.patch.common import common, wrap_seaborn
 from maidr.util.mixin import LevelExtractorMixin
 
@@ -82,7 +83,7 @@ def bar(
     # several containers, one per hue group, and registers it from `sns_bar`
     # below, where no single container is the answer -- that path keeps the
     # sweep, which is right for it.
-    return common(plot_type, wrapped, instance, args, kwargs, drawn_as="_maidr_bars")
+    return common(plot_type, wrapped, instance, args, kwargs, drawn_as=DRAWN_BARS)
 
 
 def _should_classify_as_dodged(

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -73,7 +73,16 @@ def bar(
         if should_be_dodged:
             plot_type = PlotType.DODGED
 
-    return common(plot_type, wrapped, instance, args, kwargs)
+    # Hand the layer the container this call drew. `BarPlot` otherwise sweeps
+    # every `BarContainer` on the axes, so two `ax.bar()` calls each read both
+    # containers' patches against one axis' worth of tick labels, fail the
+    # count check and raise -- which is fatal to the whole render (#380).
+    #
+    # Only the matplotlib entry point can say this. seaborn draws one layer as
+    # several containers, one per hue group, and registers it from `sns_bar`
+    # below, where no single container is the answer -- that path keeps the
+    # sweep, which is right for it.
+    return common(plot_type, wrapped, instance, args, kwargs, drawn_as="_maidr_bars")
 
 
 def _should_classify_as_dodged(

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -168,7 +168,13 @@ def _draw_quietly(wrapped: Callable, args: tuple, kwargs: dict) -> Any:
 
 
 def common(
-    plot_type: PlotType | Callable[[Axes], PlotType], wrapped, _, args, kwargs
+    plot_type: PlotType | Callable[[Axes], PlotType],
+    wrapped,
+    _,
+    args,
+    kwargs,
+    *,
+    drawn_as: str | None = None,
 ) -> Any:
     """
     Draw a patched plot and register the layer it produced with MAIDR.
@@ -190,6 +196,12 @@ def common(
         Positional arguments the caller passed.
     kwargs : dict
         Keyword arguments the caller passed.
+    drawn_as : str, optional
+        When set, the artist the call returned is handed to the layer under
+        this keyword. A layer that knows which artists its own call drew can
+        describe those rather than sweeping the axes for every artist of the
+        kind -- which is what makes two ``ax.bar()`` calls on one axes each
+        read six patches against three tick labels (#380).
 
     Returns
     -------
@@ -210,6 +222,8 @@ def common(
     kwargs.pop("ax", None)
     if callable(plot_type):
         plot_type = plot_type(ax)
+    if drawn_as is not None:
+        kwargs[drawn_as] = plot
     FigureManager.create_maidr(ax, plot_type, **kwargs)
 
     return plot

--- a/tests/core/test_bar_reads_its_own_bars.py
+++ b/tests/core/test_bar_reads_its_own_bars.py
@@ -1,0 +1,135 @@
+"""Two ``ax.bar()`` calls on one axes produced no HTML at all.
+
+``BarPlot`` swept every ``BarContainer`` on its axes rather than reading the
+bars its own call drew, so two overlaid calls each found six patches against
+three tick labels, failed the count check, and raised ``ExtractionError`` --
+which is fatal to the whole figure rather than to its own layer (#380).
+
+#377 fixed the neighbouring case, where one of the calls passes ``bottom`` and
+so registers a segmented layer for the collapse to keep. Here neither does,
+both register as plain ``BAR``, and nothing supersedes anything.
+
+The reading two overlapping bar layers *should* get is a real question rather
+than an oversight, which is why it was filed separately. Two series drawn over
+one another with alpha are two series, so two layers -- each describing its
+own bars -- is the answer that loses no data and matches what is drawn.
+
+The sweep stays for seaborn, and that is not a grudging fallback: seaborn
+draws one bar layer as several containers, one per hue group, and registers it
+from a seaborn-level patch where no single container is the answer. What the
+sweep cannot do is tell one ``ax.bar()`` call's bars from another's, and only
+the matplotlib entry point knows that.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pandas as pd
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+CATEGORIES = ["a", "b", "c"]
+SERIES_0 = np.array([10.0, 20.0, 30.0])
+SERIES_1 = np.array([30.0, 20.0, 10.0])
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _layers(fig) -> list[dict]:
+    """Every emitted layer of the first subplot cell."""
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return grid[0][0].get("layers", [])
+
+
+def test_two_overlaid_bar_calls_each_read_their_own_bars() -> None:
+    """The reproduction, asserted by data rather than by layer count.
+
+    Two layers of the right type would also be the answer if both described
+    the same six patches, so the magnitudes are what is checked: the first
+    layer is the first call's bars and the second is the second's.
+
+    Rendered as well as counted, because the old failure happened during
+    extraction -- there was no schema to inspect.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, alpha=0.6)
+    ax.bar(CATEGORIES, SERIES_1, alpha=0.6)
+
+    layers = _layers(fig)
+
+    assert [layer["type"].value for layer in layers] == ["bar", "bar"]
+    assert [point["y"] for point in layers[0]["data"]] == list(SERIES_0)
+    assert [point["y"] for point in layers[1]["data"]] == list(SERIES_1)
+    assert maidr.render(fig) is not None
+
+
+def test_one_bar_call_is_unchanged() -> None:
+    """The control, and the overwhelmingly common case.
+
+    A single call has exactly one container either way, so narrowing must
+    cost it nothing.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0)
+
+    layers = _layers(fig)
+
+    assert [layer["type"].value for layer in layers] == ["bar"]
+    assert [point["y"] for point in layers[0]["data"]] == list(SERIES_0)
+
+
+def test_a_hued_seaborn_bar_still_reads_every_group() -> None:
+    """seaborn is why the sweep exists, and it has to keep working.
+
+    A hue splits one seaborn layer across several containers, one per group,
+    and it is registered from the seaborn-level patch -- where no single
+    container is the answer and there is no ``_maidr_bars`` to narrow to. If
+    narrowing ever leaked into that path, this layer would describe one hue
+    group and quietly drop the rest.
+    """
+    frame = pd.DataFrame(
+        {
+            "group": ["a", "a", "b", "b", "c", "c"],
+            "half": ["x", "y"] * 3,
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        }
+    )
+    fig, ax = plt.subplots()
+    sns.barplot(data=frame, x="group", y="value", hue="half", ax=ax)
+
+    layers = _layers(fig)
+
+    assert len(layers) == 1
+    # Six bars: three groups times two hue levels, not the three of one group.
+    assert sum(len(series) for series in layers[0]["data"]) == 6
+
+
+def test_a_stacked_chart_is_unchanged() -> None:
+    """The #377 regression guard.
+
+    A stacked chart is still one layer describing every bar on the axes:
+    ``GroupedBarPlot`` sweeps deliberately, and only ``BarPlot`` narrows.
+    Narrowing the wrong one would announce a stacked chart as its first
+    series alone.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, label="s0")
+    ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="s1")
+
+    layers = _layers(fig)
+
+    assert [layer["type"].value for layer in layers] == ["stacked_bar"]
+    assert len(layers[0]["data"]) == 2, "both series, not just the first"

--- a/tests/core/test_bar_reads_its_own_bars.py
+++ b/tests/core/test_bar_reads_its_own_bars.py
@@ -76,6 +76,26 @@ def test_two_overlaid_bar_calls_each_read_their_own_bars() -> None:
     assert maidr.render(fig) is not None
 
 
+def test_two_overlaid_barh_calls_read_their_own_bars_too() -> None:
+    """The other half of what the patch wraps.
+
+    ``Axes.barh`` shares ``bar()``'s code path exactly, so this cannot fail
+    while the vertical case passes — which is the argument for testing it, not
+    against. A horizontal bar's magnitude is its width rather than its height,
+    read through a different branch of the extractor, so "shares the path"
+    stops being true one layer down.
+    """
+    fig, ax = plt.subplots()
+    ax.barh(CATEGORIES, SERIES_0, alpha=0.6)
+    ax.barh(CATEGORIES, SERIES_1, alpha=0.6)
+
+    layers = _layers(fig)
+
+    assert [layer["type"].value for layer in layers] == ["bar", "bar"]
+    assert [point["x"] for point in layers[0]["data"]] == list(SERIES_0)
+    assert [point["x"] for point in layers[1]["data"]] == list(SERIES_1)
+
+
 def test_one_bar_call_is_unchanged() -> None:
     """The control, and the overwhelmingly common case.
 


### PR DESCRIPTION
Closes #380. The case deferred from #376, now that #377 and #379 have landed.

`BarPlot` swept every `BarContainer` on its axes rather than the bars its own call drew, so two overlaid `ax.bar()` calls each found six patches against three tick labels, failed the count check, and raised `ExtractionError` — which is fatal to the whole figure rather than to its own layer.

```
2 calls, no bottom (overlaid)   before  ExtractionError
                                after   ['bar', 'bar']
                                        10/20/30  and  30/20/10
```

#377 fixed the neighbouring case, where one call passes `bottom` and so registers a segmented layer for the collapse to keep. Here neither does, both register as plain `BAR`, and nothing supersedes anything. The twin-axes row was always the tell — two `BarPlot`s are fine on *different* axes, because then each sweeps only its own containers. The bug is the sweep, not the count.

## The reading, which was the actual question

Two overlapping bar layers are genuinely ambiguous, which is why this was filed separately rather than folded into a merge fix. Two series drawn over one another with alpha are two series, so **two layers, each describing its own bars**, is the answer that loses no data and matches what is drawn. Asserted by data rather than by count, since two layers of the right type would also pass if both described the same six patches.

## How the layer learns which bars are its own

Only the matplotlib entry point knows. `common()` gains an optional `drawn_as`: the artist the call returned is handed to the layer under that keyword, **after** the draw so it cannot reach the wrapped function. `Axes.bar` uses it.

## What deliberately keeps sweeping

**seaborn.** It draws one bar layer as several containers, one per hue group, and registers it from `sns_bar` — where no single container is the answer. Narrowing that path would announce a hued bar chart as one group and silently drop the rest; `test_a_hued_seaborn_bar_still_reads_every_group` guards it by counting six bars rather than three.

**`GroupedBarPlot`.** A stacked layer describes every bar on its axes by design, and #377 depends on that. `test_a_stacked_chart_is_unchanged` is the regression guard.

`MaidrPlotFactory` now forwards its kwargs to `BarPlot`, which it already did for every other type.

## Falsification

| reverted | failing tests |
|---|---|
| `BarPlot` sweeps again | 1 of 4 |
| patch names no container | 1 of 4 |

The two that survive each revert are the single-call control and the seaborn/stacked guards — which is the point: those paths must not move.

## Verification

`ruff check` clean. Full suite: **1211 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_