### PR TITLE
fix(bar): emit a bar with no height as a gap rather than as NaN

### DIFF
--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
 from matplotlib.patches import Rectangle
@@ -23,6 +25,48 @@ from maidr.util.mixin import (
 #: Lives here rather than beside ``common.drawn_as`` because ``maidr.patch``
 #: imports ``maidr.core`` and not the other way about.
 DRAWN_BARS = "_maidr_bars"
+
+
+def _magnitude(raw: float) -> float | None:
+    """
+    A bar's height, or ``None`` where it has none.
+
+    matplotlib draws a rectangle for a ``NaN`` height, so a gap in the data
+    survives as a bar with no magnitude rather than being dropped. Two things
+    then go wrong at once if it is emitted as it stands.
+
+    ``json.dumps`` writes ``NaN`` as a bare token, which is legal JavaScript
+    and invalid JSON, and the core parses the SVG's ``maidr`` attribute with
+    ``JSON.parse`` -- so one of them stops the chart initialising at all
+    (#427). And ``Number(NaN)`` is not the reading a listener wants either.
+
+    ``None`` serialises to ``null``, which is exactly what the core's
+    ``toBarValue`` has read as a gap since the bar family gained the concept:
+    it becomes ``NaN`` inside the model, is kept out of the range, sounds as
+    the empty tone rather than a floor tone, and announces as "missing". A
+    zero would be the wrong answer here for the reason that helper exists --
+    an absent bar is not one measured at zero.
+
+    Parameters
+    ----------
+    raw : float
+        The dimension the bar grows along, as matplotlib recorded it.
+
+    Returns
+    -------
+    float or None
+        The magnitude as a plain ``float``, or ``None`` when the bar has no
+        measurable one.
+
+    Notes
+    -----
+    The ``float()`` is not decoration. matplotlib hands back whatever numpy
+    type the caller's data carried, and ``json.dumps`` cannot serialise a
+    ``numpy.int64`` -- dropping the cast raised ``TypeError: Object of type
+    int64 is not JSON serializable`` on 28 tests, which is the whole render
+    rather than one bar.
+    """
+    return float(raw) if math.isfinite(raw) else None
 
 
 class BarPlot(
@@ -223,6 +267,6 @@ class BarPlot(
         # A bar's magnitude is the dimension it grows along: the width of a
         # horizontal bar, the height of a vertical one.
         if self._is_horizontal:
-            return [float(patch.get_width()) for patch in plot]
+            return [_magnitude(patch.get_width()) for patch in plot]
 
-        return [float(patch.get_height()) for patch in plot]
+        return [_magnitude(patch.get_height()) for patch in plot]

--- a/tests/core/plot/test_bar_gaps.py
+++ b/tests/core/plot/test_bar_gaps.py
@@ -1,0 +1,132 @@
+"""A bar drawn with no height announced one anyway (#429).
+
+matplotlib draws a rectangle for a ``NaN`` height, so a gap in the data
+survives as a bar with no magnitude rather than being dropped. Emitting it as
+it stood went wrong twice over:
+
+* ``json.dumps`` writes ``NaN`` as a bare token, which is legal JavaScript and
+  invalid JSON. The core parses the SVG's ``maidr`` attribute with
+  ``JSON.parse``, so one of them stops the chart initialising at all -- audio,
+  text, braille and highlight all absent, with a ``console.error`` as the only
+  trace (#427).
+* Even reaching the model, ``NaN`` is not a reading a listener wants.
+
+``None`` serialises to ``null``, which the core's ``toBarValue`` has read as a
+gap since the bar family gained the concept: it becomes ``NaN`` inside the
+model, stays out of the range, sounds as the empty tone rather than a floor
+tone, and announces as "missing". No release dependency -- that helper is in
+the currently published core.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _reject_constant(token: str):
+    raise ValueError(token)
+
+
+def bar_points(ax) -> list[dict]:
+    maidr = FigureManager.get_maidr(ax.get_figure())
+    return maidr._plots[0].schema["data"]
+
+
+def parses_as_strict_json(ax) -> None:
+    """Assert the payload survives what the core actually runs on it.
+
+    ``json.loads`` accepts the bare tokens by default, exactly as
+    ``json.dumps`` emits them, so a plain round trip passes while the browser
+    fails. ``parse_constant`` is what lets this fail.
+    """
+    schema = FigureManager.get_maidr(ax.get_figure())._flatten_maidr()
+
+    json.loads(json.dumps(schema), parse_constant=_reject_constant)
+
+
+class TestABarWithNoHeight:
+    def test_it_is_emitted_as_null_rather_than_nan(self):
+        ax = plt.bar(["a", "b", "c"], [1.0, np.nan, 3.0])[0].axes
+
+        assert bar_points(ax)[1]["y"] is None
+
+    def test_the_payload_is_loadable(self):
+        ax = plt.bar(["a", "b", "c"], [1.0, np.nan, 3.0])[0].axes
+
+        parses_as_strict_json(ax)
+
+    def test_it_keeps_its_category(self):
+        # The bar is kept rather than dropped, which is the difference between
+        # "no reading for c" and "c was never in this chart". A category that
+        # vanishes cannot be navigated to and cannot be asked about.
+        ax = plt.bar(["a", "b", "c"], [1.0, np.nan, 3.0])[0].axes
+        points = bar_points(ax)
+
+        assert len(points) == 3
+        assert [point["x"] for point in points] == ["a", "b", "c"]
+
+    def test_the_measured_bars_are_untouched(self):
+        ax = plt.bar(["a", "b", "c"], [1.0, np.nan, 3.0])[0].axes
+        points = bar_points(ax)
+
+        assert points[0]["y"] == 1.0
+        assert points[2]["y"] == 3.0
+
+    def test_a_horizontal_bar_is_covered_too(self):
+        # A horizontal bar's magnitude is its *width*, read on the other
+        # branch of the same method, so it needs its own case rather than
+        # inheriting the vertical one's.
+        #
+        # And the gap lands on **x**, not y. I first asserted `y` here and it
+        # failed with `assert 'b' is None`: a horizontal layer emits the
+        # magnitude as x and the category as y, which is the layout the
+        # renderer reads. The code was right and the expectation was wrong.
+        ax = plt.barh(["a", "b", "c"], [1.0, np.nan, 3.0])[0].axes
+        points = bar_points(ax)
+
+        assert points[1]["x"] is None
+        assert points[1]["y"] == "b"
+        parses_as_strict_json(ax)
+
+
+class TestWhatMustNotChange:
+    def test_a_bar_measured_at_zero_is_still_a_reading(self):
+        # The distinction the whole change exists to preserve. A zero-height
+        # bar was measured; a gap was not.
+        ax = plt.bar(["a", "b"], [0.0, 2.0])[0].axes
+
+        assert bar_points(ax)[0]["y"] == 0.0
+        assert bar_points(ax)[0]["y"] is not None
+
+    def test_numpy_integer_heights_still_serialise(self):
+        # Pinned because it broke. The `float()` cast in the extractor was
+        # doing two jobs, and a first version of this fix kept only the
+        # finiteness test -- which left matplotlib's numpy types in the
+        # payload and raised `TypeError: Object of type int64 is not JSON
+        # serializable` on 28 tests. That is the whole render, not one bar.
+        ax = plt.bar(["a", "b"], np.array([1, 2], dtype=np.int64))[0].axes
+
+        parses_as_strict_json(ax)
+        assert bar_points(ax)[0]["y"] == 1.0
+
+    def test_a_chart_with_no_gaps_is_unchanged(self):
+        ax = plt.bar(["a", "b", "c"], [1.0, 2.0, 3.0])[0].axes
+
+        assert [point["y"] for point in bar_points(ax)] == [1.0, 2.0, 3.0]


### PR DESCRIPTION
The bar half of #429.

## The defect

matplotlib draws a rectangle for a `NaN` height, so a gap in the data survives as a bar with **no magnitude** rather than being dropped:

```
before:  [{"x": "a", "y": 1.0}, {"x": "b", "y": NaN}, {"x": "c", "y": 3.0}]
after:   [{"x": "a", "y": 1.0}, {"x": "b", "y": null}, {"x": "c", "y": 3.0}]
```

That went wrong twice over. `json.dumps` writes `NaN` as a bare token — legal JavaScript, invalid JSON — and the core parses the SVG's `maidr` attribute with `JSON.parse`, so one of them stopped the chart initialising **at all**: audio, text, braille and highlight absent, `console.error` the only trace. And even past the parser, `NaN` is not a reading a listener wants.

## Why `null`, and why this needs no release

`null` is what the core's `toBarValue` has read as a gap since the bar family gained the concept — it becomes `NaN` inside the model, stays out of the range, sounds as the empty tone rather than a floor tone, and announces as **"missing"**.

Checked rather than assumed: `toBarValue` is present in both `v4.1.0` and `v4.2.0`, so this works against the currently published core with no version dependency.

The bar is **kept**, not dropped. That is the difference between "no reading for c" and "c was never in this chart" — a category that vanishes cannot be navigated to or asked about.

## Two things I got wrong, both caught by running it

**The `float()` cast was doing two jobs.** My first version kept only the finiteness test, which left matplotlib's numpy types in the payload:

```
TypeError: Object of type int64 is not JSON serializable   ← 28 tests
```

That is the whole render, not one bar. The cast is restored and now pinned by its own test, because the failure is remote from the change that causes it.

**A horizontal bar's gap lands on `x`, not `y`.** I asserted `points[1]["y"] is None` and got `assert 'b' is None`. `barh` emits the magnitude as x and the category as y, which is the layout the renderer reads and which `_extract_plot_data` documents. The code was right and my expectation was wrong; the test now asserts both halves of the pair so the layout itself is pinned.

## Verification

Full suite **1804 passed, 1 xfailed**. `ruff check` clean on both changed files — the 52 it reports repo-wide are the unchanged baseline.

Falsification:

| reverted | failures |
|---|---|
| gap no longer nulled | **3 of 8** |
| `float()` cast dropped | **1** |

## Still open on #429

`scatter` and `errorbar`. Each wants its own decision rather than one filter settling three questions by accident — a NaN scatter point is a point that was not drawn, while a NaN errorbar bound may leave a usable estimate with only one bound, which the grammar can now express since xability/maidr#920.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_