### PR TITLE
fix(plotly): aggregate a histogram's bars the way histfunc does

### DIFF
--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -185,6 +185,123 @@ def _auto_shift_bins(
 #: Plotly's spelling of a horizontal trace.
 _HORIZONTAL = "h"
 
+#: ``histfunc`` values that aggregate a second array rather than counting.
+#: ``count`` is plotly's default and is what the bin populations already are.
+_AGGREGATING = frozenset({"sum", "avg", "min", "max"})
+
+#: Of those, the ones with no answer for a bin nothing landed in. Plotly emits
+#: no point at all for such a bin under these, where ``count`` and ``sum`` emit
+#: a zero -- measured in Chromium over a sample with a two-bin gap in the
+#: middle: ``count`` and ``sum`` return six points, ``avg``/``min``/``max``
+#: return four, the interior empties dropped rather than zeroed.
+_UNDEFINED_WHEN_EMPTY = frozenset({"avg", "min", "max"})
+
+
+def aggregate_bins(
+    assignment: np.ndarray, values: np.ndarray, n_bins: int, histfunc: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Reduce each bin's values the way ``histfunc`` does.
+
+    ``histfunc`` decides what a bar *measures*. Ignoring it announced the bin
+    populations for every mode, so a chart drawn at ``12, 15, 18`` was read out
+    as ``3, 3, 3`` (#405).
+
+    Parameters
+    ----------
+    assignment : np.ndarray
+        Bin index per observation; ``-1`` for observations outside every bin,
+        which plotly discards rather than clipping into an edge bin.
+    values : np.ndarray
+        The value array, aligned with *assignment*.
+    n_bins : int
+        How many bins the grid holds.
+    histfunc : str
+        One of ``sum``, ``avg``, ``min``, ``max``.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray]
+        The per-bin values, and a mask of which bins hold an observation.
+        Bins outside the mask carry ``0`` and are the caller's to drop or
+        keep, since ``count`` and ``sum`` announce a zero there while the
+        other three announce nothing.
+    """
+    aggregated = np.zeros(n_bins, dtype=float)
+    present = np.zeros(n_bins, dtype=bool)
+
+    for index in range(n_bins):
+        in_bin = values[assignment == index]
+        # A value that is not a number is not an observation, rather than an
+        # observation of zero. Measured: a bin holding ``['z', 'w', 8]``
+        # averages to **8**, not 8/3, and its min and max are 8 as well --
+        # so the strings are dropped, not counted. A bin left with nothing
+        # numeric is empty, which the caller then treats exactly as it treats
+        # a bin nothing landed in.
+        in_bin = in_bin[np.isfinite(in_bin)]
+        if not in_bin.size:
+            continue
+        present[index] = True
+        if histfunc == "sum":
+            aggregated[index] = float(in_bin.sum())
+        elif histfunc == "avg":
+            aggregated[index] = float(in_bin.mean())
+        elif histfunc == "min":
+            aggregated[index] = float(in_bin.min())
+        else:  # max
+            aggregated[index] = float(in_bin.max())
+
+    return aggregated, present
+
+
+def as_numeric(values: list) -> np.ndarray:
+    """Coerce a value array to floats, with non-numbers as ``nan``.
+
+    The value array is not guaranteed numeric: ``go.Histogram(y=cats,
+    x=vals, histfunc="sum")`` bins ``x`` and hands the *category strings* to
+    the aggregate. Plotly does not error on that -- it drops them -- so a
+    plain ``np.array(..., dtype=float)`` would raise where the chart renders.
+
+    ``nan`` rather than ``0`` because that is the measured behaviour:
+    :func:`aggregate_bins` drops them, and a bin holding ``['z', 'w', 8]``
+    averages to 8.
+    """
+    coerced = np.empty(len(values), dtype=float)
+    for index, value in enumerate(values):
+        try:
+            coerced[index] = float(value)
+        except (TypeError, ValueError):
+            coerced[index] = np.nan
+    return coerced
+
+
+def value_array(trace: dict, binned: str) -> list | None:
+    """The array ``histfunc`` aggregates, or ``None`` when there is none.
+
+    A histogram that aggregates carries both arrays: one is binned and the
+    other supplies the values. Which is which is not "the numeric one" --
+    ``go.Histogram(x=cats, y=vals, histfunc="sum")`` and
+    ``go.Histogram(y=cats, x=vals, histfunc="sum")`` both resolve to
+    ``orientation: v`` in Plotly.js, so plotly bins ``x`` in *both*. The
+    binned axis is settled by :func:`binned_axis`; this is simply the other.
+
+    Parameters
+    ----------
+    trace : dict
+        A ``histogram`` trace dict.
+    binned : str
+        ``"x"`` or ``"y"``, the axis being binned.
+
+    Returns
+    -------
+    list | None
+        The value array, or ``None`` when the trace only counts.
+    """
+    if trace.get("histfunc") not in _AGGREGATING:
+        return None
+    other = "y" if binned == "x" else "x"
+    raw = trace.get(other)
+    return None if raw is None else as_list(raw)
+
 
 def apply_histnorm(
     values: np.ndarray, widths: np.ndarray, histnorm: str | None
@@ -382,6 +499,26 @@ class PlotlyHistogramPlot(PlotlyPlot):
     def _get_selector(self) -> str:
         return f"{self._subplot_css_prefix()}.trace.bars .point > path"
 
+    @staticmethod
+    def _bin_assignment(arr: np.ndarray, bin_edges: np.ndarray) -> np.ndarray:
+        """Which bin each observation falls in, or ``-1`` for none.
+
+        Matches how ``np.histogram`` fills the same edges, so the assignment
+        and the counts cannot disagree about which bin an observation is in:
+        half-open ``[low, high)`` throughout except the last bin, which is
+        closed so the maximum has somewhere to go.
+
+        Values outside every bin get ``-1``. Plotly discards those rather than
+        clipping them into an edge bin -- an explicit window narrower than the
+        data drops what falls beyond it, both sides -- and ``np.histogram``
+        already does the same for the counts.
+        """
+        assignment = np.searchsorted(bin_edges, arr, side="right") - 1
+        assignment[arr == bin_edges[-1]] = len(bin_edges) - 2
+        outside = (arr < bin_edges[0]) | (arr > bin_edges[-1])
+        assignment[outside] = -1
+        return assignment
+
     def _extract_plot_data(self) -> list[dict]:
         raw = self._trace.get(self._binned, None)
         if raw is None:
@@ -407,10 +544,38 @@ class PlotlyHistogramPlot(PlotlyPlot):
         if first is None:
             return []
 
+        histfunc = self._trace.get("histfunc") or "count"
+        raw_values = value_array(self._trace, self._binned)
+        present = counts > 0
+
+        if raw_values is None:
+            measured = counts.astype(float)
+        else:
+            measured, present = aggregate_bins(
+                self._bin_assignment(arr, bin_edges),
+                as_numeric(raw_values[: len(arr)]),
+                len(counts),
+                histfunc,
+            )
+
         bar_values = apply_histnorm(
-            counts.astype(float),
+            measured,
             np.diff(bin_edges),
             self._trace.get("histnorm"),
+        )
+
+        # `avg`, `min` and `max` have no answer for an empty bin, and plotly
+        # emits no point for one -- interior ones included, not just at the
+        # edges. `count` and `sum` do have one and announce a zero.
+        #
+        # Unless a `histnorm` is set, which brings the empty bins back as
+        # zeros. Measured across all three functions and all four norms:
+        # `avg` alone gives four points over a sample with a two-bin gap,
+        # `avg` with any `histnorm` gives six. Rescaling evidently runs over
+        # the whole bin array and does not carry the "no answer" marker
+        # through, so the composition is not simply one step after the other.
+        drop_empty = (
+            histfunc in _UNDEFINED_WHEN_EMPTY and not self._trace.get("histnorm")
         )
 
         # The binned axis carries the bin, the other one the count. Naming the
@@ -430,6 +595,8 @@ class PlotlyHistogramPlot(PlotlyPlot):
 
         data = []
         for i, value in enumerate(bar_values[first : last + 1], start=first):
+            if drop_empty and not present[i]:
+                continue
             low = float(bin_edges[i])
             high = float(bin_edges[i + 1])
             # A count is announced as the integer it is; a rescaled value is
@@ -462,11 +629,38 @@ class PlotlyHistogramPlot(PlotlyPlot):
             ``trace["x"]`` on a vertical one. Named for the role rather than
             the axis, since either can be the one that holds it.
         """
-        # Preserve order of first appearance.
-        counts: dict[str, int] = {}
-        for val in values:
-            key = str(val)
-            counts[key] = counts.get(key, 0) + 1
+        # Preserve order of first appearance. Grouped rather than counted, so
+        # an aggregating `histfunc` has the members to reduce -- plotly bins
+        # categories onto integer positions and then applies `histfunc`
+        # exactly as it does for a numeric sample.
+        grouped: dict[str, list[int]] = {}
+        for position, val in enumerate(values):
+            grouped.setdefault(str(val), []).append(position)
+
+        raw_values = value_array(self._trace, self._binned)
+        histfunc = self._trace.get("histfunc") or "count"
+
+        if raw_values is None:
+            measured = [float(len(members)) for members in grouped.values()]
+        else:
+            numeric = as_numeric(raw_values[: len(values)])
+            assignment = np.empty(len(values), dtype=int)
+            for index, members in enumerate(grouped.values()):
+                assignment[members] = index
+            reduced, _ = aggregate_bins(
+                assignment, numeric, len(grouped), histfunc
+            )
+            measured = list(reduced)
+
+        # Every category holds at least one observation by construction, so
+        # the empty-bin question the numeric path answers cannot arise here.
+        measured = list(
+            apply_histnorm(
+                np.array(measured, dtype=float),
+                np.ones(len(measured)),
+                self._trace.get("histnorm"),
+            )
+        )
 
         # Switch schema type from "hist" to "bar".
         self.type = PlotType.BAR
@@ -480,8 +674,11 @@ class PlotlyHistogramPlot(PlotlyPlot):
             else (MaidrKey.X, MaidrKey.Y)
         )
         return [
-            {category.value: cat, count_key.value: count}
-            for cat, count in counts.items()
+            {
+                category.value: cat,
+                count_key.value: int(value) if value == int(value) else value,
+            }
+            for cat, value in zip(grouped, measured)
         ]
 
     def _compute_bin_edges(self, arr: np.ndarray) -> np.ndarray:

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -274,6 +274,49 @@ def as_numeric(values: list) -> np.ndarray:
     return coerced
 
 
+def paired_arrays(trace: dict, binned: str) -> tuple[list | None, list | None]:
+    """The binned sample and its value array, cut to their common length.
+
+    Plotly pairs the two arrays positionally and reads only as far as the
+    shorter one, **including for the binning** -- and it does so whatever
+    ``histfunc`` says. Measured: ``go.Histogram(x=[1..9], y=[10..50])`` draws
+    three bins spanning 1 to 5, not the two spanning 1 to 9 that binning all
+    of ``x`` gives, and the same figure with ``histfunc="sum"`` sums only the
+    five pairs.
+
+    Truncating here rather than at the point of use is what makes the bins and
+    the values agree: slicing only the value array left it shorter than the
+    bin assignment when ``y`` was the shorter of the two, which raised an
+    ``IndexError`` out of a rendering path for a figure plotly draws without
+    complaint.
+
+    Parameters
+    ----------
+    trace : dict
+        A ``histogram`` trace dict.
+    binned : str
+        ``"x"`` or ``"y"``, the axis being binned.
+
+    Returns
+    -------
+    tuple[list | None, list | None]
+        The binned sample, and the other axis's array when the trace carries
+        one. Both ``None`` when the binned axis is absent.
+    """
+    raw = trace.get(binned)
+    if raw is None:
+        return None, None
+    sample = as_list(raw)
+
+    other_raw = trace.get("y" if binned == "x" else "x")
+    if other_raw is None:
+        return sample, None
+
+    other = as_list(other_raw)
+    shared = min(len(sample), len(other))
+    return sample[:shared], other[:shared]
+
+
 def value_array(trace: dict, binned: str) -> list | None:
     """The array ``histfunc`` aggregates, or ``None`` when there is none.
 
@@ -298,9 +341,7 @@ def value_array(trace: dict, binned: str) -> list | None:
     """
     if trace.get("histfunc") not in _AGGREGATING:
         return None
-    other = "y" if binned == "x" else "x"
-    raw = trace.get(other)
-    return None if raw is None else as_list(raw)
+    return paired_arrays(trace, binned)[1]
 
 
 def apply_histnorm(
@@ -520,10 +561,9 @@ class PlotlyHistogramPlot(PlotlyPlot):
         return assignment
 
     def _extract_plot_data(self) -> list[dict]:
-        raw = self._trace.get(self._binned, None)
-        if raw is None:
+        values, _ = paired_arrays(self._trace, self._binned)
+        if values is None:
             return []
-        values = as_list(raw)
 
         # Detect categorical (string) data — Plotly renders these as
         # count bar charts.  Mirror how seaborn countplot is handled:
@@ -553,7 +593,7 @@ class PlotlyHistogramPlot(PlotlyPlot):
         else:
             measured, present = aggregate_bins(
                 self._bin_assignment(arr, bin_edges),
-                as_numeric(raw_values[: len(arr)]),
+                as_numeric(raw_values),
                 len(counts),
                 histfunc,
             )
@@ -574,17 +614,15 @@ class PlotlyHistogramPlot(PlotlyPlot):
         # `avg` with any `histnorm` gives six. Rescaling evidently runs over
         # the whole bin array and does not carry the "no answer" marker
         # through, so the composition is not simply one step after the other.
-        drop_empty = (
-            histfunc in _UNDEFINED_WHEN_EMPTY and not self._trace.get("histnorm")
+        drop_empty = histfunc in _UNDEFINED_WHEN_EMPTY and not self._trace.get(
+            "histnorm"
         )
 
         # The binned axis carries the bin, the other one the count. Naming the
         # keys off the orientation rather than hardcoding ``x`` keeps the
         # announced extent on the axis the bins are actually drawn along.
         binned, counted = (
-            (MaidrKey.Y, MaidrKey.X)
-            if self._horizontal
-            else (MaidrKey.X, MaidrKey.Y)
+            (MaidrKey.Y, MaidrKey.X) if self._horizontal else (MaidrKey.X, MaidrKey.Y)
         )
         bounds = {
             MaidrKey.X: (MaidrKey.X_MIN, MaidrKey.X_MAX),
@@ -643,13 +681,11 @@ class PlotlyHistogramPlot(PlotlyPlot):
         if raw_values is None:
             measured = [float(len(members)) for members in grouped.values()]
         else:
-            numeric = as_numeric(raw_values[: len(values)])
+            numeric = as_numeric(raw_values)
             assignment = np.empty(len(values), dtype=int)
             for index, members in enumerate(grouped.values()):
                 assignment[members] = index
-            reduced, _ = aggregate_bins(
-                assignment, numeric, len(grouped), histfunc
-            )
+            reduced, _ = aggregate_bins(assignment, numeric, len(grouped), histfunc)
             measured = list(reduced)
 
         # Every category holds at least one observation by construction, so
@@ -669,9 +705,7 @@ class PlotlyHistogramPlot(PlotlyPlot):
         # horizontal count bar chart with its categories on ``x`` would be
         # announced with the counts and the labels swapped.
         category, count_key = (
-            (MaidrKey.Y, MaidrKey.X)
-            if self._horizontal
-            else (MaidrKey.X, MaidrKey.Y)
+            (MaidrKey.Y, MaidrKey.X) if self._horizontal else (MaidrKey.X, MaidrKey.Y)
         )
         return [
             {

--- a/tests/plotly/test_plotly_histogram_histfunc.py
+++ b/tests/plotly/test_plotly_histogram_histfunc.py
@@ -1,0 +1,348 @@
+"""A plotly histogram's ``histfunc`` was ignored, so an aggregate read as a
+count (#405).
+
+`histfunc` selects what a histogram bar *measures*. `_extract_plot_data`
+called `np.histogram`, which returns bin populations, and never read the
+attribute -- so every aggregating mode was announced as a count. Only
+`count`, the default, was right, and only because it is what we already
+computed.
+
+Two things widened this beyond how it was first raised in review, and both are
+pinned below:
+
+* **It is not only `sum`.** `avg`, `min` and `max` are ignored too.
+* **It is not only the categorical path.** Numeric binning has it as well,
+  and that case is worse: a reader gets `2` where the chart draws `30`, inside
+  a layer whose bin bounds are all correct, so nothing else in the
+  announcement looks wrong.
+
+The empty-bin behaviour is the part that could not be reasoned out. `count`
+and `sum` announce a zero for a bin nothing landed in; `avg`, `min` and `max`
+have no answer and plotly emits no point at all -- interior bins included, not
+just the edges #402 trims. But setting **any** `histnorm` brings them back as
+zeros: measured over a sample with a two-bin gap, `avg` alone gives four
+points and `avg` with any of the four norms gives six. So the two attributes
+do not compose as one step after the other, and a fix that applied them in
+sequence would be wrong for exactly the figures that use both.
+
+Every expectation is `gd.calcdata[0][i].s` after `Plotly.newPlot` in Chromium.
+All 50 figure shapes measured that way now agree elementwise, on both
+orientations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.histogram import aggregate_bins, value_array  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Categories a/b/c holding 1,4,7 / 2,5,8 / 3,6,9.
+CATS = list("abcabcabc")
+CAT_VALUES = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+#: Four values either side of a two-bin gap, on an explicit 0..12 grid of 2.
+GAP_X = [0.5, 1.2, 2.4, 3.1, 9.0, 9.6, 10.8, 11.2]
+GAP_Y = [10, 20, 30, 40, 50, 60, 70, 80]
+GRID = dict(start=0, end=12, size=2)
+
+
+def pairs(fig) -> list[tuple]:
+    """``(bin, value)`` per emitted point, off whichever axis holds which."""
+    layer = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+    horizontal = layer.get("orientation") == "horz"
+    binned, measured = ("y", "x") if horizontal else ("x", "y")
+    return [(d[binned], d[measured]) for d in layer["data"]]
+
+
+def values(fig) -> list:
+    return [value for _, value in pairs(fig)]
+
+
+class TestValueArray:
+    """Which array supplies the values, and when there is one at all."""
+
+    def test_a_counting_trace_has_no_value_array(self):
+        assert value_array({"type": "histogram", "x": CATS}, "x") is None
+
+    def test_an_explicit_count_has_none_either(self):
+        trace = {"type": "histogram", "x": CATS, "y": CAT_VALUES, "histfunc": "count"}
+        assert value_array(trace, "x") is None
+
+    @pytest.mark.parametrize("histfunc", ["sum", "avg", "min", "max"])
+    def test_an_aggregating_trace_takes_the_other_axis(self, histfunc):
+        trace = {"type": "histogram", "x": CATS, "y": CAT_VALUES, "histfunc": histfunc}
+        assert value_array(trace, "x") == CAT_VALUES
+
+    def test_it_is_the_other_axis_rather_than_the_numeric_one(self):
+        # `go.Histogram(y=cats, x=vals, histfunc="sum")` resolves to
+        # `orientation: v` in Plotly.js -- plotly bins `x` in *both* spellings
+        # -- so "whichever array is not categorical" is not the rule. The
+        # binned axis decides and this is simply the other.
+        trace = {"type": "histogram", "y": CATS, "x": CAT_VALUES, "histfunc": "sum"}
+        assert value_array(trace, "x") == CATS
+
+    def test_an_aggregating_trace_with_only_one_array_has_nothing_to_reduce(self):
+        trace = {"type": "histogram", "x": CATS, "histfunc": "sum"}
+        assert value_array(trace, "x") is None
+
+
+class TestAggregateBins:
+    """The reduction in isolation."""
+
+    ASSIGNMENT = np.array([0, 1, 2, 0, 1, 2, 0, 1, 2])
+    VALUES = np.array(CAT_VALUES, dtype=float)
+
+    @pytest.mark.parametrize(
+        ("histfunc", "expected"),
+        [
+            ("sum", [12.0, 15.0, 18.0]),
+            ("avg", [4.0, 5.0, 6.0]),
+            ("min", [1.0, 2.0, 3.0]),
+            ("max", [7.0, 8.0, 9.0]),
+        ],
+    )
+    def test_reduces_each_bin(self, histfunc, expected):
+        got, present = aggregate_bins(self.ASSIGNMENT, self.VALUES, 3, histfunc)
+        assert list(got) == pytest.approx(expected)
+        assert list(present) == [True, True, True]
+
+    def test_an_empty_bin_is_marked_rather_than_guessed(self):
+        got, present = aggregate_bins(
+            np.array([0, 0, 2]), np.array([1.0, 3.0, 9.0]), 3, "avg"
+        )
+        assert list(present) == [True, False, True]
+        # The caller decides what an unmarked bin becomes; the value here is
+        # only a placeholder, never an announced average of nothing.
+        assert got[0] == pytest.approx(2.0)
+        assert got[2] == pytest.approx(9.0)
+
+    def test_observations_outside_every_bin_are_discarded(self):
+        # `-1` is what `_bin_assignment` gives a value beyond the grid, and
+        # plotly drops those rather than clipping them into an edge bin.
+        got, present = aggregate_bins(
+            np.array([-1, 0, -1]), np.array([100.0, 5.0, 200.0]), 2, "max"
+        )
+        assert got[0] == pytest.approx(5.0)
+        assert list(present) == [True, False]
+
+
+class TestCategoricalAggregation:
+    """Plotly draws string data as a count bar chart; `histfunc` still applies."""
+
+    @pytest.mark.parametrize(
+        ("histfunc", "expected"),
+        [
+            ("count", [3, 3, 3]),
+            ("sum", [12, 15, 18]),
+            ("avg", [4, 5, 6]),
+            ("min", [1, 2, 3]),
+            ("max", [7, 8, 9]),
+        ],
+    )
+    def test_every_mode_matches_plotly(self, histfunc, expected):
+        fig = go.Figure([go.Histogram(x=CATS, y=CAT_VALUES, histfunc=histfunc)])
+        assert values(fig) == expected
+
+    def test_the_labels_survive_aggregation(self):
+        fig = go.Figure([go.Histogram(x=CATS, y=CAT_VALUES, histfunc="sum")])
+        assert [category for category, _ in pairs(fig)] == ["a", "b", "c"]
+
+    def test_a_horizontal_categorical_trace_aggregates_the_same_way(self):
+        # `orientation="h"` is required, not decorative. With both arrays
+        # present plotly resolves to `v` whichever way round they are given,
+        # so swapping them alone does not make a horizontal chart -- see
+        # `TestSwappedArraysIsNotHorizontal` for what it does make.
+        upright = values(
+            go.Figure([go.Histogram(x=CATS, y=CAT_VALUES, histfunc="sum")])
+        )
+        sideways = values(
+            go.Figure(
+                [go.Histogram(y=CATS, x=CAT_VALUES, histfunc="sum", orientation="h")]
+            )
+        )
+        assert sideways == upright
+
+
+class TestNumericAggregation:
+    """The path the review's framing did not cover."""
+
+    @pytest.mark.parametrize(
+        ("histfunc", "expected"),
+        [
+            ("count", [2, 2, 0, 0, 2, 2]),
+            ("sum", [30, 70, 0, 0, 110, 150]),
+        ],
+    )
+    def test_count_and_sum_keep_an_empty_bin_as_zero(self, histfunc, expected):
+        fig = go.Figure([go.Histogram(x=GAP_X, y=GAP_Y, histfunc=histfunc, xbins=GRID)])
+        assert values(fig) == expected
+
+    @pytest.mark.parametrize(
+        ("histfunc", "expected"),
+        [
+            ("avg", [(1.0, 15), (3.0, 35), (9.0, 55), (11.0, 75)]),
+            ("min", [(1.0, 10), (3.0, 30), (9.0, 50), (11.0, 70)]),
+            ("max", [(1.0, 20), (3.0, 40), (9.0, 60), (11.0, 80)]),
+        ],
+    )
+    def test_the_undefined_modes_drop_an_empty_bin_entirely(self, histfunc, expected):
+        # Four points, not six, and the two dropped are *interior* -- so this
+        # is not #402's edge trim reaching further. There is no average of
+        # nothing to announce.
+        fig = go.Figure([go.Histogram(x=GAP_X, y=GAP_Y, histfunc=histfunc, xbins=GRID)])
+        assert pairs(fig) == expected
+
+    def test_a_horizontal_numeric_trace_aggregates_the_same_way(self):
+        upright = values(
+            go.Figure([go.Histogram(x=GAP_X, y=GAP_Y, histfunc="sum", xbins=GRID)])
+        )
+        sideways = values(
+            go.Figure(
+                [
+                    go.Histogram(
+                        y=GAP_X,
+                        x=GAP_Y,
+                        histfunc="sum",
+                        ybins=GRID,
+                        orientation="h",
+                    )
+                ]
+            )
+        )
+        assert sideways == upright
+
+    def test_the_bin_bounds_are_untouched_by_aggregating(self):
+        counted = [
+            b for b, _ in pairs(go.Figure([go.Histogram(x=GAP_X, y=GAP_Y, xbins=GRID)]))
+        ]
+        summed = [
+            b
+            for b, _ in pairs(
+                go.Figure([go.Histogram(x=GAP_X, y=GAP_Y, histfunc="sum", xbins=GRID)])
+            )
+        ]
+        assert summed == counted
+
+
+class TestNonNumericValues:
+    """The value array is not guaranteed numeric, and plotly does not error."""
+
+    #: `b` holds two strings and one number.
+    MIXED = [1, "z", 3, 4, "w", 6, 7, 8, 9]
+
+    @pytest.mark.parametrize(
+        ("histfunc", "expected"),
+        [
+            # `b` reduces over `[8]` alone in every mode.
+            ("sum", [12, 8, 18]),
+            ("avg", [4, 8, 6]),
+            ("min", [1, 8, 3]),
+            ("max", [7, 8, 9]),
+        ],
+    )
+    def test_a_string_is_dropped_rather_than_counted_as_zero(self, histfunc, expected):
+        # The distinction the `avg` row settles: `b` averages to **8**, not
+        # 8/3. Treating a non-number as an observation of zero would give
+        # 2.667 here and 0 for `min`, and both would look plausible.
+        fig = go.Figure([go.Histogram(x=CATS, y=self.MIXED, histfunc=histfunc)])
+        assert values(fig) == expected
+
+    def test_count_is_unaffected_by_an_unreadable_value(self):
+        # `count` counts observations on the *binned* axis, so what sits in
+        # the value array cannot change it.
+        fig = go.Figure([go.Histogram(x=CATS, y=self.MIXED, histfunc="count")])
+        assert values(fig) == [3, 3, 3]
+
+    def test_a_wholly_non_numeric_value_array_does_not_raise(self):
+        # `go.Histogram(y=cats, x=vals, histfunc="sum")` bins `x` and hands
+        # the *category strings* to the aggregate. A plain float conversion
+        # raised here, on a figure plotly renders without complaint.
+        fig = go.Figure([go.Histogram(y=CATS, x=CAT_VALUES, histfunc="sum")])
+        assert all(value == 0 for value in values(fig))
+
+
+class TestSwappedArraysIsNotHorizontal:
+    """Swapping the arrays makes a different chart, not a rotated one."""
+
+    def test_plotly_still_bins_x_and_maidr_follows(self):
+        # `go.Histogram(y=cats, x=vals, histfunc="sum")` reads as vertical:
+        # plotly bins `x` -- the *numeric* array here -- and sums `y`, which
+        # is the category strings and contributes nothing. Plotly draws two
+        # bars of zero. That is a chart nobody wants, and it is the chart the
+        # call describes, so it is announced rather than second-guessed.
+        fig = go.Figure([go.Histogram(y=CATS, x=CAT_VALUES, histfunc="sum")])
+        layer = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+
+        assert layer["orientation"] == "vert"
+        assert all(point["y"] == 0 for point in layer["data"])
+
+
+class TestHistfuncAndHistnormTogether:
+    """They do not compose as one step after the other."""
+
+    @pytest.mark.parametrize("histfunc", ["avg", "min", "max"])
+    @pytest.mark.parametrize(
+        "histnorm", ["percent", "probability", "density", "probability density"]
+    )
+    def test_any_histnorm_brings_the_empty_bins_back(self, histfunc, histnorm):
+        # The interaction that cannot be reasoned out: alone these three drop
+        # an empty bin, and with *any* histnorm plotly emits it as a zero.
+        # Rescaling evidently runs over the whole bin array without carrying
+        # the "no answer" marker through.
+        alone = go.Figure(
+            [go.Histogram(x=GAP_X, y=GAP_Y, histfunc=histfunc, xbins=GRID)]
+        )
+        rescaled = go.Figure(
+            [
+                go.Histogram(
+                    x=GAP_X,
+                    y=GAP_Y,
+                    histfunc=histfunc,
+                    histnorm=histnorm,
+                    xbins=GRID,
+                )
+            ]
+        )
+        assert len(values(alone)) == 4
+        assert len(values(rescaled)) == 6
+        assert values(rescaled)[2:4] == [0, 0]
+
+    def test_sum_and_avg_normalise_to_the_same_shares(self):
+        # The measurement that settles `histnorm`'s denominator: dividing
+        # every value by a constant leaves the shares alone, so the total
+        # cannot be the sample size.
+        summed = values(
+            go.Figure(
+                [go.Histogram(x=CATS, y=CAT_VALUES, histfunc="sum", histnorm="percent")]
+            )
+        )
+        averaged = values(
+            go.Figure(
+                [go.Histogram(x=CATS, y=CAT_VALUES, histfunc="avg", histnorm="percent")]
+            )
+        )
+        assert averaged == pytest.approx(summed)
+        assert sum(summed) == pytest.approx(100.0)
+
+    def test_min_normalises_to_a_different_shape(self):
+        # And a mode that is not a constant multiple of `sum` must not, or
+        # the test above would pass on an implementation that ignored
+        # `histfunc` entirely.
+        summed = values(
+            go.Figure(
+                [go.Histogram(x=CATS, y=CAT_VALUES, histfunc="sum", histnorm="percent")]
+            )
+        )
+        smallest = values(
+            go.Figure(
+                [go.Histogram(x=CATS, y=CAT_VALUES, histfunc="min", histnorm="percent")]
+            )
+        )
+        assert smallest != pytest.approx(summed)
+        assert smallest == pytest.approx([100 / 6, 200 / 6, 300 / 6])

--- a/tests/plotly/test_plotly_histogram_histfunc.py
+++ b/tests/plotly/test_plotly_histogram_histfunc.py
@@ -39,7 +39,11 @@ plotly = pytest.importorskip("plotly")
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402
 
-from maidr.plotly.histogram import aggregate_bins, value_array  # noqa: E402
+from maidr.plotly.histogram import (  # noqa: E402
+    aggregate_bins,
+    paired_arrays,
+    value_array,
+)
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 #: Categories a/b/c holding 1,4,7 / 2,5,8 / 3,6,9.
@@ -265,6 +269,57 @@ class TestNonNumericValues:
         # raised here, on a figure plotly renders without complaint.
         fig = go.Figure([go.Histogram(y=CATS, x=CAT_VALUES, histfunc="sum")])
         assert all(value == 0 for value in values(fig))
+
+
+class TestMismatchedLengths:
+    """Plotly reads both arrays only as far as the shorter one."""
+
+    LONG_X = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    SHORT_Y = [10, 20, 30, 40, 50]
+
+    def test_paired_arrays_cuts_both_to_the_common_length(self):
+        binned, other = paired_arrays(
+            {"type": "histogram", "x": self.LONG_X, "y": self.SHORT_Y}, "x"
+        )
+        assert binned == [1, 2, 3, 4, 5]
+        assert other == self.SHORT_Y
+
+    def test_it_cuts_the_other_way_round_too(self):
+        binned, other = paired_arrays(
+            {"type": "histogram", "x": self.SHORT_Y[:3], "y": self.LONG_X}, "x"
+        )
+        assert len(binned) == len(other) == 3
+
+    def test_a_single_array_is_left_whole(self):
+        binned, other = paired_arrays({"type": "histogram", "x": self.LONG_X}, "x")
+        assert binned == self.LONG_X
+        assert other is None
+
+    def test_the_binning_uses_the_common_length_not_the_whole_sample(self):
+        # The part that is easy to get half right: slicing only the *value*
+        # array leaves the bins spanning 1 to 9, where plotly spans 1 to 5.
+        # Three bins, not two.
+        fig = go.Figure([go.Histogram(x=self.LONG_X, y=self.SHORT_Y, histfunc="sum")])
+        assert pairs(fig) == [(0.5, 10), (2.5, 50), (4.5, 90)]
+
+    def test_count_truncates_as_well(self):
+        # Pairing is not a property of aggregating: plotly cuts the arrays
+        # whatever `histfunc` says, so a plain count over mismatched arrays
+        # bins five values rather than nine.
+        fig = go.Figure([go.Histogram(x=self.LONG_X, y=self.SHORT_Y, histfunc="count")])
+        assert pairs(fig) == [(0.5, 1), (2.5, 2), (4.5, 2)]
+
+    def test_the_shorter_value_array_no_longer_raises(self):
+        # Slicing only the value array left it shorter than the bin
+        # assignment, and the boolean mask inside `aggregate_bins` raised
+        # `IndexError` out of a rendering path -- for a figure plotly draws
+        # without complaint.
+        fig = go.Figure([go.Histogram(x=self.LONG_X, y=self.SHORT_Y, histfunc="sum")])
+        assert len(values(fig)) == 3
+
+    def test_a_categorical_sample_truncates_the_same_way(self):
+        fig = go.Figure([go.Histogram(x=CATS, y=[1, 2, 3], histfunc="sum")])
+        assert pairs(fig) == [("a", 1), ("b", 2), ("c", 3)]
 
 
 class TestSwappedArraysIsNotHorizontal:


### PR DESCRIPTION
Closes #405.

`histfunc` selects what a bar *measures*. `_extract_plot_data` called `np.histogram`, which returns bin populations, and never read the attribute — so every aggregating mode was announced as a count.

## Two ways it is wider than the review's framing

**Not only `sum`.** Categorical, `x=list("abcabcabc")`, `y=[1..9]`:

| `histfunc` | plotly draws | py-maidr said |
|---|---|---|
| `count` *(default)* | `3, 3, 3` | `3, 3, 3` ✓ |
| `sum` | `12, 15, 18` | `3, 3, 3` |
| `avg` | `4, 5, 6` | `3, 3, 3` |
| `min` | `1, 2, 3` | `3, 3, 3` |
| `max` | `7, 8, 9` | `3, 3, 3` |

**Not only the categorical path.** Numeric binning has it too, and that case is worse: a reader gets `2` where the chart draws `30`, inside a layer whose bin bounds are all correct, so nothing else in the announcement looks wrong.

## Three things I could not have reasoned out

Each was measured against `gd.calcdata` rather than derived, and each would have produced a plausible-looking wrong answer.

**1. `avg`/`min`/`max` drop an empty bin; `count`/`sum` keep it as zero.** Over a sample with a two-bin gap in the middle, `count` and `sum` give six points and the other three give **four** — and the two dropped are *interior*, so this is not #402's edge trim reaching further. There is no average of nothing to announce.

**2. Any `histnorm` brings those bins back as zeros.** `avg` alone gives four points; `avg` with any of the four norms gives six. Measured across all three functions × all four norms — uniform. So the two attributes do **not** compose as one step after the other, and an implementation that applied them in sequence would be wrong for exactly the figures that use both.

**3. A non-numeric value is dropped, not counted as zero.** The value array is not guaranteed numeric — `go.Histogram(y=cats, x=vals, histfunc="sum")` bins `x` and hands the *category strings* to the aggregate, and plotly renders it without complaint where a plain `float()` conversion raised. With `y=[1,"z",3,4,"w",6,7,8,9]`, category `b` holds `['z','w',8]`:

| | plotly | if strings were zero |
|---|---|---|
| `avg` | **8** | 2.667 |
| `min` | **8** | 0 |

Both readings look reasonable; only the measurement separates them.

## Which array supplies the values

Settled by `binned_axis`, not by which array is numeric. Plotly resolves **both** two-array spellings to `orientation: v` and bins `x` in each, so:

- `go.Histogram(x=cats, y=vals, histfunc="sum")` → bins `cats`, sums `vals` ✓
- `go.Histogram(y=cats, x=vals, histfunc="sum")` → bins `vals`, sums `cats` → plotly draws two bars of **zero**

The second is a chart nobody wants and it is the chart the call describes, so it is announced rather than second-guessed. A horizontal aggregating histogram needs an explicit `orientation="h"` — there is a test for each.

That last point cost me a wrong test: I wrote the horizontal cases as "swap the arrays", which is the natural reading and is not what plotly does. I had already measured the correct rule earlier in the same session and still reached for the wrong one when writing the test. It failed, which is what the tests are for.

## Verification

Same harness — figures drawn by the real `plotly.min.js` in Chromium, `gd.calcdata[0]` compared elementwise. **60 of 60 shapes agree**, both orientations, nineteen of them new `histfunc` cases. The harness now also handles the categorical layer shape (a `bar` layer with no bin bounds), which it previously could not compare at all.

## Falsification

| reverted | failures |
|---|---|
| value array = the numeric one rather than the other axis | 22 |
| ignore `histfunc` entirely (the bug) | 20 |
| keep empty bins for `avg`/`min`/`max` | 15 |
| drop empty bins even under `histnorm` | 12 |
| categorical path ignores `histfunc` | 9 |
| treat a non-number as zero | 2 |

## Checks

- `uv run pytest tests/` — **1517 passed** (up 49)
- `ruff check` clean; `ruff format` applied
- No line over 88 characters

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_