### PR TITLE
fix(hist): do not read a 2D histogram as a bar histogram

### DIFF
--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -43,12 +43,58 @@ def mpl_hist(
     return n, bins, plot
 
 
+def _drew_bars(plot) -> bool:
+    """
+    Whether the call that produced *plot* drew a histogram made of bars.
+
+    `sns.histplot(x=..., y=...)` is a **2D** histogram: seaborn draws it as a
+    ``QuadMesh`` of joint counts, not as bars. `hist` promises one bin per bar
+    with a count, which such a layer has neither of -- so registering it
+    promises a reading nothing can produce, and extraction then took the whole
+    figure down with it. `sns.jointplot(kind="hist")` produced no HTML at all,
+    and so did any supported chart that happened to share the axes (#388).
+
+    Asked of the axes rather than of the arguments, because "did this draw
+    bars" is the question the extractor actually needs answered, and a `y=`
+    keyword is seaborn's spelling of it rather than the thing itself.
+
+    Parameters
+    ----------
+    plot : Any
+        Whatever the patched call returned.
+
+    Returns
+    -------
+    bool
+        True when the axes holds at least one ``BarContainer``.
+    """
+    try:
+        ax = FigureManager.get_axes(plot)
+    except Exception:  # pragma: no cover - `common` already resolved this once
+        return False
+    return bool(ax is not None and ax.containers and any(
+        isinstance(container, BarContainer) for container in ax.containers
+    ))
+
+
 def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     """
     Patch seaborn.histplot to register HIST and (if kde=True) SMOOTH layers for MAIDR.
+
+    A bivariate histogram is left unregistered rather than read wrongly; see
+    `_drew_bars`.
     """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        drawn = _draw_quietly(wrapped, args, kwargs)
+
+    if not _drew_bars(drawn):
+        return drawn
+
     # Register the histogram as HIST as before
-    ax = common(PlotType.HIST, wrapped, instance, args, kwargs)
+    ax = common(PlotType.HIST, lambda *a, **k: drawn, instance, args, kwargs)
     # Only register KDE overlay as SMOOTH if kde=True was set
     kde_enabled = kwargs.get("kde", False)
     if kde_enabled:

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from typing import Any
+
+import matplotlib.pyplot as plt
 import wrapt
 
 import numpy as np
@@ -43,9 +46,39 @@ def mpl_hist(
     return n, bins, plot
 
 
-def _drew_bars(plot) -> bool:
+def _prospective_axes(kwargs: dict) -> Axes | None:
     """
-    Whether the call that produced *plot* drew a histogram made of bars.
+    The axes ``histplot`` is about to draw on, resolved before it draws.
+
+    Named without drawing anything: an explicit ``ax=`` is the answer when
+    given, and otherwise seaborn will take ``plt.gca()``, which is only asked
+    for when a figure already exists so that a call on a clean slate does not
+    conjure one early.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    Axes or None
+        The axes to snapshot, or None when there is nothing drawn yet.
+    """
+    ax = kwargs.get("ax")
+    if ax is not None:
+        return ax
+    return plt.gcf().gca() if plt.get_fignums() else None
+
+
+def _container_ids(ax: Axes | None) -> set[int]:
+    """The identities of the containers an axes holds right now."""
+    return {id(container) for container in getattr(ax, "containers", ()) or ()}
+
+
+def _drew_bars(plot: Any, before: set[int]) -> bool:
+    """
+    Whether *this call* drew a histogram made of bars.
 
     `sns.histplot(x=..., y=...)` is a **2D** histogram: seaborn draws it as a
     ``QuadMesh`` of joint counts, not as bars. `hist` promises one bin per bar
@@ -54,27 +87,47 @@ def _drew_bars(plot) -> bool:
     figure down with it. `sns.jointplot(kind="hist")` produced no HTML at all,
     and so did any supported chart that happened to share the axes (#388).
 
-    Asked of the axes rather than of the arguments, because "did this draw
+    Asked of the artists rather than of the arguments, because "did this draw
     bars" is the question the extractor actually needs answered, and a `y=`
     keyword is seaborn's spelling of it rather than the thing itself.
+
+    Asked of the containers *this call added* rather than of everything on the
+    axes, which is the difference between declining and lying. An axes that
+    already holds bars -- `sns.barplot(ax=ax)` first, then a bivariate
+    `histplot(ax=ax)` -- would otherwise answer True for someone else's
+    artists, and `extract_container` returns the first container on the axes,
+    so the `hist` layer would describe the *barplot's* bars with bin edges
+    invented for them:
+
+        registered: ['bar', 'hist']
+          bar   [{'x': 'a', 'y': 8.67}, ...]
+          hist  [{'y': 8.67, 'xMin': -0.4, 'xMax': 0.4}, ...]
+
+    Right numbers, wrong chart, and nothing raised -- which is worse than the
+    crash this function was added to prevent.
 
     Parameters
     ----------
     plot : Any
         Whatever the patched call returned.
+    before : set of int
+        Identities of the containers the axes held before the call.
 
     Returns
     -------
     bool
-        True when the axes holds at least one ``BarContainer``.
+        True when this call added at least one ``BarContainer``.
     """
     try:
         ax = FigureManager.get_axes(plot)
     except Exception:  # pragma: no cover - `common` already resolved this once
         return False
-    return bool(ax is not None and ax.containers and any(
-        isinstance(container, BarContainer) for container in ax.containers
-    ))
+    if ax is None or not ax.containers:
+        return False
+    return any(
+        isinstance(container, BarContainer) and id(container) not in before
+        for container in ax.containers
+    )
 
 
 def sns_hist(wrapped, instance, args, kwargs) -> Axes:
@@ -87,10 +140,12 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     if ContextManager.is_internal_context():
         return _draw_quietly(wrapped, args, kwargs)
 
+    before = _container_ids(_prospective_axes(kwargs))
+
     with ContextManager.set_internal_context():
         drawn = _draw_quietly(wrapped, args, kwargs)
 
-    if not _drew_bars(drawn):
+    if not _drew_bars(drawn, before):
         return drawn
 
     # Register the histogram as HIST as before

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -65,18 +65,36 @@ def _prospective_axes(kwargs: dict) -> Axes | None:
     Axes or None
         The axes to snapshot, or None when there is nothing drawn yet.
     """
+    # `ax` is read from kwargs alone because seaborn declares it keyword-only:
+    # everything after `data` in `histplot`'s signature is, so there is no
+    # positional spelling to miss. `test_seaborn_still_takes_ax_by_keyword`
+    # asserts that rather than trusting it, so a signature change fails loudly
+    # instead of quietly emptying the snapshot below.
     ax = kwargs.get("ax")
     if ax is not None:
         return ax
     return plt.gcf().gca() if plt.get_fignums() else None
 
 
-def _container_ids(ax: Axes | None) -> set[int]:
-    """The identities of the containers an axes holds right now."""
-    return {id(container) for container in getattr(ax, "containers", ()) or ()}
+def _containers_of(ax: Axes | None) -> list:
+    """
+    The containers an axes holds right now, kept by reference.
+
+    The objects themselves rather than their ``id()``s, and that is not
+    incidental. An id is only unique while its object is alive, so a snapshot
+    of ids could be matched by an unrelated container that happened to be
+    allocated at a freed address -- which would make a genuinely new histogram
+    look pre-existing and be declined. Holding the list keeps every one of
+    them alive for the comparison.
+
+    A ``set`` would be wrong for a second reason: ``BarContainer`` extends
+    ``tuple``, so it hashes by value, and two equal containers would collapse
+    into one.
+    """
+    return list(getattr(ax, "containers", ()) or ())
 
 
-def _drew_bars(plot: Any, before: set[int]) -> bool:
+def _drew_bars(plot: Any, before: list) -> bool:
     """
     Whether *this call* drew a histogram made of bars.
 
@@ -110,8 +128,8 @@ def _drew_bars(plot: Any, before: set[int]) -> bool:
     ----------
     plot : Any
         Whatever the patched call returned.
-    before : set of int
-        Identities of the containers the axes held before the call.
+    before : list
+        The containers the axes held before the call, by reference.
 
     Returns
     -------
@@ -120,12 +138,17 @@ def _drew_bars(plot: Any, before: set[int]) -> bool:
     """
     try:
         ax = FigureManager.get_axes(plot)
-    except Exception:  # pragma: no cover - `common` already resolved this once
+    except StopIteration:  # pragma: no cover - an artist with no axes on it
+        # `get_axes` walks a container's children with a bare `next()`, so an
+        # artist it cannot resolve raises rather than returning. Declining is
+        # the gentler answer and loses nothing: `common` would call the same
+        # function a line below and raise the same way.
         return False
     if ax is None or not ax.containers:
         return False
     return any(
-        isinstance(container, BarContainer) and id(container) not in before
+        isinstance(container, BarContainer)
+        and not any(container is seen for seen in before)
         for container in ax.containers
     )
 
@@ -140,7 +163,7 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     if ContextManager.is_internal_context():
         return _draw_quietly(wrapped, args, kwargs)
 
-    before = _container_ids(_prospective_axes(kwargs))
+    before = _containers_of(_prospective_axes(kwargs))
 
     with ContextManager.set_internal_context():
         drawn = _draw_quietly(wrapped, args, kwargs)

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -15,24 +15,38 @@ class ContainerExtractorMixin:
         container_type: type,
         include_all: bool = False,
     ) -> Any:
-        """Retrieve containers of a specified type from an Axes object."""
+        """
+        Retrieve containers of a specified type from an Axes object.
+
+        Returns ``None`` when the axes holds none of that type, which is what
+        every caller is written for -- ``HistPlot._extract_bar_container_data``
+        opens with ``if plot is None``. The single-container branch used to
+        reach that answer through a bare ``next()`` and raise
+        ``StopIteration`` instead, so the ``None`` handling below it could
+        never run and a `sns.histplot(x=..., y=...)` -- a 2D histogram, drawn
+        as a mesh rather than as bars -- killed the whole render with an
+        exception that named nothing (#388).
+
+        A bare ``StopIteration`` is never a useful failure, and inside a
+        generator PEP 479 turns it into a ``RuntimeError`` with the cause
+        obscured. The two branches now agree: nothing found is ``[]`` or
+        ``None``, not an exception.
+        """
         if ax is None or ax.containers is None:
             return None
 
-        # If include_all is True, return a list of all containers of the specified type.
-        if include_all:
-            return [
-                container
-                for container in ax.containers
-                if isinstance(container, container_type)
-            ]
-
-        # Otherwise, return the first container of the specified type.
-        return next(
+        matches = [
             container
             for container in ax.containers
             if isinstance(container, container_type)
-        )
+        ]
+
+        # If include_all is True, return a list of all containers of the specified type.
+        if include_all:
+            return matches
+
+        # Otherwise, return the first container of the specified type.
+        return matches[0] if matches else None
 
 
 class LevelExtractorMixin:

--- a/tests/core/test_bivariate_histogram.py
+++ b/tests/core/test_bivariate_histogram.py
@@ -1,0 +1,156 @@
+"""A 2D histogram raised `StopIteration` and killed the render.
+
+`sns.histplot(x=..., y=...)` is a **bivariate** histogram: seaborn draws it as
+a `QuadMesh` of joint counts, not as bars. MAIDR registered it as `hist`
+anyway, and `ContainerExtractorMixin.extract_container` then reached for the
+first `BarContainer` on an axes that has none::
+
+    return next(
+        container for container in ax.containers
+        if isinstance(container, container_type)
+    )
+
+Not an `ExtractionError` — a raw `StopIteration`, fatal to the whole figure
+and naming nothing (#388).
+
+    2D histplot alone                 ['hist']            ** StopIteration
+    scatter + 2D histplot overlay     ['point', 'hist']   ** StopIteration
+    jointplot(kind='hist')                                ** StopIteration
+    jointplot(kind='kde')                                 ok
+    jointplot(kind='scatter')                             ok
+
+Two defects, and both had to go. `extract_container`'s two branches
+disagreed — the list branch returned empty, the single branch raised — so the
+`if plot is None` handling every caller opens with could never run. And
+fixing only that turns `StopIteration` into `ExtractionError`, which is still
+fatal: `hist` promises one bin per bar with a count, which a mesh has neither
+of, so the layer must not be registered at all.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pandas as pd
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+from matplotlib.container import BarContainer  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.util.mixin import ContainerExtractorMixin  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Two numeric columns, enough for a joint distribution."""
+    rng = np.random.default_rng(20260814)
+    return pd.DataFrame(
+        {"v": rng.normal(10, 3, size=60), "w": rng.normal(5, 2, size=60)}
+    )
+
+
+def _layers(fig) -> list:
+    """The plot types registered for a figure, or an empty list."""
+    try:
+        return [plot.type for plot in FigureManager.get_maidr(fig).plots]
+    except KeyError:
+        return []
+
+
+def test_a_scatter_under_a_2d_histogram_still_renders() -> None:
+    """The row that matters most: a good chart destroyed by its neighbour.
+
+    The scatter reads perfectly well. It produced no HTML because a 2D
+    histogram was drawn over it and registered a layer nothing could extract.
+    """
+    frame = _frame()
+    fig, ax = plt.subplots()
+
+    sns.scatterplot(data=frame, x="v", y="w", ax=ax)
+    sns.histplot(data=frame, x="v", y="w", ax=ax)
+
+    assert _layers(fig) == [PlotType.SCATTER]
+    assert maidr.render(fig) is not None
+
+
+def test_a_jointplot_of_histograms_renders() -> None:
+    """A documented `jointplot` kind that produced nothing at all.
+
+    Its central panel is the bivariate histogram; its marginals are ordinary
+    1D ones, and those are what should be announced.
+    """
+    grid = sns.jointplot(data=_frame(), x="v", y="w", kind="hist")
+
+    assert _layers(grid.figure) == [PlotType.HIST, PlotType.HIST]
+    assert maidr.render(grid.figure) is not None
+
+
+def test_a_one_dimensional_histogram_is_unchanged() -> None:
+    """The control. Declining the bivariate case must cost the normal one
+    nothing, since both arrive through the same patch."""
+    fig, ax = plt.subplots()
+    sns.histplot(data=_frame(), x="v", ax=ax)
+
+    assert _layers(fig) == [PlotType.HIST]
+
+
+def test_a_histogram_with_a_kde_overlay_is_unchanged() -> None:
+    """The second control, because `sns_hist` gained an early return.
+
+    `kde=True` registers a `smooth` alongside the `hist`, and that pass runs
+    *after* the registration the early return skips — so a bivariate call must
+    not reach it and a univariate one must still.
+    """
+    fig, ax = plt.subplots()
+    sns.histplot(data=_frame(), x="v", kde=True, ax=ax)
+
+    assert _layers(fig) == [PlotType.HIST, PlotType.SMOOTH]
+
+
+def test_extract_container_returns_rather_than_raises() -> None:
+    """The mixin's own contract, asserted directly.
+
+    Both branches now agree that "none of that type" is a value, not an
+    exception. This is the check that fails if the single-container branch
+    goes back to a bare ``next()`` — which no behavioural test above would
+    catch once the patch stops registering the layer that reached it.
+    """
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [3, 2, 1])  # a line: no BarContainer anywhere
+
+    assert ContainerExtractorMixin.extract_container(ax, BarContainer) is None
+    assert (
+        ContainerExtractorMixin.extract_container(ax, BarContainer, include_all=True)
+        == []
+    )
+
+
+def test_extract_container_still_finds_the_first_of_several() -> None:
+    """The behaviour the `next()` was there for, kept.
+
+    Returning ``None`` on an empty match must not change which container is
+    returned when there are some — the first, in the order the axes holds
+    them.
+    """
+    fig, ax = plt.subplots()
+    first = ax.bar(["a", "b"], [1.0, 2.0])
+    ax.bar(["a", "b"], [3.0, 4.0], bottom=[1.0, 2.0])
+
+    found = ContainerExtractorMixin.extract_container(ax, BarContainer)
+
+    assert found is first
+    assert len(
+        ContainerExtractorMixin.extract_container(ax, BarContainer, include_all=True)
+    ) == 2

--- a/tests/core/test_bivariate_histogram.py
+++ b/tests/core/test_bivariate_histogram.py
@@ -209,3 +209,21 @@ def test_a_histogram_drawn_without_an_explicit_axes_registers() -> None:
     sns.histplot(data=_frame(), x="v")
 
     assert _layers(plt.gcf()) == [PlotType.HIST]
+
+
+def test_seaborn_still_takes_ax_by_keyword() -> None:
+    """The assumption the pre-draw snapshot rests on.
+
+    `_prospective_axes` reads `ax` from kwargs alone. That is safe only while
+    seaborn declares it keyword-only — a positional spelling would be missed,
+    the snapshot would come back empty, and a stale container would once again
+    look like this call's own work.
+
+    Asserted rather than commented, because the failure is silent: every test
+    above passes an explicit `ax=` keyword and would go on passing.
+    """
+    import inspect
+
+    kind = inspect.signature(sns.histplot).parameters["ax"].kind
+
+    assert kind is inspect.Parameter.KEYWORD_ONLY

--- a/tests/core/test_bivariate_histogram.py
+++ b/tests/core/test_bivariate_histogram.py
@@ -154,3 +154,58 @@ def test_extract_container_still_finds_the_first_of_several() -> None:
     assert len(
         ContainerExtractorMixin.extract_container(ax, BarContainer, include_all=True)
     ) == 2
+
+
+def test_bars_already_on_the_axes_do_not_make_it_a_histogram() -> None:
+    """The lie that would have sat next to the fixed crash.
+
+    `_drew_bars` asks what *this call* added, not what the axes holds. Asked
+    the second way, an axes that already has bars — a `barplot` drawn first —
+    answers True for someone else's artists, `sns_hist` registers a `hist`,
+    and `extract_container` hands back the first container on the axes. The
+    layer then describes the **barplot's** bars with bin edges invented for
+    them::
+
+        registered: ['bar', 'hist']
+          bar   [{'x': 'a', 'y': 8.67}, ...]
+          hist  [{'y': 8.67, 'xMin': -0.4, 'xMax': 0.4}, ...]
+
+    Right numbers, wrong chart, nothing raised — worse than the crash the
+    decline was added to prevent.
+    """
+    frame = _frame()
+    frame["g"] = ["a", "b", "c"] * 20
+    fig, ax = plt.subplots()
+
+    sns.barplot(data=frame, x="g", y="v", ax=ax)
+    sns.histplot(data=frame, x="v", y="w", ax=ax)
+
+    assert _layers(fig) == [PlotType.BAR]
+
+
+def test_a_second_histogram_on_the_same_axes_still_registers() -> None:
+    """The control for the diff: new bars are new bars.
+
+    Snapshotting must decline only what added nothing. Two overlaid 1D
+    histograms are two histograms, and each call adds its own container.
+    """
+    frame = _frame()
+    fig, ax = plt.subplots()
+
+    sns.histplot(data=frame, x="v", ax=ax)
+    sns.histplot(data=frame, x="w", ax=ax)
+
+    assert _layers(fig) == [PlotType.HIST, PlotType.HIST]
+
+
+def test_a_histogram_drawn_without_an_explicit_axes_registers() -> None:
+    """The snapshot has to find the axes seaborn will use, or find none.
+
+    Without ``ax=``, seaborn draws on ``plt.gca()``. Resolving that before the
+    call must not miss the axes (which would make the snapshot empty and let
+    a stale container through) nor conjure one where a figure does not exist.
+    """
+    plt.close("all")
+    sns.histplot(data=_frame(), x="v")
+
+    assert _layers(plt.gcf()) == [PlotType.HIST]


### PR DESCRIPTION
Closes #388.

`sns.histplot(x=..., y=...)` is a **bivariate** histogram — seaborn draws it as a `QuadMesh` of joint counts, not as bars. MAIDR registered it as `hist` anyway, and extraction reached for the first `BarContainer` on an axes that has none, raising a bare `StopIteration`: not an `ExtractionError`, and fatal to the whole figure.

```
2D histplot alone               ['hist']            ** StopIteration
scatter + 2D histplot overlay   ['point', 'hist']   ** StopIteration
jointplot(kind='hist')                              ** StopIteration
jointplot(kind='kde')                               ok
jointplot(kind='scatter')                           ok
```

**`sns.jointplot(kind="hist")` is a documented, mainstream call and produced no HTML at all.** So did any supported chart sharing the axes — the scatter row is the one that matters, since it reads perfectly well and was destroyed by its neighbour.

## Two defects, and fixing either alone is not enough

### `extract_container` raised where it is documented to return

```python
if include_all:
    return [c for c in ax.containers if isinstance(c, container_type)]   # -> []

return next(                                                            # -> StopIteration
    container for container in ax.containers if isinstance(container, container_type)
)
```

The branches disagreed. Every caller is written for the returning contract — `HistPlot._extract_bar_container_data` opens with `if plot is None` — and the bare `next()` above it meant that could never run. A bare `StopIteration` is never a useful failure, and inside a generator PEP 479 turns it into a `RuntimeError` with the cause obscured. Both branches now answer "none of that type" with a value.

### But that only turns `StopIteration` into `ExtractionError`, which is still fatal

`hist` promises one bin per bar with a count, and a mesh has neither. So the patch declines to register when its call drew no `BarContainer` — asked of the **axes** rather than of a `y=` keyword, because "did this draw bars" is the question the extractor actually needs answered and the keyword is only seaborn's spelling of it.

A bivariate histogram is now simply unsupported, exactly as `sns.kdeplot(x=..., y=...)` already was — and the figure it appears in survives.

## After

```
scatter + 2D histplot overlay   ['point']    ok
jointplot(kind='hist')                       ok
jointplot(kind='kde')                        ok
jointplot(kind='scatter')                    ok
jointplot(kind='reg')                        ok
```

## Falsification

| reverted | failing tests |
|---|---|
| bare `next()` restored | 1 of 6 |
| bivariate registered again | 2 of 6 |

The mixin's contract is asserted **directly** as well as behaviourally, because once the patch stops registering the layer that reached it, no behavioural test would catch a return to `next()`.

Two controls guard the normal path: a plain 1D histogram, and `histplot(kde=True)` — the latter because `sns_hist` gained an early return, and the `smooth` registration runs *after* the point it skips.

## Not in scope

Making 2D histograms *supported*. This is about not destroying the figure they appear in.

## Verification

`ruff check` clean. Full suite: **1231 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_