### PR TITLE
fix(plotly): read a histogram's bins from the axis it bins

### DIFF
--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -290,16 +290,23 @@ class PlotlyHistogramPlot(PlotlyPlot):
             )
         return data
 
-    def _extract_categorical_data(self, x: list) -> list[dict]:
+    def _extract_categorical_data(self, values: list) -> list[dict]:
         """Count occurrences of categorical values and return bar-format data.
 
         Mirrors how seaborn ``countplot`` produces ``type: "bar"`` schemas.
         The plot type is switched from HIST to BAR so the JS side renders
         it as a bar chart with proper categorical navigation.
+
+        Parameters
+        ----------
+        values : list
+            The binned axis's sample -- ``trace["y"]`` on a horizontal trace,
+            ``trace["x"]`` on a vertical one. Named for the role rather than
+            the axis, since either can be the one that holds it.
         """
         # Preserve order of first appearance.
         counts: dict[str, int] = {}
-        for val in x:
+        for val in values:
             key = str(val)
             counts[key] = counts.get(key, 0) + 1
 

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -166,44 +166,126 @@ def _auto_shift_bins(
     return bin_start
 
 
+#: Plotly's spelling of a horizontal trace.
+_HORIZONTAL = "h"
+
+
+def binned_axis(trace: dict) -> str:
+    """Return which of ``x``/``y`` plotly bins for *trace*.
+
+    A histogram bins one axis and counts into the other, and which one is not
+    always stated: ``px.histogram(y=...)`` writes ``orientation`` onto the
+    trace, but ``go.Histogram(y=...)`` writes nothing and lets Plotly.js infer
+    it. Reading only ``x`` therefore left every horizontal histogram with no
+    data at all (#401).
+
+    The rule below is Plotly.js's own, measured rather than assumed --
+    ``gd._fullData[i].orientation`` read back out of Chromium for each shape:
+
+    ==================================================  ===========  ======
+    trace                                               orientation  binned
+    ==================================================  ===========  ======
+    ``go.Histogram(x=v)``                               ``v``        ``x``
+    ``go.Histogram(y=v)``                               ``h``        ``y``
+    ``px.histogram(y="v")``                             ``h``        ``y``
+    ``go.Histogram(x=cats, y=vals, histfunc="sum")``    ``v``        ``x``
+    ``go.Histogram(y=cats, x=vals, histfunc="sum")``    ``v``        ``x``
+    ``go.Histogram(x=v, orientation="h")``              ``h``        ``y``
+    ==================================================  ===========  ======
+
+    So an explicit ``orientation`` wins outright, and only in its absence does
+    the presence of the arrays decide. The last row is the one that settles
+    the precedence: plotly honours the attribute and bins the *absent* ``y``,
+    drawing an empty trace rather than falling back to ``x``.
+
+    Parameters
+    ----------
+    trace : dict
+        A ``histogram`` trace dict.
+
+    Returns
+    -------
+    str
+        ``"x"`` or ``"y"``.
+    """
+    orientation = trace.get("orientation")
+    if orientation is not None:
+        return "y" if orientation == _HORIZONTAL else "x"
+    if trace.get("y") is not None and trace.get("x") is None:
+        return "y"
+    return "x"
+
+
 class PlotlyHistogramPlot(PlotlyPlot):
     """Extract data from a Plotly histogram trace."""
 
     def __init__(self, trace: dict, layout: dict, **kwargs: str) -> None:
         super().__init__(trace, layout, PlotType.HIST, **kwargs)
+        self._binned = binned_axis(trace)
+
+    @property
+    def _horizontal(self) -> bool:
+        """Whether the bins run along the y axis."""
+        return self._binned == "y"
+
+    def render(self) -> dict:
+        """Add ``orientation`` to the base schema.
+
+        The core reads a histogram's bin bounds from ``xMin``/``xMax`` or from
+        ``yMin``/``yMax`` depending on this, so a horizontal layer that did not
+        carry it would have its counts announced as the bin range.
+        """
+        schema = super().render()
+        schema[MaidrKey.ORIENTATION] = "horz" if self._horizontal else "vert"
+        return schema
 
     def _get_selector(self) -> str:
         return f"{self._subplot_css_prefix()}.trace.bars .point > path"
 
     def _extract_plot_data(self) -> list[dict]:
-        raw_x = self._trace.get("x", None)
-        if raw_x is None:
+        raw = self._trace.get(self._binned, None)
+        if raw is None:
             return []
-        x = as_list(raw_x)
+        values = as_list(raw)
 
         # Detect categorical (string) data — Plotly renders these as
         # count bar charts.  Mirror how seaborn countplot is handled:
         # produce type "bar" data with category counts.
         try:
-            arr = np.array(x, dtype=float)
+            arr = np.array(values, dtype=float)
         except (ValueError, TypeError):
-            return self._extract_categorical_data(x)
+            return self._extract_categorical_data(values)
 
         bin_edges = self._compute_bin_edges(arr)
         counts, bin_edges = np.histogram(arr, bins=bin_edges)
 
+        # The binned axis carries the bin, the other one the count. Naming the
+        # keys off the orientation rather than hardcoding ``x`` keeps the
+        # announced extent on the axis the bins are actually drawn along.
+        binned, counted = (
+            (MaidrKey.Y, MaidrKey.X)
+            if self._horizontal
+            else (MaidrKey.X, MaidrKey.Y)
+        )
+        bounds = {
+            MaidrKey.X: (MaidrKey.X_MIN, MaidrKey.X_MAX),
+            MaidrKey.Y: (MaidrKey.Y_MIN, MaidrKey.Y_MAX),
+        }
+        bin_min, bin_max = bounds[binned]
+        count_min, count_max = bounds[counted]
+
         data = []
         for i, count in enumerate(counts):
-            x_min = float(bin_edges[i])
-            x_max = float(bin_edges[i + 1])
+            low = float(bin_edges[i])
+            high = float(bin_edges[i + 1])
             data.append(
                 {
-                    MaidrKey.X.value: (x_min + x_max) / 2,
-                    MaidrKey.Y.value: int(count),
-                    MaidrKey.X_MIN.value: x_min,
-                    MaidrKey.X_MAX.value: x_max,
-                    MaidrKey.Y_MIN.value: 0,
-                    MaidrKey.Y_MAX.value: int(count),
+                    binned.value: (low + high) / 2,
+                    counted.value: int(count),
+                    bin_min.value: low,
+                    bin_max.value: high,
+                    count_min.value: 0,
+                    count_max.value: int(count),
                 }
             )
         return data
@@ -224,18 +306,35 @@ class PlotlyHistogramPlot(PlotlyPlot):
         # Switch schema type from "hist" to "bar".
         self.type = PlotType.BAR
 
+        # As above, the category belongs on whichever axis plotly binned. A
+        # horizontal count bar chart with its categories on ``x`` would be
+        # announced with the counts and the labels swapped.
+        category, count_key = (
+            (MaidrKey.Y, MaidrKey.X)
+            if self._horizontal
+            else (MaidrKey.X, MaidrKey.Y)
+        )
         return [
-            {MaidrKey.X.value: cat, MaidrKey.Y.value: count}
+            {category.value: cat, count_key.value: count}
             for cat, count in counts.items()
         ]
 
     def _compute_bin_edges(self, arr: np.ndarray) -> np.ndarray:
         """Compute bin edges that match Plotly's autobinning algorithm.
 
-        Plotly treats ``nbinsx`` as a *hint* and rounds the bin size to a
+        Plotly treats ``nbins`` as a *hint* and rounds the bin size to a
         'nice' number via ``autoTicks`` (sequence ``{2, 5, 10} * 10^n``)
-        before aligning the start edge.  When ``xbins.size`` is specified
+        before aligning the start edge.  When the bin ``size`` is specified
         explicitly, it is used directly without rounding.
+
+        The bin spec is read off the *binned* axis, so a horizontal trace is
+        governed by ``ybins``/``nbinsy`` and a vertical one by
+        ``xbins``/``nbinsx``. Plotly ignores the other axis's spec outright
+        rather than falling back to it -- measured both ways in Chromium:
+        ``go.Histogram(y=v, xbins=dict(size=2))`` autobins to 13 bins of 0.5
+        exactly as if no spec were given, and ``go.Histogram(x=v,
+        ybins=dict(size=2))`` does the same. Reading ``xbins`` for every trace
+        would have honoured a spec plotly discards and missed the one it uses.
 
         Parameters
         ----------
@@ -247,19 +346,19 @@ class PlotlyHistogramPlot(PlotlyPlot):
         np.ndarray
             Bin edges matching what Plotly renders.
         """
-        xbins = self._trace.get("xbins", None)
+        bins = self._trace.get(f"{self._binned}bins", None)
 
         # Explicit bin size — use it directly.
-        if xbins is not None and "size" in xbins:
-            size = float(xbins["size"])
+        if bins is not None and "size" in bins:
+            size = float(bins["size"])
             start = (
-                float(xbins["start"])
-                if "start" in xbins
+                float(bins["start"])
+                if "start" in bins
                 else math.floor(arr.min() / size) * size
             )
             end = (
-                float(xbins["end"])
-                if "end" in xbins
+                float(bins["end"])
+                if "end" in bins
                 else math.ceil(arr.max() / size) * size + size
             )
             return np.arange(start, end + size / 2, size)
@@ -270,9 +369,9 @@ class PlotlyHistogramPlot(PlotlyPlot):
             return np.array([data_min - 0.5, data_max + 0.5])
 
         # 1. Compute nice bin size (mirrors axes.autoTicks + roundDTick)
-        nbinsx = self._trace.get("nbinsx", None)
-        if nbinsx is not None:
-            size0 = data_range / max(1, nbinsx)
+        nbins = self._trace.get(f"nbins{self._binned}", None)
+        if nbins is not None:
+            size0 = data_range / max(1, nbins)
         else:
             size0 = _plotly_default_size0(arr)
         dtick = _plotly_dtick(size0)

--- a/tests/plotly/test_plotly_histogram_orientation.py
+++ b/tests/plotly/test_plotly_histogram_orientation.py
@@ -1,0 +1,234 @@
+"""A plotly histogram binned on y announced nothing at all (#401).
+
+A histogram bins one axis and counts into the other. ``PlotlyHistogramPlot``
+read the sample from ``x`` and gave up when it was absent, so every horizontal
+histogram emitted a layer with an empty ``data`` list -- correctly typed, both
+axes correctly named from ``layout``, and nothing in it to navigate. Nothing
+errored, and nothing in the schema's metadata showed the emptiness, so it read
+as a histogram of nothing rather than a histogram that failed to read.
+
+Which axis is binned is not always stated. ``px.histogram(y=...)`` writes
+``orientation`` onto the trace; ``go.Histogram(y=...)`` writes nothing and
+leaves Plotly.js to infer it. The rule in ``binned_axis`` is plotly's own,
+taken from ``gd._fullData[i].orientation`` read back out of Chromium rather
+than from the documentation, and the case that fixes the precedence is
+``go.Histogram(x=v, orientation="h")``: plotly honours the attribute and bins
+the *absent* ``y``, drawing an empty trace rather than falling back to ``x``.
+
+The bin spec follows the binned axis too, and plotly discards the other axis's
+spec outright rather than falling back to it. Measured both ways: a horizontal
+trace given ``xbins`` autobins exactly as if none were given, and a vertical
+one given ``ybins`` does the same.
+
+Every expectation below was checked against what Plotly.js drew for the same
+figure -- ``gd.calcdata[0]`` after ``Plotly.newPlot`` in Chromium, where a bin
+is ``[p - size/2, p + size/2)`` with ``size`` from ``gd._fullData[0]``. Across
+eighteen figure shapes the emitted bins now agree elementwise, bin bounds and
+counts alike, on both orientations. Four shapes still disagree, all of them on
+the explicit-bin-size path and all of them identically on ``x`` and ``y``: see
+#402, which is orientation-independent and predates this.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import plotly.express as px  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.histogram import binned_axis  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: A fixed normal sample. Rounded so the figure JSON handed to the browser and
+#: the array handed to numpy hold the same values to the last bit.
+SAMPLE = [round(float(v), 4) for v in np.random.default_rng(3).normal(0, 1, 60)]
+
+
+def only_layer(fig) -> dict:
+    """The single layer of a single-subplot figure."""
+    schema = PlotlyMaidr(fig)._flatten_maidr()
+    return schema["subplots"][0][0]["layers"][0]
+
+
+def bins(layer: dict) -> list[tuple[float, float, int]]:
+    """``(low, high, count)`` per bin, read off whichever axis was binned."""
+    horizontal = layer.get("orientation") == "horz"
+    low, high, count = (
+        ("yMin", "yMax", "x") if horizontal else ("xMin", "xMax", "y")
+    )
+    return [(d[low], d[high], d[count]) for d in layer["data"]]
+
+
+class TestBinnedAxis:
+    """The x-or-y decision, against Plotly.js's own resolved orientation."""
+
+    @pytest.mark.parametrize(
+        ("trace", "expected"),
+        [
+            ({"type": "histogram", "x": SAMPLE}, "x"),
+            ({"type": "histogram", "y": SAMPLE}, "y"),
+            ({"type": "histogram", "y": SAMPLE, "orientation": "h"}, "y"),
+            ({"type": "histogram", "x": SAMPLE, "orientation": "v"}, "x"),
+            # Both arrays present: plotly bins x and aggregates y, whichever
+            # of the two happens to be the categorical one.
+            ({"type": "histogram", "x": SAMPLE, "y": SAMPLE}, "x"),
+            # An explicit orientation wins over the arrays. Plotly bins the
+            # absent axis and draws an empty trace rather than falling back.
+            ({"type": "histogram", "x": SAMPLE, "orientation": "h"}, "y"),
+        ],
+    )
+    def test_matches_plotlys_resolved_orientation(self, trace, expected):
+        assert binned_axis(trace) == expected
+
+
+class TestHorizontalHistogram:
+    """The defect itself: bins on y, counts on x."""
+
+    def test_a_horizontal_histogram_is_no_longer_empty(self):
+        fig = go.Figure([go.Histogram(y=SAMPLE)])
+        layer = only_layer(fig)
+
+        # The count is what plotly's calcdata holds for the same figure. An
+        # assertion on `len(data) > 0` alone would pass on any binning at all,
+        # including the per-trace one #394 is about.
+        assert len(layer["data"]) == 13
+        assert layer["orientation"] == "horz"
+
+    def test_the_bins_run_along_the_axis_they_are_drawn_on(self):
+        fig = go.Figure([go.Histogram(y=SAMPLE)])
+        layer = only_layer(fig)
+        first = layer["data"][0]
+
+        # `yMin`/`yMax` bound the bin and `x` carries the count -- the reverse
+        # of the vertical case. Emitting the bin on `x` would have the reader
+        # told the count where the range belongs, which the core cannot detect
+        # because both are numbers.
+        assert (first["yMin"], first["yMax"]) == (-3.0, -2.5)
+        assert first["x"] == first["xMax"] == 2
+        assert first["xMin"] == 0
+
+    def test_the_two_orientations_describe_the_same_sample(self):
+        # Same numbers, same bins, transposed. Anything that read one axis for
+        # part of the work and the other for the rest would show up here.
+        vertical = bins(only_layer(go.Figure([go.Histogram(x=SAMPLE)])))
+        horizontal = bins(only_layer(go.Figure([go.Histogram(y=SAMPLE)])))
+        assert horizontal == vertical
+
+    def test_plotly_express_horizontal_is_read_too(self):
+        import pandas as pd
+
+        fig = px.histogram(pd.DataFrame({"v": SAMPLE}), y="v")
+        layer = only_layer(fig)
+
+        assert layer["orientation"] == "horz"
+        assert bins(layer) == bins(
+            only_layer(go.Figure([go.Histogram(x=SAMPLE)]))
+        )
+
+    def test_a_vertical_histogram_still_says_so(self):
+        # `orientation` is emitted either way rather than left off for the
+        # default, so a reader of the schema never has to infer it.
+        assert only_layer(go.Figure([go.Histogram(x=SAMPLE)]))["orientation"] == (
+            "vert"
+        )
+
+
+class TestBinSpecFollowsTheBinnedAxis:
+    """``ybins``/``nbinsy`` govern a horizontal trace; ``xbins``/``nbinsx`` do not."""
+
+    def test_ybins_is_honoured_on_a_horizontal_trace(self):
+        fig = go.Figure([go.Histogram(y=SAMPLE, ybins=dict(size=2))])
+        # plotly's own bins for this figure, its trailing empty bin aside
+        # (#402): four bins of width 2 starting at -4.
+        assert bins(only_layer(fig))[:4] == [
+            (-4.0, -2.0, 4),
+            (-2.0, 0.0, 27),
+            (0.0, 2.0, 27),
+            (2.0, 4.0, 2),
+        ]
+
+    def test_nbinsy_is_honoured_on_a_horizontal_trace(self):
+        fig = go.Figure([go.Histogram(y=SAMPLE, nbinsy=4)])
+        assert bins(only_layer(fig)) == [
+            (-4.0, -2.0, 4),
+            (-2.0, 0.0, 27),
+            (0.0, 2.0, 27),
+            (2.0, 4.0, 2),
+        ]
+
+    @pytest.mark.parametrize(
+        "ignored",
+        [
+            pytest.param({"xbins": dict(size=2)}, id="xbins"),
+            pytest.param({"nbinsx": 4}, id="nbinsx"),
+        ],
+    )
+    def test_the_other_axiss_spec_is_discarded_the_way_plotly_discards_it(
+        self, ignored
+    ):
+        # Plotly does not fall back to the other axis: it autobins. Honouring
+        # the spec here would announce four wide bins for a chart drawn with
+        # thirteen narrow ones.
+        autobinned = bins(only_layer(go.Figure([go.Histogram(y=SAMPLE)])))
+        with_spec = bins(only_layer(go.Figure([go.Histogram(y=SAMPLE, **ignored)])))
+
+        assert with_spec == autobinned
+        assert len(autobinned) == 13
+
+    def test_ybins_on_a_vertical_trace_is_discarded_too(self):
+        autobinned = bins(only_layer(go.Figure([go.Histogram(x=SAMPLE)])))
+        with_spec = bins(
+            only_layer(go.Figure([go.Histogram(x=SAMPLE, ybins=dict(size=2))]))
+        )
+        assert with_spec == autobinned
+
+
+class TestCategoricalHorizontal:
+    """A horizontal count bar chart keeps its labels on the binned axis."""
+
+    def test_categories_land_on_the_axis_they_are_drawn_on(self):
+        labels = list("abcabca")
+        layer = only_layer(go.Figure([go.Histogram(y=labels)]))
+
+        # Plotly draws string data as a count bar chart, and the extractor
+        # switches the schema type to match. The categories still belong on
+        # the binned axis: on `x` they would be announced as counts, and the
+        # counts as labels.
+        assert layer["type"] == PlotType.BAR.value
+        assert layer["orientation"] == "horz"
+        assert layer["data"] == [
+            {"y": "a", "x": 3},
+            {"y": "b", "x": 2},
+            {"y": "c", "x": 2},
+        ]
+
+    def test_a_vertical_count_chart_is_unchanged(self):
+        labels = list("abcabca")
+        layer = only_layer(go.Figure([go.Histogram(x=labels)]))
+        assert layer["data"] == [
+            {"x": "a", "y": 3},
+            {"x": "b", "y": 2},
+            {"x": "c", "y": 2},
+        ]
+
+
+class TestEmptyTrace:
+    """An orientation with nothing on it still declines rather than guessing."""
+
+    def test_a_trace_with_neither_array_yields_no_data(self):
+        assert only_layer(go.Figure([go.Histogram()]))["data"] == []
+
+    def test_an_explicit_orientation_pointing_at_an_absent_axis_yields_no_data(
+        self,
+    ):
+        # Plotly draws essentially nothing for this figure -- one empty entry
+        # in calcdata -- so announcing the `x` sample instead would describe a
+        # distribution the chart does not show.
+        fig = go.Figure([go.Histogram(x=SAMPLE, orientation="h")])
+        assert only_layer(fig)["data"] == []

--- a/tests/plotly/test_plotly_histogram_orientation.py
+++ b/tests/plotly/test_plotly_histogram_orientation.py
@@ -37,7 +37,6 @@ import pytest
 # does, so a minimal install skips rather than failing at collection.
 plotly = pytest.importorskip("plotly")
 
-import numpy as np  # noqa: E402
 import plotly.express as px  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402
 
@@ -45,9 +44,26 @@ from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.plotly.histogram import binned_axis  # noqa: E402
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
-#: A fixed normal sample. Rounded so the figure JSON handed to the browser and
-#: the array handed to numpy hold the same values to the last bit.
-SAMPLE = [round(float(v), 4) for v in np.random.default_rng(3).normal(0, 1, 60)]
+#: The sample every expectation below is pinned to. It began as
+#: ``np.random.default_rng(3).normal(0, 1, 60)`` rounded to four places -- the
+#: rounding so the figure JSON handed to the browser and the array handed to
+#: numpy hold the same values to the last bit -- and is written out in full
+#: rather than regenerated. The bin edges and counts here are what Plotly.js
+#: drew for *these* numbers, so a future numpy that changes the ``PCG64``
+#: stream would otherwise leave the expectations describing a sample the test
+#: no longer uses.
+SAMPLE = [
+    2.0409, -2.5557, 0.4181, -0.5678, -0.4526, -0.2156,
+    -2.02, -0.2319, -0.8652, 3.323, 0.2258, -0.3526,
+    -0.2813, -0.668, -1.0552, -0.3908, 0.4819, -0.2386,
+    0.9578, -0.1998, 0.0243, 1.5458, 0.5451, -0.5052,
+    -0.1828, 0.5405, 1.9351, -0.2696, -0.2436, 1.0023,
+    -0.8865, -0.2917, 0.8825, 0.5804, 0.0915, 0.6701,
+    -2.8282, 1.0213, -0.9596, -1.6686, 0.2764, 0.7005,
+    -0.4448, -1.0764, 0.0261, -0.0527, 1.4056, 0.7474,
+    0.1938, 1.1116, -0.2055, -0.9259, 0.5841, 0.5825,
+    -0.2148, -0.7828, 0.2292, -2.4939, 0.6901, 0.4914,
+]  # fmt: skip
 
 
 def only_layer(fig) -> dict:
@@ -59,9 +75,7 @@ def only_layer(fig) -> dict:
 def bins(layer: dict) -> list[tuple[float, float, int]]:
     """``(low, high, count)`` per bin, read off whichever axis was binned."""
     horizontal = layer.get("orientation") == "horz"
-    low, high, count = (
-        ("yMin", "yMax", "x") if horizontal else ("xMin", "xMax", "y")
-    )
+    low, high, count = ("yMin", "yMax", "x") if horizontal else ("xMin", "xMax", "y")
     return [(d[low], d[high], d[count]) for d in layer["data"]]
 
 
@@ -127,9 +141,7 @@ class TestHorizontalHistogram:
         layer = only_layer(fig)
 
         assert layer["orientation"] == "horz"
-        assert bins(layer) == bins(
-            only_layer(go.Figure([go.Histogram(x=SAMPLE)]))
-        )
+        assert bins(layer) == bins(only_layer(go.Figure([go.Histogram(x=SAMPLE)])))
 
     def test_a_vertical_histogram_still_says_so(self):
         # `orientation` is emitted either way rather than left off for the


### PR DESCRIPTION
Closes #401.

A histogram bins one axis and counts into the other. `PlotlyHistogramPlot` read the sample from `x` and returned early when it was absent, so every horizontal histogram emitted a layer with an empty `data` list:

```json
{
  "type": "hist",
  "axes": {"x": {"label": "count"}, "y": {"label": "v"}},
  "data": [],
  "selectors": ".subplot.xy .trace.bars .point > path"
}
```

Correctly typed, both axes correctly named — and nothing to navigate. The labels are right because they come from `layout` rather than the trace, so nothing in the schema's metadata shows the emptiness. It reads as a histogram of nothing rather than one that failed to read.

## Which axis is binned

Not always stated. `px.histogram(y=...)` writes `orientation` onto the trace; `go.Histogram(y=...)` writes nothing and leaves Plotly.js to infer it. Rather than guess the rule, I read `gd._fullData[i].orientation` back out of Chromium for each shape:

| trace | plotly's orientation | binned |
|---|---|---|
| `go.Histogram(x=v)` | `v` | `x` |
| `go.Histogram(y=v)` | `h` | `y` |
| `px.histogram(y="v")` | `h` | `y` |
| `go.Histogram(x=cats, y=vals, histfunc="sum")` | `v` | `x` |
| `go.Histogram(y=cats, x=vals, histfunc="sum")` | `v` | `x` |
| `go.Histogram(x=v, orientation="h")` | `h` | `y` |

The last row settles the precedence, and it is the one I would have got wrong by reasoning: plotly honours the explicit attribute and bins the **absent** `y`, drawing an empty trace rather than falling back to `x`. So an explicit `orientation` wins outright, and only in its absence do the arrays decide.

## The bin spec follows the binned axis

`_compute_bin_edges` read `xbins`/`nbinsx` for every trace. Measured, plotly discards the other axis's spec outright rather than falling back to it:

| figure | plotly draws |
|---|---|
| `go.Histogram(y=v, ybins=dict(size=2))` | 4 bins of width 2 |
| `go.Histogram(y=v, xbins=dict(size=2))` | 13 bins of width 0.5 — **autobinned, spec ignored** |
| `go.Histogram(y=v, nbinsx=4)` | 13 bins — **ignored** |
| `go.Histogram(x=v, ybins=dict(size=2))` | 13 bins — **ignored** |

So reading `xbins` for everything did both halves wrong on a horizontal trace: honoured a spec plotly throws away, missed the one it uses.

Categorical samples move with it. Plotly draws string data as a count bar chart, and on a horizontal one the labels belong on `y`; left on `x` they would be announced as counts and the counts as labels.

## Verification

I built a like-for-like harness rather than comparing by eye: the same figure objects serialized to JSON, drawn by the real `plotly.min.js` in Chromium, and `gd.calcdata[0]` compared elementwise against the emitted layer. A bin is `[p - size/2, p + size/2)` with `size` from `gd._fullData[0]`.

**14 of 18 shapes agree exactly** — every bin bound and every count, on both orientations. Before this change all 9 horizontal shapes emitted nothing at all.

The 4 that still disagree are all on the explicit-bin-size path, and all fail *identically* on `x` and `y`, which is how I know they are not mine: an extra empty bin past the end (`xbins=dict(size=2)`), and empty bins kept when an explicit `start`/`end` is wider than the data. Filed as **#402** with the measurements. This PR does not fix it, and does extend its reach — a horizontal trace with `ybins` now takes that path, where before it emitted nothing.

Worth recording one hypothesis I had and killed: I first read those 4 as plotly discarding empty bins. It does not. A bimodal sample with a hole in the middle gives 7 bins from both sides, the two empty ones included, agreeing exactly. Only bins outside the data's own extent are dropped. My original ad-hoc check had hardcoded the bin width and looked convincing.

## Falsification

Each mechanism reverted in turn, against the 20 new tests:

| reverted | failures |
|---|---|
| `binned_axis` always returns `"x"` (the original bug) | 13 |
| explicit `orientation` ignored, arrays only | 2 |
| bin spec always read off `x` | 4 |
| `orientation` key dropped from the schema | 7 |
| categorical data always on `x` | 1 |

## Checks

- `uv run pytest tests/` — **1377 passed**
- `ruff check` on both changed files — clean. The repo has 52 pre-existing findings on `main`; the count is unchanged.
- No line over 88 characters in either file (checked directly — `ruff` does not select `E501`).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_