### PR TITLE
fix(plotly): emit the histogram bins plotly actually draws

### DIFF
--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -108,10 +108,26 @@ def _auto_shift_bins(
     Exact port of Plotly.js ``autoShiftNumericBins`` from
     ``src/plots/cartesian/axes.js``.
 
+    *bin_start* need only be **some** multiple of *dtick* within one *dtick*
+    of the true unshifted start -- not one particular formula. The two callers
+    rely on that: the autobin path passes
+    ``ceil(data_min / dtick) * dtick - dtick`` and the explicit-size path
+    ``floor(data_min / size) * size``. Those agree except when ``data_min`` is
+    itself a multiple of the width, where they differ by exactly one bin, and
+    the branches below then correct both to the same answer -- ``near_edge``
+    is trivially true of a seed equal to ``data_min``, so the no-shift
+    fallback cannot fire for it either.
+
+    That convergence is a property of the branches rather than of the
+    arithmetic that produced the seed, so it is worth keeping deliberate:
+    ``test_plotly_histogram_bins.py`` asserts the two seeds land on the same
+    start across a spread of samples and widths, which would otherwise be
+    rediscovered by hand the next time this function is touched.
+
     Parameters
     ----------
     bin_start : float
-        Initial bin start (a round multiple of *dtick*).
+        A multiple of *dtick* within one *dtick* of the unshifted start.
     data : np.ndarray
         Raw data values.
     dtick : float
@@ -327,8 +343,7 @@ class PlotlyHistogramPlot(PlotlyPlot):
         count_min, count_max = bounds[counted]
 
         data = []
-        for i in range(first, last + 1):
-            count = counts[i]
+        for i, count in enumerate(counts[first : last + 1], start=first):
             low = float(bin_edges[i])
             high = float(bin_edges[i + 1])
             data.append(

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -170,6 +170,55 @@ def _auto_shift_bins(
 _HORIZONTAL = "h"
 
 
+def _occupied_span(counts: np.ndarray) -> tuple[int | None, int | None]:
+    """Return the first and last bin index that anything landed in.
+
+    Plotly emits bins from the first that holds an observation to the last,
+    and keeps every empty bin between them. It does **not** emit the empty
+    ones outside that span, however the grid came to reach past the data
+    (#402).
+
+    The rule is exactly that -- trim the ends, keep the middle -- and it took
+    a figure narrower than its data on both sides to establish it. The reading
+    it replaced was "span the data, clamped to the caller's ``[start, end)``",
+    which fits every wider window and predicts one bin too many here:
+
+    ==========================================  ==============  ============
+    ``xbins`` on ``[-2.8, -1.2, .3, 1.1, 2.4, 3.3]``  Plotly.js       clamping
+    ==========================================  ==============  ============
+    ``start=-1, end=2, size=1``                 ``(0,1) (1,2)`` adds ``(-1,0)``
+    ==========================================  ==============  ============
+
+    Data exists below ``start``, so clamping keeps bin ``(-1, 0)``; plotly
+    drops it because nothing landed *in* it, discarding the out-of-window
+    values rather than piling them into the edge bin.
+
+    Trimming subsumes the other half of #402 as well. The explicit-size path
+    computed ``end`` one bin past plotly's, and that surplus bin is empty and
+    at the end, so it goes without the arithmetic needing to be reasoned about
+    separately.
+
+    Empty bins matter beyond the announced values: plotly draws no ``.point``
+    element for one, and the layer's selector resolves positionally, so a
+    phantom bin shifts the highlight of every bin after it.
+
+    Parameters
+    ----------
+    counts : np.ndarray
+        Per-bin counts, in bin order.
+
+    Returns
+    -------
+    tuple[int | None, int | None]
+        Inclusive first and last occupied index, or ``(None, None)`` when
+        every bin is empty.
+    """
+    occupied = np.flatnonzero(counts)
+    if not occupied.size:
+        return None, None
+    return int(occupied[0]), int(occupied[-1])
+
+
 def binned_axis(trace: dict) -> str:
     """Return which of ``x``/``y`` plotly bins for *trace*.
 
@@ -258,6 +307,9 @@ class PlotlyHistogramPlot(PlotlyPlot):
 
         bin_edges = self._compute_bin_edges(arr)
         counts, bin_edges = np.histogram(arr, bins=bin_edges)
+        first, last = _occupied_span(counts)
+        if first is None:
+            return []
 
         # The binned axis carries the bin, the other one the count. Naming the
         # keys off the orientation rather than hardcoding ``x`` keeps the
@@ -275,7 +327,8 @@ class PlotlyHistogramPlot(PlotlyPlot):
         count_min, count_max = bounds[counted]
 
         data = []
-        for i, count in enumerate(counts):
+        for i in range(first, last + 1):
+            count = counts[i]
             low = float(bin_edges[i])
             high = float(bin_edges[i + 1])
             data.append(
@@ -355,18 +408,38 @@ class PlotlyHistogramPlot(PlotlyPlot):
         """
         bins = self._trace.get(f"{self._binned}bins", None)
 
-        # Explicit bin size — use it directly.
+        # Explicit bin size — the width is used as given, without the 'nice'
+        # rounding an `nbins` hint goes through.
         if bins is not None and "size" in bins:
             size = float(bins["size"])
-            start = (
-                float(bins["start"])
-                if "start" in bins
-                else math.floor(arr.min() / size) * size
-            )
+            data_min, data_max = float(arr.min()), float(arr.max())
+
+            # An explicit `start` is honoured verbatim. Without one, plotly
+            # still runs the same anti-clustering shift it applies when
+            # autobinning, which the round multiple of `size` alone does not
+            # reproduce: `go.Histogram(x=[0, 1, 2, 3, 4], xbins=dict(size=2))`
+            # is drawn from -0.5, not 0, because every value is an integer and
+            # they would otherwise sit on the bin edges.
+            if "start" in bins:
+                start = float(bins["start"])
+            else:
+                start = _auto_shift_bins(
+                    math.floor(data_min / size) * size,
+                    arr,
+                    size,
+                    data_min,
+                    data_max,
+                )
+
+            # One bin past the last value, so a value sitting exactly on a
+            # grid multiple gets the bin starting there rather than being
+            # folded into the one below by numpy's closed final interval.
+            # Any bin this reaches past the data is empty, and `_occupied_span`
+            # trims it back off.
             end = (
                 float(bins["end"])
                 if "end" in bins
-                else math.ceil(arr.max() / size) * size + size
+                else math.floor((data_max - start) / size) * size + start + size
             )
             return np.arange(start, end + size / 2, size)
 

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -47,7 +47,7 @@ plotly = pytest.importorskip("plotly")
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402
 
-from maidr.plotly.histogram import _occupied_span  # noqa: E402
+from maidr.plotly.histogram import _auto_shift_bins, _occupied_span  # noqa: E402
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 #: Spans a window given below in one test and above it in another.
@@ -182,6 +182,49 @@ class TestBinStartShift:
     def test_the_shift_applies_on_a_horizontal_trace_too(self):
         fig = go.Figure([go.Histogram(y=[0, 1, 2, 3, 4], ybins=dict(size=2))])
         assert bins(fig) == [(-0.5, 1.5, 2), (1.5, 3.5, 2), (3.5, 5.5, 1)]
+
+
+class TestBothCallersSeedTheShiftEquivalently:
+    """``_auto_shift_bins`` has two callers that seed it differently.
+
+    The autobin path passes ``ceil(data_min / dtick) * dtick - dtick``; the
+    explicit-size path passes ``floor(data_min / size) * size``. Those agree
+    except when ``data_min`` is itself a multiple of the width, where they
+    differ by exactly one bin — and the branches inside then correct both to
+    the same start.
+
+    That is a property of those branches, not of the seed arithmetic, so a
+    refactor of the shift could break the coupling with nothing failing. This
+    pins it instead of leaving it to be re-derived by hand.
+    """
+
+    SAMPLES = {
+        "integers from zero": [0, 1, 2, 3, 4],
+        "integers spanning zero": [-4, -3, 0, 1],
+        "one value on an edge": [0.5, 1.5, 4.0],
+        "min on a multiple": [2.0, 3.7, 5.1, 8.9],
+        "every value a multiple": [0.0, 2.0, 4.0, 6.0],
+        "negative multiples": [-6.0, -4.0, -2.0, 0.0],
+        "barely any spread": [1.0, 1.0000001],
+        "sub-unit": [0.001, 0.002, 0.004],
+    }
+
+    @pytest.mark.parametrize("label", sorted(SAMPLES))
+    @pytest.mark.parametrize("width", [0.001, 0.5, 1, 2, 3, 5])
+    def test_the_two_seeds_land_on_the_same_start(self, label, width):
+        import math
+
+        arr = np.array(self.SAMPLES[label], dtype=float)
+        low, high = float(arr.min()), float(arr.max())
+
+        from_explicit = _auto_shift_bins(
+            math.floor(low / width) * width, arr, width, low, high
+        )
+        from_autobin = _auto_shift_bins(
+            math.ceil(low / width) * width - width, arr, width, low, high
+        )
+
+        assert from_explicit == pytest.approx(from_autobin, abs=1e-12)
 
 
 class TestNothingToAnnounce:

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -1,0 +1,192 @@
+"""A plotly histogram announced bins the chart never drew (#402).
+
+Three defects, all on the explicit-bin-size path, all identical on both
+orientations. An empty bin is not a harmless extra row: plotly draws no
+``.point`` element for one, and the layer's selector resolves positionally, so
+a phantom bin shifts the highlight of every bin after it. A leading phantom
+shifts all of them.
+
+1. **Empty edge bins were emitted.** Plotly emits bins from the first that
+   holds an observation to the last, and keeps every empty bin between them.
+   It does not emit the empty ones outside that span.
+
+2. **The end fallback overshot by a bin.** ``ceil(max / size) * size + size``
+   put an extra bin past the data, where plotly stops at the data. The trim in
+   (1) subsumes it, but the arithmetic was also describing a grid plotly does
+   not use, and the boundary case below needs it stated correctly.
+
+3. **The bin start skipped plotly's anti-clustering shift.** Only the autobin
+   path ran ``_auto_shift_bins``; an explicit ``size`` took a bare round
+   multiple. So ``go.Histogram(x=[0, 1, 2, 3, 4], xbins=dict(size=2))`` was
+   announced from 0 where plotly draws from -0.5.
+
+The rule behind (1) took a figure narrower than its data on *both* sides to
+pin down. The reading it replaced -- "span the data, clamped to the caller's
+``[start, end)``" -- fits every wider window and predicts one bin too many
+there, because clamping keeps a leading bin that nothing landed in. Plotly
+discards the out-of-window values rather than piling them into the edge bin.
+
+Every expectation here is what Plotly.js drew for the same figure:
+``gd.calcdata[0]`` after ``Plotly.newPlot`` in Chromium, a bin being
+``[p - size/2, p + size/2)`` with ``size`` from ``gd._fullData[0]``. With
+these fixes all 29 shapes measured that way agree elementwise, bin bounds and
+counts alike, on both orientations -- up from 16 of 29.
+
+That 16 is worth stating precisely, because the count of bins hides most of
+it. Six of the thirteen disagreements emitted the *right number* of bins on
+the *wrong grid*, so anything checking only the length would have called them
+equal. The comparison is elementwise for that reason.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.histogram import _occupied_span  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Spans a window given below in one test and above it in another.
+NARROW = [-2.8, -1.2, 0.3, 1.1, 2.4, 3.3]
+
+#: Two clusters with a hole between them, so interior empties have somewhere
+#: to appear.
+BIMODAL = [0.2, 0.6, 1.4, 2.9, 9.1, 9.8, 10.4, 11.7]
+
+
+def bins(fig) -> list[tuple[float, float, int]]:
+    """``(low, high, count)`` per emitted bin, off whichever axis was binned."""
+    layer = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+    horizontal = layer.get("orientation") == "horz"
+    low, high, count = ("yMin", "yMax", "x") if horizontal else ("xMin", "xMax", "y")
+    return [(d[low], d[high], d[count]) for d in layer["data"]]
+
+
+class TestOccupiedSpan:
+    """The helper, in isolation."""
+
+    @pytest.mark.parametrize(
+        ("counts", "expected"),
+        [
+            ([1, 2, 3], (0, 2)),
+            ([0, 2, 3], (1, 2)),
+            ([1, 2, 0], (0, 1)),
+            ([0, 0, 5, 0, 0], (2, 2)),
+            # An interior run of empties is inside the span, not trimmed.
+            ([4, 0, 0, 7], (0, 3)),
+            ([0, 0, 0], (None, None)),
+            ([], (None, None)),
+        ],
+    )
+    def test_finds_the_first_and_last_occupied_bin(self, counts, expected):
+        assert _occupied_span(np.array(counts, dtype=int)) == expected
+
+
+class TestEmptyEdgeBinsAreTrimmed:
+    def test_a_window_wider_than_the_data_emits_only_the_data(self):
+        # Plotly's resolved spec keeps start=-10 and end=10, and draws seven
+        # bins from -3 to 4. Emitting all twenty put thirteen phantom bins in
+        # the layer, thirteen of them before the first real one.
+        fig = go.Figure([go.Histogram(x=NARROW, xbins=dict(start=-10, end=10, size=1))])
+        assert bins(fig) == [
+            (-3.0, -2.0, 1),
+            (-2.0, -1.0, 1),
+            (-1.0, 0.0, 0),
+            (0.0, 1.0, 1),
+            (1.0, 2.0, 1),
+            (2.0, 3.0, 1),
+            (3.0, 4.0, 1),
+        ]
+
+    def test_a_window_narrower_on_both_sides_still_trims_its_leading_empty(self):
+        # The case that settled the rule. Data exists below `start`, so
+        # "clamp the span to the window" keeps bin (-1, 0); plotly drops it
+        # because nothing landed *in* it -- the values below `start` are
+        # discarded rather than piled into the first bin.
+        fig = go.Figure([go.Histogram(x=NARROW, xbins=dict(start=-1, end=2, size=1))])
+        assert bins(fig) == [(0.0, 1.0, 1), (1.0, 2.0, 1)]
+
+    def test_an_interior_empty_bin_is_kept(self):
+        # Trimming is not "drop every empty bin". A gap in the middle of the
+        # distribution is a fact about the data and plotly draws the axis
+        # across it, so it stays.
+        fig = go.Figure([go.Histogram(x=BIMODAL, xbins=dict(size=2))])
+        counts = [count for _, _, count in bins(fig)]
+        assert 0 in counts[1:-1]
+        assert counts[0] > 0 and counts[-1] > 0
+
+    def test_the_same_trimming_happens_on_a_horizontal_trace(self):
+        upright = bins(
+            go.Figure([go.Histogram(x=NARROW, xbins=dict(start=-1, end=2, size=1))])
+        )
+        sideways = bins(
+            go.Figure([go.Histogram(y=NARROW, ybins=dict(start=-1, end=2, size=1))])
+        )
+        assert sideways == upright
+
+
+class TestDataOutsideAnExplicitWindow:
+    """Already correct before this, and easy to break while fixing the rest."""
+
+    @pytest.mark.parametrize(
+        ("spec", "expected_span"),
+        [
+            # Data reaches 3.3, the window stops at 1: the values above are
+            # dropped, not clipped into the last bin.
+            (dict(start=-3, end=1, size=1), (-3.0, 1.0)),
+            # ... and the same below.
+            (dict(start=0, end=4, size=1), (0.0, 4.0)),
+        ],
+    )
+    def test_values_beyond_the_window_are_dropped_rather_than_clipped(
+        self, spec, expected_span
+    ):
+        emitted = bins(go.Figure([go.Histogram(x=NARROW, xbins=spec)]))
+        assert (emitted[0][0], emitted[-1][1]) == expected_span
+        # Nothing piled up: no bin holds more than the two values that fall in
+        # it, so the discarded values did not land anywhere.
+        assert sum(count for _, _, count in emitted) < len(NARROW)
+
+
+class TestBinStartShift:
+    """Plotly runs its anti-clustering shift for an explicit size too."""
+
+    def test_integer_data_is_shifted_off_the_bin_edges(self):
+        # Every value is an integer and would otherwise sit exactly on an
+        # edge, so plotly moves the grid half a unit down. Announced from 0,
+        # each value lands in a different bin than the one drawn around it.
+        fig = go.Figure([go.Histogram(x=[0, 1, 2, 3, 4], xbins=dict(size=2))])
+        assert bins(fig) == [(-0.5, 1.5, 2), (1.5, 3.5, 2), (3.5, 5.5, 1)]
+
+    def test_the_shift_can_go_the_other_way(self):
+        fig = go.Figure([go.Histogram(x=[-4, -3, 0, 1], xbins=dict(size=2))])
+        assert bins(fig) == [(-4.5, -2.5, 2), (-2.5, -0.5, 0), (-0.5, 1.5, 2)]
+
+    def test_a_value_clustering_on_an_edge_shifts_without_all_being_integers(self):
+        # The other branch of the shift: not every value is an integer, but
+        # one sits on an edge, which is enough for plotly to move the grid.
+        fig = go.Figure([go.Histogram(x=[0.5, 1.5, 4.0], xbins=dict(size=2))])
+        assert bins(fig) == [(-1.0, 1.0, 1), (1.0, 3.0, 1), (3.0, 5.0, 1)]
+
+    def test_an_explicit_start_is_honoured_rather_than_shifted(self):
+        # The shift only chooses a start; given one, plotly uses it verbatim.
+        fig = go.Figure(
+            [go.Histogram(x=[0, 1, 2, 3, 4], xbins=dict(start=0, end=6, size=2))]
+        )
+        assert bins(fig)[0][0] == 0.0
+
+    def test_the_shift_applies_on_a_horizontal_trace_too(self):
+        fig = go.Figure([go.Histogram(y=[0, 1, 2, 3, 4], ybins=dict(size=2))])
+        assert bins(fig) == [(-0.5, 1.5, 2), (1.5, 3.5, 2), (3.5, 5.5, 1)]
+
+
+class TestNothingToAnnounce:
+    def test_a_window_holding_no_data_yields_no_bins(self):
+        # Every bin empty. Emitting them would announce a distribution made
+        # entirely of gaps, none of which the chart draws an element for.
+        fig = go.Figure([go.Histogram(x=NARROW, xbins=dict(start=20, end=24, size=1))])
+        assert bins(fig) == []


### PR DESCRIPTION
Closes #402.

Three defects on the explicit-bin-size path, all identical on both orientations. An empty bin is not a harmless extra row: plotly draws no `.point` element for one, and the layer's selector resolves positionally, so a phantom bin shifts the highlight of every bin after it — and a *leading* phantom shifts all of them. Same desync class as #354 and #378.

## 1. Empty edge bins were emitted

Plotly emits bins from the first that holds an observation to the last, and keeps every empty bin between them. It does not emit the empty ones outside that span.

```python
go.Histogram(x=[-2.8, -1.2, 0.3, 1.1, 2.4, 3.3], xbins=dict(start=-10, end=10, size=1))
```

Plotly's *resolved* spec keeps `start: -10, end: 10` and draws **7** bins, `-3` to `4`. py-maidr emitted **20**, thirteen of them phantom and all thirteen before the first real bin.

## 2. The bin start skipped plotly's anti-clustering shift

Only the autobin path ran `_auto_shift_bins`; an explicit `size` took a bare `floor(min / size) * size`.

| figure | plotly draws from | py-maidr said |
|---|---|---|
| `go.Histogram(x=[0, 1, 2, 3, 4], xbins=dict(size=2))` | `-0.5` | `0` |
| `go.Histogram(x=[-4, -3, 0, 1], xbins=dict(size=2))` | `-4.5` | `-4` |
| `go.Histogram(x=[0.5, 1.5, 4.0], xbins=dict(size=2))` | `-1.0` | `0` |

Every value in the first case is an integer, so on a grid starting at 0 they all sit exactly on bin edges; plotly moves the grid half a unit down. The result is that each value was announced in a *different bin than the one drawn around it*, with the bin count unchanged — invisible to anything checking lengths.

This one wasn't in the issue. I found it only because fixing (1) made me test values sitting exactly on the grid. The existing `_auto_shift_bins` reproduces all three of plotly's starts exactly; it was simply never called from this branch.

## 3. The `end` fallback was expressed on a grid the bins do not use

`ceil(max / size) * size + size` → one bin past the last value, measured from `start`.

**This change is not observable, and I want to be explicit about that** — its falsification row returns 0 failures. Both forms reach at least the upper edge of the bin holding the maximum, and the trim from (1) removes the surplus either way. I kept it because once the shift is applied, `ceil(max / size) * size` is computed on a different origin than the bins actually use, which reads as a bug even where it isn't. I could not write a test that distinguishes the two, and did not invent one.

## The rule, and the reading it replaced

I had "bins span the data on the caller's grid, clamped to `[start, end)`". It fits every window wider than the data. A window narrower on **both** sides refutes it:

`xbins=dict(start=-1, end=2, size=1)` on that same sample → plotly draws **2** bins; clamping predicts **3**. Data exists below `start`, so clamping keeps bin `(-1, 0)` — and plotly drops it, because nothing landed *in* it. The out-of-window values are discarded rather than piled into the edge bin.

What survives is just: **trim empty bins from both ends, keep every one between them.** That also subsumes (3)'s overshoot without it needing separate arithmetic.

Two behaviours that were *already* correct and are easy to break while fixing this — data outside an explicit window being dropped rather than clipped, on each side — now have tests of their own.

## Verification

The same harness as #403: the figure objects serialized to JSON, drawn by the real `plotly.min.js` in Chromium, and `gd.calcdata[0]` compared elementwise against the emitted layer.

**29 of 29 shapes now agree** — every bin bound and every count, both orientations. Before: **16 of 29**.

That 16 is worth stating precisely, because I first estimated it at 25 and was wrong by a wide margin. Six of the thirteen disagreements emitted the *right number of bins on the wrong grid*, so a comparison by length alone would have called them equal and I would have reported a much smaller defect than the one that was there.

## Falsification

| reverted | failures |
|---|---|
| no trim — emit every bin | 3 |
| trim every empty bin, interior included | 6 |
| no bin-start shift on the explicit-size path | 4 |
| shift applied even when `start` is given | 4 |
| old `end` fallback (`ceil + size`) | **0** — see (3) above |

## Checks

- `uv run pytest tests/` — **1396 passed** (up 19)
- `ruff check` on both changed files — clean
- `ruff format --diff` — test file clean; `histogram.py` shows 18 lines, identical with and without this branch
- No line over 88 characters

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_