### PR TITLE
feat(plotly): read candlestick and OHLC charts

### DIFF
--- a/maidr/plotly/candlestick.py
+++ b/maidr/plotly/candlestick.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+#: The two plotly trace types that carry an OHLC series. They differ only in
+#: how plotly draws a bar -- a filled body for ``candlestick``, a tick on
+#: either side of a vertical range for ``ohlc`` -- and not at all in what the
+#: numbers mean, so both are read as the same MAIDR layer.
+OHLC_TRACE_TYPES = frozenset({"candlestick", "ohlc"})
+
+#: The DOM layer each trace type draws into, measured in a browser rather than
+#: assumed: a ``candlestick`` shares plotly's box machinery (``g.boxlayer`` >
+#: ``g.trace.boxes`` > ``path.box``) while an ``ohlc`` has a layer of its own
+#: (``g.ohlclayer`` > ``g.trace.ohlc`` > ``path``).
+_LAYER_OF = {"candlestick": "boxlayer", "ohlc": "ohlclayer"}
+_GROUP_OF = {"candlestick": ".trace.boxes", "ohlc": ".trace.ohlc"}
+_MARK_OF = {"candlestick": "path.box", "ohlc": "> path"}
+
+#: Trace types that share ``g.boxlayer`` and so count towards a candlestick's
+#: position within it. A ``go.Violin`` draws into ``g.violinlayer`` and a
+#: scatter into ``g.scatterlayer``, so neither shifts the count.
+_BOXLAYER_TRACE_TYPES = frozenset({"box", "candlestick"})
+
+
+def is_ohlc_trace(trace: dict) -> bool:
+    """
+    Return whether *trace* carries an open/high/low/close series.
+
+    Parameters
+    ----------
+    trace : dict
+        A plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        ``True`` for a ``candlestick`` or ``ohlc`` trace.
+    """
+    return trace.get("type") in OHLC_TRACE_TYPES
+
+
+def layer_position(traces: list[dict], trace: dict) -> int:
+    """
+    Return *trace*'s zero-based position among its DOM layer-mates.
+
+    Plotly appends one ``<g class="trace ...">`` per trace to the layer its
+    type draws into, in the order the traces were declared, so a trace's
+    position among the traces sharing that layer is its ``nth-child`` index.
+    Counting all traces instead would skip a child for every scatter or violin
+    beside it and scope the selector to nothing.
+
+    Parameters
+    ----------
+    traces : list of dict
+        Every trace on the subplot, in declaration order.
+    trace : dict
+        The trace to locate.
+
+    Returns
+    -------
+    int
+        The zero-based position among traces drawing into the same layer.
+    """
+    kind = trace.get("type")
+    if kind == "candlestick":
+        mates = _BOXLAYER_TRACE_TYPES
+    else:
+        mates = frozenset({kind}) if kind else frozenset()
+
+    position = 0
+    for candidate in traces:
+        if candidate is trace:
+            return position
+        if candidate.get("type") in mates:
+            position += 1
+    return position
+
+
+class PlotlyCandlestickPlot(PlotlyPlot):
+    """Extract data from a Plotly ``candlestick`` or ``ohlc`` trace.
+
+    Both types state every number they draw: ``open``, ``high``, ``low`` and
+    ``close`` arrive as arrays on the trace itself, so nothing here is
+    inferred from the drawing.
+
+    ``trend`` and ``volatility`` are deliberately not emitted. The MAIDR core
+    derives both from the OHLC values and overwrites whatever a producer
+    sends, so a second copy here could only ever disagree with the one that
+    is used. The matplotlib :class:`~maidr.core.plot.candlestick.CandlestickPlot`
+    omits them for the same reason.
+
+    ``volume`` is likewise absent: neither plotly type carries it, and the
+    core announces no volume section, so there is nothing to invent.
+    """
+
+    def __init__(
+        self,
+        trace: dict,
+        layout: dict,
+        *,
+        layer_position: int = 0,
+        **kwargs: str,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        trace : dict
+            A plotly ``candlestick`` or ``ohlc`` trace dictionary.
+        layout : dict
+            The plotly layout dictionary.
+        layer_position : int, default=0
+            The trace's zero-based position among the traces drawing into its
+            DOM layer. Scopes the selector to this trace's marks.
+        **kwargs : str
+            ``xaxis_name`` / ``yaxis_name``, forwarded to :class:`PlotlyPlot`.
+        """
+        super().__init__(trace, layout, PlotType.CANDLESTICK, **kwargs)
+        self._layer_position = layer_position
+
+    def _get_selector(self) -> str:
+        """Return a CSS selector for this trace's marks.
+
+        Scoped three ways, each for a measured reason.
+
+        ``.subplot.<id>`` excludes the **rangeslider**. Plotly gives a
+        candlestick chart one by default, and it holds a complete second copy
+        of the plot -- ``g.rangeslider-rangeplot`` -- so an unscoped selector
+        matches every mark twice and the highlight for the second half of the
+        candles lands in the thumbnail.
+
+        ``nth-child`` picks this trace out of its layer. Two candlestick
+        traces put two ``g.trace.boxes`` groups in the same ``g.boxlayer``,
+        and a ``go.Box`` beside a candlestick lands there too and draws its
+        own ``path.box`` -- so without a position the selector matches both
+        traces' marks and every index after the first names the wrong bar.
+        """
+        kind = self._trace.get("type", "candlestick")
+        layer = _LAYER_OF.get(kind, "boxlayer")
+        group = _GROUP_OF.get(kind, ".trace.boxes")
+        mark = _MARK_OF.get(kind, "path.box")
+        return (
+            f"{self._subplot_css_prefix()}.{layer} > "
+            f"{group}:nth-child({self._layer_position + 1}) {mark}"
+        )
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        Return one entry per candle, in the order plotly declares them.
+
+        Returns
+        -------
+        list of dict
+            ``{"value", "open", "high", "low", "close"}`` per candle. The keys
+            are plain strings rather than :class:`MaidrKey` members because
+            the OHLC vocabulary has none, and the matplotlib emitter spells
+            them the same way.
+        """
+        opens = as_list(self._trace.get("open"))
+        highs = as_list(self._trace.get("high"))
+        lows = as_list(self._trace.get("low"))
+        closes = as_list(self._trace.get("close"))
+        values = as_list(self._trace.get("x"))
+
+        # The shortest array decides the count. Plotly draws only as many bars
+        # as it has all four numbers for, so reading past that would announce
+        # candles it never drew.
+        count = min(len(opens), len(highs), len(lows), len(closes))
+
+        candles = []
+        for index in range(count):
+            try:
+                candle = {
+                    "open": float(opens[index]),
+                    "high": float(highs[index]),
+                    "low": float(lows[index]),
+                    "close": float(closes[index]),
+                }
+            except (TypeError, ValueError):
+                # A gap plotly leaves blank. Skipping keeps the announced
+                # candles aligned with the drawn ones, which a placeholder
+                # would not.
+                continue
+
+            # Positions default to the index when the author gave no `x`,
+            # which is what plotly labels the axis with in that case.
+            label = values[index] if index < len(values) else index
+            candle["value"] = str(self._to_native(label))
+            candles.append(candle)
+
+        return candles

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, cast
 from htmltools import HTML, HTMLDocument, Tag, tags
 
 from maidr.core.enum.maidr_key import MaidrKey
+from maidr.plotly.candlestick import is_ohlc_trace, layer_position
 from maidr.plotly.plotly_plot import PlotlyPlot, domain_interval
 from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
 from maidr.plotly.step_shape import (
@@ -564,6 +565,33 @@ class PlotlyMaidr:
                     )
                     self._plots.append(plot)
                 merged.update(id(t) for t in pie_traces)
+
+            # OHLC series, one layer each. Built here rather than left to
+            # `PlotlyPlotFactory` for the same reason a lone line is: the
+            # selector needs the trace's position among its DOM layer-mates,
+            # and only this loop knows what else is on the subplot.
+            #
+            # Layer-mates rather than traces, because plotly appends one group
+            # per trace to the layer that trace's *type* draws into. A
+            # `candlestick` shares `g.boxlayer` with every `go.Box` beside it
+            # -- which draws a `path.box` of its own -- while an `ohlc` gets
+            # `g.ohlclayer` to itself. Counting either one against all the
+            # subplot's traces would scope the selector to nothing.
+            ohlc_traces = [t for t in group_traces if is_ohlc_trace(t)]
+            if ohlc_traces:
+                from maidr.plotly.candlestick import PlotlyCandlestickPlot
+
+                for ohlc_trace in ohlc_traces:
+                    plot = PlotlyCandlestickPlot(
+                        ohlc_trace,
+                        layout,
+                        layer_position=layer_position(group_traces, ohlc_trace),
+                        **axis_kwargs,
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in ohlc_traces)
 
             # Remaining traces
             for trace in group_traces:

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -105,6 +105,17 @@ class PlotlyPlotFactory:
 
             return PlotlyBoxPlot(trace, layout, **axis_kwargs)
 
+        if trace_type in ("candlestick", "ohlc"):
+            from maidr.plotly.candlestick import PlotlyCandlestickPlot
+
+            # ``layer_position`` is left at its default for the same reason
+            # the lines branch leaves ``scatter_position`` at 0: this factory
+            # sees one trace with no idea what else shares its DOM layer, and
+            # "assume it is the only one" is the only assumption available.
+            # ``PlotlyMaidr`` never reaches here precisely because it does
+            # know, and passes real positions.
+            return PlotlyCandlestickPlot(trace, layout, **axis_kwargs)
+
         if trace_type == "heatmap":
             from maidr.plotly.heatmap import PlotlyHeatmapPlot
 

--- a/tests/plotly/test_plotly_candlestick.py
+++ b/tests/plotly/test_plotly_candlestick.py
@@ -1,0 +1,344 @@
+"""A plotly candlestick chart produced a figure with no layers at all.
+
+`maidr/plotly/` builds its MAIDR schema in Python, so it needs its own handling
+per trace type, and it had none for `candlestick` or `ohlc`. Neither errored --
+`_extract_plots` simply had no branch for them, so they fell through to
+`PlotlyPlotFactory`, which returned `None`::
+
+    go.Candlestick(...)   ->  layers: []
+    go.Ohlc(...)          ->  layers: []
+
+The HTML still rendered and MAIDR still loaded. What arrived was an empty
+shell: a chart with nothing to navigate, no announcement, and no error saying
+why (#343).
+
+Nothing here is inferred. Both trace types state every number they draw --
+`open`, `high`, `low` and `close` are arrays on the trace itself -- so this is
+a transcription, not a reconstruction. The two differ only in how plotly draws
+a bar, not in what it means, so both are read as `PlotType.CANDLESTICK`.
+
+The selectors were measured in a browser rather than reasoned about, because
+plotly puts a candlestick in the DOM in three ways that a plausible selector
+gets wrong. Each is pinned by a test below with the measured counts.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Four candles, all four series distinct so a swapped pair cannot pass.
+OHLC = {
+    "x": ["d1", "d2", "d3", "d4"],
+    "open": [1.0, 2.0, 3.0, 2.5],
+    "high": [2.0, 3.0, 4.0, 3.2],
+    "low": [0.0, 1.0, 2.0, 1.8],
+    "close": [1.5, 2.5, 3.5, 2.0],
+}
+
+#: A second series, so two traces on one subplot can be told apart.
+OTHER = {
+    "x": ["d1", "d2", "d3", "d4"],
+    "open": [5.0, 6.0, 7.0, 6.5],
+    "high": [6.0, 7.0, 8.0, 7.2],
+    "low": [4.0, 5.0, 6.0, 5.8],
+    "close": [5.5, 6.5, 7.5, 6.0],
+}
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _box(name: str, seed: int = 3) -> go.Box:
+    """A box trace, which shares plotly's `boxlayer` with a candlestick."""
+    return go.Box(y=list(np.random.default_rng(seed).normal(size=20)), name=name)
+
+
+def test_a_candlestick_chart_is_read_at_all() -> None:
+    """The reproduction: a whole chart that announced nothing.
+
+    Not a crash and not a mislabel — `_extract_plots` had no branch for the
+    type, so the figure arrived with an empty layer list and MAIDR had nothing
+    to navigate.
+    """
+    layers = _layers(go.Figure([go.Candlestick(name="ACME", **OHLC)]))
+
+    assert [layer["type"] for layer in layers] == [PlotType.CANDLESTICK]
+
+
+def test_an_ohlc_chart_is_read_the_same_way() -> None:
+    """`go.Ohlc` is the same numbers drawn differently.
+
+    Plotly draws a body-and-wick for `candlestick` and a bar with ticks for
+    `ohlc`. A reader is told open, high, low and close either way, so the two
+    are one MAIDR type rather than two.
+    """
+    layers = _layers(go.Figure([go.Ohlc(name="ACME", **OHLC)]))
+
+    assert [layer["type"] for layer in layers] == [PlotType.CANDLESTICK]
+
+
+def test_the_numbers_are_the_traces_own() -> None:
+    """Every value is transcribed, not derived.
+
+    Each of the four series is distinct here, so a pair read in the wrong
+    order — `high` for `close`, say — fails rather than passing on plausible
+    numbers.
+    """
+    (layer,) = _layers(go.Figure([go.Candlestick(name="ACME", **OHLC)]))
+
+    assert layer["data"] == [
+        {"open": 1.0, "high": 2.0, "low": 0.0, "close": 1.5, "value": "d1"},
+        {"open": 2.0, "high": 3.0, "low": 1.0, "close": 2.5, "value": "d2"},
+        {"open": 3.0, "high": 4.0, "low": 2.0, "close": 3.5, "value": "d3"},
+        {"open": 2.5, "high": 3.2, "low": 1.8, "close": 2.0, "value": "d4"},
+    ]
+
+
+def test_trend_and_volatility_are_left_to_the_core() -> None:
+    """The core computes both from OHLC and overwrites what it is sent.
+
+    `Candlestick`'s constructor in the MAIDR core maps every point to one
+    carrying its own `trend` and `volatility`, so a copy emitted here could
+    only ever be a second opinion that is discarded — and would rot silently
+    if the core's rule ever changed. The matplotlib emitter omits them too.
+
+    `volume` is absent for a different reason: no plotly OHLC trace carries
+    one, and the core announces no volume section, so there is nothing to
+    invent.
+    """
+    (layer,) = _layers(go.Figure([go.Candlestick(name="ACME", **OHLC)]))
+
+    for candle in layer["data"]:
+        assert set(candle) == {"open", "high", "low", "close", "value"}
+
+
+def test_a_candle_without_an_x_is_named_by_its_index() -> None:
+    """`x` is optional, and plotly labels the axis 0, 1, 2… without it.
+
+    Naming the candles the same way keeps the announcement and the drawn axis
+    saying the same thing.
+    """
+    figure = go.Figure(
+        [go.Candlestick(open=[1.0, 2.0], high=[2.0, 3.0], low=[0.0, 1.0], close=[1.5, 2.5])]
+    )
+
+    (layer,) = _layers(figure)
+
+    assert [candle["value"] for candle in layer["data"]] == ["0", "1"]
+
+
+def test_a_ragged_trace_stops_at_the_shortest_series() -> None:
+    """Plotly draws only the candles it has all four numbers for.
+
+    Reading to the longest array instead would announce candles that were
+    never drawn, filled from whichever series happened to be longer.
+    """
+    figure = go.Figure(
+        [
+            go.Candlestick(
+                x=["d1", "d2", "d3"],
+                open=[1.0, 2.0, 3.0],
+                high=[2.0, 3.0, 4.0],
+                low=[0.0, 1.0],  # one short
+                close=[1.5, 2.5, 3.5],
+            )
+        ]
+    )
+
+    (layer,) = _layers(figure)
+
+    assert [candle["value"] for candle in layer["data"]] == ["d1", "d2"]
+
+
+# ---------------------------------------------------------------------------
+# Selectors
+#
+# Pinned as exact strings because the failure they prevent is silent: a
+# selector that matches the wrong elements highlights the wrong bar, and
+# nothing in the schema says so. Each count below was measured in Chromium
+# against real plotly output; the reasoning is in the docstrings so a future
+# edit can tell an intentional change from a regression.
+# ---------------------------------------------------------------------------
+
+
+def test_the_selector_excludes_the_rangeslider() -> None:
+    """Plotly gives a candlestick chart a rangeslider by **default**, and it
+    holds a complete second copy of the plot.
+
+    Measured for a 4-candle chart::
+
+        .trace.boxes .box                                     8   ** the copy
+        .subplot.xy .boxlayer > .trace.boxes:nth-child(1) …   4
+
+    The duplicate lives at `g.infolayer > g.rangeslider-container >
+    g.rangeslider-rangeplot.xy`, which carries the `xy` class but *not*
+    `subplot` — so the `.subplot.<id>` prefix is what excludes it. Without
+    that prefix a chart matches every mark twice, and the highlight for the
+    second half of the candles lands in the thumbnail.
+
+    This is asserted on the emitted string rather than the browser because the
+    test suite has no DOM; the count above is the measurement it stands in for.
+    """
+    (layer,) = _layers(go.Figure([go.Candlestick(name="ACME", **OHLC)]))
+
+    assert layer["selectors"] == (
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box"
+    )
+
+
+def test_an_ohlc_trace_has_a_layer_of_its_own() -> None:
+    """`ohlc` does not share the box machinery — it draws into `g.ohlclayer`.
+
+    Measured: `.subplot.xy .boxlayer …` matches 0 for an `ohlc` chart and
+    `.subplot.xy .ohlclayer > .trace.ohlc:nth-child(1) > path` matches 4. The
+    two types being one MAIDR layer type does not make them one DOM shape, so
+    the selector is chosen per trace type rather than per layer type.
+    """
+    (layer,) = _layers(go.Figure([go.Ohlc(name="ACME", **OHLC)]))
+
+    assert layer["selectors"] == (
+        ".subplot.xy .ohlclayer > .trace.ohlc:nth-child(1) > path"
+    )
+
+
+def test_two_candlesticks_address_different_marks() -> None:
+    """Two traces put two groups in one `boxlayer`.
+
+    Without a position each selector matches all 8 marks, so every candle
+    after the fourth highlights the other series — right count, wrong series,
+    nothing raised.
+    """
+    figure = go.Figure(
+        [go.Candlestick(name="A", **OHLC), go.Candlestick(name="B", **OTHER)]
+    )
+
+    positions = [layer["selectors"] for layer in _layers(figure)]
+
+    assert positions == [
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box",
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(2) path.box",
+    ]
+
+
+def test_a_box_beside_a_candlestick_takes_a_slot() -> None:
+    """A `go.Box` draws into the same `boxlayer`, and its own `path.box`.
+
+    So the position is an index among *box-family* traces, not among
+    candlesticks. Counting only candlesticks would put this one at
+    `nth-child(1)` — the box's group — and every candle would highlight a
+    box plot instead.
+    """
+    figure = go.Figure([_box("b"), go.Candlestick(name="A", **OHLC)])
+
+    candle = next(
+        layer for layer in _layers(figure) if layer["type"] is PlotType.CANDLESTICK
+    )
+
+    assert candle["selectors"] == (
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(2) path.box"
+    )
+
+
+def test_declaration_order_decides_the_slot() -> None:
+    """Plotly appends one group per trace in the order they were declared.
+
+    The mirror of the test above: the same two traces the other way round put
+    the candlestick first. Measured rather than assumed, since a library that
+    sorted by type instead would make both tests pass with one wrong.
+    """
+    figure = go.Figure([go.Candlestick(name="A", **OHLC), _box("b")])
+
+    candle = next(
+        layer for layer in _layers(figure) if layer["type"] is PlotType.CANDLESTICK
+    )
+
+    assert candle["selectors"] == (
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box"
+    )
+
+
+@pytest.mark.parametrize(
+    "neighbour",
+    [
+        pytest.param(go.Violin(y=[1.0, 2.0, 3.0, 4.0], name="v"), id="violin"),
+        pytest.param(go.Scatter(x=[1, 2], y=[1, 2], name="s"), id="scatter"),
+    ],
+)
+def test_a_trace_in_another_layer_does_not_take_a_slot(neighbour) -> None:
+    """Only `boxlayer` traces shift a candlestick's position.
+
+    A violin draws into `g.violinlayer` and a scatter into `g.scatterlayer`,
+    so neither appears among the candlestick's siblings. Counting every trace
+    on the subplot instead would push this one to `nth-child(2)`, which does
+    not exist — and a selector matching nothing loses the highlight silently,
+    with the audio and text still working, so nothing else would report it.
+    """
+    figure = go.Figure([neighbour, go.Candlestick(name="A", **OHLC)])
+
+    candle = next(
+        layer for layer in _layers(figure) if layer["type"] is PlotType.CANDLESTICK
+    )
+
+    assert candle["selectors"] == (
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box"
+    )
+
+
+def test_a_candlestick_on_a_second_subplot_is_scoped_to_it() -> None:
+    """The subplot prefix has to follow the trace, not default to `xy`.
+
+    Two panels each holding one candlestick both sit at `nth-child(1)` of
+    their own `boxlayer`, so the axis pair is the only thing telling them
+    apart.
+    """
+    figure = go.Figure(
+        [
+            go.Candlestick(name="A", **OHLC),
+            go.Candlestick(name="B", xaxis="x2", yaxis="y2", **OTHER),
+        ]
+    )
+    figure.update_layout(
+        xaxis={"domain": [0.0, 0.45]},
+        xaxis2={"domain": [0.55, 1.0], "anchor": "y2"},
+        yaxis2={"anchor": "x2"},
+    )
+
+    selectors = sorted(layer["selectors"] for layer in _layers(figure))
+
+    assert selectors == [
+        ".subplot.x2y2 .boxlayer > .trace.boxes:nth-child(1) path.box",
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box",
+    ]
+
+
+def test_a_figure_of_other_traces_is_unchanged() -> None:
+    """The control: recognising a new type must cost the existing ones nothing.
+
+    `_extract_plots` gained a branch ahead of the factory fallback, and a bar
+    and a scatter both reach that fallback, so this drives the path the new
+    branch sits in front of.
+    """
+    figure = go.Figure(
+        [
+            go.Bar(x=["a", "b"], y=[1.0, 2.0], name="bar"),
+            go.Scatter(x=[1, 2], y=[3, 4], mode="markers", name="pts"),
+        ]
+    )
+
+    assert [layer["type"] for layer in _layers(figure)] == [
+        PlotType.BAR,
+        PlotType.SCATTER,
+    ]

--- a/tests/plotly/test_plotly_candlestick.py
+++ b/tests/plotly/test_plotly_candlestick.py
@@ -132,12 +132,44 @@ def test_a_candle_without_an_x_is_named_by_its_index() -> None:
     saying the same thing.
     """
     figure = go.Figure(
-        [go.Candlestick(open=[1.0, 2.0], high=[2.0, 3.0], low=[0.0, 1.0], close=[1.5, 2.5])]
+        [
+            go.Candlestick(
+                open=[1.0, 2.0], high=[2.0, 3.0], low=[0.0, 1.0], close=[1.5, 2.5]
+            )
+        ]
     )
 
     (layer,) = _layers(figure)
 
     assert [candle["value"] for candle in layer["data"]] == ["0", "1"]
+
+
+def test_a_gap_in_the_middle_drops_only_that_candle() -> None:
+    """A missing number mid-series is a candle plotly leaves blank.
+
+    The trailing case is covered by the ragged test below, but a `None` among
+    otherwise equal-length arrays takes the other branch — the per-candle
+    `except`, not the shortest-array count. Skipping keeps the announced
+    candles aligned with the drawn ones; a placeholder would put a candle at
+    a price nothing was traded at, and carrying the gap forward would shift
+    every later candle onto the wrong date.
+    """
+    figure = go.Figure(
+        [
+            go.Candlestick(
+                x=["d1", "d2", "d3"],
+                open=[1.0, None, 3.0],
+                high=[2.0, 3.0, 4.0],
+                low=[0.0, 1.0, 2.0],
+                close=[1.5, 2.5, 3.5],
+            )
+        ]
+    )
+
+    (layer,) = _layers(figure)
+
+    assert [candle["value"] for candle in layer["data"]] == ["d1", "d3"]
+    assert [candle["open"] for candle in layer["data"]] == [1.0, 3.0]
 
 
 def test_a_ragged_trace_stops_at_the_shortest_series() -> None:

--- a/tests/plotly/test_plotly_plot_factory.py
+++ b/tests/plotly/test_plotly_plot_factory.py
@@ -10,6 +10,7 @@ from maidr.plotly.box import PlotlyBoxPlot
 from maidr.plotly.heatmap import PlotlyHeatmapPlot
 from maidr.plotly.histogram import PlotlyHistogramPlot
 from maidr.plotly.pie import PlotlyPiePlot
+from maidr.plotly.candlestick import PlotlyCandlestickPlot
 
 
 class TestPlotlyPlotFactory:
@@ -83,6 +84,51 @@ class TestPlotlyPlotFactory:
         # holds, so it scopes the selector to the first pie. `PlotlyMaidr`
         # passes real positions precisely because it does know.
         trace = {"type": "pie", "labels": ["A"], "values": [1]}
+        plot = PlotlyPlotFactory.create(trace, {})
+        assert "nth-child(1)" in plot._get_selector()
+
+    def test_candlestick_trace(self):
+        trace = {
+            "type": "candlestick",
+            "x": ["d1"],
+            "open": [1.0],
+            "high": [2.0],
+            "low": [0.0],
+            "close": [1.5],
+        }
+        plot = PlotlyPlotFactory.create(trace, {})
+        assert isinstance(plot, PlotlyCandlestickPlot)
+        assert plot.type == PlotType.CANDLESTICK
+
+    def test_ohlc_trace_is_the_same_type(self):
+        # `ohlc` draws the same numbers differently, so it is one MAIDR type
+        # with the candlestick -- but a different DOM layer, which is what
+        # the selector below is checking has followed the trace type.
+        trace = {
+            "type": "ohlc",
+            "x": ["d1"],
+            "open": [1.0],
+            "high": [2.0],
+            "low": [0.0],
+            "close": [1.5],
+        }
+        plot = PlotlyPlotFactory.create(trace, {})
+        assert isinstance(plot, PlotlyCandlestickPlot)
+        assert plot.type == PlotType.CANDLESTICK
+        assert ".ohlclayer" in plot._get_selector()
+
+    def test_candlestick_assumes_it_is_the_only_one(self):
+        # Same reasoning as the pie above: this factory sees one trace and
+        # cannot know what else shares its `boxlayer`, so it scopes to the
+        # first slot. `PlotlyMaidr` passes real positions because it does know.
+        trace = {
+            "type": "candlestick",
+            "x": ["d1"],
+            "open": [1.0],
+            "high": [2.0],
+            "low": [0.0],
+            "close": [1.5],
+        }
         plot = PlotlyPlotFactory.create(trace, {})
         assert "nth-child(1)" in plot._get_selector()
 


### PR DESCRIPTION
Part of #343 — the candlestick half. Violin and the smooth/trendline naming are left open; reasoning in [this comment](https://github.com/xability/py-maidr/issues/343#issuecomment-5295569176).

## The defect

`maidr/plotly/` builds its schema in Python and needs its own handling per trace type. It had none for `candlestick` or `ohlc`, and neither errored — both fell through to `PlotlyPlotFactory`, which returned `None`:

```
go.Candlestick(...)   ->  layers: []
go.Ohlc(...)          ->  layers: []
```

The HTML still rendered and MAIDR still loaded. What arrived was an empty shell: a chart with nothing to navigate, no announcement, and no error saying why.

## Transcription, not reconstruction

Both trace types state every number they draw — `open`, `high`, `low` and `close` are arrays on the trace itself. Nothing here is derived from the drawing.

Three things are deliberately **not** emitted:

- **`trend` and `volatility`** — `Candlestick`'s constructor in the core maps every point to one carrying its own, computed from OHLC. A copy emitted here could only ever be a second opinion that is discarded, and would rot silently if the core's rule changed. The matplotlib emitter omits them for the same reason.
- **`volume`** — no plotly OHLC trace carries one, and the core's section list (`['volatility', 'open', 'high', 'low', 'close']`) has no volume section, so there is nothing to invent.

`ohlc` and `candlestick` are one MAIDR type. Plotly draws a body-and-wick for one and a bar-with-ticks for the other; a reader is told open, high, low and close either way.

## The selectors were measured, not reasoned about

Plotly puts a candlestick in the DOM in three ways a plausible selector gets wrong. All counts below are from Chromium against real plotly output, 4 candles.

**1. The rangeslider.** Plotly gives a candlestick chart one *by default*, and it holds a complete second copy of the plot:

```
.trace.boxes .box                                      8    ** two per candle
.subplot.xy .boxlayer > .trace.boxes:nth-child(1) …    4
```

The duplicate lives at `g.infolayer > g.rangeslider-container > g.rangeslider-rangeplot.xy > … > g.boxlayer.mlayer.rangeplot`. That ancestor carries `xy` but **not** `subplot`, so the existing `.subplot.<id>` prefix excludes it. Setting `xaxis_rangeslider_visible=False` drops the unscoped count to 4, confirming the extra four are the slider's.

**2. `go.Box` shares the layer.** It lands in the same `g.boxlayer` and draws its own `path.box`:

```
one box + one candlestick:
  .subplot.xy .trace.boxes path.box                       5    (1 + 4)
  .subplot.xy .boxlayer > .trace.boxes:nth-child(1) …     1    the box
  .subplot.xy .boxlayer > .trace.boxes:nth-child(2) …     4    the candlestick
```

So the position is an index among `{box, candlestick}` traces, in declaration order — verified both ways round. A `go.Violin` (`g.violinlayer`) and a scatter (`g.scatterlayer`) do **not** shift it, also verified.

**3. `ohlc` is a different layer entirely.** It draws into `g.ohlclayer > g.trace.ohlc > path`, so `boxlayer` selectors match nothing for it.

Every emitted selector was then checked back against the DOM and resolves to exactly 4 — one per candle — in all six cases (single, two candlesticks, box-before, candle-before, no-rangeslider, second subplot).

## Where the code lives

`_extract_plots` builds these rather than the factory, for the same reason a lone line is built there: only it knows the trace's position among its layer-mates. The factory keeps a branch for direct construction with position 0, matching the comment convention the lines and pie branches already use.

## Two defects this turned up

Filed rather than folded in:

- **#395** — `PlotlyBoxPlot._get_selector` numbers boxes `1..n` from its own data, but `g.boxlayer` children are one group per *trace*. A three-category box trace has all three boxes in one child, so box 1 highlights all three and boxes 2–3 highlight nothing (measured 3 / 0 / 0). And a candlestick declared first takes slot 1, so the box's selector resolves to the candlestick.
- **xability/maidr#881** — the browser-side adapter's `.trace.boxes .box` has the rangeslider problem described above.

## Falsification

Each mechanism reverted in turn, against the 15 tests in the new file.

| reverted to | failures |
|---|---|
| feature removed entirely (both `_extract_plots` and factory branches) | 14 |
| `layer_position` counting every trace, not layer-mates | 2 |
| box-family set narrowed to `{candlestick}` | 1 |
| `.subplot` prefix dropped (rangeslider) | 8 |
| one DOM shape for both trace types | 1 |
| read to the longest series instead of the shortest | 1 |
| `volatility` emitted alongside | 2 |

Removing only the `_extract_plots` branch fails just 2 — the factory fallback still builds the layer, correctly, minus the positions. That is why the row above removes both.

Full suite **1270 passed** (1255 on `main` after #393, plus these 15). `ruff check` clean on all four files.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_