### PR TITLE
fix(line): stop announcing a reference line as data

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -124,7 +124,47 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
         if self._lines is not None:
             return self._lines
 
-        return self.ax.get_lines()
+        return [line for line in self.ax.get_lines() if self._is_in_data_space(line)]
+
+    def _is_in_data_space(self, line: Line2D) -> bool:
+        """
+        Whether a line's coordinates mean what the axes say they mean.
+
+        ``axhline`` and ``axvline`` blend the *axes* transform on one axis with
+        the data transform on the other, so their stored coordinates run 0 to 1
+        and describe the extent of the axes rather than any value. Measured on
+        ``ax.plot([10, 20, 30], [1, 2, 3])`` followed by ``ax.axhline(2)``::
+
+            [{"x": 10.0, ...}, {"x": 20.0, ...}, {"x": 30.0, ...}]
+            [{"x":  0.0, "y": 2.0}, {"x": 1.0, "y": 2.0}]   <- the axhline
+
+        The chart's x runs 10 to 30, and the reference line was announced at
+        0 and 1. That is not a degraded reading of a real series; it is a
+        confident reading of one that is not there, and nothing in the output
+        says its numbers are in a different space from every other number in
+        the chart (#434).
+
+        A reference line is decoration rather than data, and the grammar has no
+        annotation to put it in, so it is left out. Describing the threshold
+        somewhere is worth doing separately -- it is genuinely useful to know
+        one is drawn -- but that is a grammar question and should not keep a
+        wrong reading in the meantime.
+
+        Only the transform is asked about, never the values. A genuinely flat
+        data line -- ``ax.plot([1, 2], [5, 5])`` -- is drawn in data space and
+        stays, which a shape test would have thrown away.
+
+        Parameters
+        ----------
+        line : Line2D
+            A line found on the axes.
+
+        Returns
+        -------
+        bool
+            True when the line is positioned by the data transform.
+        """
+        return line.get_transform() is self.ax.transData
 
     def _extract_axes_data(self) -> dict:
         """

--- a/maidr/patch/lineplot.py
+++ b/maidr/patch/lineplot.py
@@ -41,6 +41,30 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
         # If we can't get axes from plot, try from instance
         ax = instance if isinstance(instance, Axes) else getattr(instance, "axes", None)
 
+    # A call that drew no points is not a layer. `seaborn.utils._default_color`
+    # plots a throwaway artist to resolve a default colour and removes it
+    # again -- the mechanism #373 described for area layers, which
+    # `sns.residplot` reaches here. Measured on one: the returned line is in
+    # data space and carries an empty `get_xydata()`.
+    #
+    # Registering it produces a layer with no artist of its own, so `_series()`
+    # falls back to sweeping the axes and describes whatever else is there. In
+    # a residual plot the only other thing is the `axhline`, so the chart
+    # announced a reference line as its data (#434).
+    #
+    # Emptiness is the test rather than "already detached", because seaborn
+    # removes the probe *after* this returns -- the line is still attached at
+    # the moment the decision is made, so detachment is not observable yet.
+    # It also agrees with #421: a layer with no points is a phantom, not an
+    # empty reading.
+    drawn = (
+        [line for line in plot if isinstance(line, Line2D)]
+        if isinstance(plot, list)
+        else []
+    )
+    if drawn and all(line.get_xydata().size == 0 for line in drawn):
+        return plot
+
     # Check if a MAIDR plot already exists for this axes
     if ax is not None and not hasattr(ax, "_maidr_plot_created"):
         # Classify from the rendered artists: an axes is a step plot only when

--- a/tests/core/plot/test_reference_lines.py
+++ b/tests/core/plot/test_reference_lines.py
@@ -1,0 +1,168 @@
+"""A reference line was announced as data at coordinates that do not exist (#434).
+
+``ax.axhline`` and ``ax.axvline`` blend the *axes* transform on one axis with
+the data transform on the other, so their stored coordinates run 0 to 1 and
+describe the extent of the axes rather than any value. Measured on
+``ax.plot([10, 20, 30], [1, 2, 3])`` followed by ``ax.axhline(2)``::
+
+    [{"x": 10.0, ...}, {"x": 20.0, ...}, {"x": 30.0, ...}]
+    [{"x":  0.0, "y": 2.0}, {"x": 1.0, "y": 2.0}]          <- the axhline
+
+The chart's x runs 10 to 30 and the reference line was announced at 0 and 1 —
+a confident reading of a series that is not there, with nothing to say its
+numbers are in a different space from every other number in the chart.
+
+Two independent defects produced it, which is why the fix is in two places and
+why filtering alone was not enough:
+
+* a **real** layer's ``_series()`` sweeps every line on the axes, so it picked
+  the reference line up as an extra series;
+* ``sns.residplot`` registered a line layer with **no artist of its own**.
+  Traced: ``seaborn.utils._default_color`` plots a throwaway artist to resolve
+  a default colour, and the returned line is in data space with an empty
+  ``get_xydata()`` — the #373 mechanism. That layer then fell back to sweeping
+  the axes, where the only line is the ``axhline``.
+
+Fixing only the first turns a residual plot's wrong series into a fatal
+``ExtractionError``, because the layer is left with nothing to extract. Both
+halves are needed, and both are pinned below.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+sns = pytest.importorskip("seaborn")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def layers(ax) -> list:
+    return FigureManager.get_maidr(ax.get_figure())._plots
+
+
+def series_of(ax) -> list[list[dict]]:
+    line_layers = [
+        plot
+        for plot in layers(ax)
+        if str(plot.type).endswith("LINE") or str(plot.type).endswith("STEP")
+    ]
+    assert len(line_layers) == 1, f"expected one line layer, got {len(line_layers)}"
+    return line_layers[0].schema["data"]
+
+
+class TestAReferenceLineBesideRealData:
+    def test_axhline_is_not_a_second_series(self):
+        _, ax = plt.subplots()
+        ax.plot([10, 20, 30], [1, 2, 3])
+        ax.axhline(2)
+
+        assert len(series_of(ax)) == 1
+
+    def test_the_real_series_is_untouched(self):
+        _, ax = plt.subplots()
+        ax.plot([10, 20, 30], [1, 2, 3])
+        ax.axhline(2)
+
+        assert [(point["x"], point["y"]) for point in series_of(ax)[0]] == [
+            (10.0, 1.0),
+            (20.0, 2.0),
+            (30.0, 3.0),
+        ]
+
+    def test_no_announced_x_falls_outside_the_data(self):
+        # The defect's signature, stated as what a reader would notice: the
+        # reference line was announced at x = 0 and x = 1 on a chart whose x
+        # begins at 10.
+        _, ax = plt.subplots()
+        ax.plot([10, 20, 30], [1, 2, 3])
+        ax.axhline(2)
+        xs = [point["x"] for series in series_of(ax) for point in series]
+
+        assert min(xs) >= 10.0
+
+    def test_axvline_is_covered_too(self):
+        # The mirror image: `axvline` blends the other way round, so its y
+        # values are the ones in axes space.
+        _, ax = plt.subplots()
+        ax.plot([10, 20, 30], [1, 2, 3])
+        ax.axvline(20)
+        ys = [point["y"] for series in series_of(ax) for point in series]
+
+        assert len(series_of(ax)) == 1
+        assert min(ys) >= 1.0
+
+    def test_a_step_chart_is_covered_by_the_same_rule(self):
+        _, ax = plt.subplots()
+        ax.step([1, 2, 3], [1, 2, 3])
+        ax.axhline(2)
+
+        assert len(series_of(ax)) == 1
+
+
+class TestALayerWithNoArtistOfItsOwn:
+    def test_residplot_does_not_register_a_line_layer(self):
+        # `residplot` draws a scatter and a zero reference line. The line layer
+        # it used to register came from the colour probe, not from anything the
+        # reader can see.
+        rng = np.random.default_rng(0)
+        ax = sns.residplot(x=rng.normal(size=40), y=rng.normal(size=40))
+
+        assert [str(plot.type) for plot in layers(ax)] == ["PlotType.SCATTER"]
+
+    def test_it_renders_rather_than_raising(self):
+        # Filtering the sweep without this half leaves the layer with nothing
+        # to extract, and `_extract_plot_data` raises — which is fatal to the
+        # whole figure. Trading a wrong series for a dead chart is not a fix,
+        # so this is the case that says the two halves belong together.
+        rng = np.random.default_rng(0)
+        ax = sns.residplot(x=rng.normal(size=40), y=rng.normal(size=40))
+
+        FigureManager.get_maidr(ax.get_figure())._flatten_maidr()
+
+
+class TestWhatMustNotChange:
+    def test_a_flat_data_line_is_still_data(self):
+        # Asked about the transform, never the values. A genuinely flat series
+        # looks exactly like a reference line by shape, and a shape test would
+        # have thrown it away.
+        _, ax = plt.subplots()
+        ax.plot([1, 2], [5, 5])
+
+        assert [(point["x"], point["y"]) for point in series_of(ax)[0]] == [
+            (1.0, 5.0),
+            (2.0, 5.0),
+        ]
+
+    def test_a_plain_line_chart_is_unchanged(self):
+        _, ax = plt.subplots()
+        ax.plot([10, 20, 30], [1, 2, 3])
+
+        assert len(series_of(ax)) == 1
+        assert len(series_of(ax)[0]) == 3
+
+    def test_seaborn_lineplot_still_registers(self):
+        ax = sns.lineplot(x=[1, 2, 3], y=[4, 5, 6])
+
+        assert [str(plot.type) for plot in layers(ax)] == ["PlotType.LINE"]
+
+    def test_regplot_keeps_both_of_its_layers(self):
+        ax = sns.regplot(x=[1, 2, 3, 4], y=[1, 3, 2, 4])
+
+        assert [str(plot.type) for plot in layers(ax)] == [
+            "PlotType.SCATTER",
+            "PlotType.SMOOTH",
+        ]


### PR DESCRIPTION
Closes #434.

## The defect

`axhline` and `axvline` blend the **axes** transform on one axis with the data transform on the other, so their stored coordinates run 0 to 1 and describe the extent of the axes rather than any value:

```
ax.plot([10, 20, 30], [1, 2, 3]); ax.axhline(2)

[{"x": 10.0, "y": 1.0}, {"x": 20.0, "y": 2.0}, {"x": 30.0, "y": 3.0}]
[{"x":  0.0, "y": 2.0}, {"x":  1.0, "y": 2.0}]                          ← the axhline
```

The chart's x runs 10 to 30; the reference line was announced at **0** and **1**. `axvline` is the mirror — y announced at 0 and 1 on a chart whose y runs 1 to 3.

Not a degraded reading of a real series: a confident reading of one that is not there, with nothing in the output to say its numbers are in a different space from every other number in the chart.

## Two defects, and neither can be fixed alone

I filed this expecting one fix, attempted it, and **backed it out** — the record is in the issue. What the investigation actually found:

**1. A real layer's sweep picks up the reference line.** `MultiLinePlot._series()` sweeps every line on the axes, so `plot + axhline` gets two series.

**2. `sns.residplot` registers a line layer with no artist of its own.** Traced:

```
REGISTER PlotType.LINE <- common.py:_draw_quietly | lineplot.py:line | common.py:common

returned line: in transData = True | still on axes = False | []
```

That is `seaborn.utils._default_color` plotting a throwaway artist to resolve a default colour — the **#373 mechanism**, not `axhline` at all. `Axes.axhline` never calls `Axes.plot` and explicitly rejects a `transform` keyword, so my first instinct (decline in the patch when `transform` is passed) was inert.

The layer then has no artist, falls back to sweeping the axes, and the only line there is the `axhline`.

**Fixing only (1) turns residplot's wrong series into a fatal `ExtractionError`** — the layer is left with nothing to extract, which takes the whole figure down. Trading a wrong series for a dead chart is not a fix, so both halves land together, and `test_it_renders_rather_than_raising` is the case that says so.

## Two details that took a measurement each

**Emptiness, not detachment.** The obvious decline test is "the returned line is already off the axes" — which is what I observed post-hoc. It does not work: seaborn removes the probe *after* the patch returns, so at the moment of the decision the line is still attached. The observable signal then is that it carries no points. That also agrees with #421 — a layer with no points is a phantom rather than an empty reading.

**Transform, never shape.** A genuinely flat series (`ax.plot([1, 2], [5, 5])`) is indistinguishable from a reference line by its values. Asking only about the transform keeps it; pinned.

## Measured, after

```
plot + axhline  -> 1 series, x = 10, 20, 30
plot + axvline  -> 1 series
step + axhline  -> STEP, its own data only
flat data line  -> kept
residplot       -> [SCATTER]                 ← the phantom LINE layer is gone
sns.lineplot    -> [LINE]
regplot         -> [SCATTER, SMOOTH]
```

## Verification

Full suite **1831 passed, 1 xfailed**. `ruff check` clean on all three changed files.

Falsification:

| reverted | failures |
|---|---|
| sweep filter removed | **4 of 11** |
| probe decline removed | **2** — both `TestALayerWithNoArtistOfItsOwn` cases |

The disjoint failures are the evidence that the two halves are independent rather than one fix written twice.

## Noted, not done

A reference line is genuinely useful to know about — a threshold at 2 is information. The grammar has no annotation concept to put it in, so it is omitted rather than mis-announced; describing it properly is a grammar question worth its own issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_