### PR TITLE
feat: give a seaborn regression its confidence band

### DIFF
--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -182,9 +182,13 @@ class SmoothPlot(MaidrPlot):
             chart draws no band (``ci=None``).
         """
         for collection in self.ax.collections:
+            # Every shaded region is a candidate, and the bracketing test in
+            # `_edges_of` decides. Filtering on `FillBetweenPolyCollection`
+            # first looks tighter and is not portable: matplotlib split that
+            # subclass out of `PolyCollection` in 3.10, so on an older one --
+            # which the Python 3.9 floor still resolves to -- no band exists by
+            # that name and every regression silently lost its interval.
             if not isinstance(collection, PolyCollection):
-                continue
-            if type(collection).__name__ != "FillBetweenPolyCollection":
                 continue
             bounds = self._edges_of(collection, x_data, y_data)
             if bounds is not None:
@@ -195,11 +199,13 @@ class SmoothPlot(MaidrPlot):
         """
         Read one shaded region's edges, if it is this fit's band.
 
-        The type test alone does not identify it. ``FillBetweenPolyCollection``
-        is the subclass matplotlib 3.10 split out for ``fill_between``, and
-        seaborn draws a **violin body** with ``fill_betweenx`` -- so a violin on
-        the same axes is the same class, and reading its outline would announce
-        a distribution's silhouette as a regression's uncertainty.
+        A type test cannot identify it, which is why this exists. seaborn
+        draws a **violin body** with ``fill_betweenx``, so a violin is the same
+        class as a band however that class is spelled, and reading its outline
+        would announce a distribution's silhouette as a regression's
+        uncertainty. ``FillBetweenPolyCollection`` does not help either: it is
+        the subclass matplotlib 3.10 split out, absent on the older matplotlib
+        the Python 3.9 floor resolves to.
 
         So the reading validates itself: a region is this fit's band only if it
         brackets every fitted sample. That is the property a confidence band

--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from matplotlib.axes import Axes
+from matplotlib.collections import PolyCollection
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.exception.extraction_error import ExtractionError
 import numpy as np
@@ -16,6 +17,7 @@ from maidr.util.svg_utils import (
 
 #: Default maximum number of output points per smooth curve.
 _DEFAULT_MAX_SMOOTH_POINTS = 30
+
 
 
 class SmoothPlot(MaidrPlot):
@@ -122,14 +124,126 @@ class SmoothPlot(MaidrPlot):
         x_data, y_data = self._thin_to_even_steps(x_data, y_data)
 
         x_svg, y_svg = data_to_svg_coords(self.ax, x_data, y_data)
-        return [
-            [
-                {
-                    MaidrKey.X: float(x),
-                    MaidrKey.Y: float(y),
-                    "svg_x": float(sx),
-                    "svg_y": float(sy),
-                }
-                for x, y, sx, sy in zip(x_data, y_data, x_svg, y_svg)
-            ]
-        ]
+        lower, upper = self._confidence_band_at(x_data, y_data)
+        points = []
+        for i, (x, y, sx, sy) in enumerate(zip(x_data, y_data, x_svg, y_svg)):
+            point = {
+                MaidrKey.X: float(x),
+                MaidrKey.Y: float(y),
+                "svg_x": float(sx),
+                "svg_y": float(sy),
+            }
+            if lower is not None and upper is not None:
+                point["yMin"] = float(lower[i])
+                point["yMax"] = float(upper[i])
+            points.append(point)
+        return [points]
+
+    def _confidence_band_at(self, x_data, y_data):
+        """
+        Read the interval ``regplot`` shades around its fit, at the given x.
+
+        ``ci=95`` is seaborn's default, and the band is the reason a regression
+        is drawn rather than a bare line: it says how much of the trend the
+        data supports. It reached the schema as nothing at all -- the fitted
+        line was announced alone, so a reader was told the trend without being
+        told how well determined it is.
+
+        Two things this does *not* do, each because measuring showed it wrong:
+
+        The ring is not walked positionally. seaborn shades the band with a
+        ``FillBetweenPolyCollection`` whose vertices run out along one edge and
+        back along the other; measured on a 100-sample fit, that is 203
+        vertices with individual x values appearing 2, 3 or 4 times, so a
+        position in the ring is not a fixed offset from either end. The edges
+        are recovered by taking the lowest and highest vertex at each x, which
+        is exact and needs nothing assumed about orientation.
+
+        And the result is *interpolated* rather than looked up. The curve is
+        thinned before it is emitted, and the thinning resamples to evenly
+        spaced positions rather than selecting a subset -- measured, only the
+        two endpoints of a 30-point output were among the band's own x values.
+        A lookup would therefore have attached bounds to 2 points and left 28
+        silently bare. Interpolating between vertices is also what matplotlib
+        does to draw the band, so it reads the same shape the reader sees.
+
+        Parameters
+        ----------
+        x_data : numpy.ndarray
+            The x positions the curve is emitted at.
+        y_data : numpy.ndarray
+            The fitted values at those positions, which a candidate region
+            has to bracket to be this fit's band.
+
+        Returns
+        -------
+        tuple
+            Lower and upper bounds at each x, or ``(None, None)`` when the
+            chart draws no band (``ci=None``).
+        """
+        for collection in self.ax.collections:
+            if not isinstance(collection, PolyCollection):
+                continue
+            if type(collection).__name__ != "FillBetweenPolyCollection":
+                continue
+            bounds = self._edges_of(collection, x_data, y_data)
+            if bounds is not None:
+                return bounds
+        return None, None
+
+    def _edges_of(self, collection, x_data, y_data):
+        """
+        Read one shaded region's edges, if it is this fit's band.
+
+        The type test alone does not identify it. ``FillBetweenPolyCollection``
+        is the subclass matplotlib 3.10 split out for ``fill_between``, and
+        seaborn draws a **violin body** with ``fill_betweenx`` -- so a violin on
+        the same axes is the same class, and reading its outline would announce
+        a distribution's silhouette as a regression's uncertainty.
+
+        So the reading validates itself: a region is this fit's band only if it
+        brackets every fitted sample. That is the property a confidence band
+        has by construction and an unrelated shaded region does not, and it is
+        cheaper and less brittle than trying to match seaborn's artists to each
+        other.
+
+        Parameters
+        ----------
+        collection : matplotlib.collections.PolyCollection
+            A shaded region on these axes.
+        x_data : numpy.ndarray
+            The x positions the curve is emitted at.
+        y_data : numpy.ndarray
+            The fitted values at those positions.
+
+        Returns
+        -------
+        tuple or None
+            Lower and upper bounds at each x, or None when this region is not
+            this fit's band.
+        """
+        by_x: dict[float, tuple[float, float]] = {}
+        for path in collection.get_paths():
+            for x, y in path.vertices:
+                if not (np.isfinite(x) and np.isfinite(y)):
+                    continue
+                key = float(x)
+                low, high = by_x.get(key, (float(y), float(y)))
+                by_x[key] = (min(low, float(y)), max(high, float(y)))
+
+        if len(by_x) < 2:
+            return None
+
+        band_x = np.array(sorted(by_x))
+        lower = np.interp(x_data, band_x, np.array([by_x[x][0] for x in band_x]))
+        upper = np.interp(x_data, band_x, np.array([by_x[x][1] for x in band_x]))
+
+        # `np.interp` clamps outside the region's own x range, so a region that
+        # does not span the fit would still return numbers -- the bracketing
+        # test is what rejects it, not the interpolation.
+        tolerance = 1e-9
+        if not np.all(
+            (lower <= y_data + tolerance) & (y_data - tolerance <= upper)
+        ):
+            return None
+        return lower, upper

--- a/tests/core/plot/test_regplot_confidence_band.py
+++ b/tests/core/plot/test_regplot_confidence_band.py
@@ -1,0 +1,166 @@
+"""A regression line was announced without the band around it (#919).
+
+``ci=95`` is seaborn's default, and the band is the reason a regression is
+drawn rather than a bare line: it says how much of the trend the data
+supports. ``SmoothPlot`` emitted only the fitted values, so a reader was told
+the trend and nothing about how well determined it is.
+
+The bounds ride on the fitted samples as ``yMin``/``yMax``, which is the shape
+``LineTrace`` reads since xability/maidr#920 -- so the value and its interval
+are heard at one x rather than by switching layers. ``SmoothTrace`` extends
+``LineTrace``, so a smooth layer carries them with nothing further needed.
+
+Two facts about seaborn's band decided the implementation, and both were
+measured rather than assumed:
+
+* Its polygon runs out along one edge and back along the other. On a
+  100-sample fit that is **203 vertices**, with individual x values appearing
+  2, 3 or 4 times, so a positional split of the ring would be fragile in the
+  way that yields a plausible wrong answer. The edges are recovered by taking
+  the lowest and highest vertex at each x.
+* The curve is **resampled** before it is emitted, not thinned to a subset.
+  Measured: only the two endpoints of a 30-point output were among the band's
+  own x values, so a lookup would have attached bounds to 2 points and left 28
+  silently bare. The bounds are interpolated instead, which is also how
+  matplotlib draws the band between its vertices.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+sns = pytest.importorskip("seaborn")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def regression_axes(ci: int | None = 95):
+    """Draw a regression whose scatter is loose enough to have a real band."""
+    rng = np.random.default_rng(0)
+    x = np.arange(1, 21)
+    y = x + rng.normal(scale=2.0, size=x.size)
+    return sns.regplot(x=x, y=y, ci=ci)
+
+
+def smooth_points(ax) -> list[dict]:
+    maidr = FigureManager.get_maidr(ax.get_figure())
+    smooth = [p for p in maidr._plots if str(p.type).endswith("SMOOTH")]
+    assert len(smooth) == 1, f"expected one smooth layer, got {len(smooth)}"
+    return smooth[0].schema["data"][0]
+
+
+class TestTheBandReachesTheSchema:
+    def test_every_fitted_sample_carries_its_bounds(self):
+        # Not "most of them": the resampling is what makes this the assertion
+        # worth writing, since a lookup passes on the endpoints alone.
+        points = smooth_points(regression_axes())
+
+        assert points
+        assert all("yMin" in point and "yMax" in point for point in points)
+
+    def test_the_bounds_bracket_the_fit(self):
+        # The band is around the curve, so a point outside it means the two
+        # edges were read the wrong way round -- the failure a positional
+        # split of the polygon invites.
+        points = smooth_points(regression_axes())
+
+        assert all(
+            point["yMin"] <= point["y"] <= point["yMax"] for point in points
+        )
+
+    def test_the_band_has_width(self):
+        # A band collapsed to the line would satisfy the bracketing test above
+        # while telling the reader nothing.
+        points = smooth_points(regression_axes())
+
+        assert any(point["yMax"] - point["yMin"] > 0 for point in points)
+
+    def test_the_fitted_values_are_untouched(self):
+        # The band is added beside the curve, not instead of it.
+        points = smooth_points(regression_axes())
+
+        assert all("x" in point and "y" in point for point in points)
+        assert all("svg_x" in point and "svg_y" in point for point in points)
+
+
+class TestAChartWithNoBand:
+    def test_ci_none_carries_no_bounds(self):
+        points = smooth_points(regression_axes(ci=None))
+
+        assert points
+        assert all("yMin" not in point for point in points)
+        assert all("yMax" not in point for point in points)
+
+    def test_the_curve_is_still_emitted(self):
+        # The feature has to be invisible to a regression drawn without one.
+        points = smooth_points(regression_axes(ci=None))
+
+        assert all("x" in point and "y" in point for point in points)
+
+
+class TestTheBandIsReadRatherThanGuessed:
+    """What the two measurements above are protecting.
+
+    Both would produce output that looks right at a glance -- a schema with
+    `yMin`/`yMax` keys on it -- so they are pinned by what the numbers say
+    rather than by whether the keys exist.
+    """
+
+    def test_the_interval_narrows_where_the_data_is_dense(self):
+        # A confidence band on a linear fit is narrowest near the centre of x
+        # and widest at the ends. If the bounds were read off the wrong
+        # vertices, or interpolated against a mismatched grid, that shape is
+        # the first thing to go.
+        points = smooth_points(regression_axes())
+        widths = [point["yMax"] - point["yMin"] for point in points]
+        middle = widths[len(widths) // 2]
+
+        assert middle < widths[0]
+        assert middle < widths[-1]
+
+    def test_a_shaded_region_that_is_not_the_band_is_not_read_as_one(self):
+        # The type test alone does not identify the band: seaborn draws a
+        # violin body with `fill_betweenx`, so a violin is the *same class* as
+        # a confidence band. Verified below rather than asserted from the
+        # docs.
+        #
+        # What separates them is that a band brackets every fitted sample and
+        # an unrelated shaded region does not, so the reading validates itself
+        # rather than trusting the class name.
+        rng = np.random.default_rng(1)
+        violin_ax = sns.violinplot(x=rng.normal(size=60))
+        assert [
+            c
+            for c in violin_ax.collections
+            if type(c).__name__ == "FillBetweenPolyCollection"
+        ], "expected seaborn to draw the violin body with fill_betweenx"
+        plt.close("all")
+
+        # A regression with its own band switched off, beside a shaded region
+        # of the same class sitting well away from the fit. Drawn with
+        # `fill_between` directly rather than as a violin, so the axes carries
+        # exactly one smooth layer and the assertion is about the band alone.
+        x = np.arange(1, 21)
+        y = x + rng.normal(scale=2.0, size=x.size)
+        ax = sns.regplot(x=x, y=y, ci=None)
+        ax.fill_between(x, y - 100, y - 90, alpha=0.2)
+
+        assert [
+            c
+            for c in ax.collections
+            if type(c).__name__ == "FillBetweenPolyCollection"
+        ], "the decoy region should be on the axes"
+        assert all("yMin" not in point for point in smooth_points(ax))

--- a/tests/core/plot/test_regplot_confidence_band.py
+++ b/tests/core/plot/test_regplot_confidence_band.py
@@ -13,6 +13,12 @@ are heard at one x rather than by switching layers. ``SmoothTrace`` extends
 Two facts about seaborn's band decided the implementation, and both were
 measured rather than assumed:
 
+* A class test cannot identify the band. seaborn draws a violin body with
+  ``fill_betweenx``, so a violin is the same class however that class is
+  spelled -- and ``FillBetweenPolyCollection`` is matplotlib 3.10's, absent on
+  the older matplotlib the Python 3.9 floor resolves to. The reading validates
+  itself instead: a region is this fit's band only if it brackets every fitted
+  sample.
 * Its polygon runs out along one edge and back along the other. On a
   100-sample fit that is **203 vertices**, with individual x values appearing
   2, 3 or 4 times, so a positional split of the ring would be fragile in the
@@ -37,6 +43,7 @@ import matplotlib  # noqa: E402
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.collections import PolyCollection  # noqa: E402
 
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 
@@ -143,10 +150,8 @@ class TestTheBandIsReadRatherThanGuessed:
         rng = np.random.default_rng(1)
         violin_ax = sns.violinplot(x=rng.normal(size=60))
         assert [
-            c
-            for c in violin_ax.collections
-            if type(c).__name__ == "FillBetweenPolyCollection"
-        ], "expected seaborn to draw the violin body with fill_betweenx"
+            c for c in violin_ax.collections if isinstance(c, PolyCollection)
+        ], "expected seaborn to shade the violin body with a PolyCollection"
         plt.close("all")
 
         # A regression with its own band switched off, beside a shaded region
@@ -159,8 +164,6 @@ class TestTheBandIsReadRatherThanGuessed:
         ax.fill_between(x, y - 100, y - 90, alpha=0.2)
 
         assert [
-            c
-            for c in ax.collections
-            if type(c).__name__ == "FillBetweenPolyCollection"
+            c for c in ax.collections if isinstance(c, PolyCollection)
         ], "the decoy region should be on the axes"
         assert all("yMin" not in point for point in smooth_points(ax))


### PR DESCRIPTION
The producer half of xability/maidr#919, now that #920 has landed the core side.

## The gap

`ci=95` is seaborn's default, so nearly every `sns.regplot` draws a band — and it is the reason a regression is drawn rather than a bare line: it says how much of the trend the data supports. `SmoothPlot` emitted only the fitted values, so a reader was told the trend and nothing about how well determined it is.

The bounds now ride on the fitted samples as `yMin`/`yMax`, the shape `LineTrace` reads since xability/maidr#920. `SmoothTrace` extends it, so the value and its interval are heard **at one x** rather than by switching layers.

## Three things measurement changed

Each of these would have shipped a plausible wrong answer.

**1. The ring cannot be split positionally.** The band's polygon runs out along one edge and back along the other. Measured on a 100-sample fit:

```
band verts: 203     v[0]=(1, 4.638)  v[1]=(1, 1.420)
x turning indices: [1, 100, 102, 201]
per-x vertex counts: {2, 3, 4}
```

Individual x values appear 2, 3 or 4 times, so a position in the ring is not a fixed offset from either end. The edges are recovered as the lowest and highest vertex **at each x** — exact, and needing nothing assumed about orientation. Verified: the band's x set is identical to the fit's, and every fitted value falls between the bounds.

**2. The curve is resampled, not thinned to a subset.** My first version looked the bounds up by x and it attached them to **2 of 30 points**:

```
thinned points: 30
missing band at x: [1.655, 2.310, 2.966, … 19.345]   ← 28 of them
thinned x a subset of the fit's x? False
```

`resample_curve` interpolates to evenly spaced positions. So the bounds are interpolated too — which is also how matplotlib draws the band between its vertices, so the reading matches the shape on screen.

**3. `FillBetweenPolyCollection` does not identify the band.** I asserted in a test that a violin isn't one, and the test failed: **seaborn draws a violin body with `fill_betweenx`**, so it is the same class. Trusting the class name would have read a distribution's silhouette as a regression's uncertainty.

The reading validates itself instead — a region is this fit's band only if it **brackets every fitted sample**, which a confidence band does by construction and an unrelated shaded region does not. That is cheaper and less brittle than trying to match seaborn's artists to one another.

## Verification

Full suite **1776 passed**, `ruff check` clean, 8 new tests.

```
ci=95   → 30 points, 30 with band, all bracketed
ci=None → 30 points,  0 with band
```

Two tests go past "the keys exist", since that is what a wrong reading would also produce: the interval must **narrow toward the centre of x** (the shape a linear fit's band has, and the first thing to go if the wrong vertices were read), and a decoy `fill_between` region on the same axes must not be picked up.

Falsification:

| reverted | failures |
|---|---|
| band never read | **4 of 8** |
| bracketing check dropped (class name trusted) | **1** — the decoy region |
| lookup instead of interpolation | **4** |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_