### PR TITLE
fix(plotly): announce a barnorm layer's shares rather than its counts

### DIFF
--- a/maidr/plotly/barnorm.py
+++ b/maidr/plotly/barnorm.py
@@ -1,0 +1,177 @@
+"""Rescaling a stack to a common total, the way ``layout.barnorm`` draws it.
+
+``barnorm`` tells plotly to rescale every stack position to a common total, so
+the bars a reader sees are *shares of their position* rather than the numbers
+in the data frame. The layer is typed ``stacked_normalized_bar`` for it, and
+the values underneath were the untouched inputs -- the type and the values
+contradicting each other (#409).
+
+Every rule here was measured against ``gd.calcdata[i][j].s`` after
+``Plotly.newPlot`` in Chromium rather than read from the documentation, and
+two of them are not what the documentation would suggest. See
+``stack_shares`` for the denominators.
+
+The MAIDR core does not do this arithmetic for us, and that is the settled
+convention rather than an oversight: ``SegmentedTrace`` handles ``stacked``,
+``dodged`` and ``stacked_normalized_bar`` with one class and normalises
+nothing, so a normalised layer is expected to arrive already carrying shares.
+Both r-maidr paths do exactly that -- base R because the author normalised the
+matrix before calling ``barplot()``, ggplot2 because ``position = "fill"``
+builds its data in 0..1 -- which is what makes py-maidr's plotly path the
+outlier rather than the standard-setter. Contrast ``AreaTrace``, which *does*
+compute its own stack totals, and so is deliberately fed raw values.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Hashable, Sequence
+
+#: The values ``layout.barnorm`` takes when plotly rescales a stack. ``percent``
+#: scales each position to 100 and ``fraction`` to 1; anything else -- ``None``,
+#: ``""``, an unrecognised string -- leaves the bars alone.
+_NORMALISING_BARNORMS: dict[str, float] = {"percent": 100.0, "fraction": 1.0}
+
+#: The one barmode that pools positive and negative into a single stack. Every
+#: other combining mode -- ``relative``, which is plotly's default and what
+#: ``px.bar`` leaves behind -- stacks the two sides separately.
+_POOLED_BARMODE = "stack"
+
+
+def barnorm_scale(barnorm: Any) -> float | None:
+    """The multiplier a ``barnorm`` setting scales each position to.
+
+    Parameters
+    ----------
+    barnorm : Any
+        ``layout.barnorm``, which may be absent, empty or unrecognised.
+
+    Returns
+    -------
+    float or None
+        ``100.0`` for ``percent``, ``1.0`` for ``fraction``, and ``None``
+        when plotly normalises nothing -- in which case the caller should
+        emit the values unchanged rather than scaling by 1.
+    """
+    if not isinstance(barnorm, str):
+        return None
+    return _NORMALISING_BARNORMS.get(barnorm)
+
+
+def _measured(value: Any) -> bool:
+    """Whether a value takes part in a total.
+
+    A ``None`` or non-finite entry is a gap: plotly leaves it out of the
+    denominator and leaves it undefined in the output. Measured -- a stack of
+    ``[None, 4]`` came back ``[None, 100]``, so the null neither contributed
+    to the total nor became a zero share.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and (
+        math.isfinite(value)
+    )
+
+
+def stack_totals(
+    series: Sequence[Sequence[tuple[Hashable, Any]]], barmode: Any
+) -> dict[Hashable, dict[bool, float]]:
+    """Sum each stack position, the way the active barmode stacks it.
+
+    Two denominators, and which applies is the barmode's doing:
+
+    ``relative`` -- plotly's default, and what ``px.bar`` leaves behind --
+    draws the positive and negative bars as two stacks growing away from the
+    baseline, and normalises each against its own total. So the denominator
+    is the sum of the *absolute* values sharing a sign. Measured: ``[3, -1]``
+    comes back ``100, -100``, not ``75, -25``.
+
+    ``stack`` pools both signs into one stack, so the denominator is the
+    absolute value of the signed sum, applied to every value at the position.
+    Measured: ``[3, -1, 6]`` comes back ``37.5, -12.5, 75`` -- a denominator
+    of 8. The absolute value is load-bearing rather than cosmetic: ``[0, -4]``
+    comes back ``0, -100``, and a plain signed sum of ``-4`` would have made
+    the second bar ``+100``.
+
+    Zero counts as positive. It contributes nothing either way, but the group
+    it lands in decides whether it gets a share or a gap: measured under
+    ``relative``, ``[0, -4]`` gives ``None, -100`` -- the zero's own group
+    totals zero, so its share is undefined, while under ``stack`` the same
+    input gives ``0, -100`` because the pooled total is non-zero.
+
+    Parameters
+    ----------
+    series : sequence of sequence of (hashable, Any)
+        One sequence per series, each holding ``(position, value)`` pairs.
+        Positions are matched by value, not by index, so a series that skips
+        a position contributes nothing there rather than shifting the rest.
+    barmode : Any
+        ``layout.barmode``. Only ``stack`` pools the signs.
+
+    Returns
+    -------
+    dict
+        ``{position: {sign_is_negative: total}}``. Under ``stack`` every
+        value is filed under ``False``, since one total serves both signs.
+    """
+    pooled = barmode == _POOLED_BARMODE
+    totals: dict[Hashable, dict[bool, float]] = {}
+
+    for one_series in series:
+        for position, value in one_series:
+            if not _measured(value):
+                continue
+            bucket = totals.setdefault(position, {})
+            key = False if pooled else value < 0
+            bucket[key] = bucket.get(key, 0.0) + (value if pooled else abs(value))
+
+    if pooled:
+        # Taken after summing, not per term: the pooled denominator is the
+        # magnitude of the net stack height.
+        for bucket in totals.values():
+            for key, total in bucket.items():
+                bucket[key] = abs(total)
+
+    return totals
+
+
+def stack_shares(
+    series: Sequence[Sequence[tuple[Hashable, Any]]],
+    barmode: Any,
+    scale: float,
+) -> list[list[float | None]]:
+    """Rescale every value to its share of its stack position.
+
+    Parameters
+    ----------
+    series : sequence of sequence of (hashable, Any)
+        One sequence per series, each holding ``(position, value)`` pairs.
+    barmode : Any
+        ``layout.barmode``; see :func:`stack_totals` for what it changes.
+    scale : float
+        ``100.0`` or ``1.0``, from :func:`barnorm_scale`.
+
+    Returns
+    -------
+    list of list of (float or None)
+        The shares, aligned elementwise with *series*. ``None`` marks a
+        position plotly leaves undefined -- either the value was already a
+        gap, or its stack totals zero and the share would be ``0/0``.
+        Measured: a category whose every segment is zero comes back with its
+        ``x`` intact and ``s`` null, so the position survives and only the
+        value is missing. The count of points never changes.
+    """
+    pooled = barmode == _POOLED_BARMODE
+    totals = stack_totals(series, barmode)
+    shares: list[list[float | None]] = []
+
+    for one_series in series:
+        row: list[float | None] = []
+        for position, value in one_series:
+            if not _measured(value):
+                row.append(None)
+                continue
+            bucket = totals.get(position, {})
+            total = bucket.get(False if pooled else value < 0)
+            row.append(None if not total else value / total * scale)
+        shares.append(row)
+
+    return shares

--- a/maidr/plotly/barnorm.py
+++ b/maidr/plotly/barnorm.py
@@ -35,6 +35,14 @@ _NORMALISING_BARNORMS: dict[str, float] = {"percent": 100.0, "fraction": 1.0}
 #: The one barmode that pools positive and negative into a single stack. Every
 #: other combining mode -- ``relative``, which is plotly's default and what
 #: ``px.bar`` leaves behind -- stacks the two sides separately.
+#:
+#: Tested for equality rather than resolved against a default, and that is
+#: deliberate: an unset ``barmode`` must take the ``relative`` branch, which
+#: ``!= "stack"`` already gives. It agrees with
+#: ``PlotlyMaidr._PLOTLY_DEFAULT_BARMODE``, which spells the same default the
+#: other way round, only because these are the two states that reach here --
+#: ``group`` never does, since a dodged layer is not ``NORMALIZED``. A third
+#: combining mode would have to be added in both places, not just one.
 _POOLED_BARMODE = "stack"
 
 
@@ -66,9 +74,9 @@ def _measured(value: Any) -> bool:
     ``[None, 4]`` came back ``[None, 100]``, so the null neither contributed
     to the total nor became a zero share.
     """
-    return isinstance(value, (int, float)) and not isinstance(value, bool) and (
-        math.isfinite(value)
-    )
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    return math.isfinite(value)
 
 
 def stack_totals(

--- a/maidr/plotly/grouped_bar.py
+++ b/maidr/plotly/grouped_bar.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.barnorm import barnorm_scale, stack_shares
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 
@@ -40,20 +41,31 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
     def _get_selector(self) -> str:
         return f"{self._subplot_css_prefix()}.trace.bars .point > path"
 
+    def _horizontal(self, trace: dict) -> bool:
+        """Whether this trace's value runs along ``x`` rather than ``y``."""
+        return trace.get("orientation") == "h"
+
     def _extract_plot_data(self) -> list[list[dict]]:
         """Return grouped bar data as a list-of-lists.
 
         Each inner list represents one group (hue value).  Every item has
         ``x``, ``fill`` (group name), and ``y`` keys.
+
+        A ``stacked_normalized_bar`` layer carries *shares* rather than the
+        traces' own numbers, because that is what plotly draws and what the
+        type claims. See :mod:`maidr.plotly.barnorm`.
         """
         data: list[list[dict]] = []
+        pairs: list[list[tuple]] = []
 
         for trace in self._traces:
             x_vals = as_list(trace.get("x"))
             y_vals = as_list(trace.get("y"))
             fill = trace.get("name", "")
+            horizontal = self._horizontal(trace)
 
             group: list[dict] = []
+            group_pairs: list[tuple] = []
             for xv, yv in zip(x_vals, y_vals):
                 group.append(
                     {
@@ -62,6 +74,24 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
                         MaidrKey.Y.value: self._to_native(yv),
                     }
                 )
+                # Keyed by the *category* and valued by the magnitude, which
+                # swap with the orientation. Matched by category rather than
+                # by index so a series that skips one contributes nothing
+                # there instead of shifting every later position.
+                position, value = (yv, xv) if horizontal else (xv, yv)
+                group_pairs.append((self._to_native(position), self._to_native(value)))
+
             data.append(group)
+            pairs.append(group_pairs)
+
+        scale = barnorm_scale(self._layout.get("barnorm"))
+        if scale is None or self.type != PlotType.NORMALIZED:
+            return data
+
+        shares = stack_shares(pairs, self._layout.get("barmode"), scale)
+        for group, group_shares, trace in zip(data, shares, self._traces):
+            key = MaidrKey.X.value if self._horizontal(trace) else MaidrKey.Y.value
+            for point, share in zip(group, group_shares):
+                point[key] = share
 
         return data

--- a/maidr/plotly/grouped_histogram.py
+++ b/maidr/plotly/grouped_histogram.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.barnorm import barnorm_scale, stack_shares
 from maidr.plotly.histogram import (
     _UNDEFINED_WHEN_EMPTY,
     _occupied_span,
@@ -189,6 +190,32 @@ class PlotlyGroupedHistogramPlot(PlotlyPlot):
                 )
             data.append(series)
 
+        return self._normalised(data)
+
+    def _normalised(self, data: list[list[dict]]) -> list[list[dict]]:
+        """Rescale each bin to a common total when ``barnorm`` says to.
+
+        Applied to the bar values rather than the raw counts, so it composes
+        with ``histnorm`` in plotly's own order -- ``histnorm`` first, then
+        the stack rescaled. Bins are matched by centre, which is shared: the
+        group already bins on one grid, so two series' bars at the same
+        position carry the same centre.
+
+        The bar path does the same thing through the same helper; see
+        :mod:`maidr.plotly.barnorm` for why the two must move together.
+        """
+        scale = barnorm_scale(self._layout.get("barnorm"))
+        if scale is None or self.type != PlotType.NORMALIZED:
+            return data
+
+        pairs = [
+            [(point[MaidrKey.X.value], point[MaidrKey.Y.value]) for point in series]
+            for series in data
+        ]
+        shares = stack_shares(pairs, self._layout.get("barmode"), scale)
+        for series, series_shares in zip(data, shares):
+            for point, share in zip(series, series_shares):
+                point[MaidrKey.Y.value] = share
         return data
 
 

--- a/tests/plotly/test_plotly_barnorm.py
+++ b/tests/plotly/test_plotly_barnorm.py
@@ -399,6 +399,44 @@ class TestTheEmittedHistogramLayer:
         assert got[0][1] is None and got[1][1] is None
         assert got[0] == pytest.approx([200 / 3, None, 100 / 3], nan_ok=True)
 
+    def uneven(self, histnorm=None, barnorm="percent"):
+        """Series of six and three observations, so `histnorm` scales them by
+        different factors and the composition order is actually visible.
+
+        With two equal-sized series it is not: `percent` divides each by its
+        own total, those totals agree, and the shares come out the same
+        whichever order the two are applied in. That degenerate case is why
+        this needs its own figure.
+        """
+        kw = dict(xbins=dict(start=0, end=4, size=1))
+        low = go.Histogram(x=[1, 1, 1, 1, 2, 2], name="x", **kw)
+        high = go.Histogram(x=[1, 2, 2], name="y", **kw)
+        if histnorm:
+            low.histnorm = histnorm
+            high.histnorm = histnorm
+        figure = go.Figure([low, high]).update_layout(barmode="stack")
+        return figure.update_layout(barnorm=barnorm) if barnorm else figure
+
+    def test_barnorm_rescales_the_histnormed_values_not_the_raw_counts(self):
+        # Measured. Raw counts are 4,2 and 1,2, so `barnorm` alone gives
+        # 80/20 and 50/50. Under `histnorm="percent"` the same figure draws
+        # 66.7/33.3 and 33.3/66.7 -- which is `barnorm` applied to the
+        # histnormed values. Were it applied to the counts, `histnorm` could
+        # not change the answer at all.
+        assert values(self.uneven())[0] == pytest.approx([80.0, 50.0])
+
+        composed = values(self.uneven(histnorm="percent"))
+        assert composed[0] == pytest.approx([200 / 3, 100 / 3])
+        assert composed[1] == pytest.approx([100 / 3, 200 / 3])
+
+    @pytest.mark.parametrize("histnorm", ["percent", "probability"])
+    def test_the_share_does_not_depend_on_which_histnorm(self, histnorm):
+        # Both scale a series by its own total, differing only in the factor,
+        # so once each position is rescaled to a common total the shares
+        # coincide. Measured for both.
+        got = values(self.uneven(histnorm=histnorm))
+        assert got[0] == pytest.approx([200 / 3, 100 / 3])
+
     def test_the_bar_and_histogram_paths_agree(self):
         # #409 covers both together because `PlotlyGroupedHistogramPlot`
         # matched `PlotlyGroupedBarPlot` on purpose. Same underlying tallies

--- a/tests/plotly/test_plotly_barnorm.py
+++ b/tests/plotly/test_plotly_barnorm.py
@@ -18,6 +18,17 @@ seaborn have no equivalent declaration — a user normalises the data themselves
 and calls `ax.bar(bottom=...)` — so inferring "every category totals 1.0, so
 this must be normalised" would name a chart from a coincidence in its data.
 Plotly states it, so plotly is where this can be read honestly.
+
+
+A second defect in the same setting, fixed later: the layer was typed
+`stacked_normalized_bar` correctly, and the values under it stayed the raw
+counts (#409). The type said the bars are shares of their category; the
+numbers were the tallies. Everything below the `TestTheScale` class covers
+that half, and every number in it was measured against `gd.calcdata[i][j].s`
+after `Plotly.newPlot` in Chromium rather than read from the documentation --
+including two rules the documentation does not spell out: the denominator
+depends on `barmode`, and under `stack` it is the *absolute value* of the
+signed sum.
 """
 
 from __future__ import annotations
@@ -28,9 +39,16 @@ import pytest
 # does, so a minimal install skips rather than failing at collection.
 plotly = pytest.importorskip("plotly")
 
+import pandas as pd  # noqa: E402
+import plotly.express as px  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402
 
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.barnorm import (  # noqa: E402
+    barnorm_scale,
+    stack_shares,
+    stack_totals,
+)
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 #: Every combination that decides the layer type. `barnorm` normalises a stack
@@ -139,3 +157,264 @@ def test_the_type_is_the_one_the_maidr_core_already_carries() -> None:
     """
     assert PlotType.NORMALIZED.value == "stacked_normalized_bar"
     assert PlotType.NORMALIZED.display_name == "100% stacked bar"
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"c": ["a", "a", "b", "b"], "g": ["x", "y", "x", "y"], "v": [3, 1, 2, 6]}
+    )
+
+
+def only_layer(fig) -> dict:
+    return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+
+
+def values(fig, key: str = "y") -> list[list]:
+    return [[point[key] for point in series] for series in only_layer(fig)["data"]]
+
+
+def one_position(vals: list, barmode: str, scale: float = 100.0) -> list:
+    """Run every value through one shared stack position."""
+    series = [[("a", v)] for v in vals]
+    return [row[0] for row in stack_shares(series, barmode, scale)]
+
+
+class TestTheScale:
+    @pytest.mark.parametrize(
+        ("barnorm", "expected"), [("percent", 100.0), ("fraction", 1.0)]
+    )
+    def test_the_two_normalising_settings(self, barnorm, expected):
+        assert barnorm_scale(barnorm) == expected
+
+    @pytest.mark.parametrize("barnorm", [None, "", "nonsense", 5, True])
+    def test_everything_else_normalises_nothing(self, barnorm):
+        # `None` rather than 1.0, so the caller emits the values untouched
+        # instead of multiplying them by a no-op and turning ints into floats.
+        assert barnorm_scale(barnorm) is None
+
+
+class TestTheDenominatorFollowsTheBarmode:
+    """The rule the documentation does not spell out."""
+
+    def test_relative_normalises_each_sign_against_its_own_total(self):
+        # Measured: [3, -1] comes back 100, -100 -- not 75, -25. `relative`
+        # draws the positive and negative bars as two stacks growing away
+        # from the baseline and normalises each against its own total.
+        assert one_position([3, -1], "relative") == [100.0, -100.0]
+
+    def test_stack_pools_both_signs_into_one_total(self):
+        # Measured: the same input under `stack` comes back 150, -50 --
+        # a denominator of 2, the signed sum.
+        assert one_position([3, -1], "stack") == [150.0, -50.0]
+
+    def test_the_pooled_denominator_is_the_absolute_signed_sum(self):
+        # The measurement that refutes reading it as a plain signed sum:
+        # [0, -4] comes back 0, -100. A denominator of -4 would have made
+        # the second bar +100.
+        assert one_position([0, -4], "stack") == [0.0, -100.0]
+
+    def test_three_values_pooled(self):
+        assert one_position([3, -1, 6], "stack") == [37.5, -12.5, 75.0]
+
+    def test_three_values_by_sign(self):
+        got = one_position([3, -1, 6], "relative")
+        assert got == pytest.approx([100 / 3, -100.0, 200 / 3])
+
+    def test_a_zero_does_not_change_the_pooled_total(self):
+        assert one_position([0, 4, -2], "stack") == [0.0, 200.0, -100.0]
+
+    def test_two_negatives_share_their_own_total(self):
+        assert one_position([-3, -1], "relative") == [-75.0, -25.0]
+
+    def test_an_unset_barmode_behaves_as_relative(self):
+        # Plotly's default is `relative`, and it is what `px.bar` leaves
+        # behind, so an absent barmode must not fall into the pooled rule.
+        assert one_position([3, -1], None) == [100.0, -100.0]
+
+
+class TestUndefinedShares:
+    def test_a_position_totalling_zero_is_a_gap(self):
+        # Measured: a category whose every segment is zero comes back with
+        # its `x` intact and `s` null. The share would be 0/0.
+        assert one_position([0, 0], "relative") == [None, None]
+
+    def test_a_pooled_stack_that_cancels_is_a_gap(self):
+        # [3, -3] sums to zero under `stack`, so nothing can be a share of
+        # it -- measured as null for both.
+        assert one_position([3, -3], "stack") == [None, None]
+
+    def test_the_same_input_is_defined_under_relative(self):
+        # Same numbers, different rule: each sign has a non-zero total of
+        # its own, so both bars are full shares of their side.
+        assert one_position([3, -3], "relative") == [100.0, -100.0]
+
+    def test_a_zero_alone_in_its_sign_group_is_a_gap(self):
+        # Measured under `relative`: [0, -4] gives null, -100. Zero counts
+        # as positive, its group totals zero, so its share is undefined --
+        # where the pooled rule gives it a defined 0.
+        assert one_position([0, -4], "relative") == [None, -100.0]
+
+    def test_a_null_stays_null_and_leaves_the_total_alone(self):
+        # Measured: [None, 4] comes back null, 100 -- so the null neither
+        # contributed to the denominator nor became a zero share.
+        assert one_position([None, 4], "relative") == [None, 100.0]
+
+    def test_a_gap_keeps_its_position(self):
+        # The count of points never changes: plotly blanks the value and
+        # keeps the `x`, so the category is still reachable by a cursor.
+        series = [[("a", 0), ("b", 3)], [("a", 0), ("b", 1)]]
+        assert stack_shares(series, "relative", 100.0) == [
+            [None, 75.0],
+            [None, 25.0],
+        ]
+
+
+class TestPositionsAreMatchedByValue:
+    def test_a_series_that_skips_a_position_contributes_nothing_there(self):
+        # Ragged input: measured with one trace covering both categories and
+        # the other only the first, the lone bar at the second came back 100.
+        series = [[("a", 3), ("b", 2)], [("a", 1)]]
+        assert stack_shares(series, "relative", 100.0) == [[75.0, 100.0], [25.0]]
+
+    def test_totals_are_keyed_by_position_not_index(self):
+        # Declared in opposite orders, so an index-keyed total would pair
+        # 'a' with 'b'.
+        series = [[("a", 3), ("b", 2)], [("b", 6), ("a", 1)]]
+        assert stack_shares(series, "relative", 100.0) == [
+            [75.0, 25.0],
+            [75.0, 25.0],
+        ]
+
+    def test_stack_totals_reports_one_bucket_per_sign(self):
+        totals = stack_totals([[("a", 3)], [("a", -1)]], "relative")
+        assert totals["a"] == {False: 3.0, True: 1.0}
+
+    def test_stack_totals_pools_into_one_bucket(self):
+        totals = stack_totals([[("a", 3)], [("a", -1)]], "stack")
+        assert totals["a"] == {False: 2.0}
+
+
+class TestTheEmittedBarLayer:
+    def test_percent_reaches_the_layer(self):
+        fig = px.bar(frame(), x="c", y="v", color="g").update_layout(
+            barnorm="percent"
+        )
+        assert values(fig) == [[75.0, 25.0], [25.0, 75.0]]
+
+    def test_fraction_reaches_the_layer(self):
+        fig = px.bar(frame(), x="c", y="v", color="g").update_layout(
+            barnorm="fraction"
+        )
+        assert values(fig) == [[0.75, 0.25], [0.25, 0.75]]
+
+    def test_the_type_and_the_values_now_agree(self):
+        fig = px.bar(frame(), x="c", y="v", color="g").update_layout(
+            barnorm="percent"
+        )
+        layer = only_layer(fig)
+        assert layer["type"] == PlotType.NORMALIZED.value
+        assert sum(point["y"] for point in layer["data"][0][:1]) == 75.0
+
+    def test_without_barnorm_the_counts_are_untouched(self):
+        fig = px.bar(frame(), x="c", y="v", color="g")
+        assert only_layer(fig)["type"] == PlotType.STACKED.value
+        assert values(fig) == [[3, 2], [1, 6]]
+
+    def test_a_horizontal_bar_normalises_the_value_axis(self):
+        # The category and the magnitude swap axes, so normalising `y` would
+        # rescale the categories. Measured: the shares come back on `x`.
+        fig = px.bar(
+            frame(), y="c", x="v", color="g", orientation="h"
+        ).update_layout(barnorm="percent")
+        assert values(fig, "x") == [[75.0, 25.0], [25.0, 75.0]]
+
+    def test_a_horizontal_bar_leaves_its_categories_alone(self):
+        fig = px.bar(
+            frame(), y="c", x="v", color="g", orientation="h"
+        ).update_layout(barnorm="percent")
+        assert values(fig, "y") == [["a", "b"], ["a", "b"]]
+
+    def test_an_unrecognised_barnorm_changes_nothing(self):
+        fig = px.bar(frame(), x="c", y="v", color="g").update_layout(barnorm="")
+        assert values(fig) == [[3, 2], [1, 6]]
+
+
+class TestDodgedIsLeftAlone:
+    """A degenerate combination, pinned rather than half-handled."""
+
+    def test_a_dodged_barnorm_keeps_its_counts(self):
+        # `barmode="group"` makes every bar its own stack, so plotly draws
+        # all four at 100% -- measured, every `s` came back 100. The layer
+        # is typed `dodged_bar`, which claims no normalisation, so the type
+        # and the values do not contradict each other the way #409 describes.
+        #
+        # Emitting four 100s would be faithful to the drawn geometry and
+        # useless to a reader; emitting the counts keeps the information and
+        # matches the announced type. Neither is fully right, which is why
+        # this is pinned rather than fixed here.
+        fig = px.bar(
+            frame(), x="c", y="v", color="g", barmode="group"
+        ).update_layout(barnorm="percent")
+        assert only_layer(fig)["type"] == PlotType.DODGED.value
+        assert values(fig) == [[3, 2], [1, 6]]
+
+
+class TestTheEmittedHistogramLayer:
+    def bins(self, **layout):
+        fig = go.Figure(
+            [
+                go.Histogram(
+                    x=[1, 1, 1, 2, 2], name="x", xbins=dict(start=0, end=4, size=1)
+                ),
+                go.Histogram(
+                    x=[1, 2, 2, 2, 2], name="y", xbins=dict(start=0, end=4, size=1)
+                ),
+            ]
+        )
+        return fig.update_layout(barmode="stack", **layout)
+
+    def test_the_shares_match_the_drawn_bars(self):
+        got = values(self.bins(barnorm="percent"))
+        assert got[0] == pytest.approx([75.0, 100 / 3])
+        assert got[1] == pytest.approx([25.0, 200 / 3])
+
+    def test_without_barnorm_the_counts_stay(self):
+        assert values(self.bins()) == [[3, 2], [1, 4]]
+
+    def test_an_empty_bin_between_two_full_ones_is_a_gap(self):
+        # Measured: plotly keeps the bin's `x` and leaves `s` null, because
+        # the share would be 0/0. The bin count does not change.
+        fig = go.Figure(
+            [
+                go.Histogram(
+                    x=[1, 1, 3], name="x", xbins=dict(start=0, end=5, size=1)
+                ),
+                go.Histogram(
+                    x=[1, 3, 3], name="y", xbins=dict(start=0, end=5, size=1)
+                ),
+            ]
+        ).update_layout(barmode="stack", barnorm="percent")
+        got = values(fig)
+        assert [len(series) for series in got] == [3, 3]
+        assert got[0][1] is None and got[1][1] is None
+        assert got[0] == pytest.approx([200 / 3, None, 100 / 3], nan_ok=True)
+
+    def test_the_bar_and_histogram_paths_agree(self):
+        # #409 covers both together because `PlotlyGroupedHistogramPlot`
+        # matched `PlotlyGroupedBarPlot` on purpose. Same underlying tallies
+        # drawn both ways must produce the same shares.
+        as_bars = px.bar(
+            pd.DataFrame(
+                {
+                    "c": [1.5, 1.5, 2.5, 2.5],
+                    "g": ["x", "y", "x", "y"],
+                    "v": [3, 1, 2, 4],
+                }
+            ),
+            x="c",
+            y="v",
+            color="g",
+        ).update_layout(barnorm="percent")
+        from_bins = values(self.bins(barnorm="percent"))
+        for bar_series, bin_series in zip(values(as_bars), from_bins):
+            assert bar_series == pytest.approx(bin_series)

--- a/tests/plotly/test_plotly_grouped_histogram.py
+++ b/tests/plotly/test_plotly_grouped_histogram.py
@@ -233,15 +233,15 @@ class TestCategoricalGroupDeclines:
 
 
 class TestBarnormValuesStayRaw:
-    """Deliberate, and shared with the bar path -- see #409."""
+    """Now the shares, matching the bar path -- #409, which this pinned."""
 
-    def test_the_values_are_the_counts_rather_than_the_shares(self):
+    def test_the_values_are_the_shares_rather_than_the_counts(self):
         layer = only_layer(stacked(SMALL_A, SMALL_B, barnorm="percent"))
         first = [point["y"] for point in layer["data"][0]]
-        # Plotly draws 100 and 25 for these; the counts are 4 and 1. Pinned so
-        # that whoever takes #409 sees this test fail rather than discovering
-        # the divergence from the chart.
-        assert first == [4, 1]
+        # Plotly draws 100 and 25 for these; the counts were 4 and 1. This
+        # test previously asserted the counts, to pin the divergence until
+        # #409 was taken.
+        assert first == [100.0, 25.0]
 
     def test_the_type_still_reports_the_normalisation(self):
         layer = only_layer(stacked(SMALL_A, SMALL_B, barnorm="percent"))


### PR DESCRIPTION
Closes #409.

`layout.barnorm` rescales each stack position to a common total, so the bars a reader sees are *shares of their category*. Since #338/#393 the layer was typed `stacked_normalized_bar` for it — and the values underneath were the untouched inputs.

| | series x | series y |
|---|---|---|
| Plotly.js draws | `75, 25` | `25, 75` |
| py-maidr announced | `3, 2` | `1, 6` |

The type said the bars are proportions; the numbers were the tallies. Adding them up did not reach 100, and comparing two categories gave their counts rather than the shares — which is the one thing a 100% stacked chart exists to say.

## Why the producer, and not the core

I checked before assuming, because the opposite convention exists in this codebase. `SegmentedTrace` handles `stacked`, `dodged` and `stacked_normalized_bar` with one class and normalises nothing, so a normalised layer is expected to arrive already carrying shares. Both r-maidr paths already do:

- **base R** — `base_r_stacked_bar_layer_processor.R` says so outright: "the values are already the drawn shares, since base R has no `position = "fill"` and the author normalised the matrix before calling `barplot()`."
- **ggplot2** — `position = "fill"` builds its data in 0..1, and `ggplot2_stacked_bar_layer_processor.R` already handles the exact hazard: "the value the chart draws is a share and NOT the number sitting in the user's data frame… a normalized layer has to take the geometry route and subtract."

So the plotly path was the outlier, not the standard-setter. Contrast `AreaTrace`, which *does* compute its own stack totals and is therefore deliberately fed raw values — the two conventions coexist because the JS side differs per trace type, so this had to be established rather than assumed.

## Measured, not read

Every rule comes from `gd.calcdata[i][j].s` after `Plotly.newPlot` in Chromium. Two are not what the documentation suggests, and I only found them by measuring:

**The denominator depends on `barmode`.**

| input | `relative` (default) | `stack` |
|---|---|---|
| `[3, -1]` | `100, -100` | `150, -50` |
| `[3, -1, 6]` | `33.3, -100, 66.7` | `37.5, -12.5, 75` |

`relative` draws positive and negative as two stacks growing away from the baseline and normalises each against its own total; `stack` pools them. My first reading was "sign-grouped always", and the `stack` column refuted it.

**Under `stack` the denominator is the *absolute value* of the signed sum.** `[0, -4]` draws `0, -100`. A plain signed sum of `-4` would have made the second bar `+100`. This one is easy to get wrong and produces a sign-flipped chart when you do.

**A zero-total position is a gap that keeps its `x`.** The issue predicted plotly "has no point at all"; measured, the point survives with `x` intact and `s` null. That is better than predicted — the point count never changes, so nothing downstream has to be renumbered, and it maps onto the gap concept `SegmentedTrace` already has ("a category is only a gap in the total when every segment in it is one").

Also measured: a null contributes nothing to the denominator and stays null rather than becoming a zero share; positions are matched by category value, so a ragged series contributes nothing where it has no bar.

## Scope

Bars and histograms move together, which is what #409 asks for — `PlotlyGroupedHistogramPlot` matched `PlotlyGroupedBarPlot` on purpose, so changing one alone would make them disagree. A test asserts the two produce identical shares from the same tallies.

Horizontal bars normalise `x` rather than `y`, since the category and the magnitude swap axes; normalising `y` would have rescaled the categories.

**Dodged is deliberately left alone.** `barnorm` makes every bar its own stack under `barmode="group"`, so plotly draws four 100s. But the layer is typed `dodged_bar`, which claims no normalisation, so the type and the values do not contradict each other the way #409 describes. Emitting four 100s would be faithful to the geometry and useless to a reader; emitting the counts keeps the information and matches the announced type. Neither is fully right, so it is pinned with that reasoning rather than quietly half-fixed.

## Verification

- **Suite 1621 passed** (1584 on `main` + 37 new).
- The new module reproduces **13 of 13** Chromium-measured cases exactly before any wiring.
- Falsification: without the bar path **5** fail; without the histogram path **4**; without the sign split **7**; without the pooled absolute value **1**.
- `test_the_values_are_the_counts_rather_than_the_shares`, pinned in #394 so whoever took this would see a failure rather than a discovery, failed exactly as intended and is updated.
- `ruff check` clean; no line over 88 (checked separately, since ruff does not select `E501` here).

One note on process: this PR's test file already existed from #393, and my first pass overwrote it. Caught before committing — the diff is **279 additions, 0 deletions**, and all five original tests are still present and passing.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_