### PR TITLE
fix(violin): emit box statistics raw instead of rounded to four decimals

### DIFF
--- a/maidr/core/plot/violin_box_plot.py
+++ b/maidr/core/plot/violin_box_plot.py
@@ -111,20 +111,15 @@ class ViolinBoxPlot(MaidrPlot):
 
         Notes
         -----
-        The statistics are emitted raw. They were rounded to four decimals,
-        which sounds like precision and is not: ``round(x, 4)`` is absolute,
-        so nothing below ``1e-4`` survives it. For data in micrograms, molar
-        concentrations, failure probabilities or seconds of a fast benchmark,
-        every one of ``min``/``q1``/``q2``/``q3``/``max`` came out ``0.0`` and
-        the box read as a flat line at zero -- silently, since the chart drew
-        correctly and only the numbers were gone. At the other end a dataset
-        in millions carried four decimals of noise no one can hear.
+        Emitted raw. Rounding to four decimals here is absolute, not
+        significant, so data below ``1e-4`` collapsed to five identical
+        ``0.0``\\ s and the box read as a flat line at zero (#398).
 
-        How many digits a reader hears is the frontend's decision, and it is
-        the only place that can make it relative to the magnitude. Emitting
-        raw also settles two disagreements this file was on the wrong side
-        of: the outliers beside these keys were never rounded, and neither
-        the matplotlib box plot nor the plotly violin path rounds at all.
+        The frontend already handles this correctly and needs the raw value
+        to do it: ``defaultFormat`` rounds to two decimals for the
+        announcement, then falls back to three significant digits when that
+        would erase a non-zero value. Rounding here defeated that guard
+        before the number reached it.
         """
         # Tag artists and register elements for SVG highlighting.
         self._tag_artists()

--- a/maidr/core/plot/violin_box_plot.py
+++ b/maidr/core/plot/violin_box_plot.py
@@ -108,6 +108,23 @@ class ViolinBoxPlot(MaidrPlot):
         list[dict]
             One dict per violin with keys: ``z, lowerOutliers, min,
             q1, q2, q3, max, upperOutliers, mean?``.
+
+        Notes
+        -----
+        The statistics are emitted raw. They were rounded to four decimals,
+        which sounds like precision and is not: ``round(x, 4)`` is absolute,
+        so nothing below ``1e-4`` survives it. For data in micrograms, molar
+        concentrations, failure probabilities or seconds of a fast benchmark,
+        every one of ``min``/``q1``/``q2``/``q3``/``max`` came out ``0.0`` and
+        the box read as a flat line at zero -- silently, since the chart drew
+        correctly and only the numbers were gone. At the other end a dataset
+        in millions carried four decimals of noise no one can hear.
+
+        How many digits a reader hears is the frontend's decision, and it is
+        the only place that can make it relative to the magnitude. Emitting
+        raw also settles two disagreements this file was on the wrong side
+        of: the outliers beside these keys were never rounded, and neither
+        the matplotlib box plot nor the plotly violin path rounds at all.
         """
         # Tag artists and register elements for SVG highlighting.
         self._tag_artists()
@@ -124,11 +141,11 @@ class ViolinBoxPlot(MaidrPlot):
             record: dict = {
                 MaidrKey.Z.value: str(group),
                 MaidrKey.LOWER_OUTLIER.value: stats[MaidrKey.LOWER_OUTLIER.value],
-                MaidrKey.MIN.value: round(stats[MaidrKey.MIN.value], 4),
-                MaidrKey.Q1.value: round(stats[MaidrKey.Q1.value], 4),
-                MaidrKey.Q2.value: round(stats[MaidrKey.Q2.value], 4),
-                MaidrKey.Q3.value: round(stats[MaidrKey.Q3.value], 4),
-                MaidrKey.MAX.value: round(stats[MaidrKey.MAX.value], 4),
+                MaidrKey.MIN.value: stats[MaidrKey.MIN.value],
+                MaidrKey.Q1.value: stats[MaidrKey.Q1.value],
+                MaidrKey.Q2.value: stats[MaidrKey.Q2.value],
+                MaidrKey.Q3.value: stats[MaidrKey.Q3.value],
+                MaidrKey.MAX.value: stats[MaidrKey.MAX.value],
                 MaidrKey.UPPER_OUTLIER.value: stats[MaidrKey.UPPER_OUTLIER.value],
             }
 
@@ -139,7 +156,7 @@ class ViolinBoxPlot(MaidrPlot):
                 else False
             )
             if show_mean and MaidrKey.MEAN.value in stats:
-                record[MaidrKey.MEAN.value] = round(stats[MaidrKey.MEAN.value], 4)
+                record[MaidrKey.MEAN.value] = stats[MaidrKey.MEAN.value]
 
             box_data.append(record)
 

--- a/tests/core/plot/test_violin_box_precision.py
+++ b/tests/core/plot/test_violin_box_precision.py
@@ -1,0 +1,124 @@
+"""Rounding violin box statistics to 4 decimals flattened small data (#398).
+
+`round(x, 4)` is absolute, not significant. It does not keep four digits of
+precision; it discards everything below `1e-4`. For any dataset sitting under
+that -- micrograms, molar concentrations, failure probabilities, seconds in a
+fast benchmark -- every statistic came out `0.0`, so `min`, `q1`, `q2`, `q3`
+and `max` were identical and the box read as a flat line at zero.
+
+Nothing errored. The chart drew correctly, the layer was present, the count of
+violins was right. Only the distribution was gone.
+
+Formatting for announcement belongs to the frontend, which is the only place
+that can choose digits relative to the magnitude. Emitting raw also settles
+two disagreements this path was on the wrong side of: the outliers emitted
+beside these keys were never rounded, and neither the matplotlib box plot nor
+the plotly violin path rounds at all.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+import maidr  # noqa: E402,F401
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+sns = pytest.importorskip("seaborn")
+pd = pytest.importorskip("pandas")
+
+#: Well below the old 1e-4 floor, and the scale at which the failure was total.
+MICRO = 2e-6
+
+
+def box_layer(frame) -> dict:
+    figure, axes = plt.subplots()
+    try:
+        sns.violinplot(data=frame, x="g", y="v", ax=axes)
+        layers = FigureManager.get_maidr(figure)._flatten_maidr()["subplots"][0][0][
+            "layers"
+        ]
+        return next(
+            layer for layer in layers if layer["type"].name == "VIOLIN_BOX"
+        )["data"][0]
+    finally:
+        plt.close(figure)
+
+
+def micro_frame() -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    return pd.DataFrame({"g": ["a"] * 40, "v": rng.normal(MICRO, 3e-7, 40)})
+
+
+class TestSmallMagnitudesSurvive:
+    def test_the_quartiles_are_not_all_zero(self):
+        record = box_layer(micro_frame())
+        stats = [record[key] for key in ("min", "q1", "q2", "q3", "max")]
+        assert not all(value == 0.0 for value in stats)
+
+    def test_the_five_statistics_stay_distinct(self):
+        # The failure's real shape: not merely small numbers, but a box whose
+        # every edge collapsed onto the same one, so the distribution stopped
+        # being announced at all.
+        record = box_layer(micro_frame())
+        stats = [record[key] for key in ("min", "q1", "q2", "q3", "max")]
+        assert len(set(stats)) == len(stats)
+
+    def test_the_values_land_at_the_data_s_own_scale(self):
+        record = box_layer(micro_frame())
+        assert record["q2"] == pytest.approx(MICRO, rel=0.5)
+
+    def test_the_order_still_holds(self):
+        record = box_layer(micro_frame())
+        assert (
+            record["min"]
+            <= record["q1"]
+            <= record["q2"]
+            <= record["q3"]
+            <= record["max"]
+        )
+
+
+class TestOrdinaryMagnitudesAreUnchangedInMeaning:
+    def frame(self) -> pd.DataFrame:
+        rng = np.random.default_rng(0)
+        return pd.DataFrame({"g": ["a"] * 40, "v": rng.normal(2.0, 0.3, 40)})
+
+    def test_the_statistics_are_still_ordered(self):
+        record = box_layer(self.frame())
+        assert (
+            record["min"]
+            <= record["q1"]
+            <= record["q2"]
+            <= record["q3"]
+            <= record["max"]
+        )
+
+    def test_full_precision_now_reaches_the_schema(self):
+        # The other end of the same change: at an ordinary scale the old code
+        # truncated real digits rather than erasing the number. At least one
+        # of the five must now differ from its own four-decimal rounding, or
+        # the rounding is still happening somewhere.
+        record = box_layer(self.frame())
+        stats = [record[key] for key in ("min", "q1", "q2", "q3", "max")]
+        assert any(value != round(value, 4) for value in stats)
+
+
+class TestTheRecordIsInternallyConsistent:
+    def test_outliers_and_quartiles_are_both_raw(self):
+        # The outliers were never rounded, so a rounded quartile could sit
+        # beside a full-precision outlier in one record and the two would not
+        # be comparable.
+        frame = pd.DataFrame(
+            {"g": ["a"] * 11, "v": [-5e-5] + [1e-6 * i for i in range(1, 11)]}
+        )
+        record = box_layer(frame)
+        outliers = record["lowerOutliers"] + record["upperOutliers"]
+        if outliers:
+            assert not all(value == 0.0 for value in outliers)
+        assert record["q1"] != 0.0

--- a/tests/core/plot/test_violin_box_precision.py
+++ b/tests/core/plot/test_violin_box_precision.py
@@ -27,6 +27,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 
 import maidr  # noqa: E402,F401
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 
 sns = pytest.importorskip("seaborn")
@@ -44,7 +45,7 @@ def box_layer(frame) -> dict:
             "layers"
         ]
         return next(
-            layer for layer in layers if layer["type"].name == "VIOLIN_BOX"
+            layer for layer in layers if layer["type"] is PlotType.VIOLIN_BOX
         )["data"][0]
     finally:
         plt.close(figure)


### PR DESCRIPTION
Closes #398.

`round(x, 4)` sounds like precision and is not. It is absolute, so it does not keep four significant digits — it discards everything below `1e-4`.

| scale | raw q1 | `round(q1, 4)` |
|---|---|---|
| units | `1.7901224999999998` | `1.7901` |
| millis | `0.0017901225` | `0.0018` |
| micros | `1.7901225e-06` | **`0.0`** |

Reproduced exactly as filed, at `2e-6`:

```python
{'z': 'a', 'lowerOutliers': [], 'min': 0.0, 'q1': 0.0, 'q2': 0.0,
 'q3': 0.0, 'max': 0.0, 'upperOutliers': []}
```

All five statistics collapse onto one number, so the box reads as a flat line at zero and the distribution stops being announced. This is the session's recurring shape: nothing errors, the chart draws correctly, the layer is present and the violin count is right — only the meaning is gone. Micrograms, molar concentrations, failure probabilities and fast-benchmark seconds all live below that floor.

At the other end, a dataset in millions carried four decimals of noise no one can hear.

## Why raw

How many digits a reader hears is the frontend's decision, and it is the only place that can make it relative to the magnitude rather than assuming one.

Emitting raw also settles two disagreements this file was on the wrong side of, both checked rather than assumed:

- **Within the same record** — `lowerOutliers` and `upperOutliers` sit beside these keys and were never rounded, so a truncated quartile could already appear next to a full-precision outlier drawn from the same data.
- **Across the codebase** — I grepped every `round(..., 4)` in `maidr/`: these six were the only ones. `boxplot.py` emits `cap["min"]` and `whisker["q1"]` unrounded, and the plotly violin path added in #397 emits raw floats. The remaining `round()` calls elsewhere are coordinate and tick lookups, not announced statistics.

That covers the issue's second checklist item: no other summary emitter does this.

## Verification

- **Suite 1631 passed** (1624 + 7 new). **No existing test depended on the rounded values** — worth stating explicitly, since this changes shipped output and a silent expectation would have been the risk.
- Falsification: restoring the six `round(..., 4)` calls fails **5 of the 7** new tests. The two that still pass are the ordering assertions, which rounding preserves — that is the point of the other five.
- `ruff check` clean; no line over 88.

One note on the tests: my first version of `test_full_precision_now_reaches_the_schema` asserted `a != round(a, 4) or a == approx(round(a, 4))`, which is a tautology and passes either way. Replaced with an assertion that at least one of the five differs from its own four-decimal rounding, which actually fails when the rounding returns.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_