### PR TITLE
fix(bar): read `left` as a stacked bar's baseline, as `bottom` is

### DIFF
--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -20,7 +20,8 @@ def bar(
 
     This function patches the bar plotting functions to identify whether the
     plot should be rendered as a normal, stacked, or dodged bar plot.
-    It uses the 'bottom' keyword to identify stacked bar plots. For dodged
+    It uses the 'bottom' keyword -- or 'left', which is how a horizontal bar
+    spells the same thing -- to identify stacked bar plots. For dodged
     plots, it uses robust detection logic that considers both width and
     context to avoid misclassifying simple bar plots with narrow widths as
     dodged plots. Seaborn's bar plots do not come through here — they are

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -51,11 +51,16 @@ def bar(
     """
     plot_type = PlotType.BAR
 
-    # Check for stacked plots first (explicit bottom parameter)
-    if "bottom" in kwargs:
-        bottom = kwargs.get("bottom")
-        if bottom is not None:
-            plot_type = PlotType.STACKED
+    # A stacked bar is the one that says where its baseline is. `bottom` is
+    # how a vertical bar says it and `left` is how a horizontal one does --
+    # the same argument for the two orientations, and reading only the first
+    # meant `ax.barh(..., left=...)` arrived as two independent bar layers.
+    # The numbers were right and the layer count was plausible; what a reader
+    # was not told is that the second bar sits on top of the first, which is
+    # the whole content of a stacked chart (#385).
+    baseline = kwargs.get("bottom", kwargs.get("left"))
+    if baseline is not None:
+        plot_type = PlotType.STACKED
     else:
         # Extract width and align parameters
         if len(args) >= 3:

--- a/tests/core/test_numeric_segmented_bar_positions.py
+++ b/tests/core/test_numeric_segmented_bar_positions.py
@@ -178,3 +178,28 @@ def test_a_plain_horizontal_bar_is_still_plain() -> None:
     grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
 
     assert [layer["type"].value for layer in grid[0][0]["layers"]] == ["bar"]
+
+
+def test_an_explicit_none_baseline_still_reaches_dodge_detection() -> None:
+    """`bottom=None` is not a baseline, and used to skip the dodge check.
+
+    The old test was ``if "bottom" in kwargs``, so passing it explicitly as
+    ``None`` -- which matplotlib treats exactly as omitting it -- took the
+    stacked branch's `else` away and dodge detection never ran. The inner
+    ``is not None`` guard kept the layer from being called stacked, so the
+    result was a *plain* bar where a dodged one was drawn.
+
+    Reading the value rather than the key fixes it as a side effect, and this
+    is here so the fix is deliberate rather than incidental.
+    """
+    fig, ax = plt.subplots()
+    positions = np.arange(len(SPECIES), dtype=float)
+    ax.bar(positions - 0.2, LOWER, 0.4, bottom=None, label="lower")
+    ax.bar(positions + 0.2, UPPER, 0.4, bottom=None, label="upper")
+    ax.legend()
+
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    types = [layer["type"].value for layer in grid[0][0]["layers"]]
+
+    assert "stacked_bar" not in types, "None is not a baseline"
+    assert types == ["dodged_bar"], types

--- a/tests/core/test_numeric_segmented_bar_positions.py
+++ b/tests/core/test_numeric_segmented_bar_positions.py
@@ -131,23 +131,19 @@ def test_the_same_chart_with_ticks_set_is_unchanged() -> None:
     ] == [SPECIES, SPECIES]
 
 
-def test_a_horizontal_stack_is_not_recognised_as_one() -> None:
-    """A boundary this change does not move, pinned rather than discovered.
+def test_a_horizontal_stack_over_numeric_positions() -> None:
+    """The mirror, which could not be written until `left=` was recognised.
 
-    `ax.barh(..., left=...)` is how a stacked bar is written horizontally,
-    and the patch classifies on ``"bottom" in kwargs`` alone — so it arrives
-    as two independent `bar` layers rather than one `stacked_bar`. A reader is
-    told there are two charts, and is not told the second sits on top of the
-    first.
+    `ax.barh(..., left=...)` is how a stacked bar is written horizontally.
+    The patch used to classify on ``"bottom" in kwargs`` alone, so this
+    arrived as two independent `bar` layers -- the numbers right, the layer
+    count plausible, and a reader never told the second sits on top of the
+    first. This test was originally named for that defect so it would fail
+    the day it was fixed; #385 fixed it, so here is what it should say.
 
-    That is a wrong *reading* rather than a dead render, it is not what #384
-    is about, and it is filed as its own issue. What is asserted here is that
-    the positions half works regardless: whatever the layers are called, each
-    announces the bars it drew rather than raising, which is what #383 and
-    this change are between them responsible for.
-
-    Named for the defect, so the day the classification is fixed this test
-    fails and has to be rewritten.
+    A horizontal bar reads its label off y and its magnitude off x, through
+    the mirrored branch of the shared position formatter, so it exercises
+    what the vertical cases above cannot.
     """
     fig, ax = plt.subplots()
     positions = np.arange(len(SPECIES))
@@ -155,9 +151,30 @@ def test_a_horizontal_stack_is_not_recognised_as_one() -> None:
     ax.barh(positions, UPPER, left=LOWER, label="upper")
     ax.legend()
 
-    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
-    layers = grid[0][0]["layers"]
+    layer = _layer(fig)
 
-    assert [layer["type"].value for layer in layers] == ["bar", "bar"]
-    for layer in layers:
-        assert [point["y"] for point in layer["data"]] == ["0", "1", "2"]
+    assert layer["type"].value == "stacked_bar"
+    assert [[point["y"] for point in series] for series in layer["data"]] == [
+        ["0", "1", "2"],
+        ["0", "1", "2"],
+    ]
+    assert [[point["x"] for point in series] for series in layer["data"]] == [
+        list(LOWER),
+        list(UPPER),
+    ]
+    assert [series[0]["z"] for series in layer["data"]] == ["lower", "upper"]
+
+
+def test_a_plain_horizontal_bar_is_still_plain() -> None:
+    """The control for reading `left`: no baseline, no stack.
+
+    `left` names a stacked bar's baseline the way `bottom` does for a
+    vertical one, so a `barh` without it must stay a plain bar -- otherwise
+    every horizontal bar chart would be announced as a stack of one.
+    """
+    fig, ax = plt.subplots()
+    ax.barh(SPECIES, LOWER)
+
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+
+    assert [layer["type"].value for layer in grid[0][0]["layers"]] == ["bar"]


### PR DESCRIPTION
Closes #385, found while writing #386's horizontal mirror.

A stacked bar is the one that says where its baseline is. `bottom` is how a **vertical** bar says it and `left` is how a **horizontal** one does — the same argument for the two orientations — and only the first was read:

```python
if "bottom" in kwargs:
    ...
    plot_type = PlotType.STACKED
```

So the standard horizontal stacked bar arrived as two independent `bar` layers:

```python
ax.barh(positions, lower, left=np.zeros(n), label="lower")
ax.barh(positions, upper, left=lower,       label="upper")
```

| | emitted |
|---|---|
| before | `['bar', 'bar']` |
| after | `['stacked_bar']` |

## What a reader was losing

The numbers were right and the layer count was plausible, so nothing looked wrong. What was missing is the relationship: a reader was told there are two bar charts, and was **not** told the second sits on top of the first. That is the whole content of a stacked chart, and the reason `stacked_bar` exists as a distinct trace rather than as a label — it announces the segment's own value against the running total.

## The pinning test did its job

`test_a_horizontal_stack_is_not_recognised_as_one`, added by #386 and named for the defect precisely so it would fail the day it was fixed, failed. Rewritten as `test_a_horizontal_stack_over_numeric_positions` — which is also the horizontal mirror #386 could not write, since the case did not reach `GroupedBarPlot` at all. It reads its label off `y` and its magnitude off `x`, through the branch of `BarPositionMixin` the vertical cases cannot reach.

## Falsification

| reverted | result |
|---|---|
| read `bottom` only | 1 of 6 fail |
| treat every bar as stacked | **23 of the suite fail** |

The second is the one worth having. `left` and `bottom` are absent from most bar calls, so a baseline check that fired unconditionally would announce every plain bar chart as a stack of one — and `test_a_plain_horizontal_bar_is_still_plain` is the control that names that directly.

## Verification

`ruff check` clean. Full suite: **1224 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_