### PR TITLE
feat(plotly): read a 100% stacked bar as one

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -28,6 +28,7 @@ class PlotType(str, Enum):
     PIE = "pie"
     SCATTER = "point"
     STACKED = "stacked_bar"
+    NORMALIZED = "stacked_normalized_bar"
     STEP = "step"
     SMOOTH = "smooth"
     CANDLESTICK = "candlestick"
@@ -63,6 +64,7 @@ _DISPLAY_NAMES = {
     PlotType.HEAT: "heatmap",
     PlotType.HIST: "histogram",
     PlotType.SCATTER: "scatter",
+    PlotType.NORMALIZED: "100% stacked bar",
     PlotType.STACKED: "stacked bar",
     PlotType.STACKED_AREA: "stacked area",
     PlotType.VIOLIN_BOX: "violin",

--- a/maidr/plotly/grouped_bar.py
+++ b/maidr/plotly/grouped_bar.py
@@ -6,7 +6,14 @@ from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
 class PlotlyGroupedBarPlot(PlotlyPlot):
-    """Extract data from multiple Plotly bar traces (dodged or stacked).
+    """Extract data from multiple Plotly bar traces (dodged, stacked or
+    normalised).
+
+    The class does not branch on *plot_type*: every combination hands the
+    traces' own ``x``/``y``/``fill`` through unchanged, and the type decides
+    only how the MAIDR core reads them. Which one applies is worked out from
+    ``layout.barmode`` and ``layout.barnorm`` by
+    :meth:`~maidr.plotly.plotly_maidr.PlotlyMaidr._extract_plots`.
 
     Parameters
     ----------
@@ -15,7 +22,8 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
     layout : dict
         The Plotly figure layout.
     plot_type : PlotType
-        Either ``PlotType.DODGED`` or ``PlotType.STACKED``.
+        ``PlotType.DODGED``, ``PlotType.STACKED`` or
+        ``PlotType.NORMALIZED``.
     """
 
     def __init__(

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -88,6 +88,12 @@ def _is_domain_trace(trace: dict) -> bool:
 #: way a stacked bar chart arrives rather than an exotic one.
 _PLOTLY_DEFAULT_BARMODE = "relative"
 
+#: The values `layout.barnorm` takes when plotly normalises each stack to a
+#: common total -- its own switch for a 100% stacked bar. `percent` scales to
+#: 100 and `fraction` to 1; both mean the segment values are *shares of their
+#: category* rather than counts, which is what the distinct trace type says.
+_NORMALISING_BARNORMS = frozenset({"percent", "fraction"})
+
 #: The barmodes under which plotly *combines* several bar traces into one
 #: chart, and so the ones MAIDR merges into a single layer. ``relative`` is
 #: plotly's name for a stack that lets negative values run below the axis.
@@ -382,9 +388,19 @@ class PlotlyMaidr:
                 from maidr.core.enum.plot_type import PlotType
                 from maidr.plotly.grouped_bar import PlotlyGroupedBarPlot
 
-                plot_type = (
-                    PlotType.DODGED if barmode == "group" else PlotType.STACKED
-                )
+                # `barnorm` only means anything for a stack: plotly scales
+                # each category's segments to a common total, so the values
+                # are shares rather than counts. Read as a plain `stacked_bar`
+                # a reader is told nothing about that, and is left to suppose
+                # the equal totals are a property of the data rather than of
+                # the chart (#338).
+                normalised = layout.get("barnorm") in _NORMALISING_BARNORMS
+                if barmode == "group":
+                    plot_type = PlotType.DODGED
+                elif normalised:
+                    plot_type = PlotType.NORMALIZED
+                else:
+                    plot_type = PlotType.STACKED
                 plot = PlotlyGroupedBarPlot(
                     bar_traces, layout, plot_type, **axis_kwargs
                 )

--- a/tests/plotly/test_plotly_barnorm.py
+++ b/tests/plotly/test_plotly_barnorm.py
@@ -101,6 +101,34 @@ def test_an_empty_barnorm_is_not_normalisation() -> None:
     assert _types(_figure("stack", "")) == ["stacked_bar"]
 
 
+def test_the_express_spelling_reaches_the_same_answer() -> None:
+    """How a user actually writes one, rather than a hand-built layout.
+
+    `px.bar` takes no `barnorm` argument -- unlike `px.histogram`, which does
+    -- so the express route to a 100% stacked bar is `update_layout`. That
+    still has to arrive as `relative` + `percent` in `to_dict()` for the
+    lookup above to fire, which is the part worth driving rather than assuming
+    from the `go.Figure` cases.
+    """
+    pd = pytest.importorskip("pandas")
+    np = pytest.importorskip("numpy")
+    import plotly.express as px
+
+    rng = np.random.default_rng(3)
+    frame = pd.DataFrame(
+        {
+            "g": list("abc") * 10,
+            "h": ["x", "y"] * 15,
+            "v": rng.normal(10, 3, size=30),
+        }
+    )
+
+    figure = px.bar(frame, x="g", y="v", color="h").update_layout(barnorm="percent")
+
+    assert figure.layout.barmode == "relative"
+    assert _types(figure) == ["stacked_normalized_bar"]
+
+
 def test_the_type_is_the_one_the_maidr_core_already_carries() -> None:
     """The wire value has to match the core, or the bundle cannot draw it.
 

--- a/tests/plotly/test_plotly_barnorm.py
+++ b/tests/plotly/test_plotly_barnorm.py
@@ -1,0 +1,113 @@
+"""A 100% stacked bar chart was announced as an ordinary stacked one.
+
+`layout.barnorm` is plotly's own switch for normalising each stack to a common
+total — `'percent'` scales to 100, `'fraction'` to 1. Either way the segment
+values are *shares of their category* rather than counts. MAIDR did not read
+it, so such a chart arrived as `stacked_bar` (#338).
+
+What a reader loses is not the numbers, which are announced either way, but
+what they *are*. A `stacked_bar` invites the reading that each segment is a
+count and that the categories happen to total the same; `stacked_normalized_bar`
+says the totals are equal by construction and the parts are proportions. The
+MAIDR core has carried `TraceType.NORMALIZED = 'stacked_normalized_bar'` for
+some time; `PlotType` simply had no member to emit it with, so the type was
+unreachable from Python.
+
+This is a lookup rather than a heuristic, and deliberately so. matplotlib and
+seaborn have no equivalent declaration — a user normalises the data themselves
+and calls `ax.bar(bottom=...)` — so inferring "every category totals 1.0, so
+this must be normalised" would name a chart from a coincidence in its data.
+Plotly states it, so plotly is where this can be read honestly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Every combination that decides the layer type. `barnorm` normalises a stack
+#: whatever spelling of stacking got it there, and means nothing to a dodge.
+CASES = [
+    (None, None, "stacked_bar"),
+    ("stack", None, "stacked_bar"),
+    ("stack", "percent", "stacked_normalized_bar"),
+    ("stack", "fraction", "stacked_normalized_bar"),
+    ("relative", "percent", "stacked_normalized_bar"),
+    (None, "percent", "stacked_normalized_bar"),
+    ("group", "percent", "dodged_bar"),
+    ("group", None, "dodged_bar"),
+]
+
+
+def _figure(barmode: str | None, barnorm: str | None) -> go.Figure:
+    """Two bar traces over one category axis, at *barmode* and *barnorm*."""
+    figure = go.Figure(
+        [
+            go.Bar(x=["a", "b", "c"], y=[1.0, 2.0, 3.0], name="lower"),
+            go.Bar(x=["a", "b", "c"], y=[3.0, 2.0, 1.0], name="upper"),
+        ]
+    )
+    layout = {}
+    if barmode is not None:
+        layout["barmode"] = barmode
+    if barnorm is not None:
+        layout["barnorm"] = barnorm
+    if layout:
+        figure.update_layout(**layout)
+    return figure
+
+
+def _types(figure: go.Figure) -> list[str]:
+    """The layer types MAIDR extracts from a plotly figure."""
+    return [plot.type.value for plot in PlotlyMaidr(figure)._plots]
+
+
+@pytest.mark.parametrize("barmode,barnorm,expected", CASES)
+def test_barnorm_decides_only_what_it_should(barmode, barnorm, expected) -> None:
+    """The whole table, since the failure is a silent mislabel.
+
+    Two axes of a small closed set, so every combination is named rather than
+    left to a representative case — including the two rows where `barnorm` is
+    set and must *not* change the answer.
+    """
+    assert _types(_figure(barmode, barnorm)) == [expected]
+
+
+def test_a_dodge_is_not_normalised_by_barnorm() -> None:
+    """`barnorm` normalises a *stack*, and a dodge has none to normalise.
+
+    Stated on its own because it is the row a "barnorm means normalised"
+    shortcut would get wrong, and the answer would look plausible: side-by-side
+    bars announced as shares of a total that the chart never draws.
+    """
+    assert _types(_figure("group", "percent")) == ["dodged_bar"]
+
+
+def test_an_empty_barnorm_is_not_normalisation() -> None:
+    """Plotly's own "off" value is the empty string, not absence.
+
+    `barnorm=""` is how a figure says *not* normalised after something set it,
+    so membership of the normalising set is the test rather than truthiness of
+    the key.
+    """
+    assert _types(_figure("stack", "")) == ["stacked_bar"]
+
+
+def test_the_type_is_the_one_the_maidr_core_already_carries() -> None:
+    """The wire value has to match the core, or the bundle cannot draw it.
+
+    `TraceType.NORMALIZED = 'stacked_normalized_bar'` has existed in the JS
+    grammar for some time; what was missing was a `PlotType` member to emit
+    it. A mismatch here would render an unknown trace rather than a chart, so
+    the string is pinned rather than left to a constructor.
+    """
+    assert PlotType.NORMALIZED.value == "stacked_normalized_bar"
+    assert PlotType.NORMALIZED.display_name == "100% stacked bar"


### PR DESCRIPTION
Closes #338.

## The defect

`layout.barnorm` is plotly's own switch for normalising each stack to a common total — `'percent'` scales to 100, `'fraction'` to 1. Either way the segment values are *shares of their category* rather than counts. MAIDR did not read it, so such a chart arrived as `stacked_bar`.

```
                          plotly draws           maidr said
barmode=stack             a stack of counts      stacked_bar          ok
barmode=stack             a stack of shares      stacked_bar          ** wrong
  + barnorm=percent       summing to 100
barmode=stack             a stack of shares      stacked_bar          ** wrong
  + barnorm=fraction      summing to 1
```

What a reader loses is not the numbers, which are announced either way, but what they *are*. A `stacked_bar` invites the reading that each segment is a count and that the categories happen to total the same; `stacked_normalized_bar` says the totals are equal by construction and the parts are proportions. Every category totalling exactly 100 reads as a striking finding about the data when it is a property of the chart.

## Why this was reachable at all

The MAIDR core has carried the type for some time:

```ts
// maidr/src/type/grammar.ts:1435
NORMALIZED = 'stacked_normalized_bar'
```

`PlotType` simply had no member to emit it with, so the type was unreachable from Python. This adds it, and reads plotly's declaration into it.

## Lookup, not heuristic

I had earlier flagged this issue as needing a heuristic I was not comfortable writing — something like "every category totals 1.0, so this must be normalised". That would name a chart from a coincidence in its data, and a chart whose parts genuinely happen to sum to 1 would be relabelled.

It turns out no heuristic is needed, because plotly states it:

```
layout.barnorm = 'percent' | barmode = 'stack'
to_dict layout keys: ['barmode', 'barnorm', 'template']
```

`barnorm` is present in `to_dict()` when set, so this is the same shape as #391's `barmode` — a lookup table, read from what the library declares.

matplotlib and seaborn have **no** equivalent declaration. A user normalises the data themselves and calls `ax.bar(bottom=...)`, and nothing in the artists says whether that was normalisation or arithmetic. Those paths are deliberately untouched; plotly is where this can be read honestly.

## Two decisions worth stating

**The dodge check stays ahead of the normalisation check.** `barnorm` normalises a *stack*, and a dodge has none to normalise — plotly ignores it there. Ordered the other way, `barmode='group' + barnorm='percent'` would announce side-by-side bars as shares of a total the chart never draws, which is plausible-looking and wrong.

**Membership of the normalising set, not key presence.** Plotly's own "off" value is the empty string, so `barnorm=""` is how a figure says *not* normalised after something set it. `"barnorm" in layout` would call that normalised — the same bug shape as the `"bottom" in kwargs` test fixed in #387.

## Behaviour

| `barmode` | `barnorm` | emitted |
|---|---|---|
| — | — | `stacked_bar` |
| `stack` | — | `stacked_bar` |
| `stack` | `percent` | `stacked_normalized_bar` |
| `stack` | `fraction` | `stacked_normalized_bar` |
| `relative` | `percent` | `stacked_normalized_bar` |
| — | `percent` | `stacked_normalized_bar` |
| `group` | `percent` | `dodged_bar` |
| `group` | — | `dodged_bar` |
| `stack` | `""` | `stacked_bar` |

Both axes of a small closed set, so every combination is named rather than left to a representative case — including the rows where `barnorm` is set and must *not* change the answer.

## Falsification

Each mechanism reverted in turn, to confirm the tests fail for the reason claimed rather than passing alongside it.

| reverted to | failures |
|---|---|
| `normalised = False` (stop reading `barnorm`) | 4 |
| normalisation checked ahead of the dodge | 2 |
| `"barnorm" in layout` (key presence, not value) | 1 |
| `NORMALIZED = "normalized_bar"` (wrong wire value) | 5 |
| display name removed | 1 |

Restored, `tests/plotly/test_plotly_barnorm.py` is 11 passed; the full suite is **1254 passed** (1243 before, plus these 11).

`ruff check` is clean on all three files. `ruff format` reports drift in `plotly_maidr.py`, but it predates this change — the file at `HEAD` fails the same check, and no reformat hunk touches the lines added here — so it is left for a separate pass rather than mixed into this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_