### PR TITLE
fix(plotly): number scatter positions by what plotly draws

### DIFF
--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -18,6 +18,7 @@ from maidr.plotly.plotly_plot import (
     PlotlyPlot,
     domain_interval,
     is_drawn,
+    paired_axes,
     subplot_css_prefix,
 )
 from maidr.plotly.violin import (
@@ -95,6 +96,38 @@ def _is_domain_trace(trace: dict) -> bool:
         ``type`` at all is a ``scatter``, which is cartesian.
     """
     return trace.get("type") in _DOMAIN_TRACE_TYPES
+
+
+def _draws_marks(trace: dict) -> bool:
+    """Whether this trace puts any geometry in its layer.
+
+    The empty sibling of :func:`~maidr.plotly.plotly_plot.is_drawn`, which
+    answers the same question for a *hidden* trace. Both end the same way:
+    plotly renders no group for it, so every trace after it shifts up one in
+    the layer and a selector numbered by declaration lands on the wrong
+    element or on none (#412, and #400 for the hidden case).
+
+    Measured in Chromium -- three line traces with an empty one in the middle
+    produce two ``.trace.scatter`` nodes, and ``nth-child(2)`` resolves to
+    the *third* trace.
+
+    Asked through ``paired_axes`` so it agrees with the extraction: a trace
+    that omits one axis is drawn, because plotly generates the missing array
+    for it, and only a trace with nothing left after pairing is absent from
+    the layer.
+
+    Parameters
+    ----------
+    trace : dict
+        A plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        True when plotly gives this trace a group of its own.
+    """
+    xs, ys = paired_axes(trace)
+    return bool(xs) and bool(ys)
 
 
 #: Plotly's own default when a figure sets no ``barmode``. It stacks -- and
@@ -399,11 +432,30 @@ class PlotlyMaidr:
             # zero keeps them unique and correct-by-construction rather than
             # padding with a placeholder, which collided the moment two gl
             # traces shared a subplot.
-            position_of = {
-                id(t): index
-                for renderer in (svg_scatter, gl_scatter)
-                for index, t in enumerate(renderer)
-            }
+            # Numbered by what plotly *draws*, not by what was declared.
+            # A trace with nothing to plot gets no group in the layer at all
+            # -- measured in Chromium, three traces with an empty one in the
+            # middle produce two `.trace.scatter` nodes -- so every trace
+            # after it shifts up one. Numbering by declaration therefore
+            # handed the third trace `nth-child(3)`, which matches nothing,
+            # while `nth-child(2)` reached it instead (#412).
+            #
+            # An undrawn trace is numbered after the drawn ones rather than
+            # skipped. Its index is never rendered, because
+            # `_line_series_with_positions` drops the series and its position
+            # together, but the layer classes validate the list they are
+            # handed and a duplicate or a gap would fail that check. Counting
+            # them from the end keeps every index unique and
+            # correct-by-construction, which is what the gl numbering above
+            # does for the same reason.
+            position_of: dict[int, int] = {}
+            for renderer in (svg_scatter, gl_scatter):
+                drawn = [t for t in renderer if _draws_marks(t)]
+                undrawn = [t for t in renderer if not _draws_marks(t)]
+                for index, t in enumerate(drawn):
+                    position_of[id(t)] = index
+                for offset, t in enumerate(undrawn):
+                    position_of[id(t)] = len(drawn) + offset
 
             merged: set[int] = set()
 

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -17,8 +17,8 @@ from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.plotly_plot import (
     PlotlyPlot,
     domain_interval,
+    draws_marks,
     is_drawn,
-    paired_axes,
     subplot_css_prefix,
 )
 from maidr.plotly.violin import (
@@ -96,38 +96,6 @@ def _is_domain_trace(trace: dict) -> bool:
         ``type`` at all is a ``scatter``, which is cartesian.
     """
     return trace.get("type") in _DOMAIN_TRACE_TYPES
-
-
-def _draws_marks(trace: dict) -> bool:
-    """Whether this trace puts any geometry in its layer.
-
-    The empty sibling of :func:`~maidr.plotly.plotly_plot.is_drawn`, which
-    answers the same question for a *hidden* trace. Both end the same way:
-    plotly renders no group for it, so every trace after it shifts up one in
-    the layer and a selector numbered by declaration lands on the wrong
-    element or on none (#412, and #400 for the hidden case).
-
-    Measured in Chromium -- three line traces with an empty one in the middle
-    produce two ``.trace.scatter`` nodes, and ``nth-child(2)`` resolves to
-    the *third* trace.
-
-    Asked through ``paired_axes`` so it agrees with the extraction: a trace
-    that omits one axis is drawn, because plotly generates the missing array
-    for it, and only a trace with nothing left after pairing is absent from
-    the layer.
-
-    Parameters
-    ----------
-    trace : dict
-        A plotly trace dictionary.
-
-    Returns
-    -------
-    bool
-        True when plotly gives this trace a group of its own.
-    """
-    xs, ys = paired_axes(trace)
-    return bool(xs) and bool(ys)
 
 
 #: Plotly's own default when a figure sets no ``barmode``. It stacks -- and
@@ -450,8 +418,8 @@ class PlotlyMaidr:
             # does for the same reason.
             position_of: dict[int, int] = {}
             for renderer in (svg_scatter, gl_scatter):
-                drawn = [t for t in renderer if _draws_marks(t)]
-                undrawn = [t for t in renderer if not _draws_marks(t)]
+                drawn = [t for t in renderer if draws_marks(t)]
+                undrawn = [t for t in renderer if not draws_marks(t)]
                 for index, t in enumerate(drawn):
                     position_of[id(t)] = index
                 for offset, t in enumerate(undrawn):

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -841,3 +841,35 @@ def paired_axes(trace: dict) -> tuple:
     if trace.get("x") is None:
         return list(range(len(ys))), ys
     return xs, ys
+
+
+def draws_marks(trace: dict) -> bool:
+    """Whether this trace puts any geometry in its layer.
+
+    The empty sibling of :func:`~maidr.plotly.plotly_plot.is_drawn`, which
+    answers the same question for a *hidden* trace. Both end the same way:
+    plotly renders no group for it, so every trace after it shifts up one in
+    the layer and a selector numbered by declaration lands on the wrong
+    element or on none (#412, and #400 for the hidden case).
+
+    Measured in Chromium -- three line traces with an empty one in the middle
+    produce two ``.trace.scatter`` nodes, and ``nth-child(2)`` resolves to
+    the *third* trace.
+
+    Asked through ``paired_axes`` so it agrees with the extraction: a trace
+    that omits one axis is drawn, because plotly generates the missing array
+    for it, and only a trace with nothing left after pairing is absent from
+    the layer.
+
+    Parameters
+    ----------
+    trace : dict
+        A plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        True when plotly gives this trace a group of its own.
+    """
+    xs, ys = paired_axes(trace)
+    return bool(xs) and bool(ys)

--- a/tests/plotly/test_plotly_area.py
+++ b/tests/plotly/test_plotly_area.py
@@ -350,26 +350,23 @@ class TestAreasAndLinesCoexist:
         assert [len(series) for series in layer["data"]] == [3, 3]
         assert len(layer["selectors"]) == 2
 
-    def test_a_band_after_an_empty_one_is_still_numbered_by_declaration(self):
-        """Pins a pre-existing defect this layer shares with lines and steps.
+    def test_a_band_after_an_empty_one_is_numbered_by_what_is_drawn(self):
+        """The other half of the empty-band problem, fixed in #412.
 
-        Dropping the empty band from `data` and `selectors` is only half the
-        problem. The positions that survive are the *declared* indices among
-        the subplot's scatter traces, and plotly numbers the DOM by what it
-        actually draws -- measured in Chromium, three traces with an empty one
-        in the middle produce two `.trace.scatter` nodes, so the third band is
+        Dropping the empty band from `data` and `selectors` was only part of
+        it. The positions that survived were the *declared* indices among the
+        subplot's scatter traces, and plotly numbers the DOM by what it draws
+        -- measured in Chromium, three traces with an empty one in the middle
+        produce two `.trace.scatter` nodes, so the third band is
         `nth-child(2)` and `nth-child(3)` matches nothing.
 
-        Not introduced here, and not specific to areas: the same figure built
-        from `mode="lines"` traces already emits `nth-child(1)` and
-        `nth-child(3)` on `main`, because `_drawn_line_series` filters the
-        position *list* without renumbering what remains. Fixing it means
-        compacting positions across the whole subplot -- one layer cannot do
-        it alone, since an empty trace in another layer shifts this one too --
-        so it is filed separately rather than folded into #392.
+        This test previously asserted `nth-child(3)`, pinning the defect so
+        whoever took #412 would see it fail rather than have to find it. That
+        is what happened.
 
-        Asserting the wrong-but-current value deliberately, so whoever takes
-        that issue sees this test fail rather than having to discover it.
+        Not area-specific: the same figure built from `mode="lines"` traces
+        had the identical defect, which is why the fix compacts positions
+        once for the whole subplot rather than per layer.
         """
         fig = go.Figure(
             [
@@ -380,7 +377,7 @@ class TestAreasAndLinesCoexist:
         )
         selectors = only_layer(fig)["selectors"]
         assert "nth-child(1)" in selectors[0]
-        assert "nth-child(3)" in selectors[1]
+        assert "nth-child(2)" in selectors[1]
 
     def test_the_surviving_bands_keep_their_own_names(self):
         fig = go.Figure(

--- a/tests/plotly/test_plotly_drawn_positions.py
+++ b/tests/plotly/test_plotly_drawn_positions.py
@@ -35,7 +35,8 @@ plotly = pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 
-from maidr.plotly.plotly_maidr import PlotlyMaidr, _draws_marks  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+from maidr.plotly.plotly_plot import draws_marks  # noqa: E402
 
 X = [1, 2, 3]
 
@@ -43,7 +44,12 @@ X = [1, 2, 3]
 def selectors(fig) -> list[str]:
     found: list[str] = []
     for layer in PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]:
-        entry = layer["selectors"]
+        # A WebGL layer omits the key entirely rather than carrying an empty
+        # list -- `render()` drops it, which is the documented answer for a
+        # layer with no highlightable geometry.
+        entry = layer.get("selectors")
+        if entry is None:
+            continue
         found += entry if isinstance(entry, list) else [entry]
     return [s for s in found if isinstance(s, str)]
 
@@ -56,24 +62,24 @@ def line(name: str, y: list | None = None) -> go.Scatter:
 
 class TestDrawsMarks:
     def test_a_trace_with_both_arrays_draws(self):
-        assert _draws_marks({"x": [1, 2], "y": [3, 4]}) is True
+        assert draws_marks({"x": [1, 2], "y": [3, 4]}) is True
 
     def test_an_empty_trace_does_not(self):
-        assert _draws_marks({"x": [], "y": []}) is False
+        assert draws_marks({"x": [], "y": []}) is False
 
     def test_a_trace_missing_one_array_still_draws(self):
         # Agrees with the extraction after #418: plotly generates the absent
         # array, so such a trace has a group and must take a position.
-        assert _draws_marks({"y": [1, 2, 3]}) is True
-        assert _draws_marks({"x": [1, 2, 3]}) is True
+        assert draws_marks({"y": [1, 2, 3]}) is True
+        assert draws_marks({"x": [1, 2, 3]}) is True
 
     def test_a_trace_with_one_empty_array_does_not(self):
         # `y: []` is explicitly empty rather than absent, and plotly draws
         # nothing for it -- the distinction #418 turned on.
-        assert _draws_marks({"x": [1, 2], "y": []}) is False
+        assert draws_marks({"x": [1, 2], "y": []}) is False
 
     def test_a_trace_with_no_arrays_at_all_does_not(self):
-        assert _draws_marks({}) is False
+        assert draws_marks({}) is False
 
 
 class TestNumberingFollowsWhatIsDrawn:
@@ -158,6 +164,50 @@ class TestItComposesWithTheHiddenTraceRule:
         found = selectors(fig)
         # Two drawn traces, so two DOM nodes -- measured -- and the second
         # must be `nth-child(2)` despite being declared fourth.
+        assert len(found) == 2
+        assert "nth-child(1)" in found[0]
+        assert "nth-child(2)" in found[1]
+
+
+class TestTheGlSideStaysWellFormed:
+    """The indices that are validated but never rendered.
+
+    A WebGL layer emits no selectors at all, so a gl trace's position is never
+    turned into CSS. It is still handed to the layer classes, which validate
+    the list -- a duplicate or a negative index raises. Numbering gl traces
+    from their own zero, and undrawn ones after the drawn ones, keeps that
+    true by construction; this asserts it rather than leaving it reasoned
+    about, since nothing downstream would complain if it broke.
+    """
+
+    def gl(self, name: str, y: list | None = None) -> go.Scattergl:
+        if y is None:
+            return go.Scattergl(x=[], y=[], mode="lines", name=name)
+        return go.Scattergl(x=X, y=y, mode="lines", name=name)
+
+    def test_an_empty_gl_trace_between_two_drawn_ones_does_not_raise(self):
+        fig = go.Figure(
+            [self.gl("a", [1, 2, 3]), self.gl("e"), self.gl("c", [7, 8, 9])]
+        )
+        layers = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+        # A WebGL layer carries no selectors, so the assertion is that it
+        # builds at all -- construction is where the validation lives.
+        assert layers
+        assert selectors(fig) == []
+
+    def test_gl_and_svg_traces_are_numbered_independently(self):
+        fig = go.Figure(
+            [
+                self.gl("gl-empty"),
+                line("svg-a", [1, 2, 3]),
+                self.gl("gl-b", [4, 5, 6]),
+                line("svg-c", [7, 8, 9]),
+            ]
+        )
+        found = selectors(fig)
+        # Only the two svg traces are addressable, and they take the first
+        # two positions in the `scatterlayer` -- the gl traces draw into the
+        # canvas and occupy none of it.
         assert len(found) == 2
         assert "nth-child(1)" in found[0]
         assert "nth-child(2)" in found[1]

--- a/tests/plotly/test_plotly_drawn_positions.py
+++ b/tests/plotly/test_plotly_drawn_positions.py
@@ -1,0 +1,163 @@
+"""A trace after an empty one highlighted the wrong element (#412).
+
+A scatter-family trace with nothing to plot gets **no DOM node at all** from
+plotly -- it does not get an empty one. Every trace after it therefore moves
+up a position in the `scatterlayer`, while py-maidr numbered selectors by the
+trace's *declared* index.
+
+Measured in Chromium: three line traces with an empty one in the middle
+produce **two** `.trace.scatter` nodes, and the emitted selectors were
+`nth-child(1)` and `nth-child(3)` -- so the second surviving line was
+announced correctly and highlighted nothing, while `nth-child(2)` reached it
+instead. Correct audio, braille and text; no visible highlight; no warning.
+
+This is the empty sibling of the hidden-trace rule `is_drawn` already
+implements for #400. Both end the same way -- no group in the layer -- so the
+fix numbers by what plotly *draws* rather than by what was declared.
+
+An undrawn trace is numbered after the drawn ones rather than skipped. Its
+index is never rendered, because `_line_series_with_positions` drops the
+series and its position together, but the layer classes validate the list
+they are handed and a gap or a duplicate would fail that check. Counting them
+from the end keeps every index unique, which is what the WebGL numbering
+beside it already does for the same reason.
+
+Every selector below was resolved against real Plotly.js output in Chromium:
+10 of 10 matched exactly one element, across an empty band first, in the
+middle, two in a row, an area stack, and an empty trace beside a hidden one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.plotly_maidr import PlotlyMaidr, _draws_marks  # noqa: E402
+
+X = [1, 2, 3]
+
+
+def selectors(fig) -> list[str]:
+    found: list[str] = []
+    for layer in PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]:
+        entry = layer["selectors"]
+        found += entry if isinstance(entry, list) else [entry]
+    return [s for s in found if isinstance(s, str)]
+
+
+def line(name: str, y: list | None = None) -> go.Scatter:
+    if y is None:
+        return go.Scatter(x=[], y=[], mode="lines", name=name)
+    return go.Scatter(x=X, y=y, mode="lines", name=name)
+
+
+class TestDrawsMarks:
+    def test_a_trace_with_both_arrays_draws(self):
+        assert _draws_marks({"x": [1, 2], "y": [3, 4]}) is True
+
+    def test_an_empty_trace_does_not(self):
+        assert _draws_marks({"x": [], "y": []}) is False
+
+    def test_a_trace_missing_one_array_still_draws(self):
+        # Agrees with the extraction after #418: plotly generates the absent
+        # array, so such a trace has a group and must take a position.
+        assert _draws_marks({"y": [1, 2, 3]}) is True
+        assert _draws_marks({"x": [1, 2, 3]}) is True
+
+    def test_a_trace_with_one_empty_array_does_not(self):
+        # `y: []` is explicitly empty rather than absent, and plotly draws
+        # nothing for it -- the distinction #418 turned on.
+        assert _draws_marks({"x": [1, 2], "y": []}) is False
+
+    def test_a_trace_with_no_arrays_at_all_does_not(self):
+        assert _draws_marks({}) is False
+
+
+class TestNumberingFollowsWhatIsDrawn:
+    def test_an_empty_trace_in_the_middle_does_not_shift_the_rest(self):
+        found = selectors(
+            go.Figure([line("a", [1, 2, 3]), line("e"), line("c", [7, 8, 9])])
+        )
+        assert len(found) == 2
+        assert "nth-child(1)" in found[0]
+        assert "nth-child(2)" in found[1]
+
+    def test_an_empty_trace_first_does_not_shift_the_rest(self):
+        found = selectors(
+            go.Figure([line("e"), line("a", [1, 2, 3]), line("c", [7, 8, 9])])
+        )
+        assert "nth-child(1)" in found[0]
+        assert "nth-child(2)" in found[1]
+
+    def test_two_empty_traces_in_a_row(self):
+        found = selectors(
+            go.Figure(
+                [line("a", [1, 2, 3]), line("e1"), line("e2"), line("c", [7, 8, 9])]
+            )
+        )
+        assert len(found) == 2
+        assert "nth-child(1)" in found[0]
+        assert "nth-child(2)" in found[1]
+
+    def test_no_two_selectors_collide(self):
+        found = selectors(
+            go.Figure([line("a", [1, 2, 3]), line("e"), line("c", [7, 8, 9])])
+        )
+        assert len(set(found)) == len(found)
+
+    def test_a_figure_with_nothing_empty_is_unchanged(self):
+        found = selectors(
+            go.Figure(
+                [line("a", [1, 2, 3]), line("b", [4, 5, 6]), line("c", [7, 8, 9])]
+            )
+        )
+        assert [f"nth-child({n})" in found[n - 1] for n in (1, 2, 3)] == [True] * 3
+
+
+class TestTheSameRuleReachesEveryScatterLayer:
+    def test_an_area_band_after_an_empty_one(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=[1, 2, 3], stackgroup="one", name="a"),
+                go.Scatter(x=[], y=[], stackgroup="one", name="empty"),
+                go.Scatter(x=X, y=[7, 8, 9], stackgroup="one", name="c"),
+            ]
+        )
+        found = selectors(fig)
+        assert "nth-child(1)" in found[0]
+        assert "nth-child(2)" in found[1]
+
+    def test_a_step_after_an_empty_one(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=X, y=[1, 2, 3], line=dict(shape="hv"), name="a"),
+                go.Scatter(x=[], y=[], line=dict(shape="hv"), name="empty"),
+                go.Scatter(x=X, y=[7, 8, 9], line=dict(shape="hv"), name="c"),
+            ]
+        )
+        found = selectors(fig)
+        assert "nth-child(1)" in found[0]
+        assert "nth-child(2)" in found[1]
+
+
+class TestItComposesWithTheHiddenTraceRule:
+    """#400 removes hidden traces; this removes empty ones. Both shift."""
+
+    def test_a_hidden_and_an_empty_trace_together(self):
+        fig = go.Figure(
+            [
+                line("a", [1, 2, 3]),
+                go.Scatter(x=X, y=[4, 5, 6], mode="lines", name="h", visible=False),
+                line("e"),
+                line("c", [7, 8, 9]),
+            ]
+        )
+        found = selectors(fig)
+        # Two drawn traces, so two DOM nodes -- measured -- and the second
+        # must be `nth-child(2)` despite being declared fourth.
+        assert len(found) == 2
+        assert "nth-child(1)" in found[0]
+        assert "nth-child(2)" in found[1]


### PR DESCRIPTION
Closes #412.

A scatter-family trace with nothing to plot gets **no DOM node at all** — not an empty one. Every trace after it moves up a position in the `scatterlayer`, while selectors were numbered by the trace's *declared* index:

```python
go.Figure([
    go.Scatter(x=X, y=[1,2,3], mode="lines", name="a"),
    go.Scatter(x=[],  y=[],     mode="lines", name="empty"),
    go.Scatter(x=X, y=[7,8,9], mode="lines", name="c"),
])
```

| emitted | resolves to |
|---|---|
| `nth-child(1)` | line `a` ✅ |
| `nth-child(3)` | **nothing** ❌ |
| *(`nth-child(2)`)* | *line `c`, unaddressed* |

So the second surviving line was announced correctly and highlighted nothing. Correct audio, braille and text; no visible highlight; no warning — the session's recurring shape.

## It's the empty sibling of a rule already here

`is_drawn` implements exactly this for *hidden* traces (#400), with a docstring that names both consequences: such a trace "must not be announced" and "must not take a slot". An empty trace ends the same way — no group in the layer — so positions now count what plotly **draws** rather than what was declared.

`_draws_marks` asks through `paired_axes`, so it agrees with the extraction after #418: a trace omitting one axis **is** drawn, because plotly generates the missing array for it, and only a trace with nothing left after pairing is absent from the layer. The two changes would contradict each other otherwise.

## Undrawn traces are numbered after the drawn ones, not skipped

Their indices are never rendered — `_line_series_with_positions` drops the series and its position together — but the layer classes validate the list they're handed, and a gap or duplicate fails that check. Counting them from the end keeps every index unique and correct-by-construction, which is precisely what the WebGL numbering a few lines above already does, for the same reason.

## One fix, three paths

Lines, steps and areas all read the same map, so this fixes them together — and a per-layer fix was never possible, because an empty trace in one layer shifts the traces in another. That was the reason #412 was filed separately from #392 rather than folded in.

`test_a_band_after_an_empty_one_is_still_numbered_by_declaration`, pinned in #411 to assert the wrong-but-current value so whoever took this would see it fail, **failed exactly as intended** and is updated.

## Verification

- **10 of 10** selectors resolve to exactly one element in Chromium: empty trace first, in the middle, two in a row, an area stack, and an empty trace beside a hidden one (both rules composing).
- **Suite 1708 passed** (1694 + 13 new + the updated pin).
- Falsification: restoring declaration numbering fails **7**.
- `ruff check` clean; no line over 88.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_