### PR TITLE
fix(plotly): read a stacked bar chart as stacked

### DIFF
--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -83,6 +83,20 @@ def _is_domain_trace(trace: dict) -> bool:
     return trace.get("type") in _DOMAIN_TRACE_TYPES
 
 
+#: Plotly's own default when a figure sets no ``barmode``. It stacks -- and
+#: it is the value `px.bar(color=...)` leaves behind, so it is the ordinary
+#: way a stacked bar chart arrives rather than an exotic one.
+_PLOTLY_DEFAULT_BARMODE = "relative"
+
+#: The barmodes under which plotly *combines* several bar traces into one
+#: chart, and so the ones MAIDR merges into a single layer. ``relative`` is
+#: plotly's name for a stack that lets negative values run below the axis.
+#:
+#: ``overlay`` is deliberately absent: those bars are drawn over one another
+#: rather than joined, so separate layers is the honest reading.
+_COMBINED_BARMODES = frozenset({"group", "stack", "relative"})
+
+
 class PlotlyMaidr:
     """
     Handles rendering Plotly figures as accessible MAIDR HTML.
@@ -230,8 +244,11 @@ class PlotlyMaidr:
         Groups traces by their subplot position (axis pair), then applies
         merging rules within each group:
 
-        * Multiple bar traces with ``barmode='group'`` or ``'stack'`` are
-          merged into a single :class:`PlotlyGroupedBarPlot`.
+        * Multiple bar traces that plotly combines -- ``barmode`` of
+          ``'group'``, ``'stack'`` or ``'relative'`` -- are merged into a
+          single :class:`PlotlyGroupedBarPlot`. ``'overlay'`` is not combined:
+          those bars are drawn over one another rather than joined, so they
+          stay separate layers.
         * Scatter/lines traces are split by *renderer* first — SVG traces
           apart from canvas-painted ``scattergl`` ones — because a layer's
           selector list is all-or-nothing, so a mixed layer could only claim a
@@ -267,7 +284,13 @@ class PlotlyMaidr:
         fig_dict = self._fig.to_dict()
         layout = fig_dict.get("layout", {})
         traces = fig_dict.get("data", [])
-        barmode = layout.get("barmode", "group")
+        # Plotly's own default is `relative`, which stacks. Defaulting to
+        # `group` here meant a figure that plotly drew stacked was announced
+        # as *dodged* -- not a lost relationship but an inverted one, telling
+        # a reader the bars sit side by side when they sit on top of each
+        # other, so every segment means something other than what is said and
+        # the totals a stack is read for are absent (#390).
+        barmode = layout.get("barmode") or _PLOTLY_DEFAULT_BARMODE
 
         # Group traces by their subplot axis pair
         axis_groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
@@ -351,14 +374,12 @@ class PlotlyMaidr:
             merged: set[int] = set()
 
             # Grouped / stacked bars
-            if len(bar_traces) > 1 and barmode in ("group", "stack"):
+            if len(bar_traces) > 1 and barmode in _COMBINED_BARMODES:
                 from maidr.core.enum.plot_type import PlotType
                 from maidr.plotly.grouped_bar import PlotlyGroupedBarPlot
 
                 plot_type = (
-                    PlotType.DODGED
-                    if barmode == "group"
-                    else PlotType.STACKED
+                    PlotType.DODGED if barmode == "group" else PlotType.STACKED
                 )
                 plot = PlotlyGroupedBarPlot(
                     bar_traces, layout, plot_type, **axis_kwargs

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -290,6 +290,10 @@ class PlotlyMaidr:
         # a reader the bars sit side by side when they sit on top of each
         # other, so every segment means something other than what is said and
         # the totals a stack is read for are absent (#390).
+        # `or` rather than `get(key, default)`: the key is absent when unset
+        # today, but a future plotly could export it as an explicit `None`, and
+        # every barmode plotly accepts is a non-empty string, so nothing valid
+        # is falsy here.
         barmode = layout.get("barmode") or _PLOTLY_DEFAULT_BARMODE
 
         # Group traces by their subplot axis pair

--- a/tests/plotly/test_plotly_barmode.py
+++ b/tests/plotly/test_plotly_barmode.py
@@ -34,12 +34,18 @@ row and carrying the wrong fallback, so every barmode is enumerated below.
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
-import plotly.express as px
-import plotly.graph_objects as go
 import pytest
 
-from maidr.plotly.plotly_maidr import PlotlyMaidr
+# `plotly` is an optional extra, so guard the import the way every other file
+# in this directory does -- without it, a minimal install fails at *collection*
+# rather than skipping.
+plotly = pytest.importorskip("plotly")
+pd = pytest.importorskip("pandas")
+
+import plotly.express as px  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 #: Every value plotly accepts, with the layer types MAIDR should emit.
 #: `relative` and `stack` both combine; `group` dodges; `overlay` draws the

--- a/tests/plotly/test_plotly_barmode.py
+++ b/tests/plotly/test_plotly_barmode.py
@@ -1,0 +1,126 @@
+"""A stacked plotly bar chart was announced as a grouped one.
+
+`PlotlyMaidr._extract_plots` classifies multi-trace bar figures from
+`layout.barmode`::
+
+    barmode = layout.get("barmode", "group")
+    ...
+    if len(bar_traces) > 1 and barmode in ("group", "stack"):
+        plot_type = PlotType.DODGED if barmode == "group" else PlotType.STACKED
+
+Plotly's default `barmode` is **`relative`**, which stacks. That line defaulted
+to `group`, which dodges — and `relative` was missing from the tuple besides:
+
+                             plotly draws          maidr said
+    no barmode               relative (default)    ['dodged_bar']
+    barmode=relative         relative              ['bar', 'bar']
+    barmode=stack            stack                 ['stacked_bar']
+    barmode=group            group                 ['dodged_bar']
+    barmode=overlay          overlay               ['bar', 'bar']
+
+Row 1 is the severe one: not a lost relationship but an inverted one. A reader
+was told the bars sit side by side when plotly drew them on top of each other,
+so every segment means something other than what was announced and the totals
+a stack is read for are absent entirely. Nothing errored (#390).
+
+Row 2 is how `px.bar(color=...)` — the ordinary way to draw a stacked bar
+chart in plotly express — arrives.
+
+Unlike the matplotlib side, where stacking is inferred from a `bottom=`
+argument, plotly *states* this in the layout. It was a lookup table missing a
+row and carrying the wrong fallback, so every barmode is enumerated below.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import pytest
+
+from maidr.plotly.plotly_maidr import PlotlyMaidr
+
+#: Every value plotly accepts, with the layer types MAIDR should emit.
+#: `relative` and `stack` both combine; `group` dodges; `overlay` draws the
+#: bars over one another rather than joining them, so they stay separate.
+BARMODES = [
+    (None, ["stacked_bar"]),
+    ("relative", ["stacked_bar"]),
+    ("stack", ["stacked_bar"]),
+    ("group", ["dodged_bar"]),
+    ("overlay", ["bar", "bar"]),
+]
+
+
+def _two_bar_traces(barmode: str | None) -> go.Figure:
+    """Two bar traces over one category axis, at *barmode*."""
+    figure = go.Figure(
+        [
+            go.Bar(x=["a", "b", "c"], y=[1.0, 2.0, 3.0], name="lower"),
+            go.Bar(x=["a", "b", "c"], y=[3.0, 2.0, 1.0], name="upper"),
+        ]
+    )
+    if barmode is not None:
+        figure.update_layout(barmode=barmode)
+    return figure
+
+
+def _types(figure: go.Figure) -> list[str]:
+    """The layer types MAIDR extracts from a plotly figure."""
+    return [plot.type.value for plot in PlotlyMaidr(figure)._plots]
+
+
+@pytest.mark.parametrize("barmode,expected", BARMODES)
+def test_every_barmode_is_read_the_way_plotly_draws_it(barmode, expected) -> None:
+    """The whole table, because the failure is a silent mislabel.
+
+    The set is small and enumerable, and three of these five rows were wrong
+    in a way nothing downstream could detect — so each is named rather than
+    left to a representative case.
+    """
+    assert _types(_two_bar_traces(barmode)) == expected
+
+
+def test_the_default_matches_plotly_rather_than_the_old_guess() -> None:
+    """The row that inverted the relationship, stated on its own.
+
+    A figure that sets no `barmode` is drawn stacked by plotly. It was
+    announced as dodged — bars side by side where plotly put them on top of
+    one another. This asserts against plotly's own reported default rather
+    than a literal, so the two cannot drift apart silently.
+    """
+    figure = _two_bar_traces(None)
+
+    assert figure.layout.barmode is None, "plotly leaves it unset"
+    assert _types(figure) == ["stacked_bar"]
+
+
+def test_a_plotly_express_stacked_bar_is_stacked() -> None:
+    """`px.bar(color=...)` is the ordinary way to draw one, and it sets
+    `relative` — the value that used to fall through to two plain layers."""
+    rng = np.random.default_rng(3)
+    frame = pd.DataFrame(
+        {
+            "g": list("abc") * 10,
+            "h": ["x", "y"] * 15,
+            "v": rng.normal(10, 3, size=30),
+        }
+    )
+
+    figure = px.bar(frame, x="g", y="v", color="h")
+
+    assert figure.layout.barmode == "relative"
+    assert _types(figure) == ["stacked_bar"]
+
+
+def test_a_single_bar_trace_is_not_merged() -> None:
+    """The control: merging needs more than one trace, whatever the barmode.
+
+    A one-trace figure carries plotly's stacking default too, so reading the
+    barmode alone would turn every plain bar chart into a stack of one.
+    """
+    rng = np.random.default_rng(3)
+    frame = pd.DataFrame({"g": list("abc") * 10, "v": rng.normal(10, 3, size=30)})
+
+    assert _types(px.bar(frame, x="g", y="v")) == ["bar"]


### PR DESCRIPTION
Closes #390.

The plotly bar classification is a lookup on `layout.barmode`. It was missing a row *and* carrying the wrong fallback:

```python
barmode = layout.get("barmode", "group")
...
if len(bar_traces) > 1 and barmode in ("group", "stack"):
```

| | plotly draws | maidr said |
|---|---|---|
| no barmode | `relative` (default) | **`['dodged_bar']`** |
| `barmode=relative` | `relative` | `['bar', 'bar']` |
| `barmode=stack` | `stack` | `['stacked_bar']` |
| `barmode=group` | `group` | `['dodged_bar']` |
| `barmode=overlay` | `overlay` | `['bar', 'bar']` |

## Row 1 inverts the relationship rather than losing it

Plotly's default `barmode` is `relative`, which **stacks**. The code defaulted to `group`, which **dodges**. A reader was told the bars sit side by side when plotly drew them on top of each other — so every segment means something other than what was announced, and the totals a stacked chart is read *for* are absent from the reading entirely. Nothing errored.

## Row 2 is how plotly express writes a stacked bar chart

`px.bar(df, x="g", y="v", color="h")` sets `barmode='relative'`. Asking for stacking explicitly fell straight through to two independent `bar` layers.

## The fix

`relative` is plotly's own name for a stack that lets negative values run below the axis, so it joins `group` and `stack` as a mode that **combines** traces. `overlay` deliberately does not: those bars are drawn over one another rather than joined, and separate layers is the honest reading.

Unlike the matplotlib side, where stacking has to be inferred from a `bottom=`/`left=` argument (#385), plotly **states** this in the layout — so this is a table to correct rather than a heuristic to design. Every value plotly accepts is now enumerated in a parametrized test, since three of the five rows were wrong in a way nothing downstream could detect and the set is small.

The default is asserted against plotly's own reported value rather than against a literal, so the two cannot drift apart silently.

## Falsification

| reverted | failing tests |
|---|---|
| default back to `group` | 2 of 8 |
| `relative` not merged | 4 of 8 |

Plus a control: a single-trace figure carries the stacking default too, so reading `barmode` alone would turn every plain bar chart into a stack of one.

## Related, filed separately

`px.area` declares itself with `stackgroup='1'` on a `Scatter` trace, which the adapter does not read — so an area chart is announced as `line`.

## Verification

`ruff check` clean. Full suite: **1243 passed**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_