### PR TITLE
feat(plotly): read stacked and dodged histograms as one layer

### DIFF
--- a/maidr/plotly/grouped_histogram.py
+++ b/maidr/plotly/grouped_histogram.py
@@ -1,0 +1,203 @@
+"""Multiple plotly histogram traces that share a subplot, and a bin grid.
+
+Plotly stacks or dodges histogram traces on one axis pair exactly as it does
+bar traces, and bins them **jointly**: the grid is computed once from every
+trace's values together, and each trace is then binned on it. Reading each
+trace on a grid of its own announced bins the chart never draws (#394).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.histogram import (
+    _UNDEFINED_WHEN_EMPTY,
+    _occupied_span,
+    aggregate_bins,
+    apply_histnorm,
+    as_numeric,
+    binned_axis,
+    compute_bin_edges,
+    paired_arrays,
+)
+from maidr.plotly.plotly_plot import PlotlyPlot
+
+
+def is_histogram_trace(trace: dict) -> bool:
+    """Whether *trace* is a histogram."""
+    return trace.get("type") == "histogram"
+
+
+def group_bin_spec(traces: list[dict], binned: str) -> tuple[dict | None, int | None]:
+    """The bin spec governing a group, from whichever trace carries one.
+
+    Not "the first trace's spec". Measured: with ``xbins=dict(size=3)`` on the
+    *second* of two traces, plotly resolves the first trace's spec to
+    ``{start: 0, end: 6}`` and the second's to ``{size: 3}``, and bins **both**
+    at width 3 -- output identical to putting the same spec on the first
+    trace, and different from the width 2 the pair autobins to.
+
+    Parameters
+    ----------
+    traces : list[dict]
+        The group's histogram traces, in declaration order.
+    binned : str
+        ``"x"`` or ``"y"``, the axis being binned.
+
+    Returns
+    -------
+    tuple[dict | None, int | None]
+        The ``bins`` dict and the ``nbins`` hint, each from the first trace
+        that supplies one.
+    """
+    bins: dict | None = None
+    nbins: int | None = None
+    for trace in traces:
+        if bins is None:
+            bins = trace.get(f"{binned}bins") or None
+        if nbins is None:
+            nbins = trace.get(f"nbins{binned}")
+    return bins, nbins
+
+
+class PlotlyGroupedHistogramPlot(PlotlyPlot):
+    """Histogram traces plotly draws as one stack or one dodged group.
+
+    Emits the same ``list[list[dict]]`` shape as
+    :class:`~maidr.plotly.grouped_bar.PlotlyGroupedBarPlot`: one inner list per
+    trace, each item carrying ``x`` (the bin centre), ``z`` (the trace's name)
+    and ``y`` (its value). The plot type decides how the core reads them, and
+    is worked out from ``barmode``/``barnorm`` by
+    :meth:`~maidr.plotly.plotly_maidr.PlotlyMaidr._extract_plots`, the same way
+    it is for bars.
+
+    Merging also settles the highlight. Left as separate layers, every
+    histogram in a subplot emitted the identical selector -- ``.trace.bars
+    .point > path`` matches every bar in the panel -- so each layer
+    highlighted its neighbours' bars as well as its own. One layer holding
+    every series is what that selector actually describes.
+    """
+
+    def __init__(
+        self,
+        traces: list[dict],
+        layout: dict,
+        plot_type: PlotType,
+        **kwargs: str,
+    ) -> None:
+        # The first trace stands for the group when the base class needs a
+        # title or an axis pair, as the grouped bar and multi-box layers do.
+        super().__init__(traces[0], layout, plot_type, **kwargs)
+        self._traces = traces
+        self._binned = binned_axis(traces[0])
+
+    @property
+    def _horizontal(self) -> bool:
+        return self._binned == "y"
+
+    def render(self) -> dict:
+        """Add ``orientation`` to the base schema."""
+        schema = super().render()
+        schema[MaidrKey.ORIENTATION] = "horz" if self._horizontal else "vert"
+        return schema
+
+    def _get_selector(self) -> str:
+        return f"{self._subplot_css_prefix()}.trace.bars .point > path"
+
+    def _shared_edges(self, samples: list[np.ndarray]) -> np.ndarray | None:
+        """One grid, from every trace's values together.
+
+        The union is what makes this joint rather than per-trace: fed the two
+        samples of ``px.histogram(frame, x="v", color="h")`` separately the
+        existing port returns widths of 0.2 and 1.0, and fed their union it
+        returns plotly's own ``size=1, start=-2, end=12``.
+        """
+        pooled = np.concatenate([s for s in samples if s.size])
+        if not pooled.size:
+            return None
+        bins, nbins = group_bin_spec(self._traces, self._binned)
+        return compute_bin_edges(pooled, bins, nbins)
+
+    def _extract_plot_data(self) -> list[list[dict]]:
+        samples: list[np.ndarray] = []
+        values: list[list | None] = []
+        for trace in self._traces:
+            sample, other = paired_arrays(trace, self._binned)
+            if sample is None:
+                samples.append(np.empty(0))
+                values.append(None)
+                continue
+            try:
+                samples.append(np.array(sample, dtype=float))
+            except (ValueError, TypeError):
+                # A categorical group is drawn as a count bar chart rather
+                # than binned, and is a different layer shape entirely. The
+                # factory handles those one trace at a time; declining here
+                # leaves them to it rather than half-describing them.
+                return []
+            values.append(other)
+
+        edges = self._shared_edges(samples)
+        if edges is None:
+            return []
+
+        histfunc = self._traces[0].get("histfunc") or "count"
+        histnorm = self._traces[0].get("histnorm")
+        drop_empty = histfunc in _UNDEFINED_WHEN_EMPTY and not histnorm
+        widths = np.diff(edges)
+
+        data: list[list[dict]] = []
+        for trace, sample, other in zip(self._traces, samples, values):
+            counts, _ = np.histogram(sample, bins=edges)
+            first, last = _occupied_span(counts)
+            if first is None:
+                # A trace with nothing in the grid still holds a place in the
+                # group, so the series' names stay paired with their data.
+                data.append([])
+                continue
+
+            if other is None or histfunc == "count":
+                measured, present = counts.astype(float), counts > 0
+            else:
+                measured, present = aggregate_bins(
+                    _bin_assignment(sample, edges),
+                    as_numeric(other),
+                    len(counts),
+                    histfunc,
+                )
+
+            bar_values = apply_histnorm(measured, widths, histnorm)
+            fill = str(trace.get("name", ""))
+
+            series: list[dict] = []
+            for index in range(first, last + 1):
+                if drop_empty and not present[index]:
+                    continue
+                low = float(edges[index])
+                high = float(edges[index + 1])
+                value = float(bar_values[index])
+                series.append(
+                    {
+                        MaidrKey.X.value: (low + high) / 2,
+                        MaidrKey.Z.value: fill,
+                        MaidrKey.Y.value: (
+                            int(value) if value == int(value) else value
+                        ),
+                    }
+                )
+            data.append(series)
+
+        return data
+
+
+def _bin_assignment(arr: np.ndarray, edges: np.ndarray) -> np.ndarray:
+    """Which bin each observation falls in, or ``-1`` for none.
+
+    The same convention :meth:`PlotlyHistogramPlot._bin_assignment` uses, so a
+    grouped layer and a single one cannot disagree about where a value sits.
+    """
+    from maidr.plotly.histogram import PlotlyHistogramPlot
+
+    return PlotlyHistogramPlot._bin_assignment(arr, edges)

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -716,92 +716,101 @@ class PlotlyHistogramPlot(PlotlyPlot):
         ]
 
     def _compute_bin_edges(self, arr: np.ndarray) -> np.ndarray:
-        """Compute bin edges that match Plotly's autobinning algorithm.
+        """This trace's own bin edges. See :func:`compute_bin_edges`."""
+        return compute_bin_edges(
+            arr,
+            self._trace.get(f"{self._binned}bins", None),
+            self._trace.get(f"nbins{self._binned}", None),
+        )
 
-        Plotly treats ``nbins`` as a *hint* and rounds the bin size to a
-        'nice' number via ``autoTicks`` (sequence ``{2, 5, 10} * 10^n``)
-        before aligning the start edge.  When the bin ``size`` is specified
-        explicitly, it is used directly without rounding.
 
-        The bin spec is read off the *binned* axis, so a horizontal trace is
-        governed by ``ybins``/``nbinsy`` and a vertical one by
-        ``xbins``/``nbinsx``. Plotly ignores the other axis's spec outright
-        rather than falling back to it -- measured both ways in Chromium:
-        ``go.Histogram(y=v, xbins=dict(size=2))`` autobins to 13 bins of 0.5
-        exactly as if no spec were given, and ``go.Histogram(x=v,
-        ybins=dict(size=2))`` does the same. Reading ``xbins`` for every trace
-        would have honoured a spec plotly discards and missed the one it uses.
+def compute_bin_edges(
+    arr: np.ndarray, bins: dict | None = None, nbins: int | None = None
+) -> np.ndarray:
+    """Compute bin edges that match Plotly's autobinning algorithm.
 
-        Parameters
-        ----------
-        arr : np.ndarray
-            The raw data values.
+    Plotly treats ``nbins`` as a *hint* and rounds the bin size to a
+    'nice' number via ``autoTicks`` (sequence ``{2, 5, 10} * 10^n``)
+    before aligning the start edge.  When the bin ``size`` is specified
+    explicitly, it is used directly without rounding.
 
-        Returns
-        -------
-        np.ndarray
-            Bin edges matching what Plotly renders.
-        """
-        bins = self._trace.get(f"{self._binned}bins", None)
+    The bin spec is read off the *binned* axis, so a horizontal trace is
+    governed by ``ybins``/``nbinsy`` and a vertical one by
+    ``xbins``/``nbinsx``. Plotly ignores the other axis's spec outright
+    rather than falling back to it -- measured both ways in Chromium:
+    ``go.Histogram(y=v, xbins=dict(size=2))`` autobins to 13 bins of 0.5
+    exactly as if no spec were given, and ``go.Histogram(x=v,
+    ybins=dict(size=2))`` does the same. Reading ``xbins`` for every trace
+    would have honoured a spec plotly discards and missed the one it uses.
 
-        # Explicit bin size — the width is used as given, without the 'nice'
-        # rounding an `nbins` hint goes through.
-        if bins is not None and "size" in bins:
-            size = float(bins["size"])
-            data_min, data_max = float(arr.min()), float(arr.max())
+    Parameters
+    ----------
+    arr : np.ndarray
+        The raw data values.
 
-            # An explicit `start` is honoured verbatim. Without one, plotly
-            # still runs the same anti-clustering shift it applies when
-            # autobinning, which the round multiple of `size` alone does not
-            # reproduce: `go.Histogram(x=[0, 1, 2, 3, 4], xbins=dict(size=2))`
-            # is drawn from -0.5, not 0, because every value is an integer and
-            # they would otherwise sit on the bin edges.
-            if "start" in bins:
-                start = float(bins["start"])
-            else:
-                start = _auto_shift_bins(
-                    math.floor(data_min / size) * size,
-                    arr,
-                    size,
-                    data_min,
-                    data_max,
-                )
-
-            # One bin past the last value, so a value sitting exactly on a
-            # grid multiple gets the bin starting there rather than being
-            # folded into the one below by numpy's closed final interval.
-            # Any bin this reaches past the data is empty, and `_occupied_span`
-            # trims it back off.
-            end = (
-                float(bins["end"])
-                if "end" in bins
-                else math.floor((data_max - start) / size) * size + start + size
-            )
-            return np.arange(start, end + size / 2, size)
-
+    Returns
+    -------
+    np.ndarray
+        Bin edges matching what Plotly renders.
+    """
+    # Explicit bin size — the width is used as given, without the 'nice'
+    # rounding an `nbins` hint goes through.
+    if bins is not None and "size" in bins:
+        size = float(bins["size"])
         data_min, data_max = float(arr.min()), float(arr.max())
-        data_range = data_max - data_min
-        if data_range == 0:
-            return np.array([data_min - 0.5, data_max + 0.5])
 
-        # 1. Compute nice bin size (mirrors axes.autoTicks + roundDTick)
-        nbins = self._trace.get(f"nbins{self._binned}", None)
-        if nbins is not None:
-            size0 = data_range / max(1, nbins)
+        # An explicit `start` is honoured verbatim. Without one, plotly
+        # still runs the same anti-clustering shift it applies when
+        # autobinning, which the round multiple of `size` alone does not
+        # reproduce: `go.Histogram(x=[0, 1, 2, 3, 4], xbins=dict(size=2))`
+        # is drawn from -0.5, not 0, because every value is an integer and
+        # they would otherwise sit on the bin edges.
+        if "start" in bins:
+            start = float(bins["start"])
         else:
-            size0 = _plotly_default_size0(arr)
-        dtick = _plotly_dtick(size0)
+            start = _auto_shift_bins(
+                math.floor(data_min / size) * size,
+                arr,
+                size,
+                data_min,
+                data_max,
+            )
 
-        # 2. Initial bin start: one tick below the first tick >= data_min
-        #    (mirrors axes.tickFirst → axes.tickIncrement(reverse))
-        first_tick = math.ceil(data_min / dtick) * dtick
-        bin_start = first_tick - dtick
+        # One bin past the last value, so a value sitting exactly on a
+        # grid multiple gets the bin starting there rather than being
+        # folded into the one below by numpy's closed final interval.
+        # Any bin this reaches past the data is empty, and `_occupied_span`
+        # trims it back off.
+        end = (
+            float(bins["end"])
+            if "end" in bins
+            else math.floor((data_max - start) / size) * size + start + size
+        )
+        return np.arange(start, end + size / 2, size)
 
-        # 3. Shift to avoid data clustering at bin edges
-        bin_start = _auto_shift_bins(bin_start, arr, dtick, data_min, data_max)
+    data_min, data_max = float(arr.min()), float(arr.max())
+    data_range = data_max - data_min
+    if data_range == 0:
+        return np.array([data_min - 0.5, data_max + 0.5])
 
-        # 4. Compute bin count and end
-        bin_count = 1 + math.floor((data_max - bin_start) / dtick)
-        bin_end = bin_start + bin_count * dtick
+    # 1. Compute nice bin size (mirrors axes.autoTicks + roundDTick)
+    if nbins is not None:
+        size0 = data_range / max(1, nbins)
+    else:
+        size0 = _plotly_default_size0(arr)
+    dtick = _plotly_dtick(size0)
 
-        return np.arange(bin_start, bin_end + dtick / 2, dtick)
+    # 2. Initial bin start: one tick below the first tick >= data_min
+    #    (mirrors axes.tickFirst → axes.tickIncrement(reverse))
+    first_tick = math.ceil(data_min / dtick) * dtick
+    bin_start = first_tick - dtick
+
+    # 3. Shift to avoid data clustering at bin edges
+    bin_start = _auto_shift_bins(bin_start, arr, dtick, data_min, data_max)
+
+    # 4. Compute bin count and end
+    bin_count = 1 + math.floor((data_max - bin_start) / dtick)
+    bin_end = bin_start + bin_count * dtick
+
+    return np.arange(bin_start, bin_end + dtick / 2, dtick)
+

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -12,6 +12,7 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.candlestick import is_ohlc_trace, layer_position
+from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.plotly_plot import (
     PlotlyPlot,
     domain_interval,
@@ -403,31 +404,54 @@ class PlotlyMaidr:
 
             merged: set[int] = set()
 
+            # `barnorm` only means anything for a stack: plotly scales each
+            # category's segments to a common total, so the values are shares
+            # rather than counts. Read as a plain `stacked_bar` a reader is
+            # told nothing about that, and is left to suppose the equal totals
+            # are a property of the data rather than of the chart (#338).
+            def _combined_type() -> Any:
+                from maidr.core.enum.plot_type import PlotType
+
+                if barmode == "group":
+                    return PlotType.DODGED
+                if layout.get("barnorm") in _NORMALISING_BARNORMS:
+                    return PlotType.NORMALIZED
+                return PlotType.STACKED
+
             # Grouped / stacked bars
             if len(bar_traces) > 1 and barmode in _COMBINED_BARMODES:
-                from maidr.core.enum.plot_type import PlotType
                 from maidr.plotly.grouped_bar import PlotlyGroupedBarPlot
 
-                # `barnorm` only means anything for a stack: plotly scales
-                # each category's segments to a common total, so the values
-                # are shares rather than counts. Read as a plain `stacked_bar`
-                # a reader is told nothing about that, and is left to suppose
-                # the equal totals are a property of the data rather than of
-                # the chart (#338).
-                normalised = layout.get("barnorm") in _NORMALISING_BARNORMS
-                if barmode == "group":
-                    plot_type = PlotType.DODGED
-                elif normalised:
-                    plot_type = PlotType.NORMALIZED
-                else:
-                    plot_type = PlotType.STACKED
                 plot = PlotlyGroupedBarPlot(
-                    bar_traces, layout, plot_type, **axis_kwargs
+                    bar_traces, layout, _combined_type(), **axis_kwargs
                 )
                 plot.row_index = row
                 plot.col_index = col
                 self._plots.append(plot)
                 merged.update(id(t) for t in bar_traces)
+
+            # Grouped / stacked histograms. Plotly combines these exactly as
+            # it combines bars, and bins them jointly -- one grid computed
+            # from every trace's values together. Left as one layer each they
+            # were announced as independent distributions binned on grids of
+            # their own, so a reader was told neither that the bars stack nor
+            # what the bins are (#394).
+            histogram_traces = [t for t in group_traces if is_histogram_trace(t)]
+            if len(histogram_traces) > 1 and barmode in _COMBINED_BARMODES:
+                from maidr.plotly.grouped_histogram import (
+                    PlotlyGroupedHistogramPlot,
+                )
+
+                plot = PlotlyGroupedHistogramPlot(
+                    histogram_traces, layout, _combined_type(), **axis_kwargs
+                )
+                # A categorical group declines rather than half-describing
+                # itself, and is left to the factory one trace at a time.
+                if plot._extract_plot_data():
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                    merged.update(id(t) for t in histogram_traces)
 
             # Lines and steps are grouped within one renderer, never across
             # two. A layer's selector list is positional and all-or-nothing

--- a/tests/plotly/test_plotly_grouped_histogram.py
+++ b/tests/plotly/test_plotly_grouped_histogram.py
@@ -1,0 +1,248 @@
+"""Stacked plotly histograms were read as independent distributions (#394).
+
+`_extract_plots` collected `bar` traces for merging and left `histogram`
+traces to the factory, one layer each. So every multi-series histogram --
+`px.histogram(color=...)` is the ordinary way to draw one, and plotly's
+default `barmode` stacks -- was announced as several separate distributions,
+with nothing saying the bars stack or that `barnorm` had rescaled them.
+
+The bins were wrong as well, which the issue did not cover and which is worse
+than the missing relationship. Plotly bins a group **jointly**: one grid from
+every trace's values together. Binned per trace, `px.histogram(frame, x="v",
+color="h")` over two well-separated samples announced the first series as 13
+bins of width 0.2 where the chart draws 4 of width 1.
+
+The joint grid needed no new arithmetic. Feeding the existing `autoBin` port
+the union returns plotly's own `size=1, start=-2, end=12` for that figure --
+so what the issue called "inference rather than transcription" was
+transcription with the wrong input.
+
+Merging also settles the highlight. Left separate, every histogram in a
+subplot emitted the identical selector -- `.trace.bars .point > path` matches
+every bar in the panel -- so each layer highlighted its neighbours' bars too.
+One layer holding every series is what that selector already described.
+
+Values under `barnorm` stay raw here, matching what the merged bar path has
+emitted since #338/#393. Plotly draws shares, and both paths diverge from it
+identically; that is #409, filed to cover the two together rather than fixed
+for histograms alone.
+
+Every expectation is `gd.calcdata[i][j]` after `Plotly.newPlot` in Chromium,
+compared per series.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import pandas as pd  # noqa: E402
+import plotly.express as px  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.grouped_histogram import group_bin_spec  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Two well-separated samples: binned apart they get very different widths,
+#: binned together they get plotly's shared grid.
+NARROW = [
+    -0.1391, -0.7975, 0.5219, 0.2044, -0.1122, -0.2371, 0.1016, -0.4166,
+    0.3011, -0.0559, 0.6082, -0.3141, 0.0776, -0.2404, 0.4448, 0.1958,
+]  # fmt: skip
+WIDE = [
+    7.2, 4.9, 6.1, 8.8, 5.4, 9.6, 3.7, 6.8,
+    5.1, 7.9, 4.2, 8.1, 6.4, 5.8, 9.1, 3.3,
+]  # fmt: skip
+
+SMALL_A = [0.1, 0.5, 1.2, 1.8, 2.4]
+SMALL_B = [2.1, 2.9, 3.5, 4.2, 4.8]
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"v": NARROW + WIDE, "h": ["x"] * len(NARROW) + ["y"] * len(WIDE)}
+    )
+
+
+def only_layer(fig) -> dict:
+    return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+
+
+def layers(fig) -> list[dict]:
+    return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+
+
+def stacked(*samples, **layout) -> go.Figure:
+    fig = go.Figure([go.Histogram(x=list(s)) for s in samples])
+    return fig.update_layout(barmode="stack", **layout)
+
+
+class TestTheGroupIsOneLayer:
+    def test_a_default_multi_series_histogram_stacks(self):
+        # Plotly's default `barmode` is `relative`, so this is what
+        # `px.histogram(color=...)` produces without asking for anything.
+        layer = only_layer(px.histogram(frame(), x="v", color="h"))
+        assert layer["type"] == PlotType.STACKED.value
+        assert len(layer["data"]) == 2
+
+    def test_barnorm_says_the_stack_is_normalised(self):
+        layer = only_layer(px.histogram(frame(), x="v", color="h", barnorm="percent"))
+        assert layer["type"] == PlotType.NORMALIZED.value
+
+    def test_barmode_group_dodges(self):
+        layer = only_layer(px.histogram(frame(), x="v", color="h", barmode="group"))
+        assert layer["type"] == PlotType.DODGED.value
+
+    def test_overlay_stays_separate_layers(self):
+        # Plotly draws overlaid bars over one another rather than joining
+        # them, so separate layers is the honest reading -- the same rule the
+        # bar path follows.
+        emitted = layers(px.histogram(frame(), x="v", color="h", barmode="overlay"))
+        assert [layer["type"] for layer in emitted] == [
+            PlotType.HIST.value,
+            PlotType.HIST.value,
+        ]
+
+    def test_a_lone_histogram_is_untouched(self):
+        layer = only_layer(px.histogram(frame(), x="v"))
+        assert layer["type"] == PlotType.HIST.value
+
+    def test_each_series_carries_its_own_name(self):
+        layer = only_layer(px.histogram(frame(), x="v", color="h"))
+        names = [{point["z"] for point in series} for series in layer["data"]]
+        assert names == [{"x"}, {"y"}]
+
+
+class TestJointBinning:
+    def test_the_group_shares_one_grid(self):
+        # The defect the issue did not name. Binned separately these two get
+        # widths of 0.2 and 1; plotly bins them together at width 1.
+        layer = only_layer(px.histogram(frame(), x="v", color="h"))
+        centres = sorted({point["x"] for series in layer["data"] for point in series})
+        # Every bin centre from *either* series sits on one lattice. Asserted
+        # as a lattice rather than a fixed width so the test says "one grid"
+        # rather than pinning whichever width autobin happens to pick.
+        width = min(round(b - a, 9) for a, b in zip(centres, centres[1:]))
+        offsets = {round((c - centres[0]) % width, 6) for c in centres}
+        assert offsets == {0.0}
+
+    def test_a_separately_binned_series_would_have_more_bins(self):
+        # Guards the assertion above against passing for the wrong reason: on
+        # its own the narrow sample really does get a much finer grid, so the
+        # joint grid is doing work rather than coinciding.
+        alone = only_layer(px.histogram(pd.DataFrame({"v": NARROW}), x="v"))
+        grouped = only_layer(px.histogram(frame(), x="v", color="h"))
+        assert len(alone["data"]) > len(grouped["data"][0])
+
+    def test_every_series_is_binned_on_the_same_edges(self):
+        layer = only_layer(stacked(SMALL_A, SMALL_B))
+        first, second = layer["data"]
+        # The two series overlap at one bin centre, which they can only do if
+        # they were binned on a shared grid.
+        assert {p["x"] for p in first} & {p["x"] for p in second}
+
+    def test_a_third_trace_joins_the_same_grid(self):
+        layer = only_layer(stacked(SMALL_A, SMALL_B, [1.1, 3.3]))
+        assert len(layer["data"]) == 3
+
+    def test_a_trace_with_nothing_in_it_keeps_its_place(self):
+        # The series' names have to stay paired with their data, so an empty
+        # trace holds its slot rather than shifting every later series' name
+        # onto the wrong values.
+        layer = only_layer(stacked(SMALL_A, []))
+        assert len(layer["data"]) == 2
+        assert layer["data"][1] == []
+
+
+class TestGroupBinSpec:
+    def test_a_spec_on_any_trace_governs_the_group(self):
+        # Not "the first trace's spec". Plotly resolves a `size` given on the
+        # *second* trace onto both, and the pair bins at that width rather
+        # than the one they would autobin to.
+        traces = [
+            {"type": "histogram", "x": SMALL_A},
+            {"type": "histogram", "x": SMALL_B, "xbins": {"size": 3}},
+        ]
+        bins, nbins = group_bin_spec(traces, "x")
+        assert bins == {"size": 3}
+        assert nbins is None
+
+    def test_the_first_supplied_spec_wins(self):
+        traces = [
+            {"type": "histogram", "x": SMALL_A, "xbins": {"size": 2}},
+            {"type": "histogram", "x": SMALL_B, "xbins": {"size": 3}},
+        ]
+        assert group_bin_spec(traces, "x")[0] == {"size": 2}
+
+    def test_no_spec_anywhere_yields_nothing(self):
+        traces = [
+            {"type": "histogram", "x": SMALL_A},
+            {"type": "histogram", "x": SMALL_B},
+        ]
+        assert group_bin_spec(traces, "x") == (None, None)
+
+    def test_it_reads_the_binned_axis(self):
+        traces = [{"type": "histogram", "y": SMALL_A, "ybins": {"size": 3}}]
+        assert group_bin_spec(traces, "y")[0] == {"size": 3}
+        assert group_bin_spec(traces, "x")[0] is None
+
+    def test_the_spec_reaches_the_emitted_bins(self):
+        wide = only_layer(
+            go.Figure(
+                [
+                    go.Histogram(x=SMALL_A),
+                    go.Histogram(x=SMALL_B, xbins=dict(size=3)),
+                ]
+            ).update_layout(barmode="stack")
+        )
+        autobinned = only_layer(stacked(SMALL_A, SMALL_B))
+        assert len(wide["data"][0]) < len(autobinned["data"][0])
+
+
+class TestOrientation:
+    def test_a_horizontal_group_says_so(self):
+        layer = only_layer(px.histogram(frame(), y="v", color="h"))
+        assert layer["orientation"] == "horz"
+        assert layer["type"] == PlotType.STACKED.value
+
+    def test_a_vertical_group_says_so(self):
+        layer = only_layer(px.histogram(frame(), x="v", color="h"))
+        assert layer["orientation"] == "vert"
+
+    def test_both_orientations_describe_the_same_sample(self):
+        upright = only_layer(px.histogram(frame(), x="v", color="h"))
+        sideways = only_layer(px.histogram(frame(), y="v", color="h"))
+        assert [len(series) for series in sideways["data"]] == [
+            len(series) for series in upright["data"]
+        ]
+
+
+class TestCategoricalGroupDeclines:
+    def test_it_is_left_to_the_factory_one_trace_at_a_time(self):
+        # Plotly draws a categorical histogram as a count bar chart rather
+        # than binning it, which is a different layer shape. Half-describing
+        # it as a binned stack would be worse than the separate layers.
+        cats = pd.DataFrame(
+            {"g": list("abc") * 6, "h": ["x", "y"] * 9},
+        )
+        emitted = layers(px.histogram(cats, x="g", color="h"))
+        assert len(emitted) == 2
+        assert all(layer["type"] == PlotType.BAR.value for layer in emitted)
+
+
+class TestBarnormValuesStayRaw:
+    """Deliberate, and shared with the bar path -- see #409."""
+
+    def test_the_values_are_the_counts_rather_than_the_shares(self):
+        layer = only_layer(stacked(SMALL_A, SMALL_B, barnorm="percent"))
+        first = [point["y"] for point in layer["data"][0]]
+        # Plotly draws 100 and 25 for these; the counts are 4 and 1. Pinned so
+        # that whoever takes #409 sees this test fail rather than discovering
+        # the divergence from the chart.
+        assert first == [4, 1]
+
+    def test_the_type_still_reports_the_normalisation(self):
+        layer = only_layer(stacked(SMALL_A, SMALL_B, barnorm="percent"))
+        assert layer["type"] == PlotType.NORMALIZED.value


### PR DESCRIPTION
Closes #394.

`_extract_plots` collected `bar` traces for merging and left `histogram` traces to the factory, one layer each. `px.histogram(color=...)` is the ordinary way to draw a multi-series histogram and plotly's default `barmode` stacks, so every one of them was announced as several separate distributions — with nothing saying the bars stack, or that `barnorm` had rescaled them.

## The bins were wrong too, which the issue did not name

And it is worse than the missing relationship. Plotly bins a group **jointly** — one grid from every trace's values together:

| | bin size | start | end |
|---|---|---|---|
| Plotly.js (`_fullData[0].xbins`) | `1` | `-2` | `12` |
| py-maidr, trace 0 | `0.2` | `-1.2` | — |
| py-maidr, trace 1 | `1` | `1` | — |

So the first series was announced as 13 bins of width 0.2 where the chart draws 4 of width 1. Not a missing label — the wrong distribution.

**This needed no new arithmetic.** The issue's premise was that reproducing plotly's binning "would be inference rather than transcription". Fed the *union*, the existing `autoBin` port returns plotly's own `size=1, start=-2, end=12` exactly. It was transcription with the wrong input.

## Two rules I had to measure

**The group's bin spec comes from whichever trace supplies one**, not the first. With `xbins=dict(size=3)` on the *second* of two traces, plotly resolves the first trace's spec to `{start: 0, end: 6}` and the second's to `{size: 3}`, and bins **both** at width 3 — identical to putting it on the first trace, and different from the width 2 they autobin to.

**Bin groups follow the subplot.** Two histograms on one axis pair always bin jointly (even with `bingroup` set to different values — plotly coerces them back together); on different axis pairs, never. That is exactly the partition `_extract_plots` already computes, so no new grouping key was needed.

## Merging also settles the highlight

Left as separate layers, every histogram in a subplot emitted the identical selector — `.trace.bars .point > path` matches every bar in the panel — so each layer highlighted its neighbours' bars as well as its own. One layer holding every series is what that selector already described. The issue does not mention this.

## Two deliberate declines

**A categorical group declines rather than half-describing itself.** Plotly draws string data as a count bar chart rather than binning it, which is a different layer shape; those stay with the factory one trace at a time.

**Values under `barnorm` stay raw.** Plotly draws shares — and so does the merged **bar** path diverge, identically: `px.bar(...).update_layout(barnorm="percent")` announces `3, 2 / 1, 6` where plotly draws `75, 25 / 25, 75`. I verified that rather than relying on memory before deciding. Fixing it for histograms alone would put the two paths out of step, so it is filed as **#409** covering both, with a test here pinning the current values so whoever takes it sees a failure rather than discovering the divergence.

That is also why 2 of the 10 grouped shapes below disagree, and both are that pair.

## Verification

Per-series comparison against `gd.calcdata[i][j]` in Chromium: **8 of 10 grouped shapes agree elementwise** — including three traces, a spec on the second trace, an empty trace, `histnorm` on the group, `barmode="group"`, and the horizontal orientation. The existing single-trace harness is still **60 of 60**.

## Falsification

| reverted | failures |
|---|---|
| never merge histograms (the bug) | 12 |
| bin each trace on its own values | 3 |
| group spec from the first trace only | 2 |
| no `orientation` key | 2 |
| merge `overlay` too | 1 |
| drop an empty trace instead of holding its slot | 1 |

## Checks

- `uv run pytest tests/` — **1546 passed** (up 22)
- `ruff check` clean across `maidr/plotly/` and `tests/plotly/`
- No line over 88 characters

`_compute_bin_edges` is now a thin wrapper over a module-level `compute_bin_edges(arr, bins, nbins)`, so the grouped path can bin a union against the group's spec. No behaviour change — the 60-shape comparison and all 607 pre-existing plotly tests were green across the extraction.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_