### PR TITLE
fix(plotly): generate the positions plotly generates when x is omitted

### DIFF
--- a/maidr/plotly/bar.py
+++ b/maidr/plotly/bar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot, paired_axes
 
 
 class PlotlyBarPlot(PlotlyPlot):
@@ -15,8 +15,7 @@ class PlotlyBarPlot(PlotlyPlot):
         return f"{self._subplot_css_prefix()}.trace.bars .point > path"
 
     def _extract_plot_data(self) -> list[dict]:
-        x = as_list(self._trace.get("x"))
-        y = as_list(self._trace.get("y"))
+        x, y = paired_axes(self._trace)
 
         return [
             {MaidrKey.X: self._to_native(xv), MaidrKey.Y: self._to_native(yv)}

--- a/maidr/plotly/grouped_bar.py
+++ b/maidr/plotly/grouped_bar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.barnorm import barnorm_scale, stack_shares
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot, paired_axes
 
 
 class PlotlyGroupedBarPlot(PlotlyPlot):
@@ -64,8 +64,7 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
         pairs: list[list[tuple]] = []
 
         for trace in self._traces:
-            x_vals = as_list(trace.get("x"))
-            y_vals = as_list(trace.get("y"))
+            x_vals, y_vals = paired_axes(trace)
             fill = trace.get("name", "")
             horizontal = self._horizontal(trace)
 

--- a/maidr/plotly/line.py
+++ b/maidr/plotly/line.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot, paired_axes
 from maidr.plotly.step_shape import renders_through_webgl
 
 
@@ -66,8 +66,7 @@ class PlotlyLinePlot(PlotlyPlot):
         return [self._scatter_line_selector(self._scatter_position)]
 
     def _extract_plot_data(self) -> list[list[dict]]:
-        x = as_list(self._trace.get("x"))
-        y = as_list(self._trace.get("y"))
+        x, y = paired_axes(self._trace)
         name = self._trace.get("name", "")
 
         line_data = []

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -208,8 +208,7 @@ class PlotlyPlot(ABC):
         drawn_positions: list[int] = []
 
         for trace, position in zip(traces, positions):
-            x_values = as_list(trace.get("x"))
-            y_values = as_list(trace.get("y"))
+            x_values, y_values = paired_axes(trace)
             name = trace.get("name", "")
 
             series: list[dict] = []
@@ -784,3 +783,42 @@ def _extract_decimals(fmt: str) -> int | None:
         return None
     match = re.search(r"\.(\d+)", fmt)
     return int(match.group(1)) if match else None
+
+
+def paired_axes(trace: dict, value_key: str = "y", position_key: str = "x") -> tuple:
+    """Return a trace's position and value arrays, generating positions.
+
+    ``x`` is optional in plotly: omit it and the trace is drawn at
+    ``0, 1, 2, ...``. Measured in Chromium rather than assumed --
+    ``go.Scatter(y=[1, 2, 3])`` comes back with ``calcdata`` x of
+    ``[0, 1, 2]`` and one drawn ``path.js-line``, and ``go.Bar(y=[3, 1, 2])``
+    with the same x and three drawn bars.
+
+    Reading the absent array through :func:`as_list`, which answers ``[]``,
+    and pairing the two with ``zip`` then yielded nothing, so every such
+    trace announced a layer of the right type carrying no data at all
+    (#418). Omitting ``x`` is how most quick plots are written, so this was
+    not a corner.
+
+    Generated only when the array is missing entirely. A short one is left
+    short, because plotly pairs the two positionally and draws only as far
+    as the shorter reaches -- truncating is its behaviour, not an error to
+    repair here.
+
+    Parameters
+    ----------
+    trace : dict
+        The plotly trace dictionary.
+    value_key : str, default "y"
+        The key holding the magnitudes. ``"x"`` for a horizontal trace.
+    position_key : str, default "x"
+        The key holding the positions, which is the one plotly generates.
+
+    Returns
+    -------
+    tuple of (list, list)
+        The positions and the values, in that order.
+    """
+    values = as_list(trace.get(value_key))
+    positions = as_list(trace.get(position_key))
+    return (positions or list(range(len(values)))), values

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -836,8 +836,8 @@ def paired_axes(trace: dict) -> tuple:
     # `as_list` answers `[]` for both, so the raw key is the only thing that
     # tells them apart -- and reading it wrongly would invent points for a
     # trace plotly leaves blank.
-    if trace.get("y") is None and xs:
+    if trace.get("y") is None:
         return xs, list(range(len(xs)))
-    if trace.get("x") is None and ys:
+    if trace.get("x") is None:
         return list(range(len(ys))), ys
     return xs, ys

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -785,22 +785,35 @@ def _extract_decimals(fmt: str) -> int | None:
     return int(match.group(1)) if match else None
 
 
-def paired_axes(trace: dict, value_key: str = "y", position_key: str = "x") -> tuple:
-    """Return a trace's position and value arrays, generating positions.
+def paired_axes(trace: dict) -> tuple:
+    """Return a trace's ``x`` and ``y`` arrays, generating whichever is absent.
 
-    ``x`` is optional in plotly: omit it and the trace is drawn at
-    ``0, 1, 2, ...``. Measured in Chromium rather than assumed --
-    ``go.Scatter(y=[1, 2, 3])`` comes back with ``calcdata`` x of
-    ``[0, 1, 2]`` and one drawn ``path.js-line``, and ``go.Bar(y=[3, 1, 2])``
-    with the same x and three drawn bars.
+    Both are optional in plotly, and it fills in the missing one with
+    ``0, 1, 2, ...``. Measured in Chromium rather than assumed, in both
+    directions:
 
+    ===========================================  ===========  ===========
+    trace                                        calcdata x   calcdata y
+    ===========================================  ===========  ===========
+    ``go.Scatter(y=[1,2,3], mode="lines")``      ``0,1,2``    ``1,2,3``
+    ``go.Bar(y=[3,1,2])``                        ``0,1,2``    ``3,1,2``
+    ``go.Bar(x=[3,1,2], orientation="h")``       ``3,1,2``    ``0,1,2``
+    ``go.Scatter(x=[3,1,2], mode="lines")``      ``3,1,2``    ``0,1,2``
+    ===========================================  ===========  ===========
+
+    Each of those draws normally -- one ``path.js-line`` or three bars.
     Reading the absent array through :func:`as_list`, which answers ``[]``,
-    and pairing the two with ``zip`` then yielded nothing, so every such
-    trace announced a layer of the right type carrying no data at all
-    (#418). Omitting ``x`` is how most quick plots are written, so this was
-    not a corner.
+    and pairing the two with ``zip`` yielded nothing, so every such trace
+    announced a layer of the right type carrying no data at all (#418).
+    Omitting one axis is how most quick plots are written, so this was not a
+    corner.
 
-    Generated only when the array is missing entirely. A short one is left
+    Symmetric rather than keyed by which axis carries the magnitudes: a
+    horizontal bar puts its values on ``x`` and needs ``y`` generated, and
+    naming one of them "the value axis" here would make every caller decide
+    an orientation question it does not otherwise ask.
+
+    Generated only when an array is missing entirely. A short one is left
     short, because plotly pairs the two positionally and draws only as far
     as the shorter reaches -- truncating is its behaviour, not an error to
     repair here.
@@ -809,16 +822,22 @@ def paired_axes(trace: dict, value_key: str = "y", position_key: str = "x") -> t
     ----------
     trace : dict
         The plotly trace dictionary.
-    value_key : str, default "y"
-        The key holding the magnitudes. ``"x"`` for a horizontal trace.
-    position_key : str, default "x"
-        The key holding the positions, which is the one plotly generates.
 
     Returns
     -------
     tuple of (list, list)
-        The positions and the values, in that order.
+        The ``x`` and ``y`` arrays, in that order.
     """
-    values = as_list(trace.get(value_key))
-    positions = as_list(trace.get(position_key))
-    return (positions or list(range(len(values)))), values
+    xs = as_list(trace.get("x"))
+    ys = as_list(trace.get("y"))
+    # Absent, not merely empty. Plotly draws the two cases differently and
+    # measurably: with `y` absent it generates `0, 1, 2` and draws normally,
+    # while `y: []` comes back as one null point and draws nothing at all.
+    # `as_list` answers `[]` for both, so the raw key is the only thing that
+    # tells them apart -- and reading it wrongly would invent points for a
+    # trace plotly leaves blank.
+    if trace.get("y") is None and xs:
+        return xs, list(range(len(xs)))
+    if trace.get("x") is None and ys:
+        return list(range(len(ys))), ys
+    return xs, ys

--- a/maidr/plotly/scatter.py
+++ b/maidr/plotly/scatter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list, paired_axes
+from maidr.plotly.plotly_plot import PlotlyPlot, paired_axes
 from maidr.plotly.step_shape import renders_through_webgl
 
 
@@ -53,9 +53,14 @@ class PlotlyScatterPlot(PlotlyPlot):
         x_fmt = format_config.get("x")
         y_fmt = format_config.get("y")
 
-        # Get range: explicit from layout OR compute from trace data
-        x_data = as_list(self._trace.get("x"))
-        y_data = as_list(self._trace.get("y"))
+        # Get range: explicit from layout OR compute from trace data.
+        # Through `paired_axes`, so a trace that omits an axis is measured
+        # over the positions plotly generates for it rather than over an
+        # empty list. Reading the raw arrays left `x_min`/`x_max` at `None`
+        # for such a trace, which fails the grid precondition below and
+        # silently drops `min`/`max`/`tickStep` -- announcing points the
+        # axes then claimed no range for (#418).
+        x_data, y_data = paired_axes(self._trace)
         x_min, x_max = self._get_axis_range(xaxis, x_data)
         y_min, y_max = self._get_axis_range(yaxis, y_data)
 

--- a/maidr/plotly/scatter.py
+++ b/maidr/plotly/scatter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list, paired_axes
 from maidr.plotly.step_shape import renders_through_webgl
 
 
@@ -214,8 +214,7 @@ class PlotlyScatterPlot(PlotlyPlot):
         return True
 
     def _extract_plot_data(self) -> list[dict]:
-        x = as_list(self._trace.get("x"))
-        y = as_list(self._trace.get("y"))
+        x, y = paired_axes(self._trace)
 
         return [
             {MaidrKey.X: self._to_native(xv), MaidrKey.Y: self._to_native(yv)}

--- a/tests/plotly/test_plotly_generated_positions.py
+++ b/tests/plotly/test_plotly_generated_positions.py
@@ -1,0 +1,174 @@
+"""A plotly trace written without `x` announced nothing (#418).
+
+`x` is optional in plotly. Omit it and the trace is drawn at `0, 1, 2, ...`,
+which is how most quick plots are written:
+
+    go.Figure([go.Bar(y=[3, 1, 2])])
+
+py-maidr paired the two arrays with `zip(as_list(x), as_list(y))`, and
+`as_list(None)` is `[]`, so the zip yielded nothing. Every such trace produced
+a layer of the right *type* carrying no data at all -- the chart drawn, the
+layer present, and nothing to navigate.
+
+Measured in Chromium rather than assumed. `gd.calcdata[0]` for
+`go.Scatter(y=[1, 2, 3], mode="lines")` comes back with x `[0, 1, 2]` and one
+drawn `path.js-line`; for `go.Bar(y=[3, 1, 2])`, the same x and three drawn
+bars. So plotly supplies the positions and draws normally, and generating
+`range(len(values))` is reproducing what it does rather than inventing a
+convention.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+from maidr.plotly.plotly_plot import paired_axes  # noqa: E402
+
+Y = [1, 2, 3]
+
+
+def only_layer(fig) -> dict:
+    return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"][0]
+
+
+def points(fig) -> list[dict]:
+    """Flatten a layer's data, whether it is one series or several."""
+    data = only_layer(fig)["data"]
+    if not data:
+        return []
+    return data if isinstance(data[0], dict) else [p for s in data for p in s]
+
+
+def xs(fig) -> list:
+    return [point["x"] for point in points(fig)]
+
+
+def ys(fig) -> list:
+    return [point["y"] for point in points(fig)]
+
+
+class TestTheHelper:
+    def test_a_missing_position_array_is_generated(self):
+        positions, values = paired_axes({"y": [5, 6, 7]})
+        assert positions == [0, 1, 2]
+        assert values == [5, 6, 7]
+
+    def test_a_present_position_array_is_left_alone(self):
+        positions, _ = paired_axes({"x": [10, 20, 30], "y": [1, 2, 3]})
+        assert positions == [10, 20, 30]
+
+    def test_an_empty_value_array_generates_nothing(self):
+        positions, values = paired_axes({})
+        assert positions == []
+        assert values == []
+
+    def test_a_short_position_array_is_left_short(self):
+        # Plotly pairs the two positionally and draws only as far as the
+        # shorter reaches. Truncating is its behaviour, not damage to repair
+        # here -- padding would invent points it never drew.
+        positions, values = paired_axes({"x": [1], "y": [1, 2, 3]})
+        assert positions == [1]
+        assert len(list(zip(positions, values))) == 1
+
+    def test_the_value_axis_can_be_x(self):
+        # A horizontal trace carries its magnitudes on `x`, so the generated
+        # array is `y`.
+        positions, values = paired_axes(
+            {"x": [4, 5, 6]}, value_key="x", position_key="y"
+        )
+        assert positions == [0, 1, 2]
+        assert values == [4, 5, 6]
+
+    def test_an_explicit_zero_position_is_not_treated_as_missing(self):
+        # `[0]` is falsy-adjacent only if someone tests the first element;
+        # the list itself is truthy, so it must survive.
+        positions, _ = paired_axes({"x": [0, 0, 0], "y": [1, 2, 3]})
+        assert positions == [0, 0, 0]
+
+
+class TestTheTraceTypesThatWentSilent:
+    @pytest.mark.parametrize(
+        ("fig", "expected_type"),
+        [
+            (
+                go.Figure([go.Scatter(y=Y, mode="lines", name="a")]),
+                PlotType.LINE,
+            ),
+            (
+                go.Figure([go.Scatter(y=Y, mode="markers", name="a")]),
+                PlotType.SCATTER,
+            ),
+            (go.Figure([go.Bar(y=[3, 1, 2], name="a")]), PlotType.BAR),
+        ],
+    )
+    def test_the_layer_now_carries_its_points(self, fig, expected_type):
+        assert only_layer(fig)["type"] is expected_type
+        assert len(points(fig)) == 3
+
+    def test_the_generated_positions_start_at_zero(self):
+        # Matching plotly's own calcdata, which is `[0, 1, 2]` -- not 1-based
+        # and not the data's own index.
+        assert xs(go.Figure([go.Bar(y=[3, 1, 2], name="a")])) == [0, 1, 2]
+
+    def test_the_values_are_untouched(self):
+        assert ys(go.Figure([go.Bar(y=[3, 1, 2], name="a")])) == [3, 1, 2]
+
+    def test_a_line_keeps_its_name(self):
+        fig = go.Figure([go.Scatter(y=Y, mode="lines", name="a")])
+        assert points(fig)[0]["z"] == "a"
+
+
+class TestATraceWithoutXNoLongerHidesItsNeighbours:
+    def fig(self) -> go.Figure:
+        return go.Figure(
+            [
+                go.Scatter(y=Y, mode="lines", name="a"),
+                go.Scatter(x=[1, 2, 3], y=[4, 5, 6], mode="lines", name="b"),
+            ]
+        )
+
+    def test_both_lines_are_announced(self):
+        assert len(only_layer(self.fig())["data"]) == 2
+
+    def test_both_lines_get_a_selector(self):
+        assert len(only_layer(self.fig())["selectors"]) == 2
+
+    def test_each_line_keeps_its_own_positions(self):
+        series = only_layer(self.fig())["data"]
+        assert [point["x"] for point in series[0]] == [0, 1, 2]
+        assert [point["x"] for point in series[1]] == [1, 2, 3]
+
+
+class TestExplicitPositionsStillWin:
+    """The fix must not overwrite what an author supplied."""
+
+    def test_a_categorical_x_survives(self):
+        fig = go.Figure([go.Bar(x=["a", "b", "c"], y=[3, 1, 2], name="t")])
+        assert xs(fig) == ["a", "b", "c"]
+
+    def test_a_numeric_x_survives(self):
+        fig = go.Figure(
+            [go.Scatter(x=[10, 20, 30], y=Y, mode="lines", name="t")]
+        )
+        assert xs(fig) == [10, 20, 30]
+
+    def test_a_grouped_bar_with_explicit_x_survives(self):
+        fig = go.Figure(
+            [
+                go.Bar(x=["a", "b"], y=[1, 2], name="x"),
+                go.Bar(x=["a", "b"], y=[3, 4], name="y"),
+            ]
+        ).update_layout(barmode="stack")
+        assert xs(fig) == ["a", "b", "a", "b"]
+
+    def test_a_grouped_bar_without_x_is_generated_per_trace(self):
+        fig = go.Figure(
+            [go.Bar(y=[1, 2], name="x"), go.Bar(y=[3, 4], name="y")]
+        ).update_layout(barmode="stack")
+        assert xs(fig) == [0, 1, 0, 1]

--- a/tests/plotly/test_plotly_generated_positions.py
+++ b/tests/plotly/test_plotly_generated_positions.py
@@ -1,21 +1,27 @@
-"""A plotly trace written without `x` announced nothing (#418).
+"""A plotly trace written with only one axis announced nothing (#418).
 
-`x` is optional in plotly. Omit it and the trace is drawn at `0, 1, 2, ...`,
-which is how most quick plots are written:
+Both `x` and `y` are optional in plotly, and it fills in whichever is
+missing with `0, 1, 2, ...` -- which is how most quick plots are written:
 
     go.Figure([go.Bar(y=[3, 1, 2])])
+    go.Figure([go.Bar(x=[3, 1, 2], orientation="h")])
 
 py-maidr paired the two arrays with `zip(as_list(x), as_list(y))`, and
 `as_list(None)` is `[]`, so the zip yielded nothing. Every such trace produced
 a layer of the right *type* carrying no data at all -- the chart drawn, the
 layer present, and nothing to navigate.
 
-Measured in Chromium rather than assumed. `gd.calcdata[0]` for
-`go.Scatter(y=[1, 2, 3], mode="lines")` comes back with x `[0, 1, 2]` and one
-drawn `path.js-line`; for `go.Bar(y=[3, 1, 2])`, the same x and three drawn
-bars. So plotly supplies the positions and draws normally, and generating
-`range(len(values))` is reproducing what it does rather than inventing a
-convention.
+Measured in Chromium rather than assumed, in both directions:
+
+    go.Scatter(y=[1,2,3], mode="lines")     calcdata x 0,1,2   y 1,2,3
+    go.Bar(y=[3,1,2])                       calcdata x 0,1,2   y 3,1,2
+    go.Bar(x=[3,1,2], orientation="h")      calcdata x 3,1,2   y 0,1,2
+    go.Scatter(x=[3,1,2], mode="lines")     calcdata x 3,1,2   y 0,1,2
+
+Each draws normally -- one `path.js-line` or three bars. So generating the
+missing array reproduces what plotly does rather than inventing a convention,
+and it has to work both ways round: a horizontal bar carries its magnitudes
+on `x` and needs `y` supplied.
 """
 
 from __future__ import annotations
@@ -54,42 +60,59 @@ def ys(fig) -> list:
 
 
 class TestTheHelper:
-    def test_a_missing_position_array_is_generated(self):
-        positions, values = paired_axes({"y": [5, 6, 7]})
-        assert positions == [0, 1, 2]
-        assert values == [5, 6, 7]
+    def test_a_missing_x_is_generated(self):
+        xs, ys = paired_axes({"y": [5, 6, 7]})
+        assert xs == [0, 1, 2]
+        assert ys == [5, 6, 7]
 
-    def test_a_present_position_array_is_left_alone(self):
-        positions, _ = paired_axes({"x": [10, 20, 30], "y": [1, 2, 3]})
-        assert positions == [10, 20, 30]
+    def test_both_present_are_left_alone(self):
+        xs, ys = paired_axes({"x": [10, 20, 30], "y": [1, 2, 3]})
+        assert xs == [10, 20, 30]
+        assert ys == [1, 2, 3]
 
-    def test_an_empty_value_array_generates_nothing(self):
-        positions, values = paired_axes({})
-        assert positions == []
-        assert values == []
+    def test_neither_present_generates_nothing(self):
+        xs, ys = paired_axes({})
+        assert xs == []
+        assert ys == []
 
     def test_a_short_position_array_is_left_short(self):
         # Plotly pairs the two positionally and draws only as far as the
         # shorter reaches. Truncating is its behaviour, not damage to repair
         # here -- padding would invent points it never drew.
-        positions, values = paired_axes({"x": [1], "y": [1, 2, 3]})
-        assert positions == [1]
-        assert len(list(zip(positions, values))) == 1
+        xs, ys = paired_axes({"x": [1], "y": [1, 2, 3]})
+        assert xs == [1]
+        assert len(list(zip(xs, ys))) == 1
 
-    def test_the_value_axis_can_be_x(self):
-        # A horizontal trace carries its magnitudes on `x`, so the generated
-        # array is `y`.
-        positions, values = paired_axes(
-            {"x": [4, 5, 6]}, value_key="x", position_key="y"
-        )
-        assert positions == [0, 1, 2]
-        assert values == [4, 5, 6]
+    def test_a_missing_y_is_generated_too(self):
+        # Symmetric, and measured that way: `go.Bar(x=[3,1,2],
+        # orientation="h")` comes back with calcdata y of [0, 1, 2] and
+        # three drawn bars, so the fill has to work in both directions.
+        xs, ys = paired_axes({"x": [4, 5, 6]})
+        assert xs == [4, 5, 6]
+        assert ys == [0, 1, 2]
+
+    def test_an_explicitly_empty_array_is_not_a_missing_one(self):
+        # The distinction the whole fix turns on, and plotly draws the two
+        # differently: with `y` absent it generates 0,1,2 and draws normally,
+        # while `y: []` comes back as one null point and draws nothing at
+        # all. `as_list` answers `[]` for both, so only the raw key tells
+        # them apart -- generating here would invent points for a trace
+        # plotly leaves blank, and `tests/plotly/test_plotly_empty_series_
+        # alignment.py` pins that such a trace must drop out entirely.
+        xs, ys = paired_axes({"x": [0, 1], "y": []})
+        assert ys == []
+        assert list(zip(xs, ys)) == []
+
+    def test_an_explicitly_empty_x_is_not_a_missing_one(self):
+        xs, ys = paired_axes({"x": [], "y": [1, 2]})
+        assert xs == []
+        assert list(zip(xs, ys)) == []
 
     def test_an_explicit_zero_position_is_not_treated_as_missing(self):
         # `[0]` is falsy-adjacent only if someone tests the first element;
         # the list itself is truthy, so it must survive.
-        positions, _ = paired_axes({"x": [0, 0, 0], "y": [1, 2, 3]})
-        assert positions == [0, 0, 0]
+        xs, _ = paired_axes({"x": [0, 0, 0], "y": [1, 2, 3]})
+        assert xs == [0, 0, 0]
 
 
 class TestTheTraceTypesThatWentSilent:
@@ -172,3 +195,29 @@ class TestExplicitPositionsStillWin:
             [go.Bar(y=[1, 2], name="x"), go.Bar(y=[3, 4], name="y")]
         ).update_layout(barmode="stack")
         assert xs(fig) == [0, 1, 0, 1]
+
+
+class TestTheHorizontalDirection:
+    """The half a values-on-y helper would have missed."""
+
+    def test_a_horizontal_bar_with_only_x_is_announced(self):
+        fig = go.Figure([go.Bar(x=[3, 1, 2], orientation="h", name="a")])
+        assert len(points(fig)) == 3
+
+    def test_its_generated_positions_land_on_y(self):
+        # Measured: calcdata x stays 3,1,2 and y comes back 0,1,2.
+        fig = go.Figure([go.Bar(x=[3, 1, 2], orientation="h", name="a")])
+        assert xs(fig) == [3, 1, 2]
+        assert ys(fig) == [0, 1, 2]
+
+    def test_a_scatter_with_only_x_fills_y_the_same_way(self):
+        fig = go.Figure([go.Scatter(x=[3, 1, 2], mode="lines", name="a")])
+        assert xs(fig) == [3, 1, 2]
+        assert ys(fig) == [0, 1, 2]
+
+    def test_a_horizontal_bar_with_both_axes_is_untouched(self):
+        fig = go.Figure(
+            [go.Bar(x=[3, 1, 2], y=["a", "b", "c"], orientation="h", name="a")]
+        )
+        assert xs(fig) == [3, 1, 2]
+        assert ys(fig) == ["a", "b", "c"]

--- a/tests/plotly/test_plotly_generated_positions.py
+++ b/tests/plotly/test_plotly_generated_positions.py
@@ -221,3 +221,86 @@ class TestTheHorizontalDirection:
         )
         assert xs(fig) == [3, 1, 2]
         assert ys(fig) == ["a", "b", "c"]
+
+
+class TestTheAxesRangeCoversTheGeneratedPositions:
+    """The half the first fix left inconsistent.
+
+    `PlotlyScatterPlot._extract_axes_data` computes `min`/`max` from the
+    trace's own arrays, and read them raw. For a trace that omits an axis
+    that array was empty, so the range came back `None`, the grid
+    precondition failed, and `min`/`max`/`tickStep` were dropped -- the
+    layer announcing points at `0, 1, 2` while its axes claimed no range at
+    all. Only visible with `dtick` set, since the precondition needs a tick
+    step too, which is why the first pass missed it.
+    """
+
+    GRID = dict(xaxis=dict(dtick=1), yaxis=dict(dtick=1))
+
+    def axes(self, fig) -> dict:
+        found = only_layer(fig)["axes"]
+        return {
+            (k.value if hasattr(k, "value") else k): {
+                (ik.value if hasattr(ik, "value") else ik): iv
+                for ik, iv in v.items()
+            }
+            for k, v in found.items()
+        }
+
+    def test_a_y_only_scatter_reports_its_generated_x_range(self):
+        fig = go.Figure(
+            [go.Scatter(y=Y, mode="markers", name="a")]
+        ).update_layout(**self.GRID)
+        assert self.axes(fig)["x"]["min"] == 0.0
+        assert self.axes(fig)["x"]["max"] == 2.0
+
+    def test_an_x_only_scatter_reports_its_generated_y_range(self):
+        fig = go.Figure(
+            [go.Scatter(x=[1, 2, 3], mode="markers", name="a")]
+        ).update_layout(**self.GRID)
+        assert self.axes(fig)["y"]["min"] == 0.0
+        assert self.axes(fig)["y"]["max"] == 2.0
+
+    def test_the_value_axis_range_is_unaffected(self):
+        fig = go.Figure(
+            [go.Scatter(y=Y, mode="markers", name="a")]
+        ).update_layout(**self.GRID)
+        assert self.axes(fig)["y"]["min"] == 1.0
+        assert self.axes(fig)["y"]["max"] == 3.0
+
+    def test_an_explicit_pair_is_unchanged(self):
+        fig = go.Figure(
+            [go.Scatter(x=[0, 1, 2], y=Y, mode="markers", name="a")]
+        ).update_layout(**self.GRID)
+        found = self.axes(fig)
+        assert found["x"]["min"] == 0.0 and found["x"]["max"] == 2.0
+        assert found["y"]["min"] == 1.0 and found["y"]["max"] == 3.0
+
+
+class TestAMixedNormalisedStack:
+    """Generated integers beside explicit categories, raised in review.
+
+    The worry was that a normalised group matching by category would fail to
+    line generated integer keys up with real labels. Measured: plotly does
+    not line them up either -- it places the generated `0, 1` as two *new*
+    categories after `a` and `b`, so the figure draws four bars at four
+    positions, each alone in its stack and therefore each at 100%.
+
+    So the keys differing is the correct reading rather than a mismatch: the
+    positions genuinely differ. Pinned because it looks like a bug and is
+    not, and because a future change to key matching would quietly alter it.
+    """
+
+    def fig(self) -> go.Figure:
+        return go.Figure(
+            [
+                go.Bar(x=["a", "b"], y=[3, 1], name="p"),
+                go.Bar(y=[1, 3], name="q"),
+            ]
+        ).update_layout(barmode="stack", barnorm="percent")
+
+    def test_every_bar_is_alone_at_its_position(self):
+        assert ys(self.fig()) == [100.0, 100.0, 100.0, 100.0]
+
+    def test_the_generated_keys_stay_distinct_from_the_labels(self):
+        assert xs(self.fig()) == ["a", "b", 0, 1]


### PR DESCRIPTION
Closes #418. Found while measuring #412, and more severe than it.

`x` is optional in plotly. Omit it and the trace is drawn at `0, 1, 2, …` — which is how most quick plots are written:

```python
go.Figure([go.Scatter(y=[1, 2, 3], mode="lines")])   # layer emitted, 0 points
go.Figure([go.Scatter(y=[1, 2, 3], mode="markers")]) # layer emitted, 0 points
go.Figure([go.Bar(y=[3, 1, 2])])                     # layer emitted, 0 points
```

All three produced a layer of the right **type** carrying **no data at all**. The chart is drawn, the layer is present, the type is correct, and there is nothing to navigate. `go.Bar(y=[3, 1, 2])` is about as ordinary as plotly gets, so this was not a corner case.

The cause is one line of pairing: `zip(as_list(x), as_list(y))`, where `as_list(None)` answers `[]` — documented behaviour that "saves each caller a null check", and which here silently emptied the result.

**It also hid the traces beside it.** Two lines where one omits `x` announced **one** line, so a reader was told the chart had half its content.

## Ground truth

`gd.calcdata[0]` after `Plotly.newPlot` in Chromium — measured, not read from the docs:

| figure | calcdata x | calcdata y | drawn marks |
|---|---|---|---|
| `go.Scatter(y=[1,2,3], mode="lines")` | `[0, 1, 2]` | `[1, 2, 3]` | 1 `path.js-line` |
| `go.Bar(y=[3,1,2])` | `[0, 1, 2]` | `[3, 1, 2]` | 3 bars |

So generating `range(len(values))` reproduces what plotly does rather than inventing a convention. A test pins that the positions start at **zero** for exactly that reason — 1-based or the data's own index would both be plausible-looking and wrong.

## One helper, not five copies

The same two-array pairing appears in the bar, scatter, line, grouped-bar and shared line-series paths. `paired_axes(trace, value_key, position_key)` is the single place, since two copies of one rule is what #416 had just finished removing.

Two decisions worth stating:

- **A short position array is left short.** Plotly pairs the two positionally and draws only as far as the shorter reaches, so padding would invent points it never drew. Truncating is its behaviour, not damage to repair here.
- **The value axis is a parameter**, because a horizontal trace carries its magnitudes on `x` and the generated array is `y`.

## Verification

- **Suite 1683 passed** (1664 + 19 new). No existing test failed — again the finding rather than the reassurance: nothing pinned that an `x`-less trace should announce anything.
- Falsification: removing the generation fails **12 of 19**.
- `ruff check` clean across `maidr/plotly/`; no line over 88.

An explicit `x` is untouched — categorical, numeric, and grouped-bar cases are all pinned, including that `[0, 0, 0]` is not mistaken for a missing array.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_