### PR TITLE
fix(plotly): build no layer for a scatter trace that draws nothing

### DIFF
--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -347,11 +347,27 @@ class PlotlyMaidr:
             # line grouping it would be emitted twice, once as its own layer
             # and once inside the multi-line one. Split out here, before any
             # of the line/step machinery sees the group.
-            area_traces = [t for t in group_traces if is_area_trace(t)]
+            # A trace that draws nothing forms no layer. Plotly gives it no
+            # group, so there is nothing to announce and nothing to highlight,
+            # and the core does worse than ignore such a layer: a series with
+            # no points makes `LineTrace.text` dereference an undefined point
+            # and throw, which propagates out of `Figure` and takes the whole
+            # render with it (#421, and xability/maidr#905 for the core half).
+            #
+            # The multi-trace paths already reach this answer inside
+            # `_drawn_line_series`, which drops an undrawn series and its
+            # position together. Excluding them here means a lone one reaches
+            # it too, rather than bypassing it through the single-trace
+            # branches below.
+            area_traces = [
+                t for t in group_traces if is_area_trace(t) and draws_marks(t)
+            ]
             connected_traces = [
                 t
                 for t in group_traces
-                if is_connected_line_trace(t) and not is_area_trace(t)
+                if is_connected_line_trace(t)
+                and not is_area_trace(t)
+                and draws_marks(t)
             ]
             box_traces = [
                 t for t in group_traces if t.get("type") == "box"
@@ -425,7 +441,15 @@ class PlotlyMaidr:
                 for offset, t in enumerate(undrawn):
                     position_of[id(t)] = len(drawn) + offset
 
-            merged: set[int] = set()
+            # Undrawn scatter-family traces are marked handled up front, so
+            # the fallback loop at the end does not build a layer for one that
+            # the groupings above deliberately skipped. Scoped to the scatter
+            # family because `draws_marks` reads `x`/`y`: a pie carries neither
+            # and draws perfectly well, so asking it globally would drop every
+            # pie in the figure.
+            merged: set[int] = {
+                id(t) for t in scatter_family if not draws_marks(t)
+            }
 
             # `barnorm` only means anything for a stack: plotly scales each
             # category's segments to a common total, so the values are shares

--- a/tests/plotly/test_plotly_drawn_positions.py
+++ b/tests/plotly/test_plotly_drawn_positions.py
@@ -211,3 +211,66 @@ class TestTheGlSideStaysWellFormed:
         assert len(found) == 2
         assert "nth-child(1)" in found[0]
         assert "nth-child(2)" in found[1]
+
+
+class TestATraceThatDrawsNothingFormsNoLayer:
+    """A layer for an undrawn trace is not merely empty -- it crashes (#421).
+
+    Plotly gives such a trace no group, so there is nothing to announce and
+    nothing to highlight. The core does worse than ignore the layer: reading
+    the state of a series with no points dereferences an undefined point in
+    `LineTrace.text` and throws, and a throw out of trace construction
+    propagates out of `Figure`, taking the whole render with it rather than
+    the one layer (xability/maidr#905).
+
+    The multi-trace paths already reached this answer inside
+    `_drawn_line_series`; a lone trace bypassed it through the single-trace
+    branches.
+    """
+
+    @pytest.mark.parametrize(
+        "trace",
+        [
+            go.Scatter(x=[], y=[], mode="lines", name="a"),
+            go.Scatter(x=[], y=[], mode="markers", name="a"),
+            go.Scatter(x=[], y=[], stackgroup="one", name="a"),
+            go.Scatter(x=[], y=[], line=dict(shape="hv"), name="a"),
+        ],
+        ids=["line", "markers", "area", "step"],
+    )
+    def test_a_lone_undrawn_trace_emits_no_layer(self, trace):
+        layers = PlotlyMaidr(go.Figure([trace]))._flatten_maidr()["subplots"][0][0][
+            "layers"
+        ]
+        assert layers == []
+
+    def test_a_drawn_neighbour_still_gets_its_layer(self):
+        fig = go.Figure([line("a", [1, 2]), line("e")])
+        layers = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+        assert len(layers) == 1
+        assert len(layers[0]["data"]) == 1
+
+    def test_no_layer_carries_an_empty_series(self):
+        # The shape that throws in the core. Asserted over every layer rather
+        # than the first, since the fallback factory builds them separately.
+        fig = go.Figure([line("a", [1, 2]), line("e1"), line("e2")])
+        for layer in PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]:
+            data = layer["data"]
+            series = data if not data or isinstance(data[0], dict) else data
+            assert all(s for s in series), "a layer carries an empty series"
+
+    def test_a_pie_is_not_mistaken_for_undrawn(self):
+        # `draws_marks` reads `x`/`y`, and a pie carries neither. Scoping the
+        # exclusion to the scatter family is what keeps it.
+        fig = go.Figure([go.Pie(labels=["a", "b"], values=[1, 2])])
+        layers = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+        assert len(layers) == 1
+        assert len(layers[0]["data"]) == 2
+
+    def test_a_bar_with_no_data_is_left_to_its_own_path(self):
+        # Bars are not scatter-family, so this exclusion does not reach them.
+        # Pinned so a later widening of the predicate is a deliberate choice
+        # rather than a side effect.
+        fig = go.Figure([go.Bar(x=[], y=[], name="a")])
+        layers = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+        assert len(layers) == 1

--- a/tests/plotly/test_plotly_drawn_positions.py
+++ b/tests/plotly/test_plotly_drawn_positions.py
@@ -256,7 +256,12 @@ class TestATraceThatDrawsNothingFormsNoLayer:
         fig = go.Figure([line("a", [1, 2]), line("e1"), line("e2")])
         for layer in PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]:
             data = layer["data"]
-            series = data if not data or isinstance(data[0], dict) else data
+            # `data` is a flat list of points for a single-series layer and a
+            # list of series for a multi-series one. Both shapes have to be
+            # checked: an empty series is the thing that throws, and in the
+            # flat shape "empty" is the whole list.
+            assert data, "a layer carries no data at all"
+            series = data if isinstance(data[0], list) else [data]
             assert all(s for s in series), "a layer carries an empty series"
 
     def test_a_pie_is_not_mistaken_for_undrawn(self):


### PR DESCRIPTION
Closes #421.

```python
go.Figure([go.Scatter(x=[], y=[], mode="lines", name="lonely")])
→ layers: 1 | type: LINE | data: [[]] | selectors: ['...nth-child(1) path.js-line']
```

A layer holding one empty series and a selector that can never resolve.

## It does not merely announce nothing — it throws

The issue asked to check the JS side before choosing a fix. I did, by constructing the layer directly in the core:

```
TypeError: Cannot read properties of undefined (reading 'z')

  423 |       zData = point.z ? { z: { label: zLabel, value: point.z } } : {};
      at LineTrace.text        (src/model/line.ts:423:21)
      at LineTrace.state       (src/model/abstract.ts:507:18)
```

`point` is `this.points[this.row]?.[this.col]` — `undefined` for an empty series. The optional chaining stops one step short of the dereference; the guard is on the *property*, not the *point*.

A throw out of trace construction propagates out of `new Figure(...)`, so this takes the **whole render** rather than degrading to one silent layer. Filed as **xability/maidr#905** for the core half — a producer can always emit an empty series, and the core shouldn't crash on one. This PR is the producer half.

## Two attempts, because the first was wrong

Excluding undrawn traces from the groupings **alone** didn't work: they fell through to the fallback factory, which built the same layer. Worse, a drawn-plus-empty figure went from 1 layer to **2**, since the empty one became its own. They have to be marked handled as well — which is what `merged` is for, and how every other deliberate skip in `_extract_plots` works.

## Scoped to the scatter family, deliberately

`draws_marks` reads `x`/`y`. A pie carries neither and draws perfectly well, so asking it of every trace would drop **every pie in the figure**. A bar with no data is likewise left to its own path. Both are pinned, so widening the predicate later is a decision rather than a side effect.

| figure | layers before | after |
|---|---|---|
| lone empty line / markers / area / step | 1 (crashes core) | **0** |
| drawn + empty | 1 | 1 |
| pie | 1 | 1 |
| bar with no data | 1 | 1 |

## Verification

- **Suite 1718 passed** (1710 + 8 new).
- Falsification: not excluding them fails **10 of the 23** tests in the file.
- `ruff check` clean; no line over 88.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_