### PR TITLE
fix(errorbar): emit only the estimates matplotlib drew

### DIFF
--- a/maidr/core/plot/errorbar.py
+++ b/maidr/core/plot/errorbar.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from typing import Any, Sequence
 
 import numpy as np
@@ -11,6 +13,31 @@ from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
 from maidr.util.mixin import DictMergerMixin
+
+
+
+def _is_drawn(value: object) -> bool:
+    """
+    Whether matplotlib put this coordinate anywhere.
+
+    A non-finite number has no position, so nothing is rendered for it.
+    Anything ``math.isfinite`` cannot judge is a categorical coordinate,
+    which is always drawn and is never a JSON hazard.
+
+    Parameters
+    ----------
+    value : object
+        A coordinate as read off the container.
+
+    Returns
+    -------
+    bool
+        False only for a number that is NaN or infinite.
+    """
+    try:
+        return math.isfinite(value)  # type: ignore[arg-type]
+    except TypeError:
+        return True
 
 
 class ErrorBarPlot(MaidrPlot, DictMergerMixin):
@@ -135,6 +162,26 @@ class ErrorBarPlot(MaidrPlot, DictMergerMixin):
 
         data = []
         for index, (category, value) in enumerate(zip(categories, values)):
+            # Only the samples matplotlib drew. It renders neither a marker
+            # nor a bar for a non-finite estimate, so emitting one leaves the
+            # layer longer than the elements the selector resolves to and
+            # every sample after it is highlighted at its neighbour's. It also
+            # keeps the payload loadable: `json.dumps` writes `NaN` as a bare
+            # token, which is legal JavaScript and invalid JSON, and the core
+            # parses the SVG's `maidr` attribute with `JSON.parse` (#429).
+            #
+            # A missing *bound* is a different case and needs nothing here.
+            # `_extract_bounds` already returns None for one, the point keeps
+            # its estimate, and the interval is simply absent -- an estimate
+            # with no interval is a reading, not a gap.
+            #
+            # `index` goes on counting over every sample, because it addresses
+            # the segments matplotlib built for the whole series. Renumbering
+            # it against the survivors would pair each remaining estimate with
+            # the next one's bounds.
+            if not (_is_drawn(category) and _is_drawn(value)):
+                continue
+
             point = {
                 MaidrKey.X: self._scalar(category),
                 MaidrKey.Y: self._scalar(value),

--- a/tests/core/plot/test_errorbar_gaps.py
+++ b/tests/core/plot/test_errorbar_gaps.py
@@ -1,0 +1,131 @@
+"""An error bar emitted an estimate matplotlib never drew (#429).
+
+The last of the three extractors that shipped a bare ``NaN``. It differs from
+the bar and the scatter, and the difference is what the tests are about.
+
+An error bar carries *two* things that can go missing, and only one of them is
+a gap:
+
+* a missing **bound** leaves a real estimate with no interval around it. That
+  is a reading, not an absence -- ``_extract_bounds`` already returns ``None``
+  and the point is emitted without ``yMin``/``yMax``. Nothing to fix, and
+  pinned here so nothing "fixes" it.
+* a missing **estimate** leaves nothing at all: matplotlib renders neither a
+  marker nor a bar, so the sample is dropped.
+
+The subtle part is the bounds lookup. It addresses the line segments
+matplotlib built for the *whole* series, so its index has to keep counting
+over the dropped samples. Renumbering it against the survivors would pair each
+remaining estimate with the next one's interval -- a wrong interval on a real
+reading, which is worse than either failure this fix is for.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _reject_constant(token: str):
+    raise ValueError(token)
+
+
+def points() -> list[dict]:
+    maidr = FigureManager.get_maidr(plt.gcf())
+    return maidr._plots[0].schema["data"]
+
+
+def parses_as_strict_json() -> None:
+    schema = FigureManager.get_maidr(plt.gcf())._flatten_maidr()
+
+    json.loads(json.dumps(schema), parse_constant=_reject_constant)
+
+
+class TestAnEstimateThatWasNotDrawn:
+    def test_the_sample_is_dropped(self):
+        plt.errorbar([1, 2, 3], [1, np.nan, 3], yerr=[0.1, 0.1, 0.1])
+
+        assert [point["x"] for point in points()] == [1.0, 3.0]
+
+    def test_the_payload_is_loadable(self):
+        plt.errorbar([1, 2, 3], [1, np.nan, 3], yerr=[0.1, 0.1, 0.1])
+
+        parses_as_strict_json()
+
+    def test_the_survivors_keep_their_own_bounds(self):
+        # The assertion this file exists for. The bounds come from the
+        # segments matplotlib built for the whole series, so the lookup index
+        # must keep counting over the dropped sample. If it were renumbered
+        # against the survivors, the point at x=3 would be handed the
+        # *dropped* sample's interval -- 1.9 to 2.1 -- and announce a real
+        # reading with somebody else's uncertainty.
+        plt.errorbar([1, 2, 3], [1, np.nan, 3], yerr=[0.1, 0.1, 0.1])
+        emitted = points()
+
+        assert (emitted[0]["yMin"], emitted[0]["yMax"]) == (
+            pytest.approx(0.9),
+            pytest.approx(1.1),
+        )
+        assert (emitted[1]["yMin"], emitted[1]["yMax"]) == (
+            pytest.approx(2.9),
+            pytest.approx(3.1),
+        )
+
+
+class TestAMissingBoundIsNotAGap:
+    """An estimate with no interval is a reading, and must stay one."""
+
+    def test_the_estimate_survives(self):
+        plt.errorbar([1, 2, 3], [1, 2, 3], yerr=[0.1, np.nan, 0.1])
+        emitted = points()
+
+        assert len(emitted) == 3
+        assert emitted[1]["y"] == 2.0
+
+    def test_it_simply_carries_no_interval(self):
+        plt.errorbar([1, 2, 3], [1, 2, 3], yerr=[0.1, np.nan, 0.1])
+        emitted = points()
+
+        assert "yMin" not in emitted[1]
+        assert "yMax" not in emitted[1]
+        parses_as_strict_json()
+
+    def test_its_neighbours_keep_theirs(self):
+        plt.errorbar([1, 2, 3], [1, 2, 3], yerr=[0.1, np.nan, 0.1])
+        emitted = points()
+
+        assert "yMin" in emitted[0]
+        assert "yMin" in emitted[2]
+
+
+class TestWhatMustNotChange:
+    def test_a_clean_error_bar_is_untouched(self):
+        plt.errorbar([1, 2, 3], [1, 2, 3], yerr=[0.1, 0.1, 0.1])
+        emitted = points()
+
+        assert len(emitted) == 3
+        assert [point["y"] for point in emitted] == [1.0, 2.0, 3.0]
+        assert all("yMin" in point and "yMax" in point for point in emitted)
+
+    def test_an_estimate_of_zero_is_a_real_reading(self):
+        # Finiteness, not truthiness.
+        plt.errorbar([1, 2], [0, 2], yerr=[0.1, 0.1])
+
+        assert len(points()) == 2
+        assert points()[0]["y"] == 0.0


### PR DESCRIPTION
Closes #429 — the last of the three extractors, after #431 (bar) and #432 (scatter).

## The defect

matplotlib renders neither a marker nor a bar for a non-finite estimate, but it was still emitted:

```
before:  [{"x":1,"y":1,"yMin":0.9,"yMax":1.1}, {"x":2,"y":NaN}, {"x":3,"y":3,"yMin":2.9,"yMax":3.1}]
after:   [{"x":1,"y":1,"yMin":0.9,"yMax":1.1},                  {"x":3,"y":3,"yMin":2.9,"yMax":3.1}]
```

More entries than the selector resolves to, and a bare `NaN` token that `JSON.parse` rejects — which stops the chart initialising at all (#427).

## Two things can go missing, and only one is a gap

This is what makes the error bar different from the bar and the scatter, and it is why the three needed separate decisions rather than one filter:

| missing | outcome | why |
|---|---|---|
| a **bound** | keep the point, omit `yMin`/`yMax` | an estimate with no interval is a *reading* |
| the **estimate** | drop the sample | nothing to announce, nowhere to navigate |

Measured — the bound case already did the right thing and needed no change:

```
yerr NaN → [{"x":1,…,"yMin":0.9}, {"x":2,"y":2.0}, {"x":3,…,"yMin":2.9}]
                                   ↑ estimate intact, interval simply absent
```

It is pinned here so nothing "fixes" it later.

## The part that would have been easy to get wrong

The bounds lookup addresses the line segments matplotlib built for the **whole** series, so its index has to keep counting over the dropped samples. Renumbering it against the survivors would hand the point at `x = 3` the *dropped* sample's interval — `1.9` to `2.1` — and announce a real reading with somebody else's uncertainty. That is worse than either failure this PR is for.

It has its own test, and it is the **only** case that fails when the index is renumbered:

| reverted | failures |
|---|---|
| undrawn estimates kept | **3 of 8** |
| bounds index renumbered against survivors | **1** — the bounds-alignment case |

## Verification

Full suite **1812 passed, 1 xfailed**. `ruff check` clean on the changed file.

## #429 complete

| extractor | PR | answer |
|---|---|---|
| bar | #431 | keep the category, emit `y: null`, announce "missing" |
| scatter | #432 | drop — a marker's position *is* its value |
| errorbar | this | drop a missing estimate; a missing bound was already right |

Each got its own decision, which was the point of filing them together rather than fixing them together.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_