### PR TITLE
feat(plotly): read an area chart as an area rather than a line

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -25,6 +25,12 @@ class PlotType(str, Enum):
     #: a line layer announces one number per point with nothing to say which
     #: of those two it is.
     STACKED_AREA = "stacked_area"
+    #: A stacked area rescaled so every position totals the same, the area
+    #: counterpart of :attr:`NORMALIZED`. Distinct for the same reason: a band
+    #: is a *share* of its position's total rather than a magnitude, and read
+    #: as a plain stack the equal totals look like a property of the data
+    #: rather than of the chart.
+    NORMALIZED_AREA = "stacked_normalized_area"
     PIE = "pie"
     SCATTER = "point"
     STACKED = "stacked_bar"
@@ -67,6 +73,7 @@ _DISPLAY_NAMES = {
     PlotType.NORMALIZED: "100% stacked bar",
     PlotType.STACKED: "stacked bar",
     PlotType.STACKED_AREA: "stacked area",
+    PlotType.NORMALIZED_AREA: "100% stacked area",
     PlotType.VIOLIN_BOX: "violin",
     PlotType.VIOLIN_KDE: "violin",
 }

--- a/maidr/plotly/area.py
+++ b/maidr/plotly/area.py
@@ -1,0 +1,144 @@
+"""Plotly area charts, which arrive as scatter traces carrying a stackgroup.
+
+`px.area` produces a `Scatter`, and the only thing separating it from a line
+is `stackgroup`. The adapter had no area handling at all, so every one of them
+fell through to `line` -- a reader was not told the bands are filled, that they
+stack, or what the running total at each x is, which is the reason someone
+draws this chart rather than a multi-line one (#392).
+"""
+
+from __future__ import annotations
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.step_shape import is_scatter_family_trace
+
+#: The values ``groupnorm`` takes when plotly rescales a stack to a common
+#: total -- its own switch for a 100% stacked area, and the counterpart of
+#: ``barnorm`` on the bar path.
+_NORMALISING_GROUPNORMS = frozenset({"percent", "fraction"})
+
+
+def is_area_trace(trace: dict) -> bool:
+    """Whether plotly fills this trace down to a baseline.
+
+    ``stackgroup`` is the whole signal, and it is structural rather than a
+    display string: plotly stacks traces that share one and leaves traces with
+    an empty one alone. Measured in Chromium -- a trace with ``stackgroup``
+    set resolves to ``fill: "tonexty"`` and its calcdata carries an ``s`` key
+    holding the series' own value, while a plain line resolves to
+    ``fill: "none"`` and has no ``s`` at all.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        True when the trace is drawn as a filled band.
+    """
+    return bool(trace.get("stackgroup")) and is_scatter_family_trace(trace)
+
+
+def area_stack_groups(traces: list[dict]) -> list[list[dict]]:
+    """Split area traces into the stacks plotly actually accumulates.
+
+    Traces stack only with others sharing their ``stackgroup``. Two groups on
+    one subplot are two independent stacks, and measured that way: given
+    ``stackgroup='one'`` and ``stackgroup='two'``, each series' calcdata ``y``
+    equals its own ``s`` -- nothing accumulated across the two -- where within
+    one group the second series' ``y`` is the running total.
+
+    Groups come back in first-seen order so the emitted layers follow plotly's
+    own trace order rather than a sorted one.
+
+    Parameters
+    ----------
+    traces : list[dict]
+        The subplot's area traces, in declaration order.
+
+    Returns
+    -------
+    list[list[dict]]
+        One list per stack group.
+    """
+    groups: dict[str, list[dict]] = {}
+    for trace in traces:
+        groups.setdefault(str(trace.get("stackgroup")), []).append(trace)
+    return list(groups.values())
+
+
+def area_plot_type(traces: list[dict]) -> PlotType:
+    """Which area type a stack group is.
+
+    A lone band has nothing stacked on it, so it is a plain ``area`` -- the
+    same distinction the matplotlib path draws for a single ``stackplot``
+    band. ``groupnorm`` then separates a stack from a normalised one, exactly
+    as ``barnorm`` does for bars.
+    """
+    if any(t.get("groupnorm") in _NORMALISING_GROUPNORMS for t in traces):
+        return PlotType.NORMALIZED_AREA
+    if len(traces) > 1:
+        return PlotType.STACKED_AREA
+    return PlotType.AREA
+
+
+class PlotlyAreaPlot(PlotlyPlot):
+    """One stack of filled bands.
+
+    Emits each band's **own** value, with the series name alongside, matching
+    what :class:`~maidr.core.plot.areaplot.AreaPlot` produces for
+    ``stackplot``. The running total is the core's to derive: a stacked area
+    trace already sums its bands, and emitting a total here would give it two
+    sources that could disagree.
+
+    Plotly agrees about which number is which. Its calcdata carries both --
+    ``s`` for the band's own value and ``y`` for the running total -- and for
+    two series of ``1,2,3`` and ``10,20,30`` the second's ``y`` comes back
+    ``11,22,33``. So ``trace["y"]``, which the Python side has, is the band's
+    own value and needs no un-accumulating. That is the opposite of the
+    matplotlib and ggplot2 hazard, where the built data holds the cumulative
+    top and reading it straight through announces totals as values.
+    """
+
+    def __init__(
+        self,
+        traces: list[dict],
+        layout: dict,
+        plot_type: PlotType,
+        scatter_positions: list[int],
+        **kwargs: str,
+    ) -> None:
+        super().__init__(traces[0], layout, plot_type, **kwargs)
+        self._traces = traces
+        self._scatter_positions = scatter_positions
+
+    def _get_selector(self) -> list[str]:
+        """One selector per band, in the order the bands are emitted.
+
+        Reuses the scatter-family positions the subplot already assigns, since
+        an area trace is a scatter trace and sits in the same ``scatterlayer``
+        as the lines beside it.
+        """
+        return self._scatter_line_selectors(self._traces, self._scatter_positions)
+
+    def _extract_plot_data(self) -> list[list[dict]]:
+        data: list[list[dict]] = []
+        for trace in self._traces:
+            xs = as_list(trace.get("x"))
+            ys = as_list(trace.get("y"))
+            fill = str(trace.get("name", ""))
+            data.append(
+                [
+                    {
+                        MaidrKey.X.value: self._to_native(x),
+                        MaidrKey.Y.value: self._to_native(y),
+                        MaidrKey.Z.value: fill,
+                    }
+                    for x, y in zip(xs, ys)
+                ]
+            )
+        return data

--- a/maidr/plotly/area.py
+++ b/maidr/plotly/area.py
@@ -112,9 +112,16 @@ class PlotlyAreaPlot(PlotlyPlot):
         scatter_positions: list[int],
         **kwargs: str,
     ) -> None:
+        if not traces:
+            raise ValueError("an area layer needs at least one trace")
+        PlotlyPlot._validate_scatter_positions(scatter_positions, len(traces))
+
         super().__init__(traces[0], layout, plot_type, **kwargs)
-        self._traces = traces
-        self._scatter_positions = scatter_positions
+        # Copied, not aliased: a caller mutating its list afterwards would
+        # silently change this layer's selectors on the next render -- the
+        # same wrong-element failure the required parameter exists to end.
+        self._traces = list(traces)
+        self._scatter_positions = list(scatter_positions)
 
     def _get_selector(self) -> list[str]:
         """One selector per band, in the order the bands are emitted.
@@ -131,14 +138,19 @@ class PlotlyAreaPlot(PlotlyPlot):
             xs = as_list(trace.get("x"))
             ys = as_list(trace.get("y"))
             fill = str(trace.get("name", ""))
-            data.append(
-                [
-                    {
-                        MaidrKey.X.value: self._to_native(x),
-                        MaidrKey.Y.value: self._to_native(y),
-                        MaidrKey.Z.value: fill,
-                    }
-                    for x, y in zip(xs, ys)
-                ]
-            )
+            series: list[dict] = []
+            for x, y in zip(xs, ys):
+                point = {
+                    MaidrKey.X.value: self._to_native(x),
+                    MaidrKey.Y.value: self._to_native(y),
+                }
+                # Omitted rather than emitted blank, matching every sibling
+                # extractor -- `PlotlyPlot._line_series_with_positions` and
+                # the matplotlib `AreaPlot` both guard the same way. A single
+                # unnamed band is the ordinary `px.area(...)` call with no
+                # `color=`, and its traces carry `name: ""`.
+                if fill:
+                    point[MaidrKey.Z.value] = fill
+                series.append(point)
+            data.append(series)
         return data

--- a/maidr/plotly/area.py
+++ b/maidr/plotly/area.py
@@ -9,10 +9,9 @@ draws this chart rather than a multi-line one (#392).
 
 from __future__ import annotations
 
-from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
-from maidr.plotly.step_shape import is_scatter_family_trace
+from maidr.plotly.plotly_plot import PlotlyPlot
+from maidr.plotly.step_shape import is_scatter_family_trace, renders_through_webgl
 
 #: The values ``groupnorm`` takes when plotly rescales a stack to a common
 #: total -- its own switch for a 100% stacked area, and the counterpart of
@@ -30,6 +29,14 @@ def is_area_trace(trace: dict) -> bool:
     holding the series' own value, while a plain line resolves to
     ``fill: "none"`` and has no ``s`` at all.
 
+    A WebGL trace is excluded because plotly does not stack one. ``scattergl``
+    has no ``stackgroup`` attribute at all -- ``go.Scattergl(stackgroup="one")``
+    raises ``Bad property path`` -- and plotly.js ignores the key on a raw
+    ``scattergl`` dict that carries it anyway: measured in Chromium, such a
+    trace comes back with ``fill: "none"``, no ``stackgroup`` in ``_fullData``
+    and nothing accumulated. Reading it as an area would announce a filled,
+    stacked band where plotly draws a plain line.
+
     Parameters
     ----------
     trace : dict
@@ -40,7 +47,11 @@ def is_area_trace(trace: dict) -> bool:
     bool
         True when the trace is drawn as a filled band.
     """
-    return bool(trace.get("stackgroup")) and is_scatter_family_trace(trace)
+    return (
+        bool(trace.get("stackgroup"))
+        and is_scatter_family_trace(trace)
+        and not renders_through_webgl(trace)
+    )
 
 
 def area_stack_groups(traces: list[dict]) -> list[list[dict]]:
@@ -102,6 +113,23 @@ class PlotlyAreaPlot(PlotlyPlot):
     own value and needs no un-accumulating. That is the opposite of the
     matplotlib and ggplot2 hazard, where the built data holds the cumulative
     top and reading it straight through announces totals as values.
+
+    Parameters
+    ----------
+    traces : list of dict
+        The stack's traces, in declaration order. At least one is required.
+    layout : dict
+        The figure layout the axis titles and ranges come from.
+    plot_type : PlotType
+        Which of ``AREA``/``STACKED_AREA``/``NORMALIZED_AREA`` this stack is,
+        as resolved by :func:`area_plot_type`.
+    scatter_positions : list of int
+        Each trace's zero-based position among the subplot's scatter-family
+        traces. Required rather than defaulted: an area shares its
+        ``scatterlayer`` with the lines beside it, so numbering from zero
+        here would point each band at another layer's element.
+    **kwargs
+        Forwarded to :class:`~maidr.plotly.plotly_plot.PlotlyPlot`.
     """
 
     def __init__(
@@ -124,33 +152,37 @@ class PlotlyAreaPlot(PlotlyPlot):
         self._scatter_positions = list(scatter_positions)
 
     def _get_selector(self) -> list[str]:
-        """One selector per band, in the order the bands are emitted.
+        """One selector per drawn band, in the order the bands are emitted.
 
         Reuses the scatter-family positions the subplot already assigns, since
         an area trace is a scatter trace and sits in the same ``scatterlayer``
         as the lines beside it.
+
+        Positions are filtered by the same predicate that filters the data, so
+        band *i* always addresses the element band *i* is drawn as. A band with
+        no points is not merely empty in the schema -- plotly gives it no DOM
+        node at all, so every later band shifts up one. Measured in Chromium
+        with an empty band between two drawn ones: the ``scatterlayer`` holds
+        two ``.trace.scatter`` nodes, ``nth-child(2)`` resolves to the *third*
+        band and ``nth-child(3)`` to nothing. That is #316's misalignment, and
+        this is the helper written to end it.
+
+        Returns
+        -------
+        list of str
+            One CSS selector per drawn band, in trace order.
         """
-        return self._scatter_line_selectors(self._traces, self._scatter_positions)
+        _, drawn_positions = self._drawn_line_series(
+            self._traces, self._scatter_positions
+        )
+        return self._scatter_line_selectors(self._traces, drawn_positions)
 
     def _extract_plot_data(self) -> list[list[dict]]:
-        data: list[list[dict]] = []
-        for trace in self._traces:
-            xs = as_list(trace.get("x"))
-            ys = as_list(trace.get("y"))
-            fill = str(trace.get("name", ""))
-            series: list[dict] = []
-            for x, y in zip(xs, ys):
-                point = {
-                    MaidrKey.X.value: self._to_native(x),
-                    MaidrKey.Y.value: self._to_native(y),
-                }
-                # Omitted rather than emitted blank, matching every sibling
-                # extractor -- `PlotlyPlot._line_series_with_positions` and
-                # the matplotlib `AreaPlot` both guard the same way. A single
-                # unnamed band is the ordinary `px.area(...)` call with no
-                # `color=`, and its traces carry `name: ""`.
-                if fill:
-                    point[MaidrKey.Z.value] = fill
-                series.append(point)
-            data.append(series)
-        return data
+        """Return one series of ``{x, y}`` per drawn band, ``z`` its name.
+
+        Shares the single pass with :meth:`_get_selector` rather than walking
+        the traces again -- see ``_drawn_line_series`` for why the pass cannot
+        simply be repeated.
+        """
+        bands, _ = self._drawn_line_series(self._traces, self._scatter_positions)
+        return bands

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -12,6 +12,7 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.candlestick import is_ohlc_trace, layer_position
+from maidr.plotly.area import is_area_trace
 from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.plotly_plot import (
     PlotlyPlot,
@@ -346,8 +347,16 @@ class PlotlyMaidr:
             bar_traces = [
                 t for t in group_traces if t.get("type") == "bar"
             ]
+            # An area trace is a scatter trace that plotly fills, so it is a
+            # "connected line" by every structural test -- and left in the
+            # line grouping it would be emitted twice, once as its own layer
+            # and once inside the multi-line one. Split out here, before any
+            # of the line/step machinery sees the group.
+            area_traces = [t for t in group_traces if is_area_trace(t)]
             connected_traces = [
-                t for t in group_traces if is_connected_line_trace(t)
+                t
+                for t in group_traces
+                if is_connected_line_trace(t) and not is_area_trace(t)
             ]
             box_traces = [
                 t for t in group_traces if t.get("type") == "box"
@@ -417,6 +426,32 @@ class PlotlyMaidr:
                 if layout.get("barnorm") in _NORMALISING_BARNORMS:
                     return PlotType.NORMALIZED
                 return PlotType.STACKED
+
+            # Filled bands, one layer per stack group. `px.area` produces a
+            # `Scatter` whose only mark of being an area is `stackgroup`, and
+            # with that unread every one of them fell through to `line` --
+            # so a reader was told neither that the bands are filled nor that
+            # they stack, which is the reason the chart is drawn at all
+            # (#392).
+            if area_traces:
+                from maidr.plotly.area import (
+                    PlotlyAreaPlot,
+                    area_plot_type,
+                    area_stack_groups,
+                )
+
+                for stack in area_stack_groups(area_traces):
+                    plot = PlotlyAreaPlot(
+                        stack,
+                        layout,
+                        area_plot_type(stack),
+                        scatter_positions=[position_of[id(t)] for t in stack],
+                        **axis_kwargs,
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in area_traces)
 
             # Grouped / stacked bars
             if len(bar_traces) > 1 and barmode in _COMBINED_BARMODES:

--- a/tests/plotly/test_plotly_area.py
+++ b/tests/plotly/test_plotly_area.py
@@ -43,6 +43,7 @@ from maidr.plotly.area import (  # noqa: E402
     area_stack_groups,
     is_area_trace,
 )
+from maidr.plotly.area import PlotlyAreaPlot  # noqa: E402
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 X = [1, 2, 3]
@@ -186,6 +187,57 @@ class TestTheEmittedLayer:
         ]
 
 
+class TestTheConstructorRefusesPositionsItCannotDescribe:
+    """The same guard `PlotlyMultiLinePlot` and `PlotlyStepPlot` enforce.
+
+    Selectors are emitted positionally -- the frontend pairs selector *i* with
+    series *i* -- so a length mismatch slides every later band onto another
+    element, a negative index builds `nth-child(0)` and matches nothing, and a
+    repeat points two bands at one element. None of those raise on their own;
+    they highlight the wrong geometry, which is what the guard exists to stop.
+    An area trace shares `scatterlayer` with the lines beside it, so it is
+    exposed to exactly the failure mode the other two were hardened against.
+    """
+
+    def build(self, positions, count=1):
+        traces = [{"type": "scatter", "x": X, "y": LOW, "stackgroup": "one"}] * count
+        return PlotlyAreaPlot(traces, {}, PlotType.AREA, positions)
+
+    def test_no_traces_is_refused(self):
+        with pytest.raises(ValueError):
+            PlotlyAreaPlot([], {}, PlotType.AREA, [])
+
+    def test_a_length_mismatch_is_refused(self):
+        with pytest.raises(ValueError):
+            self.build([0, 1], count=1)
+
+    def test_a_negative_position_is_refused(self):
+        with pytest.raises(ValueError):
+            self.build([-1])
+
+    def test_a_repeated_position_is_refused(self):
+        with pytest.raises(ValueError):
+            self.build([0, 0], count=2)
+
+    def test_a_non_list_is_refused(self):
+        with pytest.raises(TypeError):
+            self.build(None)
+
+    def test_well_formed_positions_are_accepted(self):
+        assert self.build([0]) is not None
+
+    def test_the_lists_are_copied_not_aliased(self):
+        # A caller mutating its list afterwards would otherwise silently
+        # change this layer's selectors on the next render.
+        traces = [{"type": "scatter", "x": X, "y": LOW, "stackgroup": "one"}]
+        positions = [0]
+        plot = PlotlyAreaPlot(traces, {}, PlotType.AREA, positions)
+        positions.append(7)
+        traces.append({"type": "scatter", "x": X, "y": HIGH, "stackgroup": "one"})
+        assert len(plot._scatter_positions) == 1
+        assert len(plot._traces) == 1
+
+
 class TestAreasAndLinesCoexist:
     """An area is a scatter trace, so the two compete for the same positions."""
 
@@ -229,6 +281,26 @@ class TestAreasAndLinesCoexist:
         # Scoped by position among the subplot's scatter traces, so the two
         # layers cannot both claim `nth-child(1)`.
         assert "nth-child" in selectors[0]
+
+    def test_an_unnamed_band_omits_z_rather_than_sending_it_blank(self):
+        # `px.area` with no `color=` is the ordinary way to draw one band, and
+        # its trace carries `name: ""`. Every sibling extractor omits the key
+        # in that case -- `PlotlyPlot._line_series_with_positions` guards with
+        # `if name:`, the matplotlib `AreaPlot` with `if label:`.
+        #
+        # Not a mis-announcement either way: maidr's `LineTrace`, which
+        # `AreaTrace` extends, reads `z` through a truthiness guard
+        # (`point.z ? ... : {}`), so `""` already degrades to the absent-key
+        # behaviour. This keeps the emitted schema free of a key whose value
+        # carries nothing.
+        single = frame()[lambda d: d.g == "a"]
+        point = only_layer(px.area(single, x="x", y="y"))["data"][0][0]
+        assert "z" not in point
+        assert point["x"] == 1
+
+    def test_a_named_band_still_carries_z(self):
+        fig = px.area(frame(), x="x", y="y", color="g")
+        assert only_layer(fig)["data"][0][0]["z"] == "a"
 
     def test_the_two_layers_do_not_share_a_position(self):
         fig = go.Figure(

--- a/tests/plotly/test_plotly_area.py
+++ b/tests/plotly/test_plotly_area.py
@@ -82,6 +82,19 @@ class TestIsAreaTrace:
     def test_no_stackgroup_at_all_is_a_line(self):
         assert is_area_trace({"type": "scatter", "y": LOW}) is False
 
+    def test_a_markers_only_trace_with_a_stackgroup_is_still_an_area(self):
+        # Plotly fills from `stackgroup` alone -- `mode` chooses whether the
+        # boundary is drawn as a line or as points, not whether the band is
+        # filled. Pinned so the classifier is not later narrowed to require
+        # `"lines"` in `mode`, which would drop a real filled band back onto
+        # the scatter path.
+        assert (
+            is_area_trace(
+                {"type": "scatter", "stackgroup": "one", "mode": "markers"}
+            )
+            is True
+        )
+
     def test_a_bar_with_a_stackgroup_is_not_an_area(self):
         # Guards the scatter-family half of the test: `stackgroup` alone is
         # not enough, or a mislabelled trace of another type would be filled.
@@ -147,6 +160,13 @@ class TestPlotType:
             {"stackgroup": "one"},
         ]
         assert area_plot_type(traces) == PlotType.NORMALIZED_AREA
+
+    def test_the_normalised_type_reads_naturally_to_a_user(self):
+        # The wire value is `stacked_normalized_area`, which is not what
+        # anyone would call it out loud. Asserted here because every other
+        # user-facing name for this layer family is.
+        assert PlotType.NORMALIZED_AREA.display_name == "100% stacked area"
+        assert PlotType.STACKED_AREA.display_name == "stacked area"
 
     def test_an_unrecognised_groupnorm_is_left_alone(self):
         traces = [{"stackgroup": "one", "groupnorm": ""}, {"stackgroup": "one"}]

--- a/tests/plotly/test_plotly_area.py
+++ b/tests/plotly/test_plotly_area.py
@@ -87,8 +87,17 @@ class TestIsAreaTrace:
         # not enough, or a mislabelled trace of another type would be filled.
         assert is_area_trace({"type": "bar", "stackgroup": "one"}) is False
 
-    def test_scattergl_counts_too(self):
-        assert is_area_trace({"type": "scattergl", "stackgroup": "one"}) is True
+    def test_a_webgl_trace_is_not_an_area_even_carrying_a_stackgroup(self):
+        # Plotly does not stack one, at either level. `scattergl` has no
+        # `stackgroup` attribute -- `go.Scattergl(stackgroup="one")` raises
+        # `Bad property path` on plotly 6.7.0 -- and plotly.js ignores the key
+        # on a raw dict that carries it anyway: measured in Chromium, the gl
+        # trace came back `fill: "none"`, with no `stackgroup` in `_fullData`
+        # and nothing accumulated, while the svg trace beside it stacked
+        # normally. Reading it as an area would announce a filled, stacked
+        # band where plotly draws a plain line -- and, since a WebGL layer can
+        # carry no selectors, silently take the highlight away too.
+        assert is_area_trace({"type": "scattergl", "stackgroup": "one"}) is False
 
 
 class TestStackGroups:
@@ -301,6 +310,68 @@ class TestAreasAndLinesCoexist:
     def test_a_named_band_still_carries_z(self):
         fig = px.area(frame(), x="x", y="y", color="g")
         assert only_layer(fig)["data"][0][0]["z"] == "a"
+
+    def test_a_band_with_no_points_is_dropped_from_data_and_selectors(self):
+        # Not merely cosmetic. Plotly gives an empty trace no DOM node at
+        # all, so every later band shifts up one in the `scatterlayer`.
+        # Measured in Chromium with an empty band between two drawn ones:
+        # the layer holds two `.trace.scatter` nodes, `nth-child(2)` resolves
+        # to the *third* band and `nth-child(3)` to nothing. Emitting the
+        # phantom series would hand band 2's selector to band 3 and leave
+        # band 3 pointing at no element -- #316's misalignment exactly.
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=LOW, stackgroup="one", name="a"),
+                go.Scatter(x=[], y=[], stackgroup="one", name="empty"),
+                go.Scatter(x=X, y=HIGH, stackgroup="one", name="c"),
+            ]
+        )
+        layer = only_layer(fig)
+        assert [len(series) for series in layer["data"]] == [3, 3]
+        assert len(layer["selectors"]) == 2
+
+    def test_a_band_after_an_empty_one_is_still_numbered_by_declaration(self):
+        """Pins a pre-existing defect this layer shares with lines and steps.
+
+        Dropping the empty band from `data` and `selectors` is only half the
+        problem. The positions that survive are the *declared* indices among
+        the subplot's scatter traces, and plotly numbers the DOM by what it
+        actually draws -- measured in Chromium, three traces with an empty one
+        in the middle produce two `.trace.scatter` nodes, so the third band is
+        `nth-child(2)` and `nth-child(3)` matches nothing.
+
+        Not introduced here, and not specific to areas: the same figure built
+        from `mode="lines"` traces already emits `nth-child(1)` and
+        `nth-child(3)` on `main`, because `_drawn_line_series` filters the
+        position *list* without renumbering what remains. Fixing it means
+        compacting positions across the whole subplot -- one layer cannot do
+        it alone, since an empty trace in another layer shifts this one too --
+        so it is filed separately rather than folded into #392.
+
+        Asserting the wrong-but-current value deliberately, so whoever takes
+        that issue sees this test fail rather than having to discover it.
+        """
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=LOW, stackgroup="one", name="a"),
+                go.Scatter(x=[], y=[], stackgroup="one", name="empty"),
+                go.Scatter(x=X, y=HIGH, stackgroup="one", name="c"),
+            ]
+        )
+        selectors = only_layer(fig)["selectors"]
+        assert "nth-child(1)" in selectors[0]
+        assert "nth-child(3)" in selectors[1]
+
+    def test_the_surviving_bands_keep_their_own_names(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=LOW, stackgroup="one", name="a"),
+                go.Scatter(x=[], y=[], stackgroup="one", name="empty"),
+                go.Scatter(x=X, y=HIGH, stackgroup="one", name="c"),
+            ]
+        )
+        names = [series[0]["z"] for series in only_layer(fig)["data"]]
+        assert names == ["a", "c"]
 
     def test_the_two_layers_do_not_share_a_position(self):
         fig = go.Figure(

--- a/tests/plotly/test_plotly_area.py
+++ b/tests/plotly/test_plotly_area.py
@@ -1,0 +1,244 @@
+"""A plotly area chart was announced as a line chart (#392).
+
+`px.area` produces a `Scatter`, and the only thing separating it from a line
+is `stackgroup`. The adapter had no area handling at all -- `maidr/plotly/`
+carried bar, box, heatmap, histogram, line, pie, scatter and step, and no
+`area` -- so every one of them fell through to `line`.
+
+The numbers were right, which is why this is a parity gap rather than a wrong
+reading: plotly keeps each series' own values in `trace.y` and stacks in the
+browser, so a stacked area announced `1, 2, 3` and `10, 20, 30` rather than
+running totals. That is the opposite of the matplotlib and ggplot2 hazard,
+where the built data holds the cumulative top.
+
+What was missing is the name and the relationship. A filled, stacked band was
+announced as a line, so a reader was not told the bands are filled, that they
+stack, or what the total at each x is -- which is the reason someone draws
+this chart rather than a multi-line one.
+
+Plotly's own calcdata carries both numbers and agrees about which is which:
+`s` holds the band's own value and `y` the running total. For series of
+`1,2,3` and `10,20,30` the second's `y` comes back `11,22,33`, so `trace["y"]`
+is the band's own value and needs no un-accumulating. The total stays the
+core's to derive, as it is for `stackplot`.
+
+Every selector below was resolved against real Plotly.js output in Chromium:
+9 of 9 matched exactly one element, including the mixed area-and-line figures
+where the scatter positions interleave.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import pandas as pd  # noqa: E402
+import plotly.express as px  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.area import (  # noqa: E402
+    area_plot_type,
+    area_stack_groups,
+    is_area_trace,
+)
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+X = [1, 2, 3]
+LOW = [1, 2, 3]
+HIGH = [10, 20, 30]
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame({"x": X * 2, "y": LOW + HIGH, "g": ["a"] * 3 + ["b"] * 3})
+
+
+def layers(fig) -> list[dict]:
+    return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+
+
+def only_layer(fig) -> dict:
+    return layers(fig)[0]
+
+
+def band(fig, index: int = 0) -> list[tuple]:
+    series = only_layer(fig)["data"][index]
+    return [(point["x"], point["y"], point["z"]) for point in series]
+
+
+class TestIsAreaTrace:
+    """`stackgroup` is the whole signal, and it is structural."""
+
+    def test_a_stackgroup_makes_a_scatter_an_area(self):
+        assert is_area_trace({"type": "scatter", "stackgroup": "one"}) is True
+
+    def test_an_empty_stackgroup_is_a_line(self):
+        # Plotly's own default. `""` is what a plain scatter resolves to, and
+        # it means "do not stack" rather than "stack with the unnamed group".
+        assert is_area_trace({"type": "scatter", "stackgroup": ""}) is False
+
+    def test_no_stackgroup_at_all_is_a_line(self):
+        assert is_area_trace({"type": "scatter", "y": LOW}) is False
+
+    def test_a_bar_with_a_stackgroup_is_not_an_area(self):
+        # Guards the scatter-family half of the test: `stackgroup` alone is
+        # not enough, or a mislabelled trace of another type would be filled.
+        assert is_area_trace({"type": "bar", "stackgroup": "one"}) is False
+
+    def test_scattergl_counts_too(self):
+        assert is_area_trace({"type": "scattergl", "stackgroup": "one"}) is True
+
+
+class TestStackGroups:
+    def test_traces_sharing_a_group_stack_together(self):
+        traces = [
+            {"type": "scatter", "stackgroup": "one"},
+            {"type": "scatter", "stackgroup": "one"},
+        ]
+        assert len(area_stack_groups(traces)) == 1
+
+    def test_different_groups_are_separate_stacks(self):
+        # Measured: with `stackgroup='one'` and `'two'`, each series' calcdata
+        # `y` equals its own `s` -- plotly accumulates nothing across them.
+        traces = [
+            {"type": "scatter", "stackgroup": "one"},
+            {"type": "scatter", "stackgroup": "two"},
+        ]
+        assert len(area_stack_groups(traces)) == 2
+
+    def test_groups_come_back_in_first_seen_order(self):
+        traces = [
+            {"type": "scatter", "stackgroup": "b", "name": "first"},
+            {"type": "scatter", "stackgroup": "a", "name": "second"},
+        ]
+        assert [g[0]["name"] for g in area_stack_groups(traces)] == [
+            "first",
+            "second",
+        ]
+
+
+class TestPlotType:
+    def test_a_lone_band_is_a_plain_area(self):
+        # Nothing is stacked on it, the same distinction the matplotlib path
+        # draws for a single `stackplot` band.
+        assert area_plot_type([{"stackgroup": "one"}]) == PlotType.AREA
+
+    def test_two_bands_stack(self):
+        assert (
+            area_plot_type([{"stackgroup": "one"}, {"stackgroup": "one"}])
+            == PlotType.STACKED_AREA
+        )
+
+    @pytest.mark.parametrize("groupnorm", ["percent", "fraction"])
+    def test_groupnorm_normalises(self, groupnorm):
+        traces = [
+            {"stackgroup": "one", "groupnorm": groupnorm},
+            {"stackgroup": "one"},
+        ]
+        assert area_plot_type(traces) == PlotType.NORMALIZED_AREA
+
+    def test_an_unrecognised_groupnorm_is_left_alone(self):
+        traces = [{"stackgroup": "one", "groupnorm": ""}, {"stackgroup": "one"}]
+        assert area_plot_type(traces) == PlotType.STACKED_AREA
+
+
+class TestTheEmittedLayer:
+    def test_a_stacked_area_says_so(self):
+        assert only_layer(px.area(frame(), x="x", y="y", color="g"))["type"] == (
+            PlotType.STACKED_AREA.value
+        )
+
+    def test_a_single_band_is_an_area(self):
+        single = frame()[lambda d: d.g == "a"]
+        assert only_layer(px.area(single, x="x", y="y"))["type"] == (
+            PlotType.AREA.value
+        )
+
+    def test_groupnorm_reaches_the_layer(self):
+        layer = only_layer(
+            px.area(frame(), x="x", y="y", color="g", groupnorm="percent")
+        )
+        assert layer["type"] == PlotType.NORMALIZED_AREA.value
+
+    def test_each_band_carries_its_own_values_not_the_running_total(self):
+        # The distinction the area type exists for. Plotly's calcdata has the
+        # second band's total at 11, 22, 33; its own values are 10, 20, 30 and
+        # those are what a reader needs, with the total derived from them.
+        fig = px.area(frame(), x="x", y="y", color="g")
+        assert band(fig, 1) == [(1, 10, "b"), (2, 20, "b"), (3, 30, "b")]
+
+    def test_each_band_carries_its_name(self):
+        fig = px.area(frame(), x="x", y="y", color="g")
+        assert {point[2] for point in band(fig, 0)} == {"a"}
+
+    def test_two_stack_groups_become_two_layers(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=LOW, stackgroup="one"),
+                go.Scatter(x=X, y=HIGH, stackgroup="two"),
+            ]
+        )
+        emitted = layers(fig)
+        assert [layer["type"] for layer in emitted] == [
+            PlotType.AREA.value,
+            PlotType.AREA.value,
+        ]
+
+
+class TestAreasAndLinesCoexist:
+    """An area is a scatter trace, so the two compete for the same positions."""
+
+    def test_a_line_beside_an_area_is_still_a_line(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=LOW, stackgroup="one"),
+                go.Scatter(x=X, y=[5, 5, 5], mode="lines"),
+            ]
+        )
+        assert sorted(layer["type"] for layer in layers(fig)) == sorted(
+            [PlotType.AREA.value, PlotType.LINE.value]
+        )
+
+    def test_the_area_is_not_also_emitted_as_a_line(self):
+        # An area passes every structural test for a connected line, so left
+        # in the line grouping it would be emitted twice -- once as its own
+        # layer and once inside the multi-line one.
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=LOW, stackgroup="one"),
+                go.Scatter(x=X, y=HIGH, stackgroup="one"),
+            ]
+        )
+        assert len(layers(fig)) == 1
+
+    @pytest.mark.parametrize("area_first", [True, False])
+    def test_every_band_gets_a_selector_of_its_own(self, area_first):
+        traces = [
+            go.Scatter(x=X, y=LOW, stackgroup="one"),
+            go.Scatter(x=X, y=[5, 5, 5], mode="lines"),
+        ]
+        fig = go.Figure(traces if area_first else traces[::-1])
+
+        area = next(
+            layer for layer in layers(fig) if layer["type"] == PlotType.AREA.value
+        )
+        selectors = area["selectors"]
+        assert isinstance(selectors, list)
+        assert len(selectors) == 1
+        # Scoped by position among the subplot's scatter traces, so the two
+        # layers cannot both claim `nth-child(1)`.
+        assert "nth-child" in selectors[0]
+
+    def test_the_two_layers_do_not_share_a_position(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=LOW, stackgroup="one"),
+                go.Scatter(x=X, y=[5, 5, 5], mode="lines"),
+            ]
+        )
+        emitted = []
+        for layer in layers(fig):
+            found = layer["selectors"]
+            emitted += found if isinstance(found, list) else [found]
+        assert len(emitted) == len(set(emitted))

--- a/tests/plotly/test_plotly_mode_default.py
+++ b/tests/plotly/test_plotly_mode_default.py
@@ -217,8 +217,15 @@ class TestTheExportedLayer:
         # explicit "lines+markers" is classified the same way.
         assert self._types(6) == [PlotType.SCATTER]
 
-    def test_a_stacked_modeless_chart_is_a_line_at_any_size(self):
-        assert self._types(6, stackgroup="one") == [PlotType.LINE]
+    def test_a_stacked_modeless_chart_is_connected_at_any_size(self):
+        # `stackgroup` makes plotly connect the samples whatever the mode
+        # default would have been, so six points is a band rather than the
+        # loose markers a mode-less six-point scatter gets. This asserted
+        # `LINE` until #392 taught the adapter that a stacked trace is a
+        # filled area -- a stricter reading of the same figure, and the
+        # property being guarded here is unchanged: not `SCATTER`.
+        assert self._types(6, stackgroup="one") == [PlotType.AREA]
+        assert self._types(6) == [PlotType.SCATTER]
 
     def test_the_rescued_line_gets_a_scoped_selector(self):
         # Reclassifying is only half the job -- the layer has to carry a


### PR DESCRIPTION
Closes #392.

`px.area` produces a `Scatter`, and the only thing separating it from a line is `stackgroup`. The adapter had no area handling at all — `maidr/plotly/` carried bar, box, heatmap, histogram, line, pie, scatter and step, and no `area` — so every one of them fell through to `line`.

```
px.area                    ['line']
px.area(color=...)         ['line']    stackgroups: ['1', '1']
```

## Severity, honestly

The numbers were already right. Plotly keeps each series' own values in `trace.y` and stacks in the browser, so a stacked area announced `1, 2, 3` and `10, 20, 30` rather than running totals — the opposite of the matplotlib/ggplot2 hazard where the built data holds the cumulative top.

What was missing is the name and the relationship: a filled, stacked band announced as a line tells a reader neither that the bands are filled nor that they stack, which is the reason someone draws this chart rather than a multi-line one.

## `stackgroup` is structural, and plotly's calcdata confirms which number is which

| | `fill` | calcdata keys |
|---|---|---|
| `stackgroup` set | `tonexty` | `s` (band's own value) **and** `y` (running total) |
| plain line | `none` | no `s` at all |

For series of `1,2,3` and `10,20,30`, the second's `y` comes back `11,22,33` while its `s` stays `10,20,30`. So `trace["y"]` — which the Python side has — is the band's own value and needs no un-accumulating. The total stays the core's to derive, as it is for `stackplot`; emitting it here would give the trace two sources that could disagree.

## Two rules measured rather than assumed

**Traces stack only within their own `stackgroup`.** Given `one` and `two` on one subplot, each series' calcdata `y` equals its own `s` — nothing accumulates across them. Two groups therefore become two layers.

**An empty `stackgroup` means "do not stack"**, not "stack with the unnamed group". A plain scatter resolves to `stackgroup: ""`, so the test is truthiness rather than presence — there is a falsification row for exactly that.

## The trap this had

An area passes *every* structural test for a connected line. Left in the line grouping it is emitted **twice** — once as its own layer and once inside the multi-line one. It is split out before any of that machinery sees the group; reverting that split fails 4 tests.

## Also

Adds `PlotType.NORMALIZED_AREA` for `groupnorm="percent"`/`"fraction"`. The JS grammar already carries `stacked_normalized_area` and py-maidr had no counterpart, so a 100% stacked area had nowhere to go.

## Selector verification

Every emitted selector resolved against real Plotly.js output in Chromium: **9 of 9 matched exactly one element**, including the mixed area-and-line figures in both orders, where the two layers compete for `scatterlayer` positions.

## One existing expectation changed rather than broke

`test_a_stacked_modeless_chart_is_a_line_at_any_size` asserted `LINE` for a `stackgroup` trace. It predates area support and was guarding against the trace being announced as loose markers — `AREA` is a stricter reading of the same figure, not a regression. Renamed to `..._is_connected_at_any_size`, and the anti-`SCATTER` property it existed for is now asserted explicitly beside it.

## Falsification

| reverted | failures |
|---|---|
| no area handling at all (the bug) | 10 |
| a lone band is still `stacked_area` | 7 |
| leave areas in the line grouping | 4 |
| one layer for every stackgroup at once | 3 |
| ignore `groupnorm` | 3 |
| an empty `stackgroup` counts as an area | 1 |

## Checks

- `uv run pytest tests/` — **1570 passed** (up 24)
- `ruff check` on every changed file — clean. The tree reports 7 findings, identical with and without this branch.
- No line over 88 characters

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_