### PR TITLE
fix(scatter): read the collection each scatter call drew

### DIFF
--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -88,7 +88,7 @@ class MaidrPlotFactory:
         elif PlotType.PIE == plot_type:
             return PiePlot(single_ax, **kwargs)
         elif PlotType.SCATTER == plot_type:
-            return ScatterPlot(single_ax)
+            return ScatterPlot(single_ax, **kwargs)
         elif PlotType.DODGED == plot_type or PlotType.STACKED == plot_type:
             return GroupedBarPlot(single_ax, plot_type, **kwargs)
         elif PlotType.SMOOTH == plot_type:

--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -34,7 +34,9 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin):
         # single `PathCollection` of every point even under `hue`, so the
         # sweep finds exactly the right one.
         own_points = kwargs.get(DRAWN_POINTS, None)
-        self._own_points = own_points if isinstance(own_points, PathCollection) else None
+        self._own_points = (
+            own_points if isinstance(own_points, PathCollection) else None
+        )
 
     def _get_selector(self) -> str | list[str]:
         return ["g[maidr='true'] > g > use"]

--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -11,9 +11,30 @@ from maidr.exception import ExtractionError
 from maidr.util.mixin import CollectionExtractorMixin
 
 
+#: The keyword ``Axes.scatter`` hands its own ``PathCollection`` to this layer
+#: under. Named once and imported at both ends rather than spelled twice:
+#: ``kwargs.get`` falls back to sweeping the axes on a mismatch, so a typo
+#: would not raise -- it would quietly restore the behaviour #426 removed.
+#:
+#: Lives here rather than beside ``common.drawn_as`` because ``maidr.patch``
+#: imports ``maidr.core`` and not the other way about.
+DRAWN_POINTS = "_maidr_points"
+
+
 class ScatterPlot(MaidrPlot, CollectionExtractorMixin):
-    def __init__(self, ax: Axes) -> None:
+    def __init__(self, ax: Axes, **kwargs) -> None:
         super().__init__(ax, PlotType.SCATTER)
+        # The collection this layer's own call drew, when the patch could say.
+        # `None` falls back to the first collection on the axes, which is the
+        # right answer only while a layer *is* one collection.
+        #
+        # Guarded on the type rather than on presence: `seaborn.scatterplot`
+        # is patched through the same wrapper and returns an `Axes`, not the
+        # collection. Falling back is correct there -- measured, it draws a
+        # single `PathCollection` of every point even under `hue`, so the
+        # sweep finds exactly the right one.
+        own_points = kwargs.get(DRAWN_POINTS, None)
+        self._own_points = own_points if isinstance(own_points, PathCollection) else None
 
     def _get_selector(self) -> str | list[str]:
         return ["g[maidr='true'] > g > use"]
@@ -128,7 +149,9 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin):
         return True
 
     def _extract_plot_data(self) -> list[dict]:
-        plot = self.extract_collection(self.ax, PathCollection)
+        plot = self._own_points
+        if plot is None:
+            plot = self.extract_collection(self.ax, PathCollection)
         data = self._extract_point_data(plot)
 
         if data is None:

--- a/maidr/patch/scatterplot.py
+++ b/maidr/patch/scatterplot.py
@@ -5,11 +5,26 @@ from matplotlib.axes import Axes
 from matplotlib.collections import PathCollection
 
 from maidr.core.enum import PlotType
+from maidr.core.plot.scatterplot import DRAWN_POINTS
 from maidr.patch.common import common, wrap_seaborn
 
 
 def scatter(wrapped, instance, args, kwargs) -> Axes | PathCollection:
-    return common(PlotType.SCATTER, wrapped, instance, args, kwargs)
+    # Hand the layer the collection this call drew. `ScatterPlot` otherwise
+    # takes the *first* `PathCollection` on the axes, which is right only
+    # while a layer is one collection -- and seaborn's categorical scatters
+    # are one per category. Measured on a three-category `stripplot`: three
+    # layers registered, all three holding category "a", and 60 of the 90
+    # drawn points absent from the schema entirely (#426). Two plain
+    # `ax.scatter()` calls fail the same way.
+    #
+    # `seaborn.scatterplot` is wrapped through this same function and returns
+    # an `Axes` rather than the collection, so it falls back to the sweep --
+    # which is correct for it, since it draws every point as a single
+    # collection even under `hue`.
+    return common(
+        PlotType.SCATTER, wrapped, instance, args, kwargs, drawn_as=DRAWN_POINTS
+    )
 
 
 # Patch matplotlib function.

--- a/tests/core/plot/test_scatter_own_collection.py
+++ b/tests/core/plot/test_scatter_own_collection.py
@@ -1,0 +1,176 @@
+"""Each scatter layer reads the collection its own call drew (#426).
+
+``ScatterPlot`` took the *first* ``PathCollection`` on the axes, under an
+assumption ``extract_collection`` states outright: "We assume only one
+collection of each type is present". A layer is one collection only while
+nothing draws two, and two things routinely do -- seaborn's categorical
+scatters draw one per category, and two ``ax.scatter()`` calls draw one each.
+
+Every layer then re-read collection 0, which is the failure worth pinning
+rather than a crash: the chart is not empty and does not error. A
+three-category strip plot announced category "a" three times, once per layer
+switch with nothing to tell the layers apart, and never announced b or c at
+all -- 60 of 90 drawn points absent, with nothing in the output saying so.
+
+Measured before the fix::
+
+    stripplot: 3 scatter layers, sizes=[30, 30, 30], distinct payloads=1
+    two ax.scatter calls -> layer sizes [10, 10]   (the second drew 80)
+
+The collection is handed over by the patch through ``DRAWN_POINTS``, the
+mechanism #380 introduced for ``Axes.bar``. ``seaborn.scatterplot`` is wrapped
+through the same function and returns an ``Axes`` rather than a collection, so
+it falls back to the sweep -- correct for it, and asserted below rather than
+assumed, since it draws a single collection of every point even under ``hue``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+sns = pytest.importorskip("seaborn")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+from matplotlib.collections import PathCollection  # noqa: E402
+
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+CATEGORIES = ["a", "b", "c"]
+PER_CATEGORY = 30
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def frame() -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    size = PER_CATEGORY * len(CATEGORIES)
+    return pd.DataFrame(
+        {
+            "x": rng.normal(size=size),
+            "y": rng.normal(size=size),
+            "g": np.repeat(CATEGORIES, PER_CATEGORY),
+        }
+    )
+
+
+def scatter_layers(ax) -> list[list[dict]]:
+    maidr = FigureManager.get_maidr(ax.get_figure())
+    return [
+        plot.schema["data"]
+        for plot in maidr._plots
+        if str(plot.type).endswith("SCATTER")
+    ]
+
+
+def drawn_points(ax) -> set[tuple[float, float]]:
+    """Every point matplotlib actually put on the axes."""
+    return {
+        (round(float(x), 9), round(float(y), 9))
+        for collection in ax.collections
+        if isinstance(collection, PathCollection)
+        for x, y in collection.get_offsets()
+    }
+
+
+def announced_points(ax) -> list[tuple[float, float]]:
+    return [
+        (round(float(point["x"]), 9), round(float(point["y"]), 9))
+        for layer in scatter_layers(ax)
+        for point in layer
+    ]
+
+
+@pytest.mark.parametrize("plot", ["stripplot", "swarmplot"])
+class TestACategoricalScatter:
+    def test_each_layer_is_a_different_category(self, plot):
+        # The defect's signature: three layers holding one category's points.
+        ax = getattr(sns, plot)(data=frame(), x="g", y="y")
+        layers = scatter_layers(ax)
+
+        assert len(layers) == len(CATEGORIES)
+        assert len({repr(layer) for layer in layers}) == len(CATEGORIES)
+
+    def test_every_drawn_point_is_announced_exactly_once(self, plot):
+        # Stronger than "the layers differ": it is what the reader loses.
+        # A layer set that is distinct but still misses a category would
+        # satisfy the case above and fail this one.
+        ax = getattr(sns, plot)(data=frame(), x="g", y="y")
+        announced = announced_points(ax)
+
+        assert len(announced) == PER_CATEGORY * len(CATEGORIES)
+        assert set(announced) == drawn_points(ax)
+        assert len(set(announced)) == len(announced)
+
+    def test_the_layers_sit_at_the_three_category_positions(self, plot):
+        # Each category is drawn around its own tick, so the layers' x values
+        # must land in three separate unit-wide bands. Reading collection 0
+        # three times puts all three in the first band.
+        ax = getattr(sns, plot)(data=frame(), x="g", y="y")
+        bands = {
+            round(float(np.mean([point["x"] for point in layer])))
+            for layer in scatter_layers(ax)
+        }
+
+        assert bands == {0, 1, 2}
+
+
+class TestTwoScatterCallsOnOneAxes:
+    def test_each_call_reads_its_own_points(self):
+        # Pure matplotlib, no seaborn involved: the same defect, and the
+        # reason this is not filed as a seaborn issue.
+        data = frame()
+        first = plt.scatter(data.x[:10], data.y[:10])
+        second = plt.scatter(data.x[10:], data.y[10:])
+        sizes = [len(layer) for layer in scatter_layers(second.axes)]
+
+        assert first is not second
+        assert sizes == [10, len(data) - 10]
+
+    def test_no_point_is_announced_twice(self):
+        data = frame()
+        plt.scatter(data.x[:10], data.y[:10])
+        second = plt.scatter(data.x[10:], data.y[10:])
+        announced = announced_points(second.axes)
+
+        assert len(set(announced)) == len(announced)
+        assert set(announced) == drawn_points(second.axes)
+
+
+class TestTheSingleCollectionCasesAreUnchanged:
+    """What the sweep was right about, and must stay right about.
+
+    These are the shapes the existing tests cover, which is why the defect
+    stayed invisible -- so they are the ones a fix has to leave alone.
+    """
+
+    def test_a_plain_scatter_is_one_layer_of_every_point(self):
+        data = frame()
+        collection = plt.scatter(data.x, data.y)
+        layers = scatter_layers(collection.axes)
+
+        assert len(layers) == 1
+        assert len(layers[0]) == len(data)
+
+    def test_seaborn_scatterplot_under_hue_stays_one_layer(self):
+        # Asserted rather than assumed: it is the reason the seaborn binding
+        # keeps the sweep. seaborn draws every point as a single collection
+        # here, so the fallback finds exactly the right one -- and if that
+        # ever changes, this fails rather than the reading going quietly
+        # wrong.
+        data = frame()
+        ax = sns.scatterplot(data=data, x="x", y="y", hue="g")
+
+        assert len([c for c in ax.collections if isinstance(c, PathCollection)]) == 1
+        layers = scatter_layers(ax)
+        assert len(layers) == 1
+        assert len(layers[0]) == len(data)


### PR DESCRIPTION
Closes #426.

## The defect

`ScatterPlot._extract_plot_data()` took the **first** `PathCollection` on the axes. `extract_collection` states the assumption outright:

```python
# We assume only one collection of each type is present to avoid plot clutter,
# even though multiples are technically possible.
```

A layer is one collection only while nothing draws two, and two things routinely do.

## Measured, before

```
sns.stripplot (3 cats)   collections=3  sizes=[30,30,30]  layers=3  distinct payloads=1
sns.swarmplot (3 cats)   collections=3  sizes=[30,30,30]  layers=3  distinct payloads=1
sns.boxenplot (3 cats)   collections=3  sizes=[16,16,16]  layers=3  distinct payloads=1
two ax.scatter calls     collections=2  sizes=[10,80]     layers=2  → layer sizes [10, 10]
```

So a reader of a three-category strip plot heard category **a** three times, once per layer switch with nothing to tell the layers apart, and **never heard b or c** — 60 of the 90 drawn points absent from the schema entirely.

This is the failure mode worth prioritising over a crash: the chart is not empty and does not error. It presents a complete, plausible reading that is wrong about two thirds of the data, and nothing in the output signals anything is missing.

**It is not a seaborn issue.** Two plain `ax.scatter()` calls fail identically — the second's 80 points were never announced and the first's 10 were announced twice. That is why the fix is at the matplotlib entry point.

## The fix

The patch hands the layer the collection its own call returned, through `drawn_as` — the mechanism #380 introduced for `Axes.bar`, reused rather than reinvented.

`seaborn.scatterplot` is wrapped through the same function and returns an `Axes`, not a collection, so the type guard sends it to the existing sweep. That is **correct** for it, and asserted rather than assumed: measured, it draws every point as a single `PathCollection` even under `hue`, so the sweep finds exactly the right one. If that ever changes, the test fails rather than the reading going quietly wrong.

One thing had to be repaired before the handover could arrive: `MaidrPlotFactory` dropped `**kwargs` on the `SCATTER` branch alone —

```python
return ScatterPlot(single_ax)      # every neighbouring branch passes **kwargs
```

— so the first version of this fix changed nothing at all, and the probe still showed `distinct=1`. Worth naming because the same silent drop would defeat any future per-layer handover to a scatter.

## Measured, after

```
stripplot: layers=3  first-x per layer=[0.04, 0.958, 2.053]   distinct payloads=3
swarmplot: layers=3  first-x per layer=[0.0,  1.0,   1.968]   distinct payloads=3
boxenplot: layers=3  first-x per layer=[0.0,  1.0,   2.0]     distinct payloads=3
two ax.scatter calls -> layer sizes [10, 80]
```

## Verification

Full suite **1786 passed** (1776 + 10 new), `ruff check` clean on every changed file — the 52 findings it reports repo-wide are identical in count on `main`.

Falsification:

| reverted | failures |
|---|---|
| layer sweeps for collection 0 again | **8 of 10** |
| factory drops `**kwargs` on the SCATTER branch | **8 of 10** |

The 2 survivors in both runs are exactly the single-collection non-regression cases — a plain `plt.scatter`, and `sns.scatterplot` under `hue`. Those are the shapes the existing tests already covered, which is why this stayed invisible, so they are the ones a fix has to leave alone.

The strongest assertion is not "the layers differ" but that the announced points are exactly the drawn points, once each — a layer set that were distinct and still missed a category would pass the weaker form.

## Noted, not fixed here

The same measurement shows a categorical scatter's x announced as its numeric tick position (`g is 0.0066`) rather than its label (`g is a`). Recorded in #426; it is a separate fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_