### PR TITLE
fix(plotly): address a box by its trace group and its position within it

### DIFF
--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -14,19 +14,48 @@ _logger = logging.getLogger(__name__)
 
 def _build_box_selector(
     prefix: str,
-    nth_child: int,
-    box_sel: str,
+    group: int,
+    box: int,
     lower_count: int,
     upper_count: int,
 ) -> dict:
     """Build a ``BoxSelector``-compatible dict with split outlier selectors.
 
+    A box needs *two* indices, not one. Plotly gives each trace one
+    ``<g>`` in the ``boxlayer`` and draws that trace's boxes as direct
+    ``path.box`` children of it, so a categorical trace puts every one of
+    its boxes inside a single group. Numbering boxes as though each were
+    its own group -- which this did -- made box 1 match all of them and
+    boxes 2..n match nothing (#395).
+
+    Measured in Chromium: one ``go.Box`` over three categories produces one
+    ``.trace.boxes`` group holding three ``path.box`` children and three
+    ``g.points`` children, and the *j*-th of each pair up positionally --
+    including an empty ``g.points`` for a category with no outliers, which
+    is what keeps the pairing positional rather than a count of which
+    categories happen to have any.
+
     Plotly renders outlier ``path.point`` elements in value-sorted order
-    (ascending).  Lower outliers come first, upper outliers last.  We use
+    (ascending). Lower outliers come first, upper outliers last. We use
     CSS ``:nth-child(An+B of S)`` to address each group separately, the
     same technique matplotlib uses.
+
+    Parameters
+    ----------
+    prefix : str
+        The subplot CSS prefix.
+    group : int
+        One-based position of the trace's ``<g>`` among the ``boxlayer``'s
+        children -- ``layer_position`` + 1, so a candlestick sharing the
+        layer is counted.
+    box : int
+        One-based position of this box among its own trace's boxes.
+    lower_count, upper_count : int
+        How many outliers fall below and above the whiskers.
     """
-    base = f"{prefix}.boxlayer > g:nth-child({nth_child}) .points"
+    group_sel = f"{prefix}.boxlayer > g:nth-child({group})"
+    box_sel = f"{group_sel} > :nth-child({box} of path.box)"
+    base = f"{group_sel} > :nth-child({box} of g.points)"
 
     if lower_count > 0:
         lower_sel = [
@@ -57,33 +86,40 @@ def _build_box_selector(
 class PlotlyBoxPlot(PlotlyPlot):
     """Extract data from a Plotly box trace."""
 
-    def __init__(self, trace: dict, layout: dict, **kwargs: str) -> None:
+    def __init__(
+        self,
+        trace: dict,
+        layout: dict,
+        layer_position: int = 0,
+        **kwargs: str,
+    ) -> None:
         super().__init__(trace, layout, PlotType.BOX, **kwargs)
+        # Zero-based position of this trace's group among the boxlayer's
+        # children. Defaulted for the factory, which sees one trace and has
+        # no idea what shares its layer -- the same reason
+        # `PlotlyCandlestickPlot` defaults it. `PlotlyMaidr` passes the real
+        # one, and a `go.Candlestick` declared first is exactly what makes it
+        # non-zero.
+        self._layer_position = layer_position
         # Populated by _extract_plot_data before _get_selector runs.
         self._outlier_counts: list[tuple[int, int]] = []
 
     def _get_selector(self) -> list[dict]:
         """Return structured per-box selectors with split outliers.
 
-        Plotly renders outlier points in sorted ascending order, so lower
-        outliers appear first in the DOM.  CSS ``:nth-child`` selectors
-        split them the same way matplotlib does.
+        One trace, so every box shares a group and is told apart by its
+        position *within* that group. A categorical `go.Box` draws one box
+        per category into one `<g>`, which is why the group index alone
+        cannot address them (#395).
         """
         prefix = self._subplot_css_prefix()
-        selectors: list[dict] = []
-        num_boxes = max(len(self._outlier_counts), 1)
-        for i in range(num_boxes):
-            n = i + 1
-            box_sel = f"{prefix}.boxlayer > g:nth-child({n}) > path.box"
-            lower_count, upper_count = (
-                self._outlier_counts[i]
-                if i < len(self._outlier_counts)
-                else (0, 0)
+        group = self._layer_position + 1
+        return [
+            _build_box_selector(prefix, group, index + 1, lower, upper)
+            for index, (lower, upper) in enumerate(
+                self._outlier_counts or [(0, 0)]
             )
-            selectors.append(
-                _build_box_selector(prefix, n, box_sel, lower_count, upper_count)
-            )
-        return selectors
+        ]
 
     def _is_horizontal(self) -> bool:
         """Detect if this box trace is horizontal."""

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -29,11 +29,16 @@ def _build_box_selector(
     boxes 2..n match nothing (#395).
 
     Measured in Chromium: one ``go.Box`` over three categories produces one
-    ``.trace.boxes`` group holding three ``path.box`` children and three
+    group in the ``boxlayer`` holding three ``path.box`` children and three
     ``g.points`` children, and the *j*-th of each pair up positionally --
     including an empty ``g.points`` for a category with no outliers, which
     is what keeps the pairing positional rather than a count of which
     categories happen to have any.
+
+    The group is matched by position rather than by class. A candlestick's
+    group in this layer is built the same way, so a class would not tell the
+    two apart; ``layer_position`` counts both types for that reason, and the
+    index it returns is what distinguishes them.
 
     Plotly renders outlier ``path.point`` elements in value-sorted order
     (ascending). Lower outliers come first, upper outliers last. We use

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -90,6 +90,7 @@ class PlotlyBoxPlot(PlotlyPlot):
         self,
         trace: dict,
         layout: dict,
+        *,
         layer_position: int = 0,
         **kwargs: str,
     ) -> None:

--- a/maidr/plotly/candlestick.py
+++ b/maidr/plotly/candlestick.py
@@ -65,7 +65,13 @@ def layer_position(traces: list[dict], trace: dict) -> int:
         The zero-based position among traces drawing into the same layer.
     """
     kind = trace.get("type")
-    if kind == "candlestick":
+    if kind in _BOXLAYER_TRACE_TYPES:
+        # Both directions, not just the candlestick's. `go.Box` and
+        # `go.Candlestick` draw into the same `g.boxlayer`, so each shifts
+        # the other's group index. Counting only same-typed traces was
+        # symmetric-looking and wrong in one direction: a candlestick
+        # counted the boxes beside it, while a box ignored the candlestick
+        # and claimed the group the candlestick had already taken (#395).
         mates = _BOXLAYER_TRACE_TYPES
     else:
         mates = frozenset({kind}) if kind else frozenset()

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -27,32 +27,59 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         The Plotly figure layout.
     """
 
-    def __init__(self, traces: list[dict], layout: dict, **kwargs: str) -> None:
+    def __init__(
+        self,
+        traces: list[dict],
+        layout: dict,
+        layer_positions: list[int] | None = None,
+        **kwargs: str,
+    ) -> None:
         super().__init__(traces[0], layout, PlotType.BOX, **kwargs)
         self._traces = traces
-        # Populated by _extract_plot_data before _get_selector runs.
+        # Each trace's zero-based group position in the boxlayer. Defaulted
+        # to declaration order for the factory, which cannot see what else
+        # shares the layer; `PlotlyMaidr` passes the measured ones.
+        self._layer_positions = (
+            list(layer_positions)
+            if layer_positions is not None
+            else list(range(len(traces)))
+        )
+        # Both populated by _extract_plot_data before _get_selector runs.
         self._outlier_counts: list[tuple[int, int]] = []
+        self._boxes_per_trace: list[int] = []
 
     def _get_selector(self) -> list[dict]:
-        """Return structured per-box selectors with split outliers.
+        """Return one structured selector per box, in the order of the data.
 
-        Each box gets a dict with keys for each part (min, max, q2, iq,
-        lowerOutliers, upperOutliers).  Plotly renders outlier points in
-        sorted ascending order so CSS nth-child can split them.
+        Two indices per box, and both were wrong before (#395). A box is
+        addressed by its trace's group in the ``boxlayer`` *and* by its
+        position inside that group, because a trace with a categorical axis
+        draws all of its boxes into one group.
+
+        Numbering by trace alone also emitted the wrong *number* of
+        selectors: two traces of two categories each produced four boxes of
+        data and two selectors, so half the boxes addressed nothing while
+        the frontend paired the rest positionally.
         """
         prefix = self._subplot_css_prefix()
         selectors = []
-        for i in range(len(self._traces)):
-            n = i + 1
-            box_sel = f"{prefix}.boxlayer > g:nth-child({n}) > path.box"
-            lower_count, upper_count = (
-                self._outlier_counts[i]
-                if i < len(self._outlier_counts)
-                else (0, 0)
-            )
-            selectors.append(
-                _build_box_selector(prefix, n, box_sel, lower_count, upper_count)
-            )
+        box = 0
+        for trace_index, count in enumerate(self._boxes_per_trace):
+            group = (
+                self._layer_positions[trace_index]
+                if trace_index < len(self._layer_positions)
+                else trace_index
+            ) + 1
+            for within in range(count):
+                lower, upper = (
+                    self._outlier_counts[box]
+                    if box < len(self._outlier_counts)
+                    else (0, 0)
+                )
+                selectors.append(
+                    _build_box_selector(prefix, group, within + 1, lower, upper)
+                )
+                box += 1
         return selectors
 
     def _is_horizontal(self) -> bool:
@@ -72,22 +99,34 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         return schema
 
     def _extract_plot_data(self) -> list[dict]:
-        """Return box stats for all traces as a flat list."""
+        """Return box stats for all traces as a flat list.
+
+        The list is trace-major and so is the DOM: plotly gives each trace
+        one group and draws that trace's boxes inside it, in order. How many
+        each trace contributed is recorded as it goes, because the selectors
+        need it and it cannot be recovered afterwards -- a trace can draw one
+        box or one per category, and a flat list of stats no longer says
+        which.
+        """
         all_boxes: list[dict] = []
+        self._boxes_per_trace = []
 
         for trace in self._traces:
             y = trace.get("y", None)
             x = trace.get("x", None)
             name = trace.get("name", "")
+            before = len(all_boxes)
 
             # Pre-computed stats
             if "q1" in trace and "median" in trace:
                 all_boxes.extend(self._extract_precomputed(trace))
+                self._boxes_per_trace.append(len(all_boxes) - before)
                 continue
 
             # Grouped by x
             if x is not None and y is not None:
                 all_boxes.extend(self._extract_grouped(x, y))
+                self._boxes_per_trace.append(len(all_boxes) - before)
                 continue
 
             # Single box — data may be in y (vertical) or x (horizontal)
@@ -97,6 +136,7 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
                 stats = self._compute_stats(arr, label=name)
                 if stats is not None:
                     all_boxes.append(stats)
+            self._boxes_per_trace.append(len(all_boxes) - before)
 
         # Record outlier counts so _get_selector can split them.
         self._outlier_counts = [

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -591,7 +591,31 @@ class PlotlyMaidr:
                 from maidr.plotly.multibox import PlotlyMultiBoxPlot
 
                 plot = PlotlyMultiBoxPlot(
-                    box_traces, layout, **axis_kwargs
+                    box_traces,
+                    layout,
+                    layer_positions=[
+                        layer_position(group_traces, t) for t in box_traces
+                    ],
+                    **axis_kwargs,
+                )
+                plot.row_index = row
+                plot.col_index = col
+                self._plots.append(plot)
+                merged.update(id(t) for t in box_traces)
+
+            # A lone box is built here rather than left to the factory for
+            # one reason: the factory sees a single trace and cannot know
+            # what shares its `boxlayer`. A `go.Candlestick` declared first
+            # draws its own `path.box` group there, so the box's group is
+            # not necessarily the first (#395).
+            elif len(box_traces) == 1:
+                from maidr.plotly.box import PlotlyBoxPlot
+
+                plot = PlotlyBoxPlot(
+                    box_traces[0],
+                    layout,
+                    layer_position=layer_position(group_traces, box_traces[0]),
+                    **axis_kwargs,
                 )
                 plot.row_index = row
                 plot.col_index = col

--- a/tests/plotly/test_plotly_box_selectors.py
+++ b/tests/plotly/test_plotly_box_selectors.py
@@ -170,6 +170,69 @@ class TestSeveralTracesWithCategories:
         )
 
 
+class TestTheLoneBoxIsBuiltOnce:
+    """Guards the fall-through the two-branch structure makes possible.
+
+    A lone box is built in `_extract_plots` so it can be told its real group.
+    If that branch forgot to mark the trace merged, the trace would reach the
+    "remaining traces" loop and `PlotlyPlotFactory` would build a *second*
+    box for it -- with `layer_position` left at its default 0, which is
+    exactly #395 again for the one figure this fix is about.
+
+    Cheap to assert and invisible otherwise: the duplicate would announce the
+    same boxes twice and the wrong one might win.
+    """
+
+    def test_a_candlestick_and_a_box_make_exactly_one_box_layer(self):
+        fig = go.Figure([candle(), go.Box(y=VALUES[:15], name="b")])
+        layers = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+        assert sum(1 for layer in layers if layer["type"] is PlotType.BOX) == 1
+
+    def test_the_surviving_layer_is_the_one_that_knows_its_group(self):
+        # The factory-built fallback would carry `layer_position=0`, so this
+        # distinguishes "built once, correctly" from "built twice, wrong one
+        # kept".
+        fig = go.Figure([candle(), go.Box(y=VALUES[:15], name="b")])
+        assert "g:nth-child(2)" in box_selectors(fig)[0]
+
+    def test_a_lone_box_alone_is_also_built_once(self):
+        fig = go.Figure([go.Box(y=VALUES[:15], name="b")])
+        layers = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+        assert sum(1 for layer in layers if layer["type"] is PlotType.BOX) == 1
+
+
+class TestTheDomContractTheSelectorsAssume:
+    """The measured facts the selector shape depends on, named so a change
+    to plotly's DOM has somewhere to fail.
+
+    These assert the emitted strings, not a rendered document -- the Python
+    suite has no browser. The resolution check (15 of 15 selectors matching
+    exactly one element) was run separately against real Plotly.js in
+    Chromium, and is what the shape below was derived from rather than
+    guessed at. What these can still catch is the shape drifting back.
+    """
+
+    def test_a_box_is_addressed_inside_its_group_not_as_a_group(self):
+        # The regression that started #395: `> path.box` with no index
+        # matches every box the trace drew.
+        for selector in box_selectors(
+            go.Figure([go.Box(x=["a"] * 10 + ["b"] * 10, y=VALUES[:20], name="t")])
+        ):
+            assert "of path.box)" in selector
+            assert not selector.endswith("> path.box")
+
+    def test_outliers_are_scoped_to_one_points_group(self):
+        fig = go.Figure(
+            [go.Box(y=[-100, 1, 2, 3, 4, 5, 6, 7, 8, 100], name="o")]
+        )
+        selector = box_layer(fig)["selectors"][0]
+        for found in selector["lowerOutliers"] + selector["upperOutliers"]:
+            # `.points` as a descendant would reach every box's outliers in
+            # the trace; the indexed child reaches one box's.
+            assert "of g.points)" in found
+            assert " .points" not in found
+
+
 class TestOutliersFollowTheirBox:
     """The outlier groups are per box and positionally aligned."""
 

--- a/tests/plotly/test_plotly_box_selectors.py
+++ b/tests/plotly/test_plotly_box_selectors.py
@@ -1,0 +1,210 @@
+"""A plotly box addressed the wrong element, or none at all (#395).
+
+A box needs *two* indices and was given one. Plotly puts one ``<g>`` in the
+``boxlayer`` per trace and draws that trace's boxes as direct ``path.box``
+children of it, so a categorical `go.Box` puts all of its boxes inside a
+single group. Numbering boxes as though each were its own group made box 1
+match every box in the trace and boxes 2..n match nothing.
+
+Three separate failures, all measured in Chromium before the fix:
+
+1. **One trace, several categories.** Emitted ``g:nth-child(1..3)`` where the
+   DOM holds one group of three boxes.
+2. **A candlestick sharing the layer.** `go.Candlestick` draws its own
+   ``path.box`` group into the same ``boxlayer``, so a box declared after one
+   is not in the first group. ``layer_position`` widened its search to
+   boxlayer-mates only when the trace *was* a candlestick, so a candlestick
+   counted the boxes beside it while a box ignored the candlestick and
+   claimed the group it had already taken.
+3. **Multi-box with categories.** Two traces of two categories produced four
+   boxes of data and only *two* selectors, because the loop ran over traces
+   rather than over boxes. Half the boxes addressed nothing at all, and the
+   frontend pairs selector *i* with box *i*.
+
+Every selector asserted below was resolved against real Plotly.js output in
+Chromium: 15 of 15 matched exactly one element, and the outlier selectors
+matched the categories that actually have outliers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+np = pytest.importorskip("numpy")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.candlestick import layer_position  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+VALUES = list(np.random.default_rng(0).normal(0, 1, 45))
+
+
+def box_layer(fig) -> dict:
+    layers = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+    return next(layer for layer in layers if layer["type"] is PlotType.BOX)
+
+
+def box_selectors(fig) -> list[str]:
+    return [selector["q1"] for selector in box_layer(fig)["selectors"]]
+
+
+def candle() -> go.Candlestick:
+    return go.Candlestick(
+        x=[1, 2], open=[1, 2], high=[2, 3], low=[0, 1], close=[1.5, 2.5]
+    )
+
+
+def categorical(name: str, values: list) -> go.Box:
+    half = len(values) // 2
+    return go.Box(x=["a"] * half + ["b"] * (len(values) - half), y=values, name=name)
+
+
+class TestOneTraceManyCategories:
+    """The boxes share a group and differ by their position inside it."""
+
+    def fig(self) -> go.Figure:
+        return go.Figure(
+            [go.Box(x=["a"] * 15 + ["b"] * 15 + ["c"] * 15, y=VALUES, name="t")]
+        )
+
+    def test_a_selector_per_box(self):
+        assert len(box_selectors(self.fig())) == 3
+
+    def test_every_box_is_in_the_same_group(self):
+        assert all(
+            "g:nth-child(1)" in selector for selector in box_selectors(self.fig())
+        )
+
+    def test_the_boxes_are_told_apart_within_that_group(self):
+        selectors = box_selectors(self.fig())
+        assert "(1 of path.box)" in selectors[0]
+        assert "(2 of path.box)" in selectors[1]
+        assert "(3 of path.box)" in selectors[2]
+
+    def test_no_two_boxes_share_a_selector(self):
+        selectors = box_selectors(self.fig())
+        assert len(set(selectors)) == len(selectors)
+
+    def test_the_selector_count_matches_the_data(self):
+        layer = box_layer(self.fig())
+        assert len(layer["selectors"]) == len(layer["data"])
+
+
+class TestACandlestickSharesTheLayer:
+    """`go.Candlestick` draws `path.box` into the same `boxlayer`."""
+
+    def test_a_box_after_a_candlestick_is_in_the_second_group(self):
+        fig = go.Figure([candle(), go.Box(y=VALUES[:15], name="b")])
+        assert "g:nth-child(2)" in box_selectors(fig)[0]
+
+    def test_a_box_before_a_candlestick_stays_first(self):
+        fig = go.Figure([go.Box(y=VALUES[:15], name="b"), candle()])
+        assert "g:nth-child(1)" in box_selectors(fig)[0]
+
+    def test_layer_position_counts_both_directions(self):
+        # The asymmetry that caused it: a candlestick counted boxes, a box
+        # did not count candlesticks. Both share `g.boxlayer`, so each shifts
+        # the other.
+        traces = [{"type": "candlestick"}, {"type": "box"}]
+        assert layer_position(traces, traces[0]) == 0
+        assert layer_position(traces, traces[1]) == 1
+
+    def test_a_violin_does_not_shift_a_box(self):
+        # `go.Violin` draws into `g.violinlayer`, so it is not a layer-mate
+        # and must not be counted.
+        traces = [{"type": "violin"}, {"type": "box"}]
+        assert layer_position(traces, traces[1]) == 0
+
+    def test_a_scatter_does_not_shift_a_box(self):
+        traces = [{"type": "scatter"}, {"type": "box"}]
+        assert layer_position(traces, traces[1]) == 0
+
+
+class TestSeveralTracesWithCategories:
+    """The case that emitted fewer selectors than boxes."""
+
+    def fig(self) -> go.Figure:
+        return go.Figure(
+            [
+                categorical("t1", VALUES[:15]),
+                categorical("t2", VALUES[15:30]),
+            ]
+        )
+
+    def test_every_box_gets_a_selector(self):
+        layer = box_layer(self.fig())
+        assert len(layer["data"]) == 4
+        assert len(layer["selectors"]) == 4
+
+    def test_the_boxes_are_grouped_by_their_trace(self):
+        selectors = box_selectors(self.fig())
+        assert "g:nth-child(1)" in selectors[0]
+        assert "g:nth-child(1)" in selectors[1]
+        assert "g:nth-child(2)" in selectors[2]
+        assert "g:nth-child(2)" in selectors[3]
+
+    def test_the_order_is_trace_major_like_the_dom(self):
+        # Measured: two groups of two, and the data comes back a, b, a, b.
+        labels = [record["z"] for record in box_layer(self.fig())["data"]]
+        assert labels == ["a", "b", "a", "b"]
+
+    def test_no_two_boxes_share_a_selector(self):
+        selectors = box_selectors(self.fig())
+        assert len(set(selectors)) == len(selectors)
+
+    def test_one_box_per_trace_still_works(self):
+        fig = go.Figure(
+            [
+                go.Box(y=VALUES[:15], name="a"),
+                go.Box(y=VALUES[15:30], name="b"),
+                go.Box(y=VALUES[30:], name="c"),
+            ]
+        )
+        selectors = box_selectors(fig)
+        assert len(selectors) == 3
+        assert all(
+            f"g:nth-child({n})" in selectors[n - 1] for n in (1, 2, 3)
+        )
+
+
+class TestOutliersFollowTheirBox:
+    """The outlier groups are per box and positionally aligned."""
+
+    def fig(self) -> go.Figure:
+        return go.Figure(
+            [
+                go.Box(
+                    x=["a"] * 11 + ["b"] * 10 + ["c"] * 12,
+                    y=(
+                        [-50]
+                        + [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                        + [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                        + [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 90, 95]
+                    ),
+                    name="t",
+                    boxpoints="outliers",
+                )
+            ]
+        )
+
+    def test_only_the_categories_with_outliers_get_outlier_selectors(self):
+        # Measured: 'a' has one low, 'b' none, 'c' two high. Plotly still
+        # emits an empty `g.points` for 'b', which is what keeps the pairing
+        # positional rather than a count of which categories have any.
+        selectors = box_layer(self.fig())["selectors"]
+        assert len(selectors[0]["lowerOutliers"]) == 1
+        assert selectors[1]["lowerOutliers"] == []
+        assert selectors[1]["upperOutliers"] == []
+        assert len(selectors[2]["upperOutliers"]) == 1
+
+    def test_an_outlier_selector_is_scoped_to_its_own_box(self):
+        selectors = box_layer(self.fig())["selectors"]
+        assert "(1 of g.points)" in selectors[0]["lowerOutliers"][0]
+        assert "(3 of g.points)" in selectors[2]["upperOutliers"][0]
+
+    def test_the_outlier_group_shares_its_box_s_trace_group(self):
+        selectors = box_layer(self.fig())["selectors"]
+        assert "g:nth-child(1)" in selectors[0]["lowerOutliers"][0]


### PR DESCRIPTION
Closes #395.

A box needs **two** indices and was given one. Plotly puts one `<g>` in the `boxlayer` per trace and draws that trace's boxes as direct `path.box` children of it, so a categorical `go.Box` puts all of its boxes inside a single group. Numbering them as though each were its own group made box 1 match *every* box in the trace and boxes 2..n match nothing.

The DOM, measured in Chromium:

| figure | trace groups | children of each group |
|---|---|---|
| one `go.Box`, 3 categories | **1** | `path.box ×3`, `g.points ×3` |
| three `go.Box` traces | 3 | `path.box`, `g.points` |
| `go.Candlestick` + `go.Box` | 2 | group 1 is the candlestick's 4 boxes |

## Three failures, not one

**1. One trace, several categories.** Emitted `g:nth-child(1..3)` into a DOM with one group. Now one group, three `:nth-child(n of path.box)` positions inside it.

**2. A candlestick sharing the layer.** `layer_position` widened its search to boxlayer-mates only when the trace *was* a candlestick:

```python
if kind == "candlestick":
    mates = _BOXLAYER_TRACE_TYPES        # {"box", "candlestick"}
else:
    mates = frozenset({kind})            # a box counts only boxes
```

So a candlestick counted the boxes beside it, while a box ignored the candlestick and claimed the group the candlestick had already taken. Both draw into `g.boxlayer`, so each shifts the other. Tests assert both directions, and that a `go.Violin` (`violinlayer`) and a scatter (`scatterlayer`) shift neither.

**3. Multi-box with categories — the one the issue didn't cover.** `PlotlyMultiBoxPlot` looped over *traces* rather than boxes:

```
2 traces × 2 categories → 4 boxes of data, 2 selectors
```

Half the boxes addressed nothing at all, and since the frontend pairs selector *i* with box *i*, the two that did exist were pointing at the wrong boxes. The per-trace box count is now recorded during extraction, because a flat list of stats no longer says which trace contributed what.

## The outlier groups

The part that decides whether outliers are addressable: plotly emits one `g.points` per box, **including an empty one for a category with no outliers**, and the *j*-th pairs with the *j*-th box. That empty group is load-bearing — it keeps the pairing positional rather than a count of which categories happen to have any. Measured with 1, 0 and 2 outliers across three categories:

| box | box x | points in *j*-th `g.points` |
|---|---|---|
| 1 | 150 | 1 |
| 2 | 397 | 0 |
| 3 | 644 | 2 |

## Scope note

A lone box is now built in `_extract_plots` rather than left to `PlotlyPlotFactory`, for the reason the candlestick branch there already documents: the factory sees one trace and cannot know what shares its layer. The factory default stays `0`, which is the only assumption available to it.

## Verification

- **15 of 15** box selectors resolve to exactly one element in Chromium — across a categorical trace, three plain traces, two categorical traces, both candlestick orderings, and the mixed-outlier figure. All selectors within a figure are distinct; outlier selectors match only the categories that have outliers.
- **Suite 1659 passed** (1641 + 18 new). Notably **no existing test failed**, which is itself the finding: the old selectors were never pinned, so the defect was live and silent.
- Falsification: reverting the two-index selector fails **4**; restoring the `layer_position` asymmetry fails **2**; looping over traces again fails **2**.
- `ruff check` clean; no line over 88.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_