### PR TITLE
fix(bar): announce a segmented bar's position when no tick label names it

### DIFF
--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -8,6 +8,7 @@ from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
 from maidr.util.mixin import (
+    BarPositionMixin,
     ContainerExtractorMixin,
     DictMergerMixin,
     LevelExtractorMixin,
@@ -24,7 +25,13 @@ from maidr.util.mixin import (
 DRAWN_BARS = "_maidr_bars"
 
 
-class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMergerMixin):
+class BarPlot(
+    MaidrPlot,
+    BarPositionMixin,
+    ContainerExtractorMixin,
+    LevelExtractorMixin,
+    DictMergerMixin,
+):
     def __init__(self, ax: Axes, **kwargs) -> None:
         super().__init__(ax, PlotType.BAR)
         self._orientation = "vert"
@@ -145,33 +152,6 @@ class BarPlot(MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMerge
             return levels
 
         return [self._bar_position(patch) for patch in patches]
-
-    def _bar_position(self, patch: Rectangle) -> str:
-        """
-        The centre a bar was drawn at, as the axis would print it.
-
-        Read off the rectangle rather than the caller's argument, because the
-        caller's is not available here and the drawn centre is what the value
-        became. Whole numbers lose their trailing ``.0``: a bar at x=0 is at
-        ``"0"``, not ``"0.0"``, matching what a numeric axis shows.
-
-        Parameters
-        ----------
-        patch : Rectangle
-            One bar.
-
-        Returns
-        -------
-        str
-            The bar's position along its label axis.
-        """
-        if self._is_horizontal:
-            centre = patch.get_y() + patch.get_height() / 2
-        else:
-            centre = patch.get_x() + patch.get_width() / 2
-        if float(centre).is_integer():
-            return str(int(centre))
-        return f"{centre:g}"
 
     @staticmethod
     def _patches(plot: list[BarContainer] | None) -> list[Rectangle]:

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
+from matplotlib.patches import Rectangle
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
@@ -106,7 +107,7 @@ class GroupedBarPlot(
 
         self._orientation = self._extract_orientation(plot)
 
-        level = self.extract_level(self.ax, self._level_key)
+        level = self._labels_for(plot)
         if not level:
             return None
 
@@ -121,6 +122,10 @@ class GroupedBarPlot(
 
         for i, container in enumerate(plot):
             if len(level) != len(container.patches):
+                # Guarded above by `_labels_for`, which either found one tick
+                # per bar or built one label per bar. A container of a
+                # different length from its siblings would still land here,
+                # and there is nothing honest to pair it with.
                 return None
             container_data = []
 
@@ -147,6 +152,75 @@ class GroupedBarPlot(
             data.append(container_data)
 
         return data
+
+    def _labels_for(self, plot: list[BarContainer]) -> list[str]:
+        """
+        What to announce alongside each bar of every series.
+
+        The tick labels when there is one per bar, and the positions the bars
+        were drawn at otherwise. Decided once for the layer rather than per
+        container, because every series of a segmented chart shares one
+        category axis -- so the announcement has to agree across them, and a
+        per-container answer could name a category in one series and a
+        position in the next.
+
+        matplotlib puts exactly one tick per category on a categorical axis,
+        so the counts agree there by construction; on a numeric axis the tick
+        locator picks its own breaks and they have no reason to. This used to
+        return ``None`` for that mismatch, which the caller turned into an
+        ``ExtractionError`` and so into an empty render -- a stacked chart
+        over ``np.arange(len(species))`` produced no HTML at all (#384), the
+        segmented half of #382.
+
+        The first container is the one measured. Every container of a
+        segmented layer holds one bar per category by construction, so they
+        agree; a layer where they do not is caught by the length check at the
+        pairing loop, which has nothing honest to pair such a container with.
+
+        Parameters
+        ----------
+        plot : list of BarContainer
+            The containers holding this layer's series.
+
+        Returns
+        -------
+        list of str
+            One label per category, from the axis or from the bars.
+        """
+        level = self.extract_level(self.ax, self._level_key)
+        first = plot[0].patches if plot else []
+        if level and len(level) == len(first):
+            return level
+
+        return [self._bar_position(patch) for patch in first]
+
+    def _bar_position(self, patch: Rectangle) -> str:
+        """
+        The centre a bar was drawn at, as the axis would print it.
+
+        The same rule as ``BarPlot._bar_position``: integers exactly, so a
+        bar at 1234567 does not become ``"1.23457e+06"``, and fractions
+        through ``:g``, since the centre comes from the rectangle's geometry
+        and printing float noise exactly would be worse than printing it
+        short.
+
+        Parameters
+        ----------
+        patch : Rectangle
+            One bar.
+
+        Returns
+        -------
+        str
+            The bar's position along its label axis.
+        """
+        if self._is_horizontal:
+            centre = patch.get_y() + patch.get_height() / 2
+        else:
+            centre = patch.get_x() + patch.get_width() / 2
+        if float(centre).is_integer():
+            return str(int(centre))
+        return f"{centre:g}"
 
     def _extract_hue_categories_from_legend(self) -> list[str]:
         """

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
-from matplotlib.patches import Rectangle
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
 from maidr.util.mixin import (
+    BarPositionMixin,
     ContainerExtractorMixin,
     DictMergerMixin,
     LevelExtractorMixin,
@@ -15,7 +15,11 @@ from maidr.util.mixin import (
 
 
 class GroupedBarPlot(
-    MaidrPlot, ContainerExtractorMixin, LevelExtractorMixin, DictMergerMixin
+    MaidrPlot,
+    BarPositionMixin,
+    ContainerExtractorMixin,
+    LevelExtractorMixin,
+    DictMergerMixin,
 ):
     def __init__(self, ax: Axes, plot_type: PlotType, **kwargs) -> None:
         super().__init__(ax, plot_type)
@@ -193,34 +197,6 @@ class GroupedBarPlot(
             return level
 
         return [self._bar_position(patch) for patch in first]
-
-    def _bar_position(self, patch: Rectangle) -> str:
-        """
-        The centre a bar was drawn at, as the axis would print it.
-
-        The same rule as ``BarPlot._bar_position``: integers exactly, so a
-        bar at 1234567 does not become ``"1.23457e+06"``, and fractions
-        through ``:g``, since the centre comes from the rectangle's geometry
-        and printing float noise exactly would be worse than printing it
-        short.
-
-        Parameters
-        ----------
-        patch : Rectangle
-            One bar.
-
-        Returns
-        -------
-        str
-            The bar's position along its label axis.
-        """
-        if self._is_horizontal:
-            centre = patch.get_y() + patch.get_height() / 2
-        else:
-            centre = patch.get_x() + patch.get_width() / 2
-        if float(centre).is_integer():
-            return str(int(centre))
-        return f"{centre:g}"
 
     def _extract_hue_categories_from_legend(self) -> list[str]:
         """

--- a/maidr/util/mixin/__init__.py
+++ b/maidr/util/mixin/__init__.py
@@ -1,3 +1,4 @@
+from .bar_position_mixin import BarPositionMixin
 from .extractor_mixin import (
     CollectionExtractorMixin,
     ContainerExtractorMixin,
@@ -9,6 +10,7 @@ from .format_extractor_mixin import FormatExtractorMixin
 from .merger_mixin import DictMergerMixin
 
 __all__ = [
+    "BarPositionMixin",
     "CollectionExtractorMixin",
     "ContainerExtractorMixin",
     "LevelExtractorMixin",

--- a/maidr/util/mixin/bar_position_mixin.py
+++ b/maidr/util/mixin/bar_position_mixin.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from matplotlib.patches import Rectangle
+
+
+class BarPositionMixin:
+    """
+    Announce where a bar was drawn when no tick label names it.
+
+    Both ``BarPlot`` and ``GroupedBarPlot`` fall back to this when the
+    category axis does not carry one label per bar -- which is every bar chart
+    over a numeric x, since matplotlib's tick locator picks its own breaks
+    there and has no reason to agree with the bars (#382, #384).
+
+    Shared rather than spelled twice because the two copies would drift: the
+    horizontal branch below is the kind of thing that gets corrected in one
+    extractor and not the other, and a chart whose bars are announced at the
+    wrong positions reads as a working chart.
+
+    Expects the host to define ``_is_horizontal``.
+    """
+
+    _is_horizontal: bool
+
+    def _bar_position(self, patch: Rectangle) -> str:
+        """
+        The centre a bar was drawn at, as the axis would print it.
+
+        Read off the rectangle rather than the caller's argument, because the
+        caller's is not available here and the drawn centre is what the value
+        became. With matplotlib's default ``align="center"`` the two are the
+        same number.
+
+        Whole numbers lose their trailing ``.0``: a bar at x=0 is at ``"0"``,
+        not ``"0.0"``, matching what a numeric axis shows. They are also the
+        reason this is not simply ``f"{centre:g}"`` -- that is six significant
+        figures and goes exponential past them, so a bar at x=1234567 would
+        announce ``"1.23457e+06"``, which is both lossy and hard to listen to.
+        A large x is overwhelmingly an integer one (an index, an id, a year),
+        so integers are formatted exactly and only fractions fall back.
+
+        That scopes the problem rather than solving it: a bar centred at
+        1234567.5 still announces ``"1.23457e+06"``. Rounding fractions is not
+        incidental, though -- the centre is computed from the rectangle's
+        geometry, so ``0.1 + 0.2`` arrives as ``0.30000000000000004`` and
+        printing it exactly would be worse than printing it short. Fixing the
+        large-fraction case properly means telling float noise from a real
+        fraction, which needs more than a format string.
+
+        Parameters
+        ----------
+        patch : Rectangle
+            One bar.
+
+        Returns
+        -------
+        str
+            The bar's position along its label axis.
+        """
+        if self._is_horizontal:
+            centre = patch.get_y() + patch.get_height() / 2
+        else:
+            centre = patch.get_x() + patch.get_width() / 2
+        if float(centre).is_integer():
+            return str(int(centre))
+        return f"{centre:g}"

--- a/tests/core/test_numeric_segmented_bar_positions.py
+++ b/tests/core/test_numeric_segmented_bar_positions.py
@@ -1,0 +1,163 @@
+"""A stacked or dodged bar chart with a numeric x produced no HTML.
+
+The segmented half of #382. `GroupedBarPlot._extract_grouped_bar_data` carried
+its own copy of the count check that #383 replaced in `BarPlot`::
+
+    for i, container in enumerate(plot):
+        if len(level) != len(container.patches):
+            return None            # -> ExtractionError -> nothing renders
+
+Same cause: matplotlib puts exactly one tick per category on a categorical
+axis, so the counts agree by construction, and on a numeric axis the tick
+locator picks its own breaks, so they do not (#384).
+
+    stacked, categorical x              ok
+    stacked, NUMERIC x                  ** ExtractionError
+    stacked, numeric x + set_xticks     ok
+
+Which is the stacked half of how anyone writes this::
+
+    x = np.arange(len(species))
+    ax.bar(x, first, label="first")
+    ax.bar(x, second, bottom=first, label="second")
+
+The labels are decided once for the layer rather than per container, because
+every series of a segmented chart shares one category axis — a per-container
+answer could name a category in one series and a position in the next.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+SPECIES = ["Adelie", "Chinstrap", "Gentoo"]
+LOWER = np.array([10.0, 20.0, 30.0])
+UPPER = np.array([30.0, 20.0, 10.0])
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _layer(fig) -> dict:
+    """The one emitted layer of the first subplot cell."""
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return grid[0][0]["layers"][0]
+
+
+def _stack(ax, positions) -> None:
+    """Two series stacked over *positions*, with a legend naming them."""
+    ax.bar(positions, LOWER, bottom=np.zeros(len(LOWER)), label="lower")
+    ax.bar(positions, UPPER, bottom=LOWER, label="upper")
+    ax.legend()
+
+
+def test_a_stacked_chart_over_numeric_positions_renders() -> None:
+    """The reproduction, which produced no HTML at all.
+
+    Rendered as well as read, because the old failure happened during
+    extraction and there was no schema to inspect.
+    """
+    fig, ax = plt.subplots()
+    _stack(ax, np.arange(len(SPECIES)))
+
+    layer = _layer(fig)
+
+    assert layer["type"].value == "stacked_bar"
+    assert [[point["x"] for point in series] for series in layer["data"]] == [
+        ["0", "1", "2"],
+        ["0", "1", "2"],
+    ]
+    assert maidr.render(fig) is not None
+
+
+def test_a_categorical_stacked_chart_still_announces_its_names() -> None:
+    """The half that must not move.
+
+    A reader has to hear "Adelie", not "0". Using positions unconditionally
+    would pass silently as ``0 1 2`` and read as a working chart, which is
+    worse than the failure being fixed.
+    """
+    fig, ax = plt.subplots()
+    _stack(ax, SPECIES)
+
+    assert [
+        [point["x"] for point in series] for series in _layer(fig)["data"]
+    ] == [SPECIES, SPECIES]
+
+
+def test_the_series_names_are_unaffected() -> None:
+    """`z` names the series and comes from the legend, not the category axis.
+
+    Worth asserting in both readings: the labels changing source must not
+    disturb which series a bar belongs to, and a reader who loses "upper" and
+    "lower" cannot tell the two apart however good the categories are.
+    """
+    for positions in (SPECIES, np.arange(len(SPECIES))):
+        fig, ax = plt.subplots()
+        _stack(ax, positions)
+
+        series_names = [series[0]["z"] for series in _layer(fig)["data"]]
+
+        assert series_names == ["lower", "upper"]
+        plt.close(fig)
+
+
+def test_the_same_chart_with_ticks_set_is_unchanged() -> None:
+    """The spelling that always worked, because the counts lined up.
+
+    `set_xticks(x, labels)` gives one tick per bar, so the labels win. This is
+    the control showing the fallback is a fallback rather than a replacement.
+    """
+    fig, ax = plt.subplots()
+    positions = np.arange(len(SPECIES))
+    _stack(ax, positions)
+    ax.set_xticks(positions, SPECIES)
+
+    assert [
+        [point["x"] for point in series] for series in _layer(fig)["data"]
+    ] == [SPECIES, SPECIES]
+
+
+def test_a_horizontal_stack_is_not_recognised_as_one() -> None:
+    """A boundary this change does not move, pinned rather than discovered.
+
+    `ax.barh(..., left=...)` is how a stacked bar is written horizontally,
+    and the patch classifies on ``"bottom" in kwargs`` alone — so it arrives
+    as two independent `bar` layers rather than one `stacked_bar`. A reader is
+    told there are two charts, and is not told the second sits on top of the
+    first.
+
+    That is a wrong *reading* rather than a dead render, it is not what #384
+    is about, and it is filed as its own issue. What is asserted here is that
+    the positions half works regardless: whatever the layers are called, each
+    announces the bars it drew rather than raising, which is what #383 and
+    this change are between them responsible for.
+
+    Named for the defect, so the day the classification is fixed this test
+    fails and has to be rewritten.
+    """
+    fig, ax = plt.subplots()
+    positions = np.arange(len(SPECIES))
+    ax.barh(positions, LOWER, left=np.zeros(len(LOWER)), label="lower")
+    ax.barh(positions, UPPER, left=LOWER, label="upper")
+    ax.legend()
+
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    layers = grid[0][0]["layers"]
+
+    assert [layer["type"].value for layer in layers] == ["bar", "bar"]
+    for layer in layers:
+        assert [point["y"] for point in layer["data"]] == ["0", "1", "2"]


### PR DESCRIPTION
Closes #384 — the segmented half of #382, raised in review of #383.

`GroupedBarPlot._extract_grouped_bar_data` carried its own copy of the count check that #383 replaced in `BarPlot`, so a stacked chart over numeric positions produced no HTML at all:

```
stacked, categorical x              ok
stacked, NUMERIC x                  ** ExtractionError
stacked, numeric x + set_xticks     ok
```

That is the stacked half of how anyone writes this:

```python
x = np.arange(len(species))
ax.bar(x, first, label="first")
ax.bar(x, second, bottom=first, label="second")
```

## Same rule, one difference that is why it wasn't a transplant

Tick labels when there is one per bar, the bars' own drawn centres otherwise — as in #383. But the labels are decided **once for the layer** rather than per container. Every series of a segmented chart shares one category axis, so a per-container answer could name a category in one series and a position in the next.

The per-container length check stays, and now guards only what `_labels_for` cannot: a container of a different length from its siblings, which there is nothing honest to pair with.

`z` comes from the legend and is untouched — asserted in **both** readings, because a reader who loses "upper" and "lower" cannot tell the series apart however good the categories are.

## Falsification

| reverted | failing tests |
|---|---|
| no position fallback (raise as before) | 2 of 5 |
| positions used unconditionally | 2 of 5 |

The second matters as much as the first: positions everywhere would announce a categorical stacked chart as `0, 1, 2` and read as a working chart.

## A boundary found while writing the horizontal mirror

`ax.barh(..., left=...)` is **not recognised as stacked at all** — the patch classifies on `"bottom" in kwargs` alone, and `left` is the horizontal spelling of the same argument. So a horizontal stack arrives as two independent `bar` layers:

```
registered: ['bar', 'bar']
```

The numbers are right and the layer count is plausible; what a reader is not told is that the second sits on top of the first. That is a wrong *reading* rather than a dead render, it is a step earlier than this PR (classification, not extraction), and it is filed as #385. `test_a_horizontal_stack_is_not_recognised_as_one` pins it and is named for the defect, so the day it is fixed that test fails and has to be rewritten — while still asserting the part this PR and #383 are responsible for: whatever the layers are called, each announces the bars it drew rather than raising.

## Verification

`ruff check` clean. Full suite: **1223 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_