### PR TITLE
fix(line): drop samples that have no position on the axis

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -8,7 +8,59 @@ from maidr.core.enum.plot_type import PlotType
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.exception.extraction_error import ExtractionError
 from maidr.util.mixin.extractor_mixin import LineExtractorMixin
+import math
 import uuid
+
+
+def _has_position(x: object) -> bool:
+    """
+    Whether a sample sits anywhere a reader could be sent.
+
+    A point whose ``x`` is not finite has no position on the axis, so there is
+    nothing to announce and nothing to navigate to. Two ordinary idioms
+    produce them, and neither is an observation:
+
+    * ``sns.ecdfplot`` starts its staircase at ``-inf`` so the first step has
+      somewhere to come from;
+    * ``NaN`` is matplotlib's own way of *breaking* a line into segments --
+      it sets **both** coordinates -- and a masked array becomes one on the
+      way through.
+
+    Dropping them is also what keeps the payload loadable at all.
+    ``json.dumps`` writes ``NaN``, ``Infinity`` and ``-Infinity`` as bare
+    tokens, which are legal JavaScript but not JSON, and the core parses the
+    SVG's ``maidr`` attribute with ``JSON.parse``. One of them does not
+    degrade the chart -- ``initMaidrOnElement`` is never reached, so audio,
+    text, braille and highlight are all absent and the only trace is a
+    ``console.error`` a screen reader user has no reason to be watching
+    (#427).
+
+    Deliberately asked of ``x`` alone. A sample with a real x and a
+    non-finite ``y`` is a different thing: it has a position and no value,
+    which is how ``seaborn.pointplot`` pads a hue level missing from one
+    category so its two estimate lines stay the same length. Dropping it
+    would break that pairing, and emitting the value as ``null`` measurably
+    makes the core sonify the gap as a floor tone and announce it as
+    ``null`` -- a wrong reading in place of a missing one. Naming it properly
+    needs a per-point empty state the grammar does not have yet, so those are
+    left alone here and tracked in #429.
+
+    Parameters
+    ----------
+    x : object
+        A sample's x coordinate as extracted, numeric or categorical.
+
+    Returns
+    -------
+    bool
+        False only for a number that is NaN or infinite. A categorical x
+        arrives as its label, which is both positioned and never a JSON
+        hazard, so anything ``math.isfinite`` cannot judge is kept.
+    """
+    try:
+        return math.isfinite(x)  # type: ignore[arg-type]
+    except TypeError:
+        return True
 
 
 class MultiLinePlot(MaidrPlot, LineExtractorMixin):
@@ -180,6 +232,7 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
                     **({MaidrKey.Z: line_type} if line_type else {}),
                 }
                 for x, y in line_coords
+                if _has_position(x)
             ]
 
             if line_data:

--- a/tests/core/plot/test_non_finite_coordinates.py
+++ b/tests/core/plot/test_non_finite_coordinates.py
@@ -1,0 +1,199 @@
+"""A non-finite coordinate produced a payload the core cannot parse (#427).
+
+``json.dumps`` writes ``NaN``, ``Infinity`` and ``-Infinity`` as bare tokens.
+They are legal JavaScript literals but **not** JSON, and the core parses the
+SVG's ``maidr`` attribute with ``JSON.parse`` (``src/index.tsx``), which
+rejects all three:
+
+    JSON.parse rejects -Infinity: No number after minus sign in JSON at position 7
+
+The ``catch`` around it logs and returns, so ``initMaidrOnElement`` is never
+called. That makes this worse than a wrong reading: audio, text, braille and
+highlight are all absent, and the only trace is a ``console.error`` a screen
+reader user has no reason to be looking at.
+
+Two idioms reach it, and neither is exotic:
+
+* ``sns.ecdfplot`` starts its staircase at ``-inf``, so the first step has
+  somewhere to come from;
+* ``NaN`` is matplotlib's own way of **breaking** a line into segments, and a
+  masked array becomes one on the way through.
+
+Dropping the point is the right answer rather than the lesser evil: none of
+those coordinates names a value a reader could be told. What is lost is the
+visual gap, which MAIDR's grammar has no point shape for either way -- and
+the samples on both sides keep their real x, so the jump is still heard.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+sns = pytest.importorskip("seaborn")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _reject_constant(token: str):
+    raise ValueError(token)
+
+
+def parses_as_strict_json(ax) -> None:
+    """Assert the emitted schema survives what the core actually runs on it.
+
+    ``json.loads`` accepts the three tokens by default, exactly as
+    ``json.dumps`` emits them, so the round trip passes while the browser
+    fails. ``parse_constant`` is what makes this test able to fail.
+    """
+    ax = getattr(ax, "axes", ax)
+    schema = FigureManager.get_maidr(ax.get_figure())._flatten_maidr()
+
+    json.loads(json.dumps(schema), parse_constant=_reject_constant)
+
+
+def series_of(ax) -> list[list[dict]]:
+    ax = getattr(ax, "axes", ax)
+    maidr = FigureManager.get_maidr(ax.get_figure())
+    return [series for plot in maidr._plots for series in plot.schema["data"]]
+
+
+class TestTheEcdfThatStartsAtNegativeInfinity:
+    def test_its_payload_is_parseable(self):
+        ax = sns.ecdfplot(x=np.random.default_rng(0).normal(size=30))
+
+        parses_as_strict_json(ax)
+
+    def test_the_padding_point_is_dropped_and_the_rest_kept(self):
+        # One point per observation: the -inf row is seaborn's staircase
+        # scaffolding, not a 31st datum.
+        data = np.random.default_rng(0).normal(size=30)
+        ax = sns.ecdfplot(x=data)
+
+        assert [len(series) for series in series_of(ax)] == [len(data)]
+
+    def test_the_proportions_still_reach_one(self):
+        # Dropping from the front must not shift the curve. If the wrong row
+        # went, the last proportion is no longer 1.
+        ax = sns.ecdfplot(x=np.random.default_rng(0).normal(size=30))
+        ys = [point["y"] for point in series_of(ax)[0]]
+
+        assert ys[-1] == pytest.approx(1.0)
+        assert ys == sorted(ys)
+
+
+class TestALineBrokenByNaN:
+    """`NaN` is how matplotlib itself splits a line, so this is idiomatic."""
+
+    def test_its_payload_is_parseable(self):
+        line = plt.plot([1, 2, np.nan, 4], [10, 20, np.nan, 40])[0]
+
+        parses_as_strict_json(line)
+
+    def test_the_real_samples_survive_intact(self):
+        # The assertion that matters is not "no NaN" but that the gap costs
+        # nothing else: both sides keep their own x and y.
+        line = plt.plot([1, 2, np.nan, 4], [10, 20, np.nan, 40])[0]
+        points = [(point["x"], point["y"]) for point in series_of(line)[0]]
+
+        assert points == [(1.0, 10.0), (2.0, 20.0), (4.0, 40.0)]
+
+    def test_a_step_is_covered_by_the_same_rule(self):
+        # `StepPlot` extends `MultiLinePlot`, which is why one fix serves
+        # both -- asserted rather than left to inheritance.
+        step = plt.step([1, 2, np.nan, 4], [10, 20, np.nan, 40])[0]
+
+        parses_as_strict_json(step)
+        assert len(series_of(step)[0]) == 3
+
+    def test_a_masked_array_is_too(self):
+        # A mask becomes NaN on the way through, so it arrives by a different
+        # route at the same defect.
+        line = plt.plot(np.ma.masked_invalid([1.0, 2.0, np.nan, 4.0]), [1, 2, 3, 4])[0]
+
+        parses_as_strict_json(line)
+
+
+class TestASampleWithAPositionButNoValue:
+    """The boundary, drawn on purpose rather than by accident.
+
+    ``seaborn.pointplot`` NaN-pads a hue level that never appears in some
+    category, and that padding is load-bearing: it keeps both estimate lines
+    at one vertex per category, which is what stops the pairing failing and
+    the interval polylines travelling as data (see ``test_pointplot.py``).
+
+    So a real x with a non-finite y is *not* the same thing as a point with
+    no position, and the rule asks about x alone. Emitting the value as
+    ``null`` instead was measured against the core and is worse than it
+    looks: ``LineTrace`` yields ``audio.freq.raw = 0`` and
+    ``text.cross.value = null``, so the gap is sonified as a floor tone and
+    announced as a word. Naming it properly needs a per-point empty state the
+    grammar does not have, which is #429.
+    """
+
+    def test_the_padded_sample_is_kept(self):
+        import pandas as pd
+
+        unbalanced = pd.DataFrame(
+            {
+                "g": ["a"] * 4 + ["b"] * 4 + ["c"] * 2,
+                "half": ["x", "x", "y", "y", "x", "x", "y", "y", "x", "x"],
+                "v": [1.0, 2.0, 5.0, 6.0, 10.0, 11.0, 14.0, 15.0, 20.0, 21.0],
+            }
+        )
+        _, ax = plt.subplots()
+        sns.pointplot(unbalanced, x="g", y="v", hue="half", dodge=True, ax=ax)
+
+        series = series_of(ax)
+
+        assert len(series) == 2
+        assert all(len(one) == 3 for one in series)
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#429: a positioned sample with no value has no JSON-safe "
+        "representation until the grammar can express an empty point",
+    )
+    def test_its_payload_is_not_parseable_yet(self):
+        import pandas as pd
+
+        unbalanced = pd.DataFrame(
+            {
+                "g": ["a"] * 4 + ["b"] * 4 + ["c"] * 2,
+                "half": ["x", "x", "y", "y", "x", "x", "y", "y", "x", "x"],
+                "v": [1.0, 2.0, 5.0, 6.0, 10.0, 11.0, 14.0, 15.0, 20.0, 21.0],
+            }
+        )
+        _, ax = plt.subplots()
+        sns.pointplot(unbalanced, x="g", y="v", hue="half", dodge=True, ax=ax)
+
+        parses_as_strict_json(ax)
+
+
+class TestWhatMustNotChange:
+    def test_a_clean_line_keeps_every_point(self):
+        line = plt.plot([1, 2, 3], [10, 20, 30])[0]
+
+        assert len(series_of(line)[0]) == 3
+
+    def test_a_categorical_x_is_not_mistaken_for_non_finite(self):
+        # The guard has to be a test *of numbers*. `math.isfinite` raises on a
+        # string, and treating that as "not finite" would delete every point
+        # of any chart whose x axis is categorical.
+        line = plt.plot(["a", "b", "c"], [1, 2, 3])[0]
+
+        assert [point["x"] for point in series_of(line)[0]] == ["a", "b", "c"]


### PR DESCRIPTION
Closes #427.

## The defect

`json.dumps` writes `NaN`, `Infinity` and `-Infinity` as bare tokens. They are legal JavaScript literals but **not** JSON, and the core parses the SVG's `maidr` attribute with `JSON.parse` (`src/index.tsx:113`). Verified in node:

```
JSON.parse rejects -Infinity: No number after minus sign in JSON at position 7
```

The `catch` around it logs and returns, so `initMaidrOnElement` is never called. This is worse than a wrong reading — audio, text, braille and highlight are **all** absent, and the only trace is a `console.error` a screen reader user has no reason to be watching.

## Wider than the reported case

The issue named `sns.ecdfplot` (which starts its staircase at `-inf`). Measuring found the same failure on an idiom that is far more common — `NaN` is matplotlib's **own** way of breaking a line into segments:

```
sns.ecdfplot          INVALID JSON token: -Infinity
plot with a NaN gap   INVALID JSON token: NaN
step with a NaN gap   INVALID JSON token: NaN
masked array line     INVALID JSON token: NaN
plain line            strict-JSON OK
```

All fixed here; `StepPlot` extends `MultiLinePlot`, so one change serves the family, and that is asserted rather than left to inheritance.

## The rule asks about x alone, and that is the interesting part

My first version filtered on **both** coordinates and it broke `test_pointplot.py::test_a_hue_level_missing_a_category_does_not_break_the_pairing` — correctly. seaborn NaN-pads a hue level missing from a category, and that padding is load-bearing: it keeps both estimate lines at one vertex per category, which is what stops the pairing failing and the interval polylines travelling as data.

So the two cases are genuinely different:

| | position | value | |
|---|---|---|---|
| ECDF end, NaN line break | ✗ | ✗ | nothing to announce, nothing to navigate to → **drop** |
| pointplot padding | ✓ | ✗ | a real category with no reading → **keep** |

Before settling on that I measured the obvious alternative — emit `null` for the missing value — against the core itself, with a throwaway `LineTrace` case:

```
index 1 (y: null): audio.freq.raw = 0,  text.cross.value = null
```

It does not throw, but the gap is **sonified as a floor tone and announced as a word** — a wrong reading in place of a missing one, which is exactly what this session has been removing. Naming it properly needs a per-point empty state; `isEmptyAtCursor` in the core is whole-trace only (`rows <= 0 || cols <= 0`). So that case is left alone, and pinned with a **strict xfail** against #429 so it turns red the day the grammar can express it.

## Verification

Full suite **1796 passed, 1 xfailed**. `ruff check` clean on both changed files.

Falsification:

| reverted | failures |
|---|---|
| position filter removed | **6 of 10** |
| guard treats a categorical x as non-finite | **2** |

The second is the one worth having. `math.isfinite` raises on a string, so reading that as "not finite" would delete **every** point of any chart whose x axis is categorical — a change that would look like a tightening and be a catastrophe. The two failures are the categorical-line case and the pointplot padding, both of which have string x values.

## Filed, not fixed

#429 — `scatter`, `bar` and `errorbar` still emit `NaN`, and each wants its own decision rather than one filter settling three questions by accident (a NaN bar height is closer to #112's missing-category question than to a line gap).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_