### PR TITLE
fix(bar): announce a bar's position when no tick label names it

### DIFF
--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -80,11 +80,12 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
     def _extract_plot_data(self) -> list:
         plot = self._own_containers()
         self._orientation = self._extract_orientation(plot)
+        patches = self._patches(plot)
         data = self._extract_bar_container_data(plot)
         if data is None:
             raise ExtractionError(self.type, plot)
 
-        levels = self._labels_for(plot, data)
+        levels = self._labels_for(patches, data)
 
         # A horizontal bar's magnitude runs along x and its label sits on y,
         # which is the layout the renderer reads for a horizontal layer. The
@@ -99,7 +100,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
 
         return [{"x": x, "y": y} for x, y in combined_data]
 
-    def _labels_for(self, plot: list[BarContainer] | None, data: list) -> list[str]:
+    def _labels_for(self, patches: list[Rectangle], data: list) -> list[str]:
         """
         What to announce alongside each magnitude.
 
@@ -128,8 +129,8 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
 
         Parameters
         ----------
-        plot : list of BarContainer, optional
-            The containers this layer describes.
+        patches : list of Rectangle
+            This layer's bars, already flattened out of their containers.
         data : list
             One magnitude per bar, used for its length.
 
@@ -143,7 +144,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         if levels and len(levels) == len(data):
             return levels
 
-        return [self._bar_position(patch) for patch in self._patches(plot)]
+        return [self._bar_position(patch) for patch in patches]
 
     def _bar_position(self, patch: Rectangle) -> str:
         """

--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -79,11 +79,11 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
     def _extract_plot_data(self) -> list:
         plot = self._own_containers()
         self._orientation = self._extract_orientation(plot)
-        levels = self.extract_level(self.ax, self._level_key)
-
-        data = self._extract_bar_container_data(plot, levels)
+        data = self._extract_bar_container_data(plot, None)
         if data is None:
             raise ExtractionError(self.type, plot)
+
+        levels = self._labels_for(plot, data)
 
         # A horizontal bar's magnitude runs along x and its label sits on y,
         # which is the layout the renderer reads for a horizontal layer. The
@@ -97,6 +97,84 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
             raise ExtractionError(self.type, plot)
 
         return [{"x": x, "y": y} for x, y in combined_data]
+
+    def _labels_for(self, plot: list[BarContainer] | None, data: list) -> list[str]:
+        """
+        What to announce alongside each magnitude.
+
+        The tick labels when there is one per bar, and the positions the bars
+        were drawn at otherwise.
+
+        The labels are one *presentation* of x, not x itself. matplotlib puts
+        exactly one tick per category on a categorical axis, so the counts
+        agree there by construction -- and on a numeric axis the tick locator
+        picks its own breaks, so they have no reason to. Three bars against
+        five ticks used to return ``None`` and raise, which is fatal to the
+        whole figure, so a bar chart with a numeric x produced no HTML at all
+        (#382). That is matplotlib's own grouped-bar shape::
+
+            x = np.arange(len(species))
+            ax.bar(x + offset, measurement, width, label=attribute)
+
+        which survives in the gallery only because the example goes on to
+        call ``set_xticks(x + width, species)`` and make the counts line up.
+
+        Raising was the wrong response to a real hazard. Pairing three bars
+        against five labels would announce the wrong name for every bar, so
+        the mismatch does have to be caught -- but a bar at x=0 with no tick
+        beside it still has a position, and announcing ``0`` is honest where
+        announcing nothing is not.
+
+        Parameters
+        ----------
+        plot : list of BarContainer, optional
+            The containers this layer describes.
+        data : list
+            One magnitude per bar, used for its length.
+
+        Returns
+        -------
+        list of str
+            One label per bar, either read off the axis or derived from the
+            bars' own centres.
+        """
+        levels = self.extract_level(self.ax, self._level_key)
+        if levels and len(levels) == len(data):
+            return levels
+
+        return [self._bar_position(patch) for patch in self._patches(plot)]
+
+    def _bar_position(self, patch) -> str:
+        """
+        The centre a bar was drawn at, as the axis would print it.
+
+        Read off the rectangle rather than the caller's argument, because the
+        caller's is not available here and the drawn centre is what the value
+        became. Whole numbers lose their trailing ``.0``: a bar at x=0 is at
+        ``"0"``, not ``"0.0"``, matching what a numeric axis shows.
+
+        Parameters
+        ----------
+        patch : Rectangle
+            One bar.
+
+        Returns
+        -------
+        str
+            The bar's position along its label axis.
+        """
+        if self._is_horizontal:
+            centre = patch.get_y() + patch.get_height() / 2
+        else:
+            centre = patch.get_x() + patch.get_width() / 2
+        return f"{centre:g}"
+
+    @staticmethod
+    def _patches(plot: list[BarContainer] | None) -> list:
+        """Every bar of every container, in the order they are held."""
+        if not plot:
+            return []
+        return [patch for container in plot for patch in container.patches]
 
     def _own_containers(self) -> list[BarContainer] | None:
         """

--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
+from matplotlib.patches import Rectangle
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
@@ -79,7 +80,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
     def _extract_plot_data(self) -> list:
         plot = self._own_containers()
         self._orientation = self._extract_orientation(plot)
-        data = self._extract_bar_container_data(plot, None)
+        data = self._extract_bar_container_data(plot)
         if data is None:
             raise ExtractionError(self.type, plot)
 
@@ -144,7 +145,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
 
         return [self._bar_position(patch) for patch in self._patches(plot)]
 
-    def _bar_position(self, patch) -> str:
+    def _bar_position(self, patch: Rectangle) -> str:
         """
         The centre a bar was drawn at, as the axis would print it.
 
@@ -167,10 +168,12 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
             centre = patch.get_y() + patch.get_height() / 2
         else:
             centre = patch.get_x() + patch.get_width() / 2
+        if float(centre).is_integer():
+            return str(int(centre))
         return f"{centre:g}"
 
     @staticmethod
-    def _patches(plot: list[BarContainer] | None) -> list:
+    def _patches(plot: list[BarContainer] | None) -> list[Rectangle]:
         """Every bar of every container, in the order they are held."""
         if not plot:
             return []
@@ -203,27 +206,27 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         return self.extract_container(self.ax, BarContainer, include_all=True)
 
     def _extract_bar_container_data(
-        self, plot: list[BarContainer] | None, levels: list[str] | None
+        self, plot: list[BarContainer] | None
     ) -> list | None:
         """
         Read one magnitude per bar, in the containers' own order.
+
+        It used to take the labels as well, and return ``None`` when their
+        count disagreed with the bars' -- which the caller turned into an
+        ``ExtractionError`` and so into an empty render. That decision now
+        lives in ``_labels_for``, which answers it with the bars' positions
+        instead of with nothing, so the parameter is gone rather than left
+        vestigial (#382).
 
         Parameters
         ----------
         plot : list of BarContainer, optional
             The containers holding the bars of this layer.
-        levels : list of str, optional
-            The bar labels read off the categorical axis. Used only to check
-            that the axis has one label per bar; an axis with no tick labels
-            at all is not checked here — the caller pairs the magnitudes with
-            the labels, so it ends up raising `ExtractionError` on an empty
-            list regardless.
 
         Returns
         -------
         list, optional
-            One magnitude per bar, or None when the bars and the labels do
-            not line up.
+            One magnitude per bar, or None when there are no containers.
         """
         if plot is None:
             return None
@@ -232,9 +235,7 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
         # `list[BarContainers] for plotting bar plots.
         # So, extract data correspondingly based on the level.
         # Flatten all the `list[BarContainer]` to `list[Patch]`.
-        plot = [patch for container in plot for patch in container.patches]
-        if levels and len(plot) != len(levels):
-            return None
+        plot = self._patches(plot)
 
         self._elements.extend(plot)
 

--- a/tests/core/plot/test_bar_orientation.py
+++ b/tests/core/plot/test_bar_orientation.py
@@ -20,7 +20,6 @@ import seaborn as sns  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.figure_manager import FigureManager  # noqa: E402
-from maidr.exception import ExtractionError  # noqa: E402
 
 
 LABELS = ["a", "b", "c"]
@@ -137,14 +136,22 @@ def test_horizontal_histogram_bins_run_along_y() -> None:
 
 
 @pytest.mark.parametrize("horizontal", [False, True])
-def test_a_label_count_mismatch_raises_extraction_error(horizontal: bool) -> None:
-    """The failure this reordering fixed: an `ExtractionError`, not a `TypeError`.
+def test_a_label_count_mismatch_announces_positions(horizontal: bool) -> None:
+    """Three bars against two tick labels: positions, not an error.
 
-    Three bars against two tick labels is the shape that made
-    `_extract_bar_container_data` return None. The magnitudes and the labels
-    are zipped straight after, so before the None was checked first this
-    surfaced as `TypeError: 'NoneType' object is not iterable`. Both
-    orientations are driven because each zips its own way round.
+    This used to raise, and this test used to assert that it did. What it was
+    really guarding is in its old name -- an `ExtractionError` **rather than a
+    `TypeError`**: the magnitudes and the labels are zipped straight after the
+    None check, so before that check was reordered this surfaced as
+    `TypeError: 'NoneType' object is not iterable`.
+
+    Failing cleanly was an improvement on failing messily. Not failing is an
+    improvement on both: labels are one presentation of x, not x itself, and
+    a bar drawn at x=0 with no tick beside it still has a position (#382).
+    The guarantee the old test encoded survives -- no `TypeError`, and every
+    bar gets exactly one label -- which is what is asserted here.
+
+    Both orientations are driven because each zips its own way round.
     """
     fig, ax = plt.subplots()
     try:
@@ -158,21 +165,28 @@ def test_a_label_count_mismatch_raises_extraction_error(horizontal: bool) -> Non
             ax.set_xticklabels(LABELS[:2])
         plot = FigureManager.get_maidr(fig).plots[0]
 
-        with pytest.raises(ExtractionError):
-            plot._extract_plot_data()
+        data = plot._extract_plot_data()
     finally:
         plt.close(fig)
 
+    assert len(data) == len(VALUES)
+    label_key, value_key = ("y", "x") if horizontal else ("x", "y")
+    assert [point[label_key] for point in data] == ["0", "1", "2"]
+    assert [point[value_key] for point in data] == list(VALUES)
 
-def test_an_axis_with_no_tick_labels_raises_extraction_error() -> None:
-    """Unchanged by the refactor, and pinned here because it looks changed.
 
-    The old `_extract_bar_container_data` swapped an empty level list for a
-    list of empty strings, which reads like it emitted a blank label per bar.
-    It did not: the substitution was local to that method and existed only to
-    let its own length check pass, while the caller went on to zip against
-    the real, still-empty list. Both before and after, a bar axis stripped of
-    its tick labels raises rather than emitting blank labels.
+def test_an_axis_with_no_tick_labels_announces_positions() -> None:
+    """A bar axis stripped of its ticks, which used to delete the chart.
+
+    The guarantee this test has always encoded is that a bar never gets a
+    **blank** label. The old `_extract_bar_container_data` swapped an empty
+    level list for a list of empty strings, which reads as though it emitted
+    one blank label per bar; it did not, because the substitution was local
+    to that method while the caller zipped against the real, still-empty
+    list -- and the whole figure raised instead.
+
+    That guarantee is intact and the outcome is no longer an error: hiding
+    tick marks is a styling choice, and it should not delete the chart.
     """
     fig, ax = plt.subplots()
     try:
@@ -180,10 +194,12 @@ def test_an_axis_with_no_tick_labels_raises_extraction_error() -> None:
         ax.set_xticks([])
         plot = FigureManager.get_maidr(fig).plots[0]
 
-        with pytest.raises(ExtractionError):
-            plot._extract_plot_data()
+        data = plot._extract_plot_data()
     finally:
         plt.close(fig)
+
+    assert [point["x"] for point in data] == ["0", "1", "2"]
+    assert all(point["x"] for point in data), "no blank labels"
 
 
 def test_seaborn_horizontal_histplot() -> None:

--- a/tests/core/test_numeric_bar_positions.py
+++ b/tests/core/test_numeric_bar_positions.py
@@ -134,3 +134,16 @@ def test_a_position_is_printed_the_way_an_axis_prints_it() -> None:
     ax.bar([0.0, 1.5, 3.0], MEASUREMENTS, 0.5)
 
     assert [point["x"] for point in _points(fig)] == ["0", "1.5", "3"]
+
+
+def test_a_large_position_is_not_announced_in_scientific_notation() -> None:
+    """``f"{x:g}"`` alone would say "1.23457e+06" for a bar at 1234567.
+
+    Six significant figures, then exponential -- lossy and hard to listen to.
+    A large x is overwhelmingly an integer one (an index, an id, a year), so
+    integers are formatted exactly and only fractions fall back to ``:g``.
+    """
+    fig, ax = plt.subplots()
+    ax.bar([0, 1234567, 2.5], MEASUREMENTS, 0.4)
+
+    assert [point["x"] for point in _points(fig)] == ["0", "1234567", "2.5"]

--- a/tests/core/test_numeric_bar_positions.py
+++ b/tests/core/test_numeric_bar_positions.py
@@ -1,0 +1,136 @@
+"""A bar chart with a numeric x produced no HTML at all.
+
+`BarPlot` paired its bars with the labels on the categorical axis and raised
+when the counts disagreed. For a categorical x matplotlib puts exactly one
+tick per category, so they agree by construction. For a numeric x the tick
+locator picks its own breaks, so they have no reason to:
+
+                                                   bars  labels  render
+    x = np.arange(len(labels))  [mpl's own recipe]    3      5    raised
+    x = np.arange(...), + set_xticks(x, labels)       3      3    ok
+    plain categorical strings                         3      3    ok
+    numeric x, barh                                   3      8    raised
+    numeric x, many bars (20)                        20      8    raised
+
+`ExtractionError` is fatal to the whole render rather than to its own layer,
+so the figure produced nothing (#382).
+
+The shape in the first row is matplotlib's own grouped bar chart::
+
+    x = np.arange(len(species))
+    ax.bar(x + offset, measurement, width, label=attribute)
+
+which survives in the gallery only because the example goes on to call
+`ax.set_xticks(x + width, species)` and make the counts line up by accident.
+
+The count check was guarding something real -- three bars against five labels
+would announce the wrong name for every bar -- so it still decides. What
+changed is what it decides *between*: labels when they line up, the bars' own
+positions when they do not, rather than a reading and nothing.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+SPECIES = ["Adelie", "Chinstrap", "Gentoo"]
+MEASUREMENTS = np.array([18.0, 18.4, 14.9])
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _points(fig) -> list[dict]:
+    """The first emitted layer's data."""
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return grid[0][0]["layers"][0]["data"]
+
+
+def test_matplotlibs_own_grouped_bar_recipe_renders() -> None:
+    """The reproduction, in the shape the gallery writes it.
+
+    Without the ``set_xticks`` line the gallery goes on to add, this produced
+    no HTML at all. Rendered as well as read, because the old failure happened
+    during extraction and there was no schema to inspect.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(np.arange(len(SPECIES)), MEASUREMENTS, 0.25)
+
+    points = _points(fig)
+
+    assert [point["x"] for point in points] == ["0", "1", "2"]
+    assert [point["y"] for point in points] == list(MEASUREMENTS)
+    assert maidr.render(fig) is not None
+
+
+def test_a_categorical_bar_still_announces_its_names() -> None:
+    """The half that must not move, and the reason the check still decides.
+
+    A reader of a categorical chart has to hear "Adelie", not "0". If the
+    positions were used unconditionally this would pass silently as ``0 1 2``
+    and every bar would lose its name -- which is a worse defect than the one
+    being fixed, because it reads as a working chart.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(SPECIES, MEASUREMENTS)
+
+    assert [point["x"] for point in _points(fig)] == SPECIES
+
+
+def test_the_gallery_example_with_its_ticks_is_unchanged() -> None:
+    """The spelling that always worked, because the counts lined up.
+
+    Calling ``set_xticks(x, labels)`` gives one tick per bar, so the labels
+    win and the names are announced -- exactly as before. This is the control
+    that shows the fallback is a fallback rather than a replacement.
+    """
+    fig, ax = plt.subplots()
+    positions = np.arange(len(SPECIES))
+    ax.bar(positions, MEASUREMENTS, 0.25)
+    ax.set_xticks(positions, SPECIES)
+
+    assert [point["x"] for point in _points(fig)] == SPECIES
+
+
+def test_a_horizontal_numeric_bar_announces_its_positions() -> None:
+    """``barh`` reads its label off y and its magnitude off x.
+
+    The centre of a horizontal bar is its ``y + height / 2``, a different
+    branch from the vertical case, so the mirror is worth driving rather than
+    assuming.
+    """
+    fig, ax = plt.subplots()
+    ax.barh(np.arange(len(SPECIES)), MEASUREMENTS)
+
+    points = _points(fig)
+
+    assert [point["y"] for point in points] == ["0", "1", "2"]
+    assert [point["x"] for point in points] == list(MEASUREMENTS)
+
+
+def test_a_position_is_printed_the_way_an_axis_prints_it() -> None:
+    """A bar at x=0 is at "0", not "0.0".
+
+    The centre is a float because the rectangle's geometry is, but a numeric
+    axis writes whole numbers without a trailing zero and the announcement
+    should match what is on the chart. Half-steps keep their fraction, so
+    this is formatting rather than rounding -- a bar really at 1.5 still says
+    so.
+    """
+    fig, ax = plt.subplots()
+    ax.bar([0.0, 1.5, 3.0], MEASUREMENTS, 0.5)
+
+    assert [point["x"] for point in _points(fig)] == ["0", "1.5", "3"]


### PR DESCRIPTION
Closes #382.

`BarPlot` paired its bars with the labels on the categorical axis and raised when the counts disagreed. For a **categorical** x, matplotlib puts exactly one tick per category, so they agree by construction. For a **numeric** x, the tick locator picks its own breaks and they have no reason to — and `ExtractionError` is fatal to the whole render rather than to its own layer, so the figure produced no HTML at all.

```
                                               bars  labels  render
x = np.arange(len(labels))  [mpl's own recipe]    3      5    raised
x = np.arange(...), + set_xticks(x, labels)       3      3    ok
plain categorical strings                         3      3    ok
numeric x, barh                                   3      8    raised
numeric x, many bars (20)                        20      8    raised
```

## The first row is matplotlib's own grouped bar chart

```python
x = np.arange(len(species))
ax.bar(x + offset, measurement, width, label=attribute)
```

It survives in [the gallery](https://matplotlib.org/stable/gallery/lines_bars_and_markers/barchart.html) only because the example goes on to call `ax.set_xticks(x + width, species)`, which makes the counts line up by accident. Drop that line, or draw a bar chart whose x really is numeric, and there is nothing. Hiding tick marks — an ordinary styling choice — deleted the chart for the same reason.

## The fix keeps the check and changes what it decides between

The count check was guarding something real: three bars against five labels would announce the wrong name for every bar. So it still decides — but between **labels when they line up** and **the bars' own drawn centres when they do not**, rather than between a reading and nothing.

Labels are one *presentation* of x, not x itself. A bar at x=0 with no tick beside it still has a position, and announcing `0` is honest where announcing nothing is not.

Positions are read off the rectangle and printed the way an axis prints them — `"0"` rather than `"0.0"`, while a bar really at 1.5 still says so.

## Two existing tests changed sides

`test_a_label_count_mismatch_raises_extraction_error` and `test_an_axis_with_no_tick_labels_raises_extraction_error` asserted the old raising. Both were **rewritten rather than deleted**, because neither was arguing that raising was correct:

- the first guarded an `ExtractionError` **rather than a `TypeError`** — failing cleanly instead of messily;
- the second guarded against emitting a **blank** label per bar.

Both guarantees survive the change, and the rewritten docstrings say what each was for so the next reader knows they were satisfied rather than overruled. They did their job by failing loudly.

## Falsification

| reverted | failing tests |
|---|---|
| no position fallback (raise as before) | 3 of 5 |
| positions used unconditionally | 2 of 5 |

The second matters as much as the first: using positions everywhere would announce a categorical chart as `0, 1, 2` and would read as a *working* chart — a worse defect than the one being fixed.

## Verification

`ruff check` clean. Full suite: **1217 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_