### PR TITLE
refactor(plotly): read the normalising barnorm values from one place

### DIFF
--- a/maidr/plotly/grouped_bar.py
+++ b/maidr/plotly/grouped_bar.py
@@ -55,6 +55,11 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
         traces' own numbers, because that is what plotly draws and what the
         type claims. See :mod:`maidr.plotly.barnorm`.
         """
+        # Resolved before the loop so the ordinary, un-normalised layer does
+        # not build the `(position, value)` tuples only to discard them.
+        scale = barnorm_scale(self._layout.get("barnorm"))
+        normalising = scale is not None and self.type == PlotType.NORMALIZED
+
         data: list[list[dict]] = []
         pairs: list[list[tuple]] = []
 
@@ -74,18 +79,21 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
                         MaidrKey.Y.value: self._to_native(yv),
                     }
                 )
-                # Keyed by the *category* and valued by the magnitude, which
-                # swap with the orientation. Matched by category rather than
-                # by index so a series that skips one contributes nothing
-                # there instead of shifting every later position.
-                position, value = (yv, xv) if horizontal else (xv, yv)
-                group_pairs.append((self._to_native(position), self._to_native(value)))
+                if normalising:
+                    # Keyed by the *category* and valued by the magnitude,
+                    # which swap with the orientation. Matched by category
+                    # rather than by index so a series that skips one
+                    # contributes nothing there instead of shifting every
+                    # later position.
+                    position, value = (yv, xv) if horizontal else (xv, yv)
+                    group_pairs.append(
+                        (self._to_native(position), self._to_native(value))
+                    )
 
             data.append(group)
             pairs.append(group_pairs)
 
-        scale = barnorm_scale(self._layout.get("barnorm"))
-        if scale is None or self.type != PlotType.NORMALIZED:
+        if not normalising:
             return data
 
         shares = stack_shares(pairs, self._layout.get("barmode"), scale)

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -102,12 +102,6 @@ def _is_domain_trace(trace: dict) -> bool:
 #: way a stacked bar chart arrives rather than an exotic one.
 _PLOTLY_DEFAULT_BARMODE = "relative"
 
-#: The values `layout.barnorm` takes when plotly normalises each stack to a
-#: common total -- its own switch for a 100% stacked bar. `percent` scales to
-#: 100 and `fraction` to 1; both mean the segment values are *shares of their
-#: category* rather than counts, which is what the distinct trace type says.
-_NORMALISING_BARNORMS = frozenset({"percent", "fraction"})
-
 #: The barmodes under which plotly *combines* several bar traces into one
 #: chart, and so the ones MAIDR merges into a single layer. ``relative`` is
 #: plotly's name for a stack that lets negative values run below the axis.
@@ -420,10 +414,19 @@ class PlotlyMaidr:
             # are a property of the data rather than of the chart (#338).
             def _combined_type() -> Any:
                 from maidr.core.enum.plot_type import PlotType
+                from maidr.plotly.barnorm import barnorm_scale
 
                 if barmode == "group":
                     return PlotType.DODGED
-                if layout.get("barnorm") in _NORMALISING_BARNORMS:
+                # Asked of the same function that does the rescaling, rather
+                # than of a second copy of the value list. Two copies is how
+                # #409 comes back: a `barnorm` one of them recognised and the
+                # other did not would type the layer
+                # `stacked_normalized_bar` while leaving its values the raw
+                # counts -- the type and the numbers contradicting each other
+                # again, and silently, which is the defect this pair of
+                # readings was reconciled to end.
+                if barnorm_scale(layout.get("barnorm")) is not None:
                     return PlotType.NORMALIZED
                 return PlotType.STACKED
 

--- a/tests/plotly/test_plotly_barnorm.py
+++ b/tests/plotly/test_plotly_barnorm.py
@@ -359,6 +359,33 @@ class TestDodgedIsLeftAlone:
         assert values(fig) == [[3, 2], [1, 6]]
 
 
+class TestDodgedHistogramsAreLeftAloneToo:
+    """The histogram half of :class:`TestDodgedIsLeftAlone`, stated as its own
+    class so the parity is visible from the structure rather than only from a
+    comment.
+
+    Both paths route through ``_combined_type()``, so this is redundant today.
+    That is the point: "shares a helper today" is the assumption that ages
+    worst, and it is the same reason ``test_the_bar_and_histogram_paths_agree``
+    exists.
+    """
+
+    def test_a_dodged_histogram_keeps_its_counts(self):
+        bins = dict(start=0, end=3, size=1)
+        fig = go.Figure(
+            [
+                go.Histogram(x=[1, 1, 2], name="x", xbins=bins),
+                go.Histogram(x=[1, 2, 2], name="y", xbins=bins),
+            ]
+        ).update_layout(barmode="group", barnorm="percent")
+        layer = only_layer(fig)
+        assert layer["type"] == PlotType.DODGED.value
+        assert [[point["y"] for point in series] for series in layer["data"]] == [
+            [2, 1],
+            [1, 2],
+        ]
+
+
 class TestTheTypeAndTheScalingCannotDrift:
     """One source of truth, asserted as a property rather than a value.
 
@@ -396,25 +423,6 @@ class TestTheTypeAndTheScalingCannotDrift:
 
 
 class TestTheEmittedHistogramLayer:
-    def test_a_dodged_histogram_is_left_alone_too(self):
-        # The bar path's analog is `TestDodgedIsLeftAlone`. Both route
-        # through `_combined_type()`, so this looks redundant today -- and
-        # "shares a helper today" is the assumption that ages worst, which is
-        # the whole reason the two paths are pinned against each other.
-        fig = go.Figure(
-            [
-                go.Histogram(x=[1, 1, 2], name="x", xbins=dict(start=0, end=3, size=1)),
-                go.Histogram(x=[1, 2, 2], name="y", xbins=dict(start=0, end=3, size=1)),
-            ]
-        ).update_layout(barmode="group", barnorm="percent")
-        layer = only_layer(fig)
-        assert layer["type"] == PlotType.DODGED.value
-        assert [[point["y"] for point in series] for series in layer["data"]] == [
-            [2, 1],
-            [1, 2],
-        ]
-
-
     def bins(self, **layout):
         fig = go.Figure(
             [

--- a/tests/plotly/test_plotly_barnorm.py
+++ b/tests/plotly/test_plotly_barnorm.py
@@ -359,7 +359,62 @@ class TestDodgedIsLeftAlone:
         assert values(fig) == [[3, 2], [1, 6]]
 
 
+class TestTheTypeAndTheScalingCannotDrift:
+    """One source of truth, asserted as a property rather than a value.
+
+    The classification in `plotly_maidr` and the rescaling in `barnorm` used
+    to hold separate copies of the same two-value set, under the same name in
+    two modules. Extending or editing one without the other would type a layer
+    `stacked_normalized_bar` while leaving its values the raw counts -- #409
+    exactly, and silently. The classification now asks `barnorm_scale`, and
+    this pins the equivalence so a second copy cannot come back unnoticed.
+    """
+
+    @pytest.mark.parametrize("barnorm", ["percent", "fraction", "", None])
+    def test_normalised_typing_agrees_with_being_scaled(self, barnorm):
+        # Only the values plotly will accept: `update_layout(barnorm="x")`
+        # raises on anything else, so a figure cannot carry an unrecognised
+        # one and the equivalence is asserted over the whole reachable set.
+        layer_types = _types(_figure("stack", barnorm))
+        typed_normalised = layer_types == ["stacked_normalized_bar"]
+        assert typed_normalised is (barnorm_scale(barnorm) is not None)
+
+    @pytest.mark.parametrize("barnorm", ["nonsense", "PERCENT", 5, True])
+    def test_an_unreachable_value_scales_nothing(self, barnorm):
+        # Plotly rejects these at `update_layout`, so they cannot arrive from
+        # a real figure -- but `barnorm_scale` is also reached from a
+        # hand-built layout dict, where nothing validates. Case-sensitive on
+        # purpose: plotly's own enum is lower-case.
+        assert barnorm_scale(barnorm) is None
+
+    def test_only_one_definition_of_the_normalising_values_survives(self):
+        # The frozenset in `plotly_maidr` is gone; asked of the module rather
+        # than of the text so a re-added copy fails here rather than drifting.
+        from maidr.plotly import plotly_maidr
+
+        assert not hasattr(plotly_maidr, "_NORMALISING_BARNORMS")
+
+
 class TestTheEmittedHistogramLayer:
+    def test_a_dodged_histogram_is_left_alone_too(self):
+        # The bar path's analog is `TestDodgedIsLeftAlone`. Both route
+        # through `_combined_type()`, so this looks redundant today -- and
+        # "shares a helper today" is the assumption that ages worst, which is
+        # the whole reason the two paths are pinned against each other.
+        fig = go.Figure(
+            [
+                go.Histogram(x=[1, 1, 2], name="x", xbins=dict(start=0, end=3, size=1)),
+                go.Histogram(x=[1, 2, 2], name="y", xbins=dict(start=0, end=3, size=1)),
+            ]
+        ).update_layout(barmode="group", barnorm="percent")
+        layer = only_layer(fig)
+        assert layer["type"] == PlotType.DODGED.value
+        assert [[point["y"] for point in series] for series in layer["data"]] == [
+            [2, 1],
+            [1, 2],
+        ]
+
+
     def bins(self, **layout):
         fig = go.Figure(
             [


### PR DESCRIPTION
Follow-up to review feedback on #414, which landed after that PR merged. The reviewer was right and this is the fix.

## The problem

`plotly_maidr.py` and `barnorm.py` each held their own copy of the two values `layout.barnorm` takes when plotly rescales a stack — under **the same name** in two modules:

```python
# plotly_maidr.py:109        -> decides the layer TYPE
_NORMALISING_BARNORMS = frozenset({"percent", "fraction"})

# barnorm.py:33              -> decides whether values are RESCALED
_NORMALISING_BARNORMS: dict[str, float] = {"percent": 100.0, "fraction": 1.0}
```

They agreed, so nothing was broken. But editing one without the other is exactly how #409 comes back: a `barnorm` that one recognised and the other did not would type the layer `stacked_normalized_bar` while leaving its values the raw counts — the type and the numbers contradicting each other again, and silently. That is the defect these two readings were reconciled to end, so leaving two places to edit was the wrong ending for it.

## The fix

The classification now asks `barnorm_scale(...) is not None`, so there is one list.

## Tests

Two, both aimed at the drift rather than at the values:

- **The equivalence, over the whole reachable set.** For every `barnorm` plotly will accept, "typed `stacked_normalized_bar`" and "gets a scale" must be the same boolean. Worth noting what I found writing it: `update_layout(barnorm="nonsense")` **raises** — plotly validates the enum — so an unrecognised value cannot arrive from a real figure at all. My first version parametrized over junk strings and failed for that reason. The reachable set is `percent`, `fraction`, `""`, `None`; the junk cases moved to a separate test of `barnorm_scale` directly, since it is also reachable from a hand-built layout dict where nothing validates.
- **A guard against a second copy returning**, asserted on the module rather than by grepping text.

Falsification: reintroducing a divergent copy (dropping `fraction` from the classifier) fails **3** tests.

## Also here

The same review noted `grouped_bar._extract_plot_data` built its `(position, value)` tuples for every layer and discarded them unless the layer was normalised. `scale` is knowable before the loop, so the ordinary un-normalised path now skips them entirely.

And a dodged-**histogram** test, the analog of the existing `TestDodgedIsLeftAlone` for bars. It is redundant today because both route through `_combined_type()` — which is the point: "shares a helper today" is the assumption that ages worst, and the two paths are already pinned against each other elsewhere for the same reason.

## Verification

- **Suite 1641 passed.**
- `ruff check` clean; no line over 88.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_