### PR TITLE
feat(plotly): keep the step convention of a filled staircase

### DIFF
--- a/maidr/plotly/area.py
+++ b/maidr/plotly/area.py
@@ -9,9 +9,14 @@ draws this chart rather than a multi-line one (#392).
 
 from __future__ import annotations
 
+from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot
-from maidr.plotly.step_shape import is_scatter_family_trace, renders_through_webgl
+from maidr.plotly.step_shape import (
+    is_scatter_family_trace,
+    renders_through_webgl,
+    shared_step_direction,
+)
 
 #: The values ``groupnorm`` takes when plotly rescales a stack to a common
 #: total -- its own switch for a 100% stacked area, and the counterpart of
@@ -150,6 +155,40 @@ class PlotlyAreaPlot(PlotlyPlot):
         # same wrong-element failure the required parameter exists to end.
         self._traces = list(traces)
         self._scatter_positions = list(scatter_positions)
+
+    def render(self) -> dict:
+        """Build the base layer schema, then add the step convention.
+
+        ``line.shape`` and a fill are independent attributes in plotly, so a
+        band can be a staircase: a stacked step area is the standard way to
+        draw a cumulative count that changes at discrete events. Read as a
+        smoothly interpolated band it tells a reader the wrong thing about
+        every interval -- that the value slid between samples when it in fact
+        held and then jumped (#413).
+
+        The two facts ride together rather than one displacing the other. An
+        area that is also a staircase is still an area, so the layer keeps its
+        area type and carries ``stepDirection`` alongside it; the core reads
+        both, and announces the fill *and* what happens between samples.
+
+        Returns
+        -------
+        dict
+            The MAIDR layer schema, carrying ``stepDirection`` only when every
+            band in the stack authored one shape MAIDR has a name for.
+        """
+        schema = super().render()
+
+        # A stack cannot be split by direction the way the step layers are:
+        # the bands of one `stackgroup` are one stack, and separating them
+        # would leave the core summing a part of it and announcing that as the
+        # total. So a mixed stack is expected here, and it says nothing rather
+        # than describing one of its bands wrongly.
+        direction = shared_step_direction(self._traces)
+        if direction is not None:
+            schema[MaidrKey.STEP_DIRECTION] = direction
+
+        return schema
 
     def _get_selector(self) -> list[str]:
         """One selector per drawn band, in the order the bands are emitted.

--- a/maidr/plotly/step.py
+++ b/maidr/plotly/step.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot
-from maidr.plotly.step_shape import step_direction_of
+from maidr.plotly.step_shape import shared_step_direction
 
 
 class PlotlyStepPlot(PlotlyPlot):
@@ -109,29 +109,16 @@ class PlotlyStepPlot(PlotlyPlot):
         """
         schema = super().render()
 
-        direction = self._resolve_direction()
+        # Disagreement should not reach here -- the traces are grouped by
+        # direction before construction -- so a None from a mixed set is a
+        # guard against a caller that skipped the grouping rather than an
+        # expected case. `vhv` reaching it is expected: MAIDR has no name for
+        # that convention.
+        direction = shared_step_direction(self._traces)
         if direction is not None:
             schema[MaidrKey.STEP_DIRECTION] = direction
 
         return schema
-
-    def _resolve_direction(self) -> str | None:
-        """
-        Resolve the one step convention these traces share.
-
-        Returns
-        -------
-        str or None
-            The shared direction, or None when the traces disagree or their
-            shape has no MAIDR equivalent. Disagreement should not reach here
-            — the traces are grouped by direction before construction — so the
-            check is a guard against a caller that skipped the grouping rather
-            than an expected case.
-        """
-        directions = {step_direction_of(trace) for trace in self._traces}
-        if len(directions) != 1:
-            return None
-        return directions.pop()
 
     def _extract_plot_data(self) -> list[list[dict]]:
         """

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -310,6 +310,39 @@ def step_direction_of(trace: dict) -> str | None:
     return None if shape is None else STEP_SHAPE_DIRECTION.get(shape)
 
 
+def shared_step_direction(traces: list[dict]) -> str | None:
+    """
+    Resolve the one step convention a set of traces all author.
+
+    A MAIDR layer carries a single ``stepDirection`` for all of its series, so
+    a layer whose traces disagree cannot describe every one of them and says
+    nothing rather than describing one wrongly.
+
+    Shared by the step and area layers because they reach this question from
+    opposite directions and must not answer it differently. A step layer is
+    *split* by direction before construction, so disagreement there is a guard
+    against a caller that skipped the grouping. An area layer cannot be split
+    — the bands of one ``stackgroup`` are one stack, and separating them would
+    leave the core summing part of it — so a mixed stack reaching here is
+    expected, and withholding the key is the honest answer for it.
+
+    Parameters
+    ----------
+    traces : list of dict
+        The traces forming one layer.
+
+    Returns
+    -------
+    str or None
+        The shared direction, or None when the traces disagree, author no
+        shape, or author one MAIDR has no name for (``vhv``).
+    """
+    directions = {step_direction_of(trace) for trace in traces}
+    if len(directions) != 1:
+        return None
+    return directions.pop()
+
+
 def group_by_direction(traces: list[dict]) -> list[list[dict]]:
     """
     Split step traces into groups that share one step convention.

--- a/tests/plotly/test_plotly_step_area.py
+++ b/tests/plotly/test_plotly_step_area.py
@@ -1,0 +1,207 @@
+"""A stepped area lost its step semantics (#413).
+
+``line.shape`` and ``stackgroup`` are independent plotly attributes, so a
+trace can be both a staircase and a filled band. Since #411 the area
+classification runs first, so such a trace became a plain ``area`` layer with
+no ``stepDirection`` on it; before #411 it fell into the step grouping and
+kept the direction but was announced as a line. Neither reading was ever
+complete -- one of the two facts was always dropped.
+
+They are orthogonal, so the layer carries both: the area type says the band is
+filled and how it stacks, ``stepDirection`` says what happens between samples.
+The core reads the pair (xability/maidr#902), and its highlight only lands on
+the samples once the path parser reads the ``H``/``V`` commands a staircase is
+drawn with (xability/maidr#907).
+
+A stacked step area is the standard way to draw a cumulative count that
+changes at discrete events, which is why this is worth carrying rather than
+approximating: read as a smoothly interpolated band, every interval tells a
+reader the value slid when it in fact held and then jumped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+from maidr.plotly.step_shape import shared_step_direction  # noqa: E402
+
+X = [1, 2, 3]
+
+
+def layers(fig) -> list[dict]:
+    return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+
+
+def band(shape: str | None = None, name: str = "a", y: list | None = None):
+    line = {"shape": shape} if shape is not None else None
+    return go.Scatter(
+        x=X,
+        y=y if y is not None else [1, 2, 3],
+        stackgroup="one",
+        name=name,
+        **({"line": line} if line else {}),
+    )
+
+
+class TestAnAreaCarriesItsStepDirection:
+    @pytest.mark.parametrize(
+        ("shape", "expected"),
+        [("hv", "hv"), ("vh", "vh"), ("hvh", "mid")],
+    )
+    def test_a_lone_stepped_band(self, shape, expected):
+        found = layers(go.Figure([band(shape)]))
+        assert len(found) == 1
+        assert found[0]["stepDirection"] == expected
+
+    def test_a_stacked_step_area_keeps_both_facts(self):
+        # The shape the issue names. Neither fact displaces the other: the
+        # type still says the bands are filled and stack, and the direction
+        # still says the value holds and then jumps.
+        fig = go.Figure([band("hv", "a"), band("hv", "b", [2, 1, 4])])
+        found = layers(fig)
+        assert len(found) == 1
+        assert found[0]["type"] == PlotType.STACKED_AREA
+        assert found[0]["stepDirection"] == "hv"
+
+    def test_a_normalized_step_area_keeps_both_facts(self):
+        fig = go.Figure(
+            [
+                go.Scatter(
+                    x=X,
+                    y=[1, 2, 3],
+                    stackgroup="one",
+                    groupnorm="percent",
+                    line=dict(shape="hv"),
+                    name="a",
+                ),
+                go.Scatter(
+                    x=X,
+                    y=[2, 1, 4],
+                    stackgroup="one",
+                    line=dict(shape="hv"),
+                    name="b",
+                ),
+            ]
+        )
+        found = layers(fig)
+        assert found[0]["type"] == PlotType.NORMALIZED_AREA
+        assert found[0]["stepDirection"] == "hv"
+
+    def test_the_band_is_still_an_area_and_not_a_step(self):
+        # The regression this replaces: before #411 a stepped band kept its
+        # direction by being classified as a step, which lost the fill.
+        found = layers(go.Figure([band("hv")]))
+        assert found[0]["type"] == PlotType.AREA
+
+
+class TestSilenceIsKeptWhereThereIsNothingToSay:
+    def test_a_plain_area_authors_no_direction(self):
+        assert "stepDirection" not in layers(go.Figure([band()]))[0]
+
+    def test_a_linear_shape_authors_no_direction(self):
+        # `linear` interpolates between samples, which is what a step does
+        # not do. Naming a direction for it would be a claim about the data.
+        assert "stepDirection" not in layers(go.Figure([band("linear")]))[0]
+
+    def test_a_spline_authors_no_direction(self):
+        assert "stepDirection" not in layers(go.Figure([band("spline")]))[0]
+
+    def test_vhv_binds_as_an_area_without_claiming_a_convention(self):
+        # `vhv` holds a value *between* two samples rather than at one, so
+        # MAIDR has no name for it. The band still binds -- the data is
+        # piecewise constant -- it just does not claim a convention.
+        found = layers(go.Figure([band("vhv")]))
+        assert len(found) == 1
+        assert found[0]["type"] == PlotType.AREA
+        assert "stepDirection" not in found[0]
+
+    def test_a_stack_whose_bands_disagree_says_nothing(self):
+        # A stack cannot be split by direction the way the step layers are:
+        # its bands are one stack, and separating them would leave the core
+        # summing a part of it and announcing that as the total. So the layer
+        # stays whole and withholds the key rather than describing one of its
+        # bands wrongly.
+        fig = go.Figure([band("hv", "a"), band("vh", "b", [2, 1, 4])])
+        found = layers(fig)
+        assert len(found) == 1
+        assert found[0]["type"] == PlotType.STACKED_AREA
+        assert "stepDirection" not in found[0]
+
+    def test_a_stack_of_a_stepped_and_a_plain_band_says_nothing(self):
+        # The asymmetric case: one band authors `hv`, the other authors
+        # nothing. "Nothing" is a real disagreement -- plotly interpolates
+        # that band -- so the layer must not adopt its neighbour's direction.
+        fig = go.Figure([band("hv", "a"), band(None, "b", [2, 1, 4])])
+        assert "stepDirection" not in layers(fig)[0]
+
+
+class TestTheTwoStackGroupsAreAnsweredSeparately:
+    def test_each_group_keeps_its_own_convention(self):
+        # Groups are independent stacks, so one being mixed must not silence
+        # the other.
+        fig = go.Figure(
+            [
+                go.Scatter(
+                    x=X, y=[1, 2, 3], stackgroup="one", line=dict(shape="hv"), name="a"
+                ),
+                go.Scatter(
+                    x=X, y=[2, 1, 4], stackgroup="two", line=dict(shape="vh"), name="b"
+                ),
+            ]
+        )
+        found = layers(fig)
+        assert len(found) == 2
+        assert [entry["stepDirection"] for entry in found] == ["hv", "vh"]
+
+
+class TestSharedStepDirection:
+    """The resolver both layer types read, asked directly."""
+
+    def test_one_shape_resolves(self):
+        assert shared_step_direction([{"line": {"shape": "hv"}}]) == "hv"
+
+    def test_agreement_across_traces_resolves(self):
+        traces = [{"line": {"shape": "vh"}}, {"line": {"shape": "vh"}}]
+        assert shared_step_direction(traces) == "vh"
+
+    def test_disagreement_resolves_to_none(self):
+        traces = [{"line": {"shape": "hv"}}, {"line": {"shape": "vh"}}]
+        assert shared_step_direction(traces) is None
+
+    def test_no_shape_resolves_to_none(self):
+        assert shared_step_direction([{}]) is None
+
+    def test_an_unnamed_convention_resolves_to_none(self):
+        assert shared_step_direction([{"line": {"shape": "vhv"}}]) is None
+
+    def test_an_empty_set_resolves_to_none(self):
+        # Not reachable through either layer -- both reject an empty trace
+        # list in their constructor -- but the resolver is the shared piece,
+        # so it answers rather than raising.
+        assert shared_step_direction([]) is None
+
+
+class TestTheStepLayerIsUnchanged:
+    """The step path reads the same resolver now; its answers must not move."""
+
+    def test_a_step_line_still_carries_its_direction(self):
+        fig = go.Figure(
+            [go.Scatter(x=X, y=[1, 2, 3], mode="lines", line=dict(shape="hv"))]
+        )
+        found = layers(fig)
+        assert found[0]["type"] == PlotType.STEP
+        assert found[0]["stepDirection"] == "hv"
+
+    def test_a_vhv_step_line_still_withholds_it(self):
+        fig = go.Figure(
+            [go.Scatter(x=X, y=[1, 2, 3], mode="lines", line=dict(shape="vhv"))]
+        )
+        found = layers(fig)
+        assert found[0]["type"] == PlotType.STEP
+        assert "stepDirection" not in found[0]


### PR DESCRIPTION
Closes #413. This is the producer half; the core half landed as xability/maidr#902.

## The defect

`line.shape` and `stackgroup` are independent plotly attributes, so a trace can be both a staircase and a filled band:

```python
go.Scatter(x=[1, 2, 3], y=[1, 2, 3], stackgroup="one", line=dict(shape="hv"))
```

Since #411 `is_area_trace` is tested before `is_step_trace`, so that became a plain `area` layer with no `stepDirection`. Before #411 it fell into the step grouping and kept the direction but was announced as a line. Neither classification was ever complete — one of the two facts was always dropped.

A staircase and an interpolated line make different claims about what happens *between* samples: a step says the value holds and then jumps, a line says it slid. A stacked step area is the standard way to draw a cumulative count that changes at discrete events, so reading it as a smooth band misdescribes every interval of it.

## The fix

The two facts are orthogonal, so the layer carries both rather than becoming a fourth mutually-exclusive plot type. The area type still says the band is filled and how it stacks; `stepDirection` rides alongside it.

```
stacked step area hv     type=STACKED_AREA     stepDirection='hv'
lone step area vh        type=AREA             stepDirection='vh'
hvh                      type=AREA             stepDirection='mid'
vhv                      type=AREA             (absent)
plain area               type=AREA             (absent)
mixed stack              type=STACKED_AREA     (absent)
plain step line          type=STEP             stepDirection='hv'   ← unchanged
```

**A mixed stack says nothing.** This is the one place the area path cannot copy the step path. `PlotlyStepPlot` layers are *split* by direction before construction, so a step layer's traces always agree. A stack cannot be split that way: the bands of one `stackgroup` are one stack, and separating them would leave the core summing part of it and announcing that as the total. So a stack whose bands disagree stays whole and withholds the key rather than describing one of its bands wrongly.

That includes the asymmetric case — one band `hv`, the other authoring no shape at all. "Nothing" is a real disagreement, because plotly interpolates that band, so the layer must not adopt its neighbour's direction.

**One resolver, two callers.** `PlotlyStepPlot._resolve_direction` and the new area path asked the same question, so the logic moved to `shared_step_direction` in `step_shape.py` and both read it. The step path's answers are unchanged and pinned by `TestTheStepLayerIsUnchanged`.

## Verification

Full suite **1739 passed**, `ruff check` clean on every file touched, plus 21 new tests in `tests/plotly/test_plotly_step_area.py`.

Falsification — each mechanism reverted in turn:

| reverted | failures |
|---|---|
| area layer stops emitting `stepDirection` | **6 of 21** |
| resolver takes the first shape it finds instead of requiring agreement | **4** (across the step and area suites) |

## What a reader gets, end to end

`stepDirection` on an area layer is read by `AreaTrace` since maidr#902, which announces the convention under "Step direction" in the description for every variant.

The *highlight* needs one more piece, and it is not in this change: a staircase's rendered path is drawn with `H`/`V` commands, which the core's path parser did not read at all — so a plotly step chart of any kind got no highlight, filled or not. Found while measuring this issue's geometry, filed as xability/maidr#907, fixed in xability/maidr#908. Nothing here depends on that landing; this layer is correct either way, and the highlight starts working when #908 ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_