### PR TITLE
fix(plotly): do not read a trace the chart does not draw

### DIFF
--- a/maidr/plotly/candlestick.py
+++ b/maidr/plotly/candlestick.py
@@ -53,7 +53,9 @@ def layer_position(traces: list[dict], trace: dict) -> int:
     Parameters
     ----------
     traces : list of dict
-        Every trace on the subplot, in declaration order.
+        The subplot's *drawn* traces, in declaration order. A hidden trace
+        gets no group in the layer, so passing one would push this trace's
+        index onto a group that does not exist.
     trace : dict
         The trace to locate.
 

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -15,6 +15,7 @@ from maidr.plotly.candlestick import is_ohlc_trace, layer_position
 from maidr.plotly.plotly_plot import (
     PlotlyPlot,
     domain_interval,
+    is_drawn,
     subplot_css_prefix,
 )
 from maidr.plotly.violin import (
@@ -300,7 +301,15 @@ class PlotlyMaidr:
         """
         fig_dict = self._fig.to_dict()
         layout = fig_dict.get("layout", {})
-        traces = fig_dict.get("data", [])
+        # Dropped once, here, rather than in each branch below. Plotly renders
+        # no group at all for a hidden trace, so one that is `visible=False`
+        # or `"legendonly"` is not on the chart: reading it announces marks
+        # nobody can see, and letting it occupy a position pushes its
+        # neighbours' selectors onto groups that do not exist. Filtering at
+        # the source means every downstream reader -- bar merging, line
+        # grouping, pie and candlestick positions, the subplot grid -- sees
+        # only what was drawn, and none of them has to remember to ask.
+        traces = [trace for trace in fig_dict.get("data", []) if is_drawn(trace)]
         # Plotly's own default is `relative`, which stacks. Defaulting to
         # `group` here meant a figure that plotly drew stacked was announced
         # as *dodged* -- not a lost relationship but an inverted one, telling

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -605,6 +605,42 @@ def domain_interval(box: Any, key: str) -> tuple[float, float]:
         return whole
 
 
+#: The values of ``trace.visible`` that mean plotly drew nothing. ``False``
+#: hides a trace outright; ``"legendonly"`` is what clicking a legend entry
+#: sets, so a reader reaches it by ordinary use rather than an exotic figure.
+_HIDDEN = (False, "legendonly")
+
+
+def is_drawn(trace: dict) -> bool:
+    """
+    Return whether plotly drew this trace at all.
+
+    Plotly renders no group whatsoever for a hidden trace -- measured across
+    bar, scatter, pie, box and violin: two traces with one hidden produce a
+    single group in the layer. So a hidden trace must be dropped before
+    anything reads it, for two reasons at once.
+
+    It must not be *announced*: describing it tells a reader about marks that
+    are not on the chart, with nothing saying the series is switched off. And
+    it must not take a *slot*: every selector scoped by position among its
+    layer-mates would be pushed onto a group that does not exist, and a
+    selector matching nothing loses the highlight silently while the audio,
+    braille and text stay correct.
+
+    Parameters
+    ----------
+    trace : dict
+        A plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        ``True`` unless ``visible`` says otherwise. An absent ``visible`` is
+        plotly's default of drawn.
+    """
+    return trace.get("visible") not in _HIDDEN
+
+
 def subplot_css_prefix(xaxis_name: str, yaxis_name: str) -> str:
     """
     Return the CSS prefix scoping selectors to one subplot.

--- a/maidr/plotly/violin.py
+++ b/maidr/plotly/violin.py
@@ -28,35 +28,6 @@ VIOLIN_TRACE_TYPE = "violin"
 #: What plotly calls a horizontal violin: values along x, categories up y.
 _HORIZONTAL = "h"
 
-#: The values of ``trace.visible`` that mean plotly drew nothing. ``False``
-#: hides a trace outright; ``"legendonly"`` is what clicking a legend entry
-#: sets, so a reader reaches it by ordinary use rather than an exotic figure.
-_HIDDEN = (False, "legendonly")
-
-
-def _is_drawn(trace: dict) -> bool:
-    """
-    Return whether plotly drew this trace at all.
-
-    A hidden trace gets no group in ``g.violinlayer``, so it must not be
-    announced and must not take a slot: counting it would push every later
-    trace's selector onto a group that does not exist, and a selector matching
-    nothing loses the highlight silently.
-
-    Parameters
-    ----------
-    trace : dict
-        A plotly trace dictionary.
-
-    Returns
-    -------
-    bool
-        ``True`` unless ``visible`` says otherwise. An absent ``visible`` is
-        plotly's default of drawn.
-    """
-    return trace.get("visible") not in _HIDDEN
-
-
 def is_violin_trace(trace: dict) -> bool:
     """
     Return whether *trace* is a plotly violin.
@@ -153,7 +124,9 @@ def collect_violins(traces: list[dict], prefix: str) -> list[Violin]:
     Parameters
     ----------
     traces : list of dict
-        The subplot's violin traces, in declaration order.
+        The subplot's *drawn* violin traces, in declaration order. A hidden
+        trace gets no group in the layer, so passing one would both describe a
+        shape the reader cannot see and move everyone else's group index.
     prefix : str
         The CSS prefix scoping selectors to this subplot.
 
@@ -171,12 +144,6 @@ def collect_violins(traces: list[dict], prefix: str) -> list[Violin]:
     rendered = 0
 
     for trace in traces:
-        # A hidden trace is not a violin with no curve -- it is not on the
-        # chart. Announcing it would describe a shape the reader cannot see,
-        # and letting it advance `rendered` would move everyone else's group.
-        if not _is_drawn(trace):
-            continue
-
         samples = _samples(trace)
         computed = [(label, violin_stats(values)) for label, values in samples]
         if not any(stats is not None for _, stats in computed):

--- a/tests/plotly/test_plotly_candlestick.py
+++ b/tests/plotly/test_plotly_candlestick.py
@@ -356,6 +356,60 @@ def test_a_candlestick_on_a_second_subplot_is_scoped_to_it() -> None:
     ]
 
 
+@pytest.mark.parametrize("hidden", [False, "legendonly"], ids=["false", "legendonly"])
+def test_a_hidden_neighbour_takes_no_slot(hidden) -> None:
+    """A trace plotly did not draw gets no group, so it cannot hold a slot.
+
+    Measured in Chromium: a hidden `go.Box` beside a candlestick leaves the
+    `boxlayer` holding a single child. Counting it put the candlestick at
+    `nth-child(2)` of a one-child layer, so its selector matched nothing --
+    the highlight silently stopping while the audio, braille and text stayed
+    correct, with nothing in the output to say why.
+
+    Clicking a legend entry sets `visible="legendonly"` and re-renders, so
+    this is reached by ordinary use rather than an exotic figure.
+    """
+    figure = go.Figure(
+        [
+            go.Box(y=[1.0, 2.0, 3.0, 4.0], name="spread", visible=hidden),
+            go.Candlestick(name="A", **OHLC),
+        ]
+    )
+
+    candle = next(
+        layer for layer in _layers(figure) if layer["type"] is PlotType.CANDLESTICK
+    )
+
+    assert candle["selectors"] == (
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box"
+    )
+
+
+@pytest.mark.parametrize("hidden", [False, "legendonly"], ids=["false", "legendonly"])
+def test_a_hidden_candlestick_is_not_read(hidden) -> None:
+    """It is not on the chart, so it is not in the reading.
+
+    Announcing it would describe candles a reader cannot see -- with prices,
+    dates and trends, and nothing saying the series is switched off.
+    """
+    figure = go.Figure(
+        [
+            go.Candlestick(name="hidden", visible=hidden, **OHLC),
+            go.Candlestick(name="shown", **OTHER),
+        ]
+    )
+
+    layers = [
+        layer for layer in _layers(figure) if layer["type"] is PlotType.CANDLESTICK
+    ]
+
+    assert len(layers) == 1
+    assert layers[0]["data"][0]["open"] == OTHER["open"][0]
+    assert layers[0]["selectors"] == (
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box"
+    )
+
+
 def test_a_figure_of_other_traces_is_unchanged() -> None:
     """The control: recognising a new type must cost the existing ones nothing.
 

--- a/tests/plotly/test_plotly_hidden_traces.py
+++ b/tests/plotly/test_plotly_hidden_traces.py
@@ -169,6 +169,11 @@ def test_a_hidden_pie_does_not_shift_the_one_beside_it(hidden) -> None:
     Its selector is scoped by position among the *drawn* pies -- which is
     also what the browser-side adapter's `isDrawnPie` decides, so the two
     agree on what counts.
+
+    Pinned exactly rather than by substring, matching the candlestick and
+    violin cases beside it: a `nth-child(1) in str(...)` check can pass on a
+    coincidence elsewhere in the string, which is precisely the kind of test
+    that looks like coverage and is not.
     """
     figure = go.Figure(
         [
@@ -180,7 +185,9 @@ def test_a_hidden_pie_does_not_shift_the_one_beside_it(hidden) -> None:
     (layer,) = _layers(figure)
 
     assert layer["type"] is PlotType.PIE
-    assert "nth-child(1)" in str(layer["selectors"])
+    assert layer["selectors"] == (
+        ".pielayer > .trace:nth-child(1) > .slice > path.surface"
+    )
 
 
 @HIDDEN

--- a/tests/plotly/test_plotly_hidden_traces.py
+++ b/tests/plotly/test_plotly_hidden_traces.py
@@ -88,6 +88,16 @@ def _types(figure: go.Figure) -> list[str]:
             ),
             id="candlestick",
         ),
+        # `ohlc` is the other half of the OHLC family and draws into a layer
+        # of its own, so it is named here rather than left to the candlestick
+        # case -- the point of this parametrization is that no type is assumed
+        # to be covered by a neighbour.
+        pytest.param(
+            lambda v: go.Ohlc(
+                x=["d1"], open=[1.0], high=[2.0], low=[0.0], close=[1.5], **v
+            ),
+            id="ohlc",
+        ),
     ],
 )
 def test_a_hidden_trace_is_not_read(trace_of, hidden) -> None:

--- a/tests/plotly/test_plotly_hidden_traces.py
+++ b/tests/plotly/test_plotly_hidden_traces.py
@@ -1,0 +1,249 @@
+"""MAIDR read plotly traces the chart does not draw.
+
+`visible=False` and `visible="legendonly"` both tell plotly to draw nothing,
+and plotly obeys completely: it renders **no group at all** for such a trace.
+Measured in Chromium, two traces with one hidden produce a single group in the
+layer, for bar, scatter, pie, box and violin alike.
+
+`_extract_plots` read `fig.to_dict()["data"]` without asking, so every hidden
+trace became a layer:
+
+    hidden bar + shown bar     ['stacked_bar']   ** and merged into a stack
+    hidden scatter             ['point']
+    hidden box                 ['box']
+    hidden pie                 ['pie']
+    hidden histogram           ['hist']
+
+Nothing errored. A reader was told about series that are not on the chart —
+their values, their categories, their names — with nothing saying the series
+is switched off. The bar row is the worst of them: the hidden trace was merged
+with the visible one into a `stacked_bar`, so a plain one-series bar chart was
+announced as a stack of two, and every bar's meaning changed.
+
+There is a second failure underneath. Selectors scoped by a trace's position
+among its layer-mates — candlestick, violin, pie — counted the hidden trace as
+occupying a slot it does not have, so the drawn trace's selector pointed at a
+group that does not exist and matched nothing. The audio, braille and text
+stayed correct, so only a sighted reader could tell the highlight had stopped.
+
+Clicking a legend entry sets `visible="legendonly"` and re-renders, so this is
+reached by ordinary use rather than an exotic figure.
+
+The fix is one filter where the traces enter, rather than a guard in each
+branch: every downstream reader — bar merging, line grouping, pie and
+candlestick positions, the subplot grid — then sees only what was drawn, and
+none of them has to remember to ask.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Both spellings of "not drawn". `False` hides a trace outright;
+#: `"legendonly"` is what a legend click leaves behind.
+HIDDEN = pytest.mark.parametrize(
+    "hidden", [False, "legendonly"], ids=["false", "legendonly"]
+)
+
+VALUES = [1.0, 2.0, 3.0, 4.0]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _types(figure: go.Figure) -> list[str]:
+    """The emitted layer types."""
+    return [layer["type"].value for layer in _layers(figure)]
+
+
+@HIDDEN
+@pytest.mark.parametrize(
+    "trace_of",
+    [
+        pytest.param(lambda v: go.Bar(x=["a", "b"], y=[1.0, 2.0], **v), id="bar"),
+        pytest.param(
+            lambda v: go.Scatter(x=[1, 2], y=[3, 4], mode="markers", **v), id="scatter"
+        ),
+        pytest.param(lambda v: go.Box(y=VALUES, **v), id="box"),
+        pytest.param(lambda v: go.Violin(y=VALUES, **v), id="violin"),
+        pytest.param(lambda v: go.Histogram(x=VALUES, **v), id="histogram"),
+        pytest.param(
+            lambda v: go.Pie(labels=["a", "b"], values=[1.0, 2.0], **v), id="pie"
+        ),
+        pytest.param(
+            lambda v: go.Candlestick(
+                x=["d1"], open=[1.0], high=[2.0], low=[0.0], close=[1.5], **v
+            ),
+            id="candlestick",
+        ),
+    ],
+)
+def test_a_hidden_trace_is_not_read(trace_of, hidden) -> None:
+    """Whatever its type, a trace plotly drew nothing for is not a layer.
+
+    Parametrized across the types rather than left to one representative,
+    because the filter is meant to be type-blind and a per-type guard is
+    exactly what it replaced -- a guard that was easy to add for one type and
+    forget for the next six.
+    """
+    figure = go.Figure([trace_of({"visible": hidden})])
+
+    assert _layers(figure) == []
+
+
+@HIDDEN
+def test_a_hidden_bar_does_not_become_half_a_stack(hidden) -> None:
+    """The worst row, stated on its own.
+
+    Plotly's default `barmode` stacks, so a hidden bar trace beside a visible
+    one was merged into a `stacked_bar` -- announcing a one-series chart as a
+    stack of two, with the invisible series contributing segments a reader
+    could not see and totals that do not exist. Not a lost relationship but an
+    invented one.
+    """
+    figure = go.Figure(
+        [
+            go.Bar(x=["a", "b"], y=[1.0, 2.0], name="hidden", visible=hidden),
+            go.Bar(x=["a", "b"], y=[3.0, 4.0], name="shown"),
+        ]
+    )
+
+    (layer,) = _layers(figure)
+
+    assert layer["type"] is PlotType.BAR
+    assert [point["y"] for point in layer["data"]] == [3.0, 4.0]
+
+
+@HIDDEN
+def test_a_hidden_trace_takes_no_position(hidden) -> None:
+    """The second failure: a slot the hidden trace does not occupy.
+
+    Plotly renders one group per *drawn* trace, so a selector scoped by
+    position must count only those. With the hidden box counted, the
+    candlestick took `nth-child(2)` of a layer holding one child and its
+    selector matched nothing -- the highlight silently stopping while
+    everything else stayed right.
+    """
+    figure = go.Figure(
+        [
+            go.Box(y=VALUES, name="hidden", visible=hidden),
+            go.Candlestick(
+                x=["d1"], open=[1.0], high=[2.0], low=[0.0], close=[1.5], name="A"
+            ),
+        ]
+    )
+
+    (layer,) = _layers(figure)
+
+    assert layer["selectors"] == (
+        ".subplot.xy .boxlayer > .trace.boxes:nth-child(1) path.box"
+    )
+
+
+@HIDDEN
+def test_a_hidden_pie_does_not_shift_the_one_beside_it(hidden) -> None:
+    """A pie is positioned within the figure's `pielayer`, so it counts too.
+
+    Its selector is scoped by position among the *drawn* pies -- which is
+    also what the browser-side adapter's `isDrawnPie` decides, so the two
+    agree on what counts.
+    """
+    figure = go.Figure(
+        [
+            go.Pie(labels=["a"], values=[1.0], visible=hidden),
+            go.Pie(labels=["b", "c"], values=[2.0, 3.0]),
+        ]
+    )
+
+    (layer,) = _layers(figure)
+
+    assert layer["type"] is PlotType.PIE
+    assert "nth-child(1)" in str(layer["selectors"])
+
+
+@HIDDEN
+def test_a_hidden_violin_takes_no_group(hidden) -> None:
+    """The violin pair is built from the drawn traces alone.
+
+    Worse here than elsewhere, because a violin that is not drawn was
+    announced with its name, its quartiles and its whole density curve.
+    """
+    figure = go.Figure(
+        [
+            go.Violin(y=VALUES, name="hidden", visible=hidden),
+            go.Violin(y=[10.0, 20.0, 30.0, 40.0], name="shown"),
+        ]
+    )
+
+    box = next(
+        layer for layer in _layers(figure) if layer["type"] is PlotType.VIOLIN_BOX
+    )
+    kde = next(
+        layer for layer in _layers(figure) if layer["type"] is PlotType.VIOLIN_KDE
+    )
+
+    assert [row["z"] for row in box["data"]] == ["shown"]
+    assert kde["selectors"] == [
+        ".subplot.xy .violinlayer > g:nth-child(1) > :nth-child(1 of path.violin)"
+    ]
+
+
+def test_a_figure_of_only_hidden_traces_has_no_layers() -> None:
+    """Nothing drawn is nothing to read, and that must not raise.
+
+    An empty layer list is the honest answer, and the paths that assume at
+    least one trace -- the barmode merge, the subplot grid -- have to survive
+    reaching none.
+    """
+    figure = go.Figure(
+        [
+            go.Bar(x=["a"], y=[1.0], visible=False),
+            go.Scatter(x=[1], y=[1], mode="markers", visible="legendonly"),
+        ]
+    )
+
+    assert _layers(figure) == []
+    assert PlotlyMaidr(figure).render() is not None
+
+
+def test_an_explicitly_visible_trace_is_read() -> None:
+    """`visible=True` is the same as not saying so.
+
+    The control for reading the value rather than testing for the key: a
+    figure that sets `visible` explicitly must not be mistaken for one that
+    hid something.
+    """
+    figure = go.Figure([go.Bar(x=["a", "b"], y=[1.0, 2.0], visible=True)])
+
+    assert _types(figure) == ["bar"]
+
+
+def test_a_figure_that_hides_nothing_is_unchanged() -> None:
+    """The control: the filter must cost an ordinary figure nothing.
+
+    Every trace here reaches a different branch of `_extract_plots`, so this
+    drives the paths the filter now sits in front of -- including the order
+    those branches emit in, which is the line group before the bar group and
+    is not something the filter should disturb.
+    """
+    figure = go.Figure(
+        [
+            go.Bar(x=["a", "b"], y=[1.0, 2.0], name="bar"),
+            go.Scatter(x=[1, 2], y=[3, 4], mode="markers", name="pts"),
+            go.Scatter(x=[1, 2], y=[5, 6], mode="lines", name="line"),
+        ]
+    )
+
+    assert _types(figure) == ["line", "bar", "point"]


### PR DESCRIPTION
Closes #399, which turned out to be one symptom of a figure-wide defect rather than a candlestick one.

## The defect

`visible=False` and `visible="legendonly"` both tell plotly to draw nothing, and plotly obeys completely — it renders **no group at all**. Measured in Chromium, two traces with one hidden:

```
bar      2 declared -> 1 group drawn   ["trace bars"]
scatter  2 declared -> 1 group drawn   ["trace scatter traced00a3b"]
pie      2 declared -> 1 group drawn   ["trace"]
box      2 declared -> 1 group drawn   (from the #397 investigation)
```

`_extract_plots` read `to_dict()["data"]` without asking, so **every** hidden trace became a layer:

```
hidden bar + shown bar     ['stacked_bar']   ** and merged into a stack
hidden scatter             ['point']
hidden box                 ['box']
hidden pie                 ['pie']
hidden histogram           ['hist']
```

Nothing errored. A reader was told about series that are not on the chart — their values, their categories, their names — with nothing saying the series is switched off.

**The bar row is the worst.** Plotly's default `barmode` stacks, so the hidden trace was *merged* with the visible one: a plain one-series bar chart announced as a `stacked_bar` of two, the invisible series contributing segments nobody can see and totals that do not exist. Not a lost relationship but an invented one — the same shape as #390, arrived at from a different direction.

**Underneath that**, every selector scoped by position among layer-mates — candlestick, violin, pie — counted the hidden trace as holding a slot it does not have, so the drawn trace's selector pointed at a group that does not exist and matched nothing. The audio, braille and text stayed correct, so only a sighted reader could tell the highlight had stopped.

A legend click sets `visible="legendonly"` and re-renders, so this is reached by ordinary use.

## How it was found

A reviewer on xability/maidr#882 spotted the missing `visible` guard in the JS adapter's candlestick counting. I fixed it there, checked whether the Python binding had the same gap, and filed #399 for the candlestick case. Writing the fix for #399 I checked the other trace types out of habit — and found all of them affected, plus the bar merge, which is worse than the case originally reported.

## The fix

One filter where the traces enter:

```python
traces = [trace for trace in fig_dict.get("data", []) if is_drawn(trace)]
```

rather than a guard in each branch. Every downstream reader — bar merging, line grouping, pie and candlestick positions, the violin pair, the subplot grid — then sees only what was drawn, and none of them has to remember to ask. That matters because the per-branch version is exactly what failed here: the guard was easy to add for one type and forget for the next six.

The per-type guard added for violins in #397 is removed in favour of it, and `is_drawn` moves to `plotly_plot.py` since it is no longer candlestick-specific.

`visible` is read by **membership** rather than truthiness, because `visible=True` is a value a figure may set explicitly and `not True` would be the wrong answer — the same shape as `barnorm` in #393.

## Falsification

| reverted to | failures |
|---|---|
| no filter at all | 23 |
| `visible=True` by truthiness rather than membership | 13 |
| `False` only, not `"legendonly"` | 12 |

The middle row is the one worth noting: reading truthiness passes every test where a trace is hidden and fails the control where one is explicitly visible, which is why that control is there.

## Tests

`tests/plotly/test_plotly_hidden_traces.py`, 25 tests. The main one is parametrized across seven trace types × both spellings of hidden, deliberately rather than left to a representative case — the filter is meant to be type-blind, and the per-type guard it replaces is what went wrong.

Plus the two specific consequences (the phantom stack, the shifted position), the pie and violin position cases, a figure of only-hidden traces (which must render rather than raise), and a control that an ordinary figure is untouched — including the order its branches emit in.

Full suite **1355 passed**. `ruff check` clean, no line over 88 in any file touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_