### PR TITLE
fix(plotly): rescale a histogram's bars the way histnorm does

### DIFF
--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -186,6 +186,81 @@ def _auto_shift_bins(
 _HORIZONTAL = "h"
 
 
+def apply_histnorm(
+    values: np.ndarray, widths: np.ndarray, histnorm: str | None
+) -> np.ndarray:
+    """Rescale a histogram's bar values the way ``histnorm`` does.
+
+    ``histnorm`` decides what a bar *measures*, and ignoring it left the
+    values contradicting the axis label beside them: a ``histnorm="percent"``
+    histogram whose axis reads "percent" announced ``2`` for a bar plotly
+    draws at ``3.33`` (#404).
+
+    Every form below is checked against ``gd.calcdata[0][i].s`` after
+    ``Plotly.newPlot`` in Chromium:
+
+    =========================  ==============
+    ``histnorm``               value
+    =========================  ==============
+    *(unset)*                  ``v``
+    ``percent``                ``v / T * 100``
+    ``probability``            ``v / T``
+    ``density``                ``v / w``
+    ``probability density``    ``v / (T * w)``
+    =========================  ==============
+
+    ``T`` is the total of the bars' own values, **not** the number of
+    observations. Those coincide under the default ``histfunc="count"``, which
+    is why the distinction is easy to miss and worth stating: measured with
+    ``histfunc="sum"`` and ``histfunc="avg"`` over the same data,
+    ``histnorm="percent"`` returns *identical* output -- impossible if the
+    denominator were the sample size, since the two aggregates differ by a
+    constant factor, and required if it is their own total.
+
+    So this takes the values it is given rather than recomputing anything from
+    the sample: when ``histfunc`` support lands (#405) the aggregate flows
+    through unchanged.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        Per-bin values, before rescaling.
+    widths : np.ndarray
+        Per-bin widths, aligned with *values*.
+    histnorm : str | None
+        Plotly's ``histnorm``. Anything falsy or unrecognised leaves the
+        values alone, matching plotly's own handling of an unset attribute.
+
+    Returns
+    -------
+    np.ndarray
+        The rescaled values.
+    """
+    if not histnorm:
+        return values
+
+    total = float(values.sum())
+    per_width = values / widths
+
+    if histnorm == "density":
+        return per_width
+
+    # The remaining three all divide by the total, so an empty trace would
+    # divide by zero. It cannot reach here -- an all-empty histogram returns
+    # before this -- but the guard keeps that a property of the caller rather
+    # than an assumption made here.
+    if total == 0:
+        return values
+
+    if histnorm == "percent":
+        return values / total * 100
+    if histnorm == "probability":
+        return values / total
+    if histnorm == "probability density":
+        return per_width / total
+    return values
+
+
 def _occupied_span(counts: np.ndarray) -> tuple[int | None, int | None]:
     """Return the first and last bin index that anything landed in.
 
@@ -323,9 +398,20 @@ class PlotlyHistogramPlot(PlotlyPlot):
 
         bin_edges = self._compute_bin_edges(arr)
         counts, bin_edges = np.histogram(arr, bins=bin_edges)
+
+        # Trimmed on the raw counts rather than the rescaled values, because
+        # that is what "a bin nothing landed in" means. Every rescaling below
+        # maps zero to zero, so the two agree -- but only the counts say it
+        # without depending on that.
         first, last = _occupied_span(counts)
         if first is None:
             return []
+
+        bar_values = apply_histnorm(
+            counts.astype(float),
+            np.diff(bin_edges),
+            self._trace.get("histnorm"),
+        )
 
         # The binned axis carries the bin, the other one the count. Naming the
         # keys off the orientation rather than hardcoding ``x`` keeps the
@@ -343,17 +429,21 @@ class PlotlyHistogramPlot(PlotlyPlot):
         count_min, count_max = bounds[counted]
 
         data = []
-        for i, count in enumerate(counts[first : last + 1], start=first):
+        for i, value in enumerate(bar_values[first : last + 1], start=first):
             low = float(bin_edges[i])
             high = float(bin_edges[i + 1])
+            # A count is announced as the integer it is; a rescaled value is
+            # not one, and rounding it to look like one would put a 3.33%
+            # share on the chart as 3.
+            height = int(value) if value == int(value) else float(value)
             data.append(
                 {
                     binned.value: (low + high) / 2,
-                    counted.value: int(count),
+                    counted.value: height,
                     bin_min.value: low,
                     bin_max.value: high,
                     count_min.value: 0,
-                    count_max.value: int(count),
+                    count_max.value: height,
                 }
             )
         return data

--- a/tests/plotly/test_plotly_histogram_histnorm.py
+++ b/tests/plotly/test_plotly_histogram_histnorm.py
@@ -1,0 +1,210 @@
+"""A plotly histogram's ``histnorm`` was ignored, so a percent axis read in
+counts (#404).
+
+`histnorm` decides what a bar *measures*. `_extract_plot_data` called
+`np.histogram`, which returns counts, and never read the attribute -- so a
+`px.histogram(histnorm="percent")` layer carried an axis labelled **percent**
+and a first value of **2**, where plotly draws **3.33**.
+
+The label was right: it comes from `layout`, which plotly express fills in
+from `histnorm`. Only the values were untransformed, so the two halves of one
+layer disagreed with nothing marking which to trust. A reader working from the
+announced numbers concludes the first bin holds 2% where it holds 3.33%, and
+finds the bars do not sum to 100 either.
+
+The denominator is the part worth being careful about. It is the total of the
+**bars' own values**, not the number of observations. Those coincide under the
+default `histfunc="count"` -- the counts sum to `n` -- which is exactly why
+the wrong reading survives the obvious test. `histfunc="sum"` and
+`histfunc="avg"` over the same data return *identical* output under
+`histnorm="percent"`, which is impossible if the denominator is the sample
+size and required if it is their own total. `apply_histnorm` therefore takes
+the values it is handed rather than recomputing from the sample, so the
+aggregate flows through unchanged when #405 lands.
+
+Every expectation is `gd.calcdata[0][i].s` after `Plotly.newPlot` in Chromium.
+All 38 figure shapes measured that way now agree elementwise, on both
+orientations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.histogram import apply_histnorm  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: 60 values in [-1.2, 1.2]-ish, autobinned by plotly to width 0.2.
+SAMPLE = [
+    0.8164, -1.0223, 0.1672, -0.2271, -0.1810, -0.0862,
+    -0.8080, -0.0928, -0.3461, 1.3292, 0.0903, -0.1410,
+    -0.1125, -0.2672, -0.4221, -0.1563, 0.1928, -0.0954,
+    0.3831, -0.0799, 0.0097, 0.6183, 0.2180, -0.2021,
+    -0.0731, 0.2162, 0.7740, -0.1078, -0.0974, 0.4009,
+    -0.3546, -0.1167, 0.3530, 0.2322, 0.0366, 0.2680,
+    -1.1313, 0.4085, -0.3838, -0.6674, 0.1106, 0.2802,
+    -0.1779, -0.4306, 0.0104, -0.0211, 0.5622, 0.2990,
+    0.0775, 0.4446, -0.0822, -0.3704, 0.2336, 0.2330,
+    -0.0859, -0.3131, 0.0917, -0.9976, 0.2760, 0.1966,
+]  # fmt: skip
+
+
+def values_of(fig) -> list[float]:
+    """The announced bar value per bin, off whichever axis holds it."""
+    layer = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+    key = "x" if layer.get("orientation") == "horz" else "y"
+    return [round(float(d[key]), 6) for d in layer["data"]]
+
+
+class TestApplyHistnorm:
+    """The transform in isolation, against the closed forms."""
+
+    VALUES = np.array([2.0, 3.0, 5.0])
+    WIDTHS = np.array([0.5, 0.5, 0.5])
+
+    @pytest.mark.parametrize(
+        ("histnorm", "expected"),
+        [
+            (None, [2.0, 3.0, 5.0]),
+            ("", [2.0, 3.0, 5.0]),
+            ("percent", [20.0, 30.0, 50.0]),
+            ("probability", [0.2, 0.3, 0.5]),
+            ("density", [4.0, 6.0, 10.0]),
+            ("probability density", [0.4, 0.6, 1.0]),
+            # Plotly leaves an attribute it does not recognise alone rather
+            # than erroring, and a layer that quietly rescaled by some other
+            # rule would be worse than one that did not rescale at all.
+            ("nonsense", [2.0, 3.0, 5.0]),
+        ],
+    )
+    def test_matches_the_closed_form(self, histnorm, expected):
+        got = apply_histnorm(self.VALUES.copy(), self.WIDTHS, histnorm)
+        assert list(got) == pytest.approx(expected)
+
+    def test_the_denominator_is_the_values_own_total(self):
+        # The distinction the default `histfunc` hides. Scaling every value by
+        # a constant must leave `percent` unchanged, because the total scales
+        # with it -- which is what makes `sum` and `avg` agree in plotly, and
+        # what a sample-size denominator could not do.
+        base = apply_histnorm(self.VALUES.copy(), self.WIDTHS, "percent")
+        tripled = apply_histnorm(self.VALUES * 3, self.WIDTHS, "percent")
+        assert list(tripled) == pytest.approx(list(base))
+
+    def test_density_ignores_the_total_and_reads_the_width(self):
+        # `density` is the one form with no total in it, so the same check
+        # must come out the other way round.
+        base = apply_histnorm(self.VALUES.copy(), self.WIDTHS, "density")
+        tripled = apply_histnorm(self.VALUES * 3, self.WIDTHS, "density")
+        assert list(tripled) == pytest.approx([v * 3 for v in base])
+
+        wider = apply_histnorm(self.VALUES.copy(), self.WIDTHS * 2, "density")
+        assert list(wider) == pytest.approx([v / 2 for v in base])
+
+    def test_an_all_empty_trace_does_not_divide_by_zero(self):
+        empty = np.zeros(3)
+        got = apply_histnorm(empty, self.WIDTHS, "percent")
+        assert list(got) == [0.0, 0.0, 0.0]
+
+
+class TestEmittedValues:
+    """End to end, against what Plotly.js drew for the same figure."""
+
+    @pytest.mark.parametrize(
+        ("histnorm", "first_five"),
+        [
+            (None, [2, 2, 1, 2, 8]),
+            ("percent", [3.333333, 3.333333, 1.666667, 3.333333, 13.333333]),
+            ("probability", [0.033333, 0.033333, 0.016667, 0.033333, 0.133333]),
+            ("density", [10.0, 10.0, 5.0, 10.0, 40.0]),
+            (
+                "probability density",
+                [0.166667, 0.166667, 0.083333, 0.166667, 0.666667],
+            ),
+        ],
+    )
+    def test_every_mode_matches_plotly(self, histnorm, first_five):
+        got = values_of(go.Figure([go.Histogram(x=SAMPLE, histnorm=histnorm)]))
+        assert got[:5] == pytest.approx(first_five, abs=1e-6)
+
+    def test_percent_sums_to_a_hundred(self):
+        # Not a plotly comparison but a property the announcement has to have:
+        # a reader told these are percentages will add them up.
+        got = values_of(go.Figure([go.Histogram(x=SAMPLE, histnorm="percent")]))
+        assert sum(got) == pytest.approx(100.0)
+
+    def test_probability_sums_to_one(self):
+        got = values_of(go.Figure([go.Histogram(x=SAMPLE, histnorm="probability")]))
+        assert sum(got) == pytest.approx(1.0)
+
+    def test_the_bar_extent_moves_with_the_value(self):
+        # `yMax` carries the bar's height, so leaving it on the raw count
+        # would have the announced extent disagree with the announced value
+        # inside one point.
+        fig = go.Figure([go.Histogram(x=SAMPLE, histnorm="percent")])
+        layer = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+        for point in layer["data"]:
+            assert point["yMax"] == point["y"]
+            assert point["yMin"] == 0
+
+    def test_a_horizontal_trace_is_rescaled_the_same_way(self):
+        upright = values_of(go.Figure([go.Histogram(x=SAMPLE, histnorm="percent")]))
+        sideways = values_of(go.Figure([go.Histogram(y=SAMPLE, histnorm="percent")]))
+        assert sideways == pytest.approx(upright)
+
+    def test_density_follows_a_wider_explicit_bin(self):
+        # `density` divides by the bin width, so it is the one mode an
+        # explicit `xbins` changes the answer for. Both of these are plotly's.
+        narrow = values_of(go.Figure([go.Histogram(x=SAMPLE, histnorm="density")]))
+        wide = values_of(
+            go.Figure([go.Histogram(x=SAMPLE, xbins=dict(size=2), histnorm="density")])
+        )
+        assert max(wide) < max(narrow)
+
+    def test_an_unset_histnorm_still_announces_whole_counts(self):
+        # A count is an integer and reads as one. Turning every bar into a
+        # float to accommodate the rescaled modes would change every existing
+        # histogram's announcement for nothing.
+        fig = go.Figure([go.Histogram(x=SAMPLE)])
+        layer = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+        assert all(isinstance(d["y"], int) for d in layer["data"])
+
+    def test_a_rescaled_value_is_not_rounded_to_look_like_a_count(self):
+        fig = go.Figure([go.Histogram(x=SAMPLE, histnorm="percent")])
+        layer = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+        assert any(not float(d["y"]).is_integer() for d in layer["data"])
+
+
+class TestTrimmingIsUnaffected:
+    """#402's trim and this rescaling have to stay independent."""
+
+    def test_an_empty_edge_bin_is_still_trimmed_under_histnorm(self):
+        fig = go.Figure(
+            [
+                go.Histogram(
+                    x=[-2.8, -1.2, 0.3, 1.1, 2.4, 3.3],
+                    xbins=dict(start=-10, end=10, size=1),
+                    histnorm="percent",
+                )
+            ]
+        )
+        # Seven bins, as without the rescaling: every mode maps zero to zero,
+        # so which bins exist cannot depend on it.
+        assert len(values_of(fig)) == 7
+
+    def test_an_interior_empty_bin_survives_as_a_zero(self):
+        fig = go.Figure(
+            [
+                go.Histogram(
+                    x=[0.2, 0.6, 1.4, 2.9, 9.1, 9.8, 10.4, 11.7],
+                    xbins=dict(size=2),
+                    histnorm="percent",
+                )
+            ]
+        )
+        got = values_of(fig)
+        assert 0.0 in got[1:-1]


### PR DESCRIPTION
Closes #404.

`histnorm` decides what a bar *measures*. `_extract_plot_data` called `np.histogram`, which returns counts, and never read the attribute:

```python
fig = px.histogram(frame, x="v", histnorm="percent")
layer["axes"]["y"]["label"]   # 'percent'
layer["data"][0]["y"]         # 2       <- plotly draws 3.33
```

The axis says **percent**, the value says **2**. The label was right — it comes from `layout`, which plotly express fills in from `histnorm` — so only the values were untransformed, and the two halves of one layer disagreed with nothing marking which to trust. A reader working from the announced numbers concludes the first bin holds 2% where it holds 3.33%, and finds the bars do not sum to 100 either.

## The denominator is the part worth getting right

It is the total of the bars' **own values**, not the number of observations.

I originally wrote the closed forms on the issue as `count / n * 100` and friends. That is correct — but *only* for the default `histfunc="count"`, which is the case I measured them on. The counts sum to `n`, so the default cannot tell the two readings apart. Measured with an aggregating `histfunc` over the same data:

| `histfunc` | aggregate | total | `+ percent` draws |
|---|---|---|---|
| `sum` | `12, 15, 18` | 45 | `26.667, 33.333, 40` |
| `avg` | `4, 5, 6` | 15 | `26.667, 33.333, 40` |
| `min` | `1, 2, 3` | 6 | `16.667, 33.333, 50` |

`sum + percent` and `avg + percent` come out **identical**. Under `count / n * 100` they could not — the aggregates differ by a factor of three. Under `value / total(values)` they must.

So `apply_histnorm` takes the values it is handed rather than recomputing anything from the sample, and the aggregate will flow through unchanged when #405 lands. The corrected forms, with `v` the bin's value, `T` their total, `w` the bin width:

| `histnorm` | value |
|---|---|
| *(unset)* | `v` |
| `percent` | `v / T * 100` |
| `probability` | `v / T` |
| `density` | `v / w` |
| `probability density` | `v / (T * w)` |

## Two things that would have made a weaker fix look right

- **`density` does not rescale a categorical histogram at all.** Plotly bins categories onto integer positions, so `w = 1` and `v / w == v`. A test exercising only that path would pass on a `density` implementation that did nothing. The tests use a continuous sample and check that a wider explicit bin lowers the density.
- **`T` must be summed after aggregating.** For `histfunc="avg"` it is the sum of the per-bin averages — `15` above — which is not a total of anything in the data. Reaching for "the sum of the sample" gives `45`, wrong by a factor of three.

## Interaction with #402

The trim still runs on the raw counts, not the rescaled values, because "a bin nothing landed in" is a statement about counts. Every mode maps zero to zero so the two agree — but only the counts say it without depending on that. There are tests that a trimmed edge bin stays trimmed and an interior empty bin survives as a `0.0` under `histnorm`.

A count stays an `int`. A rescaled value does not become one: rounding a 3.33% share to `3` would reintroduce this defect from the other side.

## Verification

Same harness: figures serialized to JSON, drawn by the real `plotly.min.js` in Chromium, `gd.calcdata[0]` compared elementwise. **38 of 38 shapes agree**, both orientations — nine of them new `histnorm` cases.

The test sample is a literal rather than an RNG call, and I checked the literal itself through the browser rather than trusting that it round-trips from the generator it started as — otherwise the expectations would only have been confirming py-maidr against itself.

## Falsification

| reverted | failures |
|---|---|
| ignore `histnorm` entirely (the bug) | 14 |
| denominator = bin count instead of the values' total | 9 |
| `density` divides by the total instead of the width | 6 |
| bar extent (`yMax`) left on the raw count | 1 |
| round every value to an integer | 5 |

## Checks

- `uv run pytest tests/` — **1468 passed** (up 24)
- `ruff check` clean on both files; `ruff format --diff` clean
- No line over 88 characters

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_