### PR TITLE
fix: read trace types from the enum, and report a positioned sample with no reading

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -39,11 +39,8 @@ def _has_position(x: object) -> bool:
     non-finite ``y`` is a different thing: it has a position and no value,
     which is how ``seaborn.pointplot`` pads a hue level missing from one
     category so its two estimate lines stay the same length. Dropping it
-    would break that pairing, and emitting the value as ``null`` measurably
-    makes the core sonify the gap as a floor tone and announce it as
-    ``null`` -- a wrong reading in place of a missing one. Naming it properly
-    needs a per-point empty state the grammar does not have yet, so those are
-    left alone here and tracked in #429.
+    would break that pairing, so it is kept and its value emitted as ``null``
+    by :func:`_reading` instead.
 
     Parameters
     ----------
@@ -61,6 +58,44 @@ def _has_position(x: object) -> bool:
         return math.isfinite(x)  # type: ignore[arg-type]
     except TypeError:
         return True
+
+
+
+def _reading(y: object) -> object:
+    """
+    A sample's value, or ``None`` where it was positioned but never measured.
+
+    ``seaborn.pointplot`` pads a hue level missing from one category so its
+    estimate lines stay the same length, which is what keeps the pairing
+    working and the interval polylines out of the data. That padding has a
+    real x and no y: something to navigate to, nothing to report.
+
+    ``None`` serialises to ``null``, which the core has read as a gap since
+    maidr 4.3.0 (xability/maidr#926) -- it becomes ``NaN`` inside
+    ``LineTrace``, stays out of the range, sounds as the empty tone rather
+    than a floor tone, and announces as "missing". Before that release there
+    was no honest way to say it: the bare ``NaN`` stopped the chart
+    initialising at all, and a zero would have claimed a reading of zero
+    (#429).
+
+    Distinct from {@link _has_position}, which drops a sample outright. A
+    sample with no *position* is not on the chart; this one is.
+
+    Parameters
+    ----------
+    y : object
+        A sample's value as extracted, numeric or categorical.
+
+    Returns
+    -------
+    object
+        The value, or ``None`` when it is a non-finite number. A categorical
+        value is returned untouched.
+    """
+    try:
+        return y if math.isfinite(y) else None  # type: ignore[arg-type]
+    except TypeError:
+        return y
 
 
 class MultiLinePlot(MaidrPlot, LineExtractorMixin):
@@ -268,7 +303,7 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
             line_data = [
                 {
                     MaidrKey.X: x,
-                    MaidrKey.Y: y,
+                    MaidrKey.Y: _reading(y),
                     **({MaidrKey.Z: line_type} if line_type else {}),
                 }
                 for x, y in line_coords

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -1623,13 +1623,28 @@ def _bundle_warning_enabled() -> bool:
 # Bundled-copy capability
 # ---------------------------------------------------------------------------
 
-#: A quoted lower-snake identifier, which is how the bundle spells a trace
-#: type.  All three quote characters, because the minifier picks whichever
-#: is shortest for the surrounding context -- the 4.1.0 bundle uses
-#: backticks throughout, and a check written for double quotes alone would
-#: have reported every type missing.
+#: An enum member assignment, which is how the bundle spells a trace type.
+#: TypeScript compiles ``TraceType`` to a run of them, so the 4.3.0 bundle
+#: carries ``e.AREA=`area`,e.ALLUVIAL=`alluvial`,e.BAR=`bar`,...``.
+#:
+#: All three quote characters, because the minifier picks whichever is
+#: shortest for the surrounding context -- the 4.1.0 bundle uses backticks
+#: throughout, and a check written for double quotes alone would have
+#: reported every type missing.
+#:
+#: Anchored on the ``.UPPER_SNAKE =`` rather than matching every quoted
+#: lower-snake string anywhere. The looser form was tenable while the bundle
+#: was small, and stopped being so at 4.3.0: nine adapters gained chart types
+#: and the vocabularies that came with them (MathML attribute names among
+#: others) took the scrape from a few hundred tokens to **1265**, including
+#: ordinary words like ``count``, ``above`` and ``accent``. A capability
+#: check whose vocabulary contains most of the dictionary answers "yes, your
+#: bundle knows that" to anything, so it can no longer raise the warning it
+#: exists for -- failing silent rather than merely failing safe (#436).
+#: Narrowed, 4.3.0 yields 60.
 _BUNDLE_TOKEN_RE = re.compile(
-    r"(?P<quote>[`\"'])(?P<token>[a-z][a-z0-9_]{1,39})(?P=quote)"
+    r"\.[A-Z][A-Z0-9_]*\s*=\s*(?P<quote>[`\"'])"
+    r"(?P<token>[a-z][a-z0-9_]{1,39})(?P=quote)"
 )
 
 #: Parsed once; the bundle does not change under a running process.

--- a/tests/core/plot/test_non_finite_coordinates.py
+++ b/tests/core/plot/test_non_finite_coordinates.py
@@ -129,59 +129,68 @@ class TestALineBrokenByNaN:
 
 
 class TestASampleWithAPositionButNoValue:
-    """The boundary, drawn on purpose rather than by accident.
+    """Kept and reported as missing, rather than dropped or faked.
 
     ``seaborn.pointplot`` NaN-pads a hue level that never appears in some
     category, and that padding is load-bearing: it keeps both estimate lines
     at one vertex per category, which is what stops the pairing failing and
     the interval polylines travelling as data (see ``test_pointplot.py``).
 
-    So a real x with a non-finite y is *not* the same thing as a point with
-    no position, and the rule asks about x alone. Emitting the value as
-    ``null`` instead was measured against the core and is worse than it
-    looks: ``LineTrace`` yields ``audio.freq.raw = 0`` and
-    ``text.cross.value = null``, so the gap is sonified as a floor tone and
-    announced as a word. Naming it properly needs a per-point empty state the
-    grammar does not have, which is #429.
+    So a real x with a non-finite y is *not* the same thing as a point with no
+    position, and the position rule asks about x alone. The value is emitted
+    as ``None`` -> ``null``, which the core has read as a gap since maidr
+    4.3.0 (xability/maidr#926): it becomes ``NaN`` inside ``LineTrace``, stays
+    out of the range, sounds as the empty tone rather than a floor tone, and
+    announces as "missing".
+
+    This was a strict ``xfail`` when #430 landed, because before that release
+    there was no honest representation -- a bare ``NaN`` stopped the chart
+    initialising and a zero would have claimed a reading of zero.
     """
 
-    def test_the_padded_sample_is_kept(self):
+    @staticmethod
+    def _unbalanced():
         import pandas as pd
 
-        unbalanced = pd.DataFrame(
+        return pd.DataFrame(
             {
                 "g": ["a"] * 4 + ["b"] * 4 + ["c"] * 2,
                 "half": ["x", "x", "y", "y", "x", "x", "y", "y", "x", "x"],
                 "v": [1.0, 2.0, 5.0, 6.0, 10.0, 11.0, 14.0, 15.0, 20.0, 21.0],
             }
         )
-        _, ax = plt.subplots()
-        sns.pointplot(unbalanced, x="g", y="v", hue="half", dodge=True, ax=ax)
 
-        series = series_of(ax)
+    def _axes(self):
+        _, ax = plt.subplots()
+        sns.pointplot(self._unbalanced(), x="g", y="v", hue="half", dodge=True, ax=ax)
+        return ax
+
+    def test_the_padded_sample_is_kept(self):
+        series = series_of(self._axes())
 
         assert len(series) == 2
         assert all(len(one) == 3 for one in series)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="#429: a positioned sample with no value has no JSON-safe "
-        "representation until the grammar can express an empty point",
-    )
-    def test_its_payload_is_not_parseable_yet(self):
-        import pandas as pd
+    def test_its_value_is_null_rather_than_a_number(self):
+        # The distinction the whole thing rests on: `null` is "no reading
+        # here", where `0` would be a reading of zero at a category whose
+        # data does not exist.
+        padded = [point for one in series_of(self._axes()) for point in one]
+        gaps = [point for point in padded if point["y"] is None]
 
-        unbalanced = pd.DataFrame(
-            {
-                "g": ["a"] * 4 + ["b"] * 4 + ["c"] * 2,
-                "half": ["x", "x", "y", "y", "x", "x", "y", "y", "x", "x"],
-                "v": [1.0, 2.0, 5.0, 6.0, 10.0, 11.0, 14.0, 15.0, 20.0, 21.0],
-            }
-        )
-        _, ax = plt.subplots()
-        sns.pointplot(unbalanced, x="g", y="v", hue="half", dodge=True, ax=ax)
+        assert len(gaps) == 1
+        assert gaps[0]["x"] == "c"
 
-        parses_as_strict_json(ax)
+    def test_it_keeps_its_position(self):
+        # Dropping it would break the pairing the padding exists for.
+        series = series_of(self._axes())
+
+        for one in series:
+            assert [point["x"] for point in one] == ["a", "b", "c"]
+
+    def test_the_payload_is_loadable(self):
+        # This is the assertion that was a strict xfail until maidr 4.3.0.
+        parses_as_strict_json(self._axes())
 
 
 class TestWhatMustNotChange:

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -654,7 +654,13 @@ def test_a_hue_level_missing_a_category_does_not_break_the_pairing():
     assert [point["x"] for point in data[1]] == ["a", "b", "c"]
     # The combination the data does not have arrives as a gap, which the
     # consumer names rather than reading out -- not as cap geometry.
-    assert np.isnan(data[1][2]["y"])
+    #
+    # `None` rather than `NaN` since #429: a bare `NaN` is not JSON, so it
+    # stopped the chart initialising at all, and the core has read `null` as
+    # "positioned, no reading" since maidr 4.3.0 (xability/maidr#926). What
+    # this case is really pinning is unchanged -- the padding survives, so
+    # both estimate lines keep one vertex per category.
+    assert data[1][2]["y"] is None
 
 
 def test_an_estimate_line_without_a_marker_is_still_an_estimate():

--- a/tests/core/test_bundle_capability.py
+++ b/tests/core/test_bundle_capability.py
@@ -98,8 +98,30 @@ def test_the_bundle_names_the_types_it_can_build():
     """
     types = bundle_trace_types()
 
-    assert len(types) > 100
-    for expected in ("bar", "box", "heat", "line", "pie", "scatter"):
+    # Every type this package can emit, rather than a count. The count was
+    # `> 100` while the scan matched any quoted lower-snake string anywhere:
+    # a threshold calibrated against noise, which 4.3.0 pushed to 1265 tokens
+    # and which said nothing about whether the *right* words were found.
+    # Anchoring the scan on the enum's `.UPPER_SNAKE =` brings it to 60 real
+    # ones, so the meaningful assertion is coverage of what we emit (#436).
+    emitted = {
+        plot_type.value
+        for plot_type in PlotType
+        # `count` is classified but never emitted -- a `countplot` travels as
+        # `bar`, which is what the case below this one is about.
+        if plot_type is not PlotType.COUNT
+    }
+    missing = sorted(emitted - types)
+
+    assert not missing, f"bundle names no builder for: {missing}"
+
+    # Spot-checked against what a layer is actually *called* on the wire. The
+    # old list asked for `"scatter"`, which is not a trace type at all --
+    # `PlotType.SCATTER.value` is `point`, and the bundle agrees
+    # (`e.SCATTER=\`point\``). It passed only because the loose scan caught
+    # the word somewhere else in the file, which is the same accident this
+    # case exists to rule out.
+    for expected in ("bar", "box", "heat", "line", "pie", "point"):
         assert expected in types, expected
 
 


### PR DESCRIPTION
Two things, both consequences of maidr **4.3.0** landing. Closes #436, refs #429.

---

## 1. `main` is red — the bundle scan can no longer say no

`bundle_trace_types()` matched every quoted lower-snake string **anywhere** in the bundle. 4.3.0 took that from a few hundred tokens to **1265**:

```
token count: 1265
  'count'  in bundle: True     ← what the test asserted was absent
  'a11y'   in bundle: True
  'above'  in bundle: True
```

The failing assertion was pinning an accident of the 4.2.0 bundle's contents. But the interesting half is what the noise did to the check itself: it exists (#358) to warn when a bundle is too old to draw a trace type being emitted, and **a vocabulary containing most of the dictionary answers "yes, your bundle knows that" to anything**. The warning could no longer fire — failing silent rather than merely failing safe, which is precisely what #358 was written to prevent.

TypeScript compiles `TraceType` into a run of member assignments, so the bundle carries `` e.AREA=`area`,e.BAR=`bar`,… ``. Anchoring on the `.UPPER_SNAKE =`:

```
narrowed token count: 60
  'bar', 'line', 'smooth', 'candlestick', 'stacked_normalized_bar', 'area', 'step'  → True
  'count', 'a11y', 'above', 'accent'                                                → False
```

### Both test corrections were themselves accidents of the loose scan

- `assert len(types) > 100` — a threshold calibrated against noise, saying nothing about whether the *right* words were found. Now asserts that every `PlotType` value this package can emit is named, which is the question the check is for.
- `assert "scatter" in types` — **`scatter` is not a trace type.** `PlotType.SCATTER.value` is `point`, and the bundle agrees (`` e.SCATTER=`point` ``). It passed only because the loose scan caught the word elsewhere in the file.

Falsification: widening the scan back fails the capability suite.

---

## 2. A positioned sample with no reading is now expressible

xability/maidr#926 shipped in 4.3.0. `seaborn.pointplot` pads a hue level missing from one category so its estimate lines stay the same length — a real x, no y: something to navigate to, nothing to report.

```
before:  {"x": "c", "y": NaN,  "z": "y"}
after:   {"x": "c", "y": null, "z": "y"}
```

#430 left this as a **strict xfail** because there was no honest option: a bare `NaN` is not JSON so the chart never initialised, a zero would claim a reading of zero, and dropping it breaks the pairing it exists for. `null` answers all three — the core turns it into `NaN` inside `LineTrace`, keeps it out of the range, sounds the empty tone rather than a floor tone, and announces **"missing"**. That xfail is replaced by the assertion it was waiting for.

This is the counterpart to `_has_position`, not a widening of it:

| | on the chart? | |
|---|---|---|
| no **position** (ECDF `-inf`, NaN line break) | no | dropped |
| position, no **value** (pointplot padding) | yes | kept, reported missing |

`_has_position`'s docstring said `null` would be mis-announced — true when written, false since 4.3.0, and corrected here rather than left to mislead.

Falsification: emitting the raw value → **2 failures**; emitting `0` instead of `None` → **1**.

---

## Verification

Full suite **1834 passed, 0 failed** — `main` is green again. `ruff check` clean on all changed files.

`test_pointplot.py`'s padding case now asserts `None` rather than `NaN`; what it pins is unchanged — the padding survives, so both estimate lines keep one vertex per category.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_