### PR TITLE
fix(a11y): give every chart iframe an accessible name

### DIFF
--- a/maidr/altair/altair_maidr.py
+++ b/maidr/altair/altair_maidr.py
@@ -38,7 +38,7 @@ import tempfile
 import uuid
 import webbrowser
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, Optional, cast
 
 from htmltools import HTML, HTMLDocument, Tag, tags
 
@@ -278,7 +278,26 @@ class AltairMaidr:
         with delayed retries (500/1500/3000 ms) plus a ResizeObserver
         (MutationObserver fallback) on ``document.body``.
         """
-        return wrap_in_iframe_plotly(inner)
+        return wrap_in_iframe_plotly(inner, self._chart_title())
+
+    def _chart_title(self) -> Optional[str]:
+        """Return a name for this chart, for the iframe's accessible name.
+
+        Altair allows a title to be a plain string or a ``TitleParams``
+        carrying one, and ``Undefined`` when unset -- so the text is reached
+        defensively rather than assumed.
+
+        Returns
+        -------
+        str or None
+            The title, or ``None`` when the chart has no usable one.
+        """
+        title = getattr(self._chart, "title", None)
+        if not isinstance(title, str):
+            title = getattr(title, "text", None)
+        if not isinstance(title, str):
+            return None
+        return title.strip() or None
 
     def _open_in_browser(self) -> None:
         """Save to a temp HTML file and open it in the default browser."""

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -390,7 +390,9 @@ class Maidr:
             maidr = f"\nvar maidr = {json.dumps(schema, indent=2)}\n"
 
         # Inject plot's svg and MAIDR structure into html tag.
-        return Maidr._inject_plot(svg, maidr, self.maidr_id, use_iframe, use_cdn)
+        return Maidr._inject_plot(
+            svg, maidr, self.maidr_id, use_iframe, use_cdn, self._chart_title()
+        )
 
     def _create_html_doc(
         self,
@@ -610,6 +612,31 @@ class Maidr:
         self._plots = [plot for plot, _ in kept]
         self.selector_ids = [selector_id for _, selector_id in kept]
 
+    def _chart_title(self) -> str | None:
+        """Return a name for this figure, for the iframe's accessible name.
+
+        The figure's suptitle first, since that names the whole figure --
+        which is what the frame contains.  Falling back to an axes title
+        only when there is exactly one axes: on a multi-panel figure one
+        panel's title names a part, not the whole, and a frame announced by
+        the name of something inside it is worse than a generic one.
+
+        Returns
+        -------
+        str or None
+            The title, or ``None`` when the figure has no usable one.
+        """
+        suptitle = self._fig.get_suptitle().strip()
+        if suptitle:
+            return suptitle
+
+        axes = self._fig.get_axes()
+        if len(axes) == 1:
+            title = axes[0].get_title().strip()
+            if title:
+                return title
+        return None
+
     def _figure_metadata(self) -> dict:
         """
         Extract figure-wide metadata for the top-level MAIDR schema.
@@ -775,6 +802,7 @@ class Maidr:
         maidr_id,
         use_iframe: bool = True,
         use_cdn: bool | Literal["auto"] = "auto",
+        title: str | None = None,
     ) -> Tag:
         """Embed the plot and associated MAIDR scripts into the HTML structure.
 
@@ -800,6 +828,9 @@ class Maidr:
               bundled copy.  A no-tag dependency ensures the bundled
               files are copied to ``lib_dir`` so the fallback works
               without network access.
+        title : str, optional
+            The chart's own title, used as the accessible name of the
+            iframe when one is emitted.
         """
         # Decide whether the iframe-in-notebook "load-once" fast path applies.
         # ``Tag.get_html_string()`` (used by ``wrap_in_iframe_matplotlib``)
@@ -1083,6 +1114,6 @@ class Maidr:
         # branch that picks a source for ``maidr.js`` and the branch that
         # wraps the result cannot disagree about whether there is an iframe.
         if will_iframe:
-            base_html = wrap_in_iframe_matplotlib(base_html)
+            base_html = wrap_in_iframe_matplotlib(base_html, title)
 
         return base_html

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -918,6 +918,23 @@ class PlotlyMaidr:
         del self._plots
         del self._fig
 
+    def _chart_title(self) -> str | None:
+        """Return a name for this figure, for the iframe's accessible name.
+
+        Reads ``layout.title.text`` directly rather than through
+        ``Figure.to_dict()``, which would re-serialise every trace's data
+        just to reach one string.  ``getattr`` guards keep this safe on
+        figures whose ``layout.title`` is unset.
+
+        Returns
+        -------
+        str or None
+            The title, or ``None`` when the figure has no usable one.
+        """
+        title = getattr(getattr(self._fig.layout, "title", None), "text", None)
+        cleaned = (title or "").strip()
+        return cleaned or None
+
     def _figure_metadata(self) -> dict:
         """
         Extract figure-wide metadata for the top-level MAIDR schema.
@@ -1314,7 +1331,7 @@ class PlotlyMaidr:
         # that picks a source for ``maidr.js`` and the branch that wraps
         # the result cannot disagree about whether there is an iframe.
         if will_iframe:
-            base_html = wrap_in_iframe_plotly(base_html)
+            base_html = wrap_in_iframe_plotly(base_html, self._chart_title())
 
         return base_html
 

--- a/maidr/util/iframe_utils.py
+++ b/maidr/util/iframe_utils.py
@@ -6,8 +6,16 @@ plots in Jupyter notebooks, Google Colab, VSCode, Flask, and Shiny environments.
 """
 
 import uuid
+from typing import Optional
 
 from htmltools import Tag, tags
+
+#: Accessible name for a chart that has no title of its own.
+#:
+#: Generic, but not empty: a frame with no name is announced as just
+#: "frame", and a page of them is a page of identical, unnavigable
+#: landmarks.
+DEFAULT_IFRAME_TITLE = "MAIDR accessible chart"
 
 
 def _generate_unique_id() -> str:
@@ -15,13 +23,50 @@ def _generate_unique_id() -> str:
     return "iframe_" + str(uuid.uuid4())
 
 
-def wrap_in_iframe_matplotlib(base_html: Tag) -> Tag:
+def iframe_title(title: Optional[str] = None) -> str:
+    """Return the accessible name to put on a chart's iframe.
+
+    A frame with no ``title`` is a WCAG 2.2 4.1.2 failure: screen readers
+    announce it as "frame" and nothing more, so a notebook or dashboard of
+    several charts gives a reader several identical, indistinguishable
+    landmarks to tell apart -- which is the navigation problem this library
+    exists to solve.
+
+    The chart's own title is used when it has one, because that is the name
+    the reader is looking for.  Whitespace-only titles count as unauthored,
+    matching how the schema decides the same question.
+
+    Parameters
+    ----------
+    title : str, optional
+        The chart's own title, if it has one.
+
+    Returns
+    -------
+    str
+        A non-empty accessible name.
+
+    Examples
+    --------
+    >>> iframe_title("Tips by day")
+    'Tips by day'
+    >>> iframe_title("   ")
+    'MAIDR accessible chart'
+    """
+    cleaned = (title or "").strip()
+    return cleaned or DEFAULT_IFRAME_TITLE
+
+
+def wrap_in_iframe_matplotlib(base_html: Tag, title: Optional[str] = None) -> Tag:
     """Wrap matplotlib HTML in an auto-resizing iframe for notebooks.
 
     Parameters
     ----------
     base_html : Tag
         The HTML tag containing the matplotlib plot and MAIDR scripts.
+    title : str, optional
+        The chart's own title, used as the frame's accessible name.  See
+        :func:`iframe_title` for what happens when there is not one.
 
     Returns
     -------
@@ -155,6 +200,7 @@ def wrap_in_iframe_matplotlib(base_html: Tag) -> Tag:
 
     return tags.iframe(
         id=unique_id,
+        title=iframe_title(title),
         srcdoc=str(base_html.get_html_string()),
         width="100%",
         height="100%",
@@ -165,7 +211,7 @@ def wrap_in_iframe_matplotlib(base_html: Tag) -> Tag:
     )
 
 
-def wrap_in_iframe_plotly(base_html: Tag) -> Tag:
+def wrap_in_iframe_plotly(base_html: Tag, title: Optional[str] = None) -> Tag:
     """Wrap Plotly HTML in an auto-resizing iframe for notebooks.
 
     Mirrors the focus-delegation logic from the matplotlib wrapper
@@ -176,6 +222,9 @@ def wrap_in_iframe_plotly(base_html: Tag) -> Tag:
     ----------
     base_html : Tag
         The HTML tag containing the Plotly chart and MAIDR scripts.
+    title : str, optional
+        The chart's own title, used as the frame's accessible name.  See
+        :func:`iframe_title` for what happens when there is not one.
 
     Returns
     -------
@@ -287,6 +336,7 @@ def wrap_in_iframe_plotly(base_html: Tag) -> Tag:
 
     return tags.iframe(
         id=unique_id,
+        title=iframe_title(title),
         srcdoc=str(base_html.get_html_string()),
         width="100%",
         height="100%",

--- a/tests/core/test_iframe_accessible_name.py
+++ b/tests/core/test_iframe_accessible_name.py
@@ -1,0 +1,172 @@
+"""Every iframe maidr emits must carry an accessible name.
+
+A frame with no ``title`` is announced as "frame" and nothing else, so a
+notebook or dashboard of several charts gives a screen-reader user several
+identical, indistinguishable landmarks -- the navigation problem this
+library exists to solve. WCAG 2.2 4.1.2.
+"""
+
+from __future__ import annotations
+
+import html as html_module
+import re
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+import maidr  # noqa: E402
+from maidr.util.environment import Environment  # noqa: E402
+from maidr.util.iframe_utils import (  # noqa: E402
+    DEFAULT_IFRAME_TITLE,
+    iframe_title,
+)
+
+
+@pytest.fixture
+def iframed(monkeypatch):
+    """Force the iframe path, which only some environments take."""
+    monkeypatch.setattr(Environment, "is_shiny", staticmethod(lambda: True))
+
+
+def _title_of(tag) -> str | None:
+    """Return the ``title`` attribute of a rendered iframe, unescaped."""
+    match = re.search(r'title="(.*?)"', str(tag.get_html_string()))
+    return html_module.unescape(match.group(1)) if match else None
+
+
+@pytest.fixture
+def bar_axes():
+    """Yield the axes of a two-bar chart, closed afterwards."""
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    yield ax
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# The name itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("Tips by day", "Tips by day"),
+        # Unauthored in every shape the schema also treats as unauthored.
+        ("   ", DEFAULT_IFRAME_TITLE),
+        ("", DEFAULT_IFRAME_TITLE),
+        (None, DEFAULT_IFRAME_TITLE),
+    ],
+)
+def test_a_name_is_always_produced(given, expected):
+    """Never empty: an unnamed frame is the failure being fixed."""
+    assert iframe_title(given) == expected
+
+
+# ---------------------------------------------------------------------------
+# matplotlib
+# ---------------------------------------------------------------------------
+
+
+def test_a_titled_chart_is_named_by_its_title(iframed, bar_axes):
+    """The chart's own title is the name the reader is looking for."""
+    bar_axes.set_title("Tips by day")
+    assert _title_of(maidr.render(bar_axes, use_cdn=True)) == "Tips by day"
+
+
+def test_an_untitled_chart_still_gets_a_name(iframed, bar_axes):
+    assert _title_of(maidr.render(bar_axes, use_cdn=True)) == DEFAULT_IFRAME_TITLE
+
+
+def test_the_figure_title_outranks_a_panel_title(iframed):
+    """The frame holds the whole figure, so the whole figure names it.
+
+    Naming a multi-panel frame after one of its panels would announce a
+    part as though it were the whole.
+    """
+    fig, (left, right) = plt.subplots(1, 2)
+    left.bar(["a"], [1])
+    right.bar(["b"], [2])
+    left.set_title("Panel A")
+    fig.suptitle("Whole figure")
+    try:
+        assert _title_of(maidr.render(left, use_cdn=True)) == "Whole figure"
+    finally:
+        plt.close(fig)
+
+
+def test_a_panel_title_does_not_name_a_multi_panel_figure(iframed):
+    """With no figure title, a generic name beats a misleading one."""
+    fig, (left, right) = plt.subplots(1, 2)
+    left.bar(["a"], [1])
+    right.bar(["b"], [2])
+    left.set_title("Panel A")
+    try:
+        assert _title_of(maidr.render(left, use_cdn=True)) == DEFAULT_IFRAME_TITLE
+    finally:
+        plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Plotly and Altair
+# ---------------------------------------------------------------------------
+
+
+def test_a_plotly_chart_is_named_by_its_layout_title(iframed):
+    px = pytest.importorskip("plotly.express")
+    figure = px.bar(x=["a", "b"], y=[1, 2], title="Plotly titled")
+    assert _title_of(maidr.render(figure, use_cdn=True)) == "Plotly titled"
+
+
+def test_an_untitled_plotly_chart_still_gets_a_name(iframed):
+    px = pytest.importorskip("plotly.express")
+    figure = px.bar(x=["a", "b"], y=[1, 2])
+    assert _title_of(maidr.render(figure, use_cdn=True)) == DEFAULT_IFRAME_TITLE
+
+
+def test_an_altair_chart_is_named_by_its_title(iframed):
+    alt = pytest.importorskip("altair")
+    pd = pytest.importorskip("pandas")
+    frame = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+    chart = alt.Chart(frame, title="Altair titled").mark_bar().encode(x="a", y="b")
+    assert _title_of(maidr.render(chart)) == "Altair titled"
+
+
+def test_an_untitled_altair_chart_still_gets_a_name(iframed):
+    alt = pytest.importorskip("altair")
+    pd = pytest.importorskip("pandas")
+    frame = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+    chart = alt.Chart(frame).mark_bar().encode(x="a", y="b")
+    assert _title_of(maidr.render(chart)) == DEFAULT_IFRAME_TITLE
+
+
+def test_an_altair_title_object_is_read_rather_than_stringified(iframed):
+    """Altair accepts a ``TitleParams``, not only a plain string.
+
+    Stringifying one would produce a repr as the accessible name.
+    """
+    alt = pytest.importorskip("altair")
+    pd = pytest.importorskip("pandas")
+    frame = pd.DataFrame({"a": ["x", "y"], "b": [1, 2]})
+    chart = (
+        alt.Chart(frame, title=alt.TitleParams(text="Structured title"))
+        .mark_bar()
+        .encode(x="a", y="b")
+    )
+    assert _title_of(maidr.render(chart)) == "Structured title"
+
+
+# ---------------------------------------------------------------------------
+# The guarantee
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("use_cdn", [True, "auto", False])
+def test_no_cdn_mode_emits_an_unnamed_frame(iframed, bar_axes, use_cdn):
+    """The name must not depend on how the runtime is delivered."""
+    title = _title_of(maidr.render(bar_axes, use_cdn=use_cdn))
+    assert title


### PR DESCRIPTION
## Description

Closes #453.

Every iframe maidr emits — notebook, Shiny, Flask — was built without a `title`:

```python
return tags.iframe(
    id=unique_id,
    srcdoc=str(base_html.get_html_string()),
    width="100%", height="100%", scrolling="no",
    style="...", frameBorder=0, onload=resizing_script,
)
```

A frame with no accessible name is announced as "frame" and nothing more. A notebook or dashboard holding several charts therefore gave a screen-reader user several identical, indistinguishable landmarks to tell apart — a WCAG 2.2 **4.1.2 Name, Role, Value** failure, and the navigation problem this library exists to solve, reproduced in its own output.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Closes #453. Found while auditing the Shiny integration in #452; filed then rather than folded in, since it affects every renderer and not just Shiny.

## Changes Made

**`maidr/util/iframe_utils.py`** — both wrappers take an optional `title` and always emit one. `iframe_title()` returns the chart's own title, or `"MAIDR accessible chart"` when there isn't one. Whitespace-only counts as unauthored, matching how the schema already decides the same question.

**The name was available all along.** Each renderer already reads a figure title for its schema, so the same value now names the frame:

| Renderer | Source |
|---|---|
| matplotlib | `fig.get_suptitle()`, else the axes title when there is exactly one axes |
| Plotly | `layout.title.text`, read directly rather than through `to_dict()` |
| Altair | the chart title — read defensively, since Altair accepts a bare string *or* a `TitleParams`, and stringifying the latter would announce a repr |

**An axes title is used only when the figure has one axes.** On a multi-panel figure, naming the frame after one panel would announce a part as though it were the whole, so a generic name is the more honest answer there.

Measured across every renderer:

```
mpl titled       : 'Tips by day'
mpl untitled     : 'MAIDR accessible chart'
mpl suptitle wins: 'Whole figure'
plotly titled    : 'Plotly titled'
altair titled    : 'Altair titled'
altair untitled  : 'MAIDR accessible chart'
```

### Backwards compatibility

Additive. `title` is optional on both wrappers, so any existing caller keeps working and simply gets the generic name. The only change to emitted HTML is the new attribute.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable — no user-facing API changed.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verification.** `uv run pytest` — 2168 passed (from 2152; 16 new). `ruff check` and `uv lock --check` clean.

The tests were checked against the defect rather than only against the fix: removing `title=` from the two wrappers fails **12 of the 16**, including the parametrized guarantee that no `use_cdn` mode may emit an unnamed frame.

**What this does not do.** Streamlit embeds are unaffected — Streamlit builds its own iframe and hardcodes its accessible name as `st.iframe` with no override, which is tracked separately as an upstream report in #461. This PR covers the frames maidr builds itself.

**Not verified in a browser.** No screen-reader pass was run. The claim here is about the emitted attribute, not about how any particular AT announces it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_