### PR TITLE
fix(plotly): report when a plotly chart runs out of maidr.js sources

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -26,13 +26,13 @@ from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
 from maidr.util.dependencies import (
     MAIDR_JS_FILENAME,
+    OFFLINE_FALLBACK_REPORT,
     bundled_cdn_url,
     inline_bundle_tags,
     maidr_bundled_files_dependency,
     maidr_bundled_relative_dir,
     maidr_html_dependency,
     maidr_js_cdn_url,
-    OFFLINE_FALLBACK_REPORT,
     schema_trace_types,
     warn_if_bundle_cannot_render,
     warn_if_bundle_is_stale,

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -32,6 +32,7 @@ from maidr.util.dependencies import (
     maidr_bundled_relative_dir,
     maidr_html_dependency,
     maidr_js_cdn_url,
+    OFFLINE_FALLBACK_REPORT,
     schema_trace_types,
     warn_if_bundle_cannot_render,
     warn_if_bundle_is_stale,
@@ -67,23 +68,6 @@ _SEGMENTED_BAR_PLOTS = (GroupedBarPlot,)
 #: never set ``onerror`` at all. What the reader gets either way is a chart
 #: with no MAIDR runtime -- a picture, with nothing saying why (#455).
 #:
-#: Names the setting that works rather than describing the failure, because
-#: the person who hits this is on an air-gapped deployment and the answer
-#: (``use_cdn=False``) is otherwise only discoverable by reading the source.
-#:
-#: A plain string rather than an f-string: it is interpolated *into* f-strings,
-#: so its braces must not be doubled.
-_OFFLINE_FALLBACK_REPORT = """
-                        function reportNoRuntime(why) {
-                            console.error(
-                                '[maidr] The chart loaded but its runtime did not: '
-                                + why + '. The CDN was unreachable and the bundled '
-                                + 'copy could not be resolved from inside this frame. '
-                                + 'Re-render with use_cdn=False to inline the bundle, '
-                                + 'which works without network access.'
-                            );
-                        }
-"""
 
 
 class Maidr:
@@ -1012,7 +996,7 @@ class Maidr:
                                 if (window.main) window.main();
                             }}
                         }}
-{_OFFLINE_FALLBACK_REPORT}
+{OFFLINE_FALLBACK_REPORT}
                         function fallbackFromParent() {{
                             try {{
                                 var jsSrc = window.parent && window.parent.__maidrJsSource;
@@ -1064,7 +1048,7 @@ class Maidr:
                 rel_dir = maidr_bundled_relative_dir()
                 bundled_js_rel = f"{rel_dir}/{MAIDR_JS_FILENAME}"
                 fallback_script = f"""
-                    (function() {{{_OFFLINE_FALLBACK_REPORT}
+                    (function() {{{OFFLINE_FALLBACK_REPORT}
                         function bootstrap() {{
                             if (document.readyState === 'loading') {{
                                 document.addEventListener('DOMContentLoaded', function() {{ if (window.main) window.main(); }});

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -61,6 +61,7 @@ _AXES_WIDE_BAR_PLOTS = (BarPlot, GroupedBarPlot)
 #: the layer to keep when one axes holds more than one of the family.
 _SEGMENTED_BAR_PLOTS = (GroupedBarPlot,)
 
+
 class Maidr:
     """
     A class to handle the rendering and interaction

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -61,15 +61,6 @@ _AXES_WIDE_BAR_PLOTS = (BarPlot, GroupedBarPlot)
 #: the layer to keep when one axes holds more than one of the family.
 _SEGMENTED_BAR_PLOTS = (GroupedBarPlot,)
 
-#: What the browser says when ``use_cdn="auto"`` runs out of sources.
-#:
-#: Both fallbacks can fail to resolve, and both used to do it in silence: the
-#: notebook one only acts ``if (jsSrc)`` and swallows the miss, and the other
-#: never set ``onerror`` at all. What the reader gets either way is a chart
-#: with no MAIDR runtime -- a picture, with nothing saying why (#455).
-#:
-
-
 class Maidr:
     """
     A class to handle the rendering and interaction

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -1111,6 +1111,12 @@ class PlotlyMaidr:
             CDN was simply unreachable and the fix is ``use_cdn=False``.
             Sharing one message would send half the callers somewhere useless.
 
+            Built by placeholder replacement rather than as an f-string,
+            unlike everything else in this file: the JS body is full of
+            literal braces, and an f-string would need every one of them
+            doubled -- which is how a template like this acquires a
+            mismatched brace that only shows up as broken JS in a browser.
+
             Parameters
             ----------
             on_missing : str

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -1100,7 +1100,7 @@ class PlotlyMaidr:
         # KaTeX travels as a string because ``maidr.js`` resolves
         # ``maidr-math.css`` against the URL it was loaded from, and an
         # inline script inside a srcdoc iframe has no URL to offer it.
-        def parent_source(on_missing: str) -> str:
+        def parent_source(on_missing: str, on_unreachable: str = "") -> str:
             """Return the parent-window loader, reporting failure as told.
 
             The two ``use_cdn`` modes reach this for different reasons and so
@@ -1112,7 +1112,14 @@ class PlotlyMaidr:
             Parameters
             ----------
             on_missing : str
-                JS run when no stashed copy can be reached.
+                JS run when the parent is readable but holds no stash.
+            on_unreachable : str, optional
+                JS run when the parent could not be read at all -- a
+                cross-origin frame, or no parent. Defaults to
+                ``on_missing``, which is right only where the two have the
+                same answer; under ``"auto"`` they do not, and reporting a
+                missing stash for an unreachable parent sends the reader
+                looking in the wrong place.
 
             Returns
             -------
@@ -1142,11 +1149,16 @@ class PlotlyMaidr:
                         document.head.appendChild(s);
                         return true;
                     }
-                } catch (_) { /* cross-origin or missing parent */ }
-                __ON_MISSING__
-                return false;
+                    __ON_MISSING__
+                    return false;
+                } catch (_) {
+                    __ON_UNREACHABLE__
+                    return false;
+                }
             })();
-        """.replace("__ON_MISSING__", on_missing)
+        """.replace("__ON_MISSING__", on_missing).replace(
+                "__ON_UNREACHABLE__", on_unreachable or on_missing
+            )
 
         #: ``use_cdn=False``: the caller asked for the bundle, so the fix is
         #: to stash it, not to change the mode.
@@ -1187,7 +1199,8 @@ class PlotlyMaidr:
                 # ``use_cdn=False`` the same miss means something else
                 # (see ``parent_source``), hence the separate wording.
                 auto_parent_source = parent_source(
-                    "reportNoRuntime('the notebook page has no stashed copy');"
+                    "reportNoRuntime('the notebook page has no stashed copy');",
+                    "reportNoRuntime('the parent page is unreachable');",
                 )
                 loader = f"""
 {OFFLINE_FALLBACK_REPORT}

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -1100,7 +1100,9 @@ class PlotlyMaidr:
         # KaTeX travels as a string because ``maidr.js`` resolves
         # ``maidr-math.css`` against the URL it was loaded from, and an
         # inline script inside a srcdoc iframe has no URL to offer it.
-        def parent_source(on_missing: str, on_unreachable: str = "") -> str:
+        def parent_source(
+            on_missing: str, on_unreachable: str | None = None
+        ) -> str:
             """Return the parent-window loader, reporting failure as told.
 
             The two ``use_cdn`` modes reach this for different reasons and so
@@ -1113,13 +1115,15 @@ class PlotlyMaidr:
             ----------
             on_missing : str
                 JS run when the parent is readable but holds no stash.
-            on_unreachable : str, optional
+            on_unreachable : str or None, optional
                 JS run when the parent could not be read at all -- a
-                cross-origin frame, or no parent. Defaults to
+                cross-origin frame, or no parent. ``None`` reuses
                 ``on_missing``, which is right only where the two have the
                 same answer; under ``"auto"`` they do not, and reporting a
                 missing stash for an unreachable parent sends the reader
-                looking in the wrong place.
+                looking in the wrong place. ``None`` rather than ``""`` so
+                that "same answer" and "say nothing" stay distinguishable
+                if a caller ever wants the latter.
 
             Returns
             -------
@@ -1157,7 +1161,8 @@ class PlotlyMaidr:
                 }
             })();
         """.replace("__ON_MISSING__", on_missing).replace(
-                "__ON_UNREACHABLE__", on_unreachable or on_missing
+                "__ON_UNREACHABLE__",
+                on_missing if on_unreachable is None else on_unreachable,
             )
 
         #: ``use_cdn=False``: the caller asked for the bundle, so the fix is

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -1171,9 +1171,9 @@ class PlotlyMaidr:
                 on_missing if on_unreachable is None else on_unreachable,
             )
 
-        #: ``use_cdn=False``: the caller asked for the bundle, so the fix is
-        #: to stash it, not to change the mode.
-        _NOTEBOOK_STASH_MISSING = """
+        # ``use_cdn=False``: the caller asked for the bundle, so the fix is
+        # to stash it, not to change the mode.
+        notebook_stash_missing = """
                 if (window.console) {
                     console.warn(
                         'maidr: use_cdn=False requires maidr.init_notebook() ' +
@@ -1183,7 +1183,7 @@ class PlotlyMaidr:
                 }
         """
 
-        parent_source_snippet = parent_source(_NOTEBOOK_STASH_MISSING)
+        parent_source_snippet = parent_source(notebook_stash_missing)
 
         if use_cdn is False:
             if iframe_in_notebook:

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -37,13 +37,13 @@ from maidr.plotly.step_shape import (
 )
 from maidr.util.dependencies import (
     MAIDR_JS_FILENAME,
+    OFFLINE_FALLBACK_REPORT,
     bundled_cdn_url,
     inline_bundle_tags,
     maidr_bundled_files_dependency,
     maidr_bundled_relative_dir,
     maidr_html_dependency,
     maidr_js_cdn_url,
-    OFFLINE_FALLBACK_REPORT,
     schema_trace_types,
     warn_if_bundle_cannot_render,
     warn_if_bundle_is_stale,

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -1100,7 +1100,26 @@ class PlotlyMaidr:
         # KaTeX travels as a string because ``maidr.js`` resolves
         # ``maidr-math.css`` against the URL it was loaded from, and an
         # inline script inside a srcdoc iframe has no URL to offer it.
-        parent_source_snippet = """
+        def parent_source(on_missing: str) -> str:
+            """Return the parent-window loader, reporting failure as told.
+
+            The two ``use_cdn`` modes reach this for different reasons and so
+            need different advice. Under ``False`` the caller asked for the
+            bundle and the fix is ``init_notebook()``; under ``"auto"`` the
+            CDN was simply unreachable and the fix is ``use_cdn=False``.
+            Sharing one message would send half the callers somewhere useless.
+
+            Parameters
+            ----------
+            on_missing : str
+                JS run when no stashed copy can be reached.
+
+            Returns
+            -------
+            str
+                The loader, as JS.
+            """
+            return """
             (function() {
                 try {
                     var jsSrc = window.parent && window.parent.__maidrJsSource;
@@ -1124,6 +1143,14 @@ class PlotlyMaidr:
                         return true;
                     }
                 } catch (_) { /* cross-origin or missing parent */ }
+                __ON_MISSING__
+                return false;
+            })();
+        """.replace("__ON_MISSING__", on_missing)
+
+        #: ``use_cdn=False``: the caller asked for the bundle, so the fix is
+        #: to stash it, not to change the mode.
+        _NOTEBOOK_STASH_MISSING = """
                 if (window.console) {
                     console.warn(
                         'maidr: use_cdn=False requires maidr.init_notebook() ' +
@@ -1131,9 +1158,9 @@ class PlotlyMaidr:
                         'to be available on window.parent.__maidrJsSource.'
                     );
                 }
-                return false;
-            })();
         """
+
+        parent_source_snippet = parent_source(_NOTEBOOK_STASH_MISSING)
 
         if use_cdn is False:
             if iframe_in_notebook:
@@ -1154,14 +1181,23 @@ class PlotlyMaidr:
                 # Iframe path: try the CDN first, fall back to the
                 # parent-window source on ``onerror``.  Relative
                 # ``lib/`` paths cannot be resolved inside srcdoc.
+                # Under "auto" the CDN was simply unreachable, so the
+                # stash being empty too means there is no source left --
+                # which is what ``reportNoRuntime`` is for. Under
+                # ``use_cdn=False`` the same miss means something else
+                # (see ``parent_source``), hence the separate wording.
+                auto_parent_source = parent_source(
+                    "reportNoRuntime('the notebook page has no stashed copy');"
+                )
                 loader = f"""
+{OFFLINE_FALLBACK_REPORT}
                     var existing = document.querySelector(
                         'script[src="{js_cdn_url}"]'
                     );
                     if (!existing) {{
                         var s = document.createElement('script');
                         s.src = '{js_cdn_url}';
-                        s.onerror = function() {{{parent_source_snippet}}};
+                        s.onerror = function() {{{auto_parent_source}}};
                         document.head.appendChild(s);
                     }}
                 """

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -43,6 +43,7 @@ from maidr.util.dependencies import (
     maidr_bundled_relative_dir,
     maidr_html_dependency,
     maidr_js_cdn_url,
+    OFFLINE_FALLBACK_REPORT,
     schema_trace_types,
     warn_if_bundle_cannot_render,
     warn_if_bundle_is_stale,
@@ -1168,6 +1169,7 @@ class PlotlyMaidr:
                 rel_dir = maidr_bundled_relative_dir()
                 bundled_js_rel = f"{rel_dir}/{MAIDR_JS_FILENAME}"
                 loader = f"""
+{OFFLINE_FALLBACK_REPORT}
                     var existing = document.querySelector(
                         'script[src="{js_cdn_url}"]'
                     );
@@ -1177,6 +1179,17 @@ class PlotlyMaidr:
                         s.onerror = function() {{
                             var fb = document.createElement('script');
                             fb.src = '{bundled_js_rel}';
+                            // The relative path resolves wherever the host
+                            // serves the copied bundle -- save_html -- and
+                            // cannot inside a srcdoc iframe nobody serves
+                            // those files for. Without this the chart is an
+                            // image with no runtime and nothing said.
+                            fb.onerror = function() {{
+                                reportNoRuntime(
+                                    'the bundled copy at {bundled_js_rel} '
+                                    + 'did not load'
+                                );
+                            }};
                             document.head.appendChild(fb);
                         }};
                         document.head.appendChild(s);

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -2219,6 +2219,13 @@ def inline_bundle_tags() -> "list | None":
     ]
 
 
+#: What the browser says when ``use_cdn="auto"`` runs out of sources.
+#:
+#: Every fallback can fail to resolve, and each used to do it in silence: the
+#: notebook ones only act ``if (jsSrc)`` and swallow the miss, and the bundled
+#: ones set no ``onerror`` at all. What the reader gets either way is a chart
+#: with no MAIDR runtime -- a picture, with nothing saying why (#455).
+#:
 #: Names the setting that works rather than describing the failure, because
 #: the person who hits this is on an air-gapped deployment and the answer
 #: (``use_cdn=False``) is otherwise only discoverable by reading the source.

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -2236,13 +2236,13 @@ def inline_bundle_tags() -> "list | None":
 #: Lives here rather than beside either renderer because both emit the same
 #: failure, and one wording in two files is one wording that can drift.
 OFFLINE_FALLBACK_REPORT = """
-                        function reportNoRuntime(why) {
-                            console.error(
-                                '[maidr] The chart loaded but its runtime did not: '
-                                + why + '. The CDN was unreachable and the bundled '
-                                + 'copy could not be resolved from inside this frame. '
-                                + 'Re-render with use_cdn=False to inline the bundle, '
-                                + 'which works without network access.'
-                            );
-                        }
+    function reportNoRuntime(why) {
+        console.error(
+            '[maidr] The chart loaded but its runtime did not: '
+            + why + '. The CDN was unreachable and the bundled '
+            + 'copy could not be resolved from inside this frame. '
+            + 'Re-render with use_cdn=False to inline the bundle, '
+            + 'which works without network access.'
+        );
+    }
 """

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -2217,3 +2217,25 @@ def inline_bundle_tags() -> "list | None":
         tags.link(**{"data-maidr-math": ""}),
         tags.script(js_source, type="text/javascript"),
     ]
+
+
+#: Names the setting that works rather than describing the failure, because
+#: the person who hits this is on an air-gapped deployment and the answer
+#: (``use_cdn=False``) is otherwise only discoverable by reading the source.
+#:
+#: A plain string rather than an f-string: it is interpolated *into* f-strings,
+#: so its braces must not be doubled.
+#:
+#: Lives here rather than beside either renderer because both emit the same
+#: failure, and one wording in two files is one wording that can drift.
+OFFLINE_FALLBACK_REPORT = """
+                        function reportNoRuntime(why) {
+                            console.error(
+                                '[maidr] The chart loaded but its runtime did not: '
+                                + why + '. The CDN was unreachable and the bundled '
+                                + 'copy could not be resolved from inside this frame. '
+                                + 'Re-render with use_cdn=False to inline the bundle, '
+                                + 'which works without network access.'
+                            );
+                        }
+"""

--- a/tests/core/test_offline_fallback_report.py
+++ b/tests/core/test_offline_fallback_report.py
@@ -217,3 +217,14 @@ class TestThePlotlyRenderReportsToo:
         # from either file alone.
         assert marker in self._plotly_rendered(monkeypatch, notebook=False)
         assert marker in _rendered(monkeypatch, notebook=False)
+
+    def test_the_two_notebook_failures_are_told_apart(self, monkeypatch) -> None:
+        """An unreachable parent is not a missing stash.
+
+        Both end the same way -- no runtime -- but they send the reader to
+        different places, so reporting one as the other is worse than
+        generic. Matches how the matplotlib path words the same pair.
+        """
+        document = self._plotly_rendered(monkeypatch, notebook=True)
+        assert "the notebook page has no stashed copy" in document
+        assert "the parent page is unreachable" in document

--- a/tests/core/test_offline_fallback_report.py
+++ b/tests/core/test_offline_fallback_report.py
@@ -195,6 +195,11 @@ class TestThePlotlyRenderReportsToo:
         monkeypatch.setattr(
             "maidr.util.environment.Environment.is_shiny", lambda: False
         )
+        # Pinned like its siblings: a real Flask context would change which
+        # branch renders, so the test should not depend on not being in one.
+        monkeypatch.setattr(
+            "maidr.util.environment.Environment.is_flask", lambda: False
+        )
         document = str(
             maidr.render(px.bar(x=["a"], y=[1]), use_cdn=False).get_html_string()
         )

--- a/tests/core/test_offline_fallback_report.py
+++ b/tests/core/test_offline_fallback_report.py
@@ -29,7 +29,9 @@ import matplotlib.pyplot as plt  # noqa: E402
 
 import maidr  # noqa: E402,F401
 from maidr.core.figure_manager import FigureManager  # noqa: E402
-from maidr.core.maidr import _OFFLINE_FALLBACK_REPORT  # noqa: E402
+from maidr.util.dependencies import (  # noqa: E402
+    OFFLINE_FALLBACK_REPORT as _OFFLINE_FALLBACK_REPORT,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -108,3 +110,48 @@ class TestEveryAutoPathCanReport:
 
         assert "fb.onerror" in rendered
         assert "did not load" in rendered
+
+
+class TestThePlotlyRenderReportsToo:
+    """The same failure reaches Plotly charts, and used to pass in silence.
+
+    Plotly's ``use_cdn="auto"`` loader set the fallback's ``src`` and
+    appended it with no ``onerror`` at all, so a Plotly chart in a Shiny or
+    Flask iframe with no network became an image with no runtime and no
+    explanation -- the matplotlib case, on a path the fix for it did not
+    reach.
+    """
+
+    @staticmethod
+    def _plotly_iframe(monkeypatch) -> str:
+        """Render a Plotly chart on the iframe path and return its document."""
+        import html as html_module
+        import re
+
+        px = pytest.importorskip("plotly.express")
+        from maidr.util.environment import Environment
+
+        monkeypatch.setattr(Environment, "is_shiny", staticmethod(lambda: True))
+        tag = maidr.render(px.bar(x=["a", "b"], y=[1, 2]), use_cdn="auto")
+        html = str(tag.get_html_string())
+        match = re.search(r'srcdoc="(.*?)"\s+width', html, re.S)
+        return html_module.unescape(match.group(1)) if match else html
+
+    def test_the_plotly_render_defines_the_reporter(self, monkeypatch) -> None:
+        assert "function reportNoRuntime" in self._plotly_iframe(monkeypatch)
+
+    def test_the_plotly_fallback_script_reports_on_error(self, monkeypatch) -> None:
+        document = self._plotly_iframe(monkeypatch)
+        assert "fb.onerror" in document
+        assert "reportNoRuntime(" in document.replace("function reportNoRuntime(", "")
+
+    def test_both_renderers_say_the_same_thing(self, monkeypatch) -> None:
+        """One failure, one wording -- the point of sharing the constant.
+
+        Two diagnostics for one failure is the drift this consolidation
+        exists to prevent, and it would be invisible from either file alone.
+        """
+        marker = "The chart loaded but its runtime did not"
+        assert marker in _OFFLINE_FALLBACK_REPORT
+        assert marker in self._plotly_iframe(monkeypatch)
+        assert marker in _rendered(monkeypatch, notebook=False)

--- a/tests/core/test_offline_fallback_report.py
+++ b/tests/core/test_offline_fallback_report.py
@@ -123,8 +123,14 @@ class TestThePlotlyRenderReportsToo:
     """
 
     @staticmethod
-    def _rendered(monkeypatch, *, notebook: bool) -> str:
-        """Render a Plotly chart as the given environment would."""
+    def _plotly_rendered(monkeypatch, *, notebook: bool) -> str:
+        """Render a Plotly chart as the given environment would.
+
+        Named apart from the module-level ``_rendered`` deliberately. A bare
+        ``_rendered(...)`` inside a method resolves to the module-level one
+        -- class scope is not in the lookup chain -- so two same-named
+        helpers read as a typo even where the behaviour is intended.
+        """
         import html as html_module
         import re
 
@@ -154,12 +160,12 @@ class TestThePlotlyRenderReportsToo:
         that mocks only that exercises the relative-path branch twice and
         the notebook branch never.
         """
-        document = self._rendered(monkeypatch, notebook=notebook)
+        document = self._plotly_rendered(monkeypatch, notebook=notebook)
         assert "function reportNoRuntime" in document
 
     @pytest.mark.parametrize("notebook", [True, False])
     def test_every_plotly_auto_path_reports(self, monkeypatch, notebook) -> None:
-        document = self._rendered(monkeypatch, notebook=notebook)
+        document = self._plotly_rendered(monkeypatch, notebook=notebook)
         called = document.replace("function reportNoRuntime(", "")
         assert "reportNoRuntime(" in called
 
@@ -167,7 +173,7 @@ class TestThePlotlyRenderReportsToo:
         self, monkeypatch
     ) -> None:
         """The branch that had no ``onerror`` at all."""
-        document = self._rendered(monkeypatch, notebook=False)
+        document = self._plotly_rendered(monkeypatch, notebook=False)
         assert "fb.onerror" in document
 
     def test_use_cdn_false_still_advises_init_notebook(self, monkeypatch) -> None:
@@ -197,5 +203,7 @@ class TestThePlotlyRenderReportsToo:
         """
         marker = "The chart loaded but its runtime did not"
         assert marker in _OFFLINE_FALLBACK_REPORT
-        assert marker in self._rendered(monkeypatch, notebook=False)
+        # One from each renderer: the drift this guards against is invisible
+        # from either file alone.
+        assert marker in self._plotly_rendered(monkeypatch, notebook=False)
         assert marker in _rendered(monkeypatch, notebook=False)

--- a/tests/core/test_offline_fallback_report.py
+++ b/tests/core/test_offline_fallback_report.py
@@ -148,7 +148,12 @@ class TestThePlotlyRenderReportsToo:
         tag = maidr.render(px.bar(x=["a", "b"], y=[1, 2]), use_cdn="auto")
         html = str(tag.get_html_string())
         match = re.search(r'srcdoc="(.*?)"\s+width', html, re.S)
-        return html_module.unescape(match.group(1)) if match else html
+        # Asserted rather than fallen back from: both environments here
+        # produce an iframe, so a miss means the attribute order moved --
+        # and returning the outer HTML would quietly check the wrong
+        # document while still passing.
+        assert match is not None, "could not find the iframe's srcdoc"
+        return html_module.unescape(match.group(1))
 
     @pytest.mark.parametrize("notebook", [True, False])
     def test_every_plotly_auto_path_defines_the_reporter(

--- a/tests/core/test_offline_fallback_report.py
+++ b/tests/core/test_offline_fallback_report.py
@@ -113,37 +113,81 @@ class TestEveryAutoPathCanReport:
 
 
 class TestThePlotlyRenderReportsToo:
-    """The same failure reaches Plotly charts, and used to pass in silence.
+    """The same failure reaches Plotly charts, on both of its loader paths.
 
-    Plotly's ``use_cdn="auto"`` loader set the fallback's ``src`` and
-    appended it with no ``onerror`` at all, so a Plotly chart in a Shiny or
-    Flask iframe with no network became an image with no runtime and no
-    explanation -- the matplotlib case, on a path the fix for it did not
-    reach.
+    Plotly has the two branches matplotlib has -- the notebook one reading
+    the parent-window stash, and the one falling back to a relative path --
+    and neither reported. A Plotly chart with no network became an image
+    with no runtime and no explanation, which is the matplotlib case on a
+    path the fix for it did not reach.
     """
 
     @staticmethod
-    def _plotly_iframe(monkeypatch) -> str:
-        """Render a Plotly chart on the iframe path and return its document."""
+    def _rendered(monkeypatch, *, notebook: bool) -> str:
+        """Render a Plotly chart as the given environment would."""
         import html as html_module
         import re
 
         px = pytest.importorskip("plotly.express")
-        from maidr.util.environment import Environment
+        monkeypatch.setattr(
+            "maidr.util.environment.Environment.is_notebook", lambda: notebook
+        )
+        monkeypatch.setattr(
+            "maidr.util.environment.Environment.is_shiny", lambda: not notebook
+        )
+        monkeypatch.setattr(
+            "maidr.util.environment.Environment.is_flask", lambda: False
+        )
 
-        monkeypatch.setattr(Environment, "is_shiny", staticmethod(lambda: True))
         tag = maidr.render(px.bar(x=["a", "b"], y=[1, 2]), use_cdn="auto")
         html = str(tag.get_html_string())
         match = re.search(r'srcdoc="(.*?)"\s+width', html, re.S)
         return html_module.unescape(match.group(1)) if match else html
 
-    def test_the_plotly_render_defines_the_reporter(self, monkeypatch) -> None:
-        assert "function reportNoRuntime" in self._plotly_iframe(monkeypatch)
+    @pytest.mark.parametrize("notebook", [True, False])
+    def test_every_plotly_auto_path_defines_the_reporter(
+        self, monkeypatch, notebook
+    ) -> None:
+        """Parametrized because only one of the two paths was covered.
 
-    def test_the_plotly_fallback_script_reports_on_error(self, monkeypatch) -> None:
-        document = self._plotly_iframe(monkeypatch)
+        Forcing ``is_shiny`` alone leaves ``is_notebook`` false, so a test
+        that mocks only that exercises the relative-path branch twice and
+        the notebook branch never.
+        """
+        document = self._rendered(monkeypatch, notebook=notebook)
+        assert "function reportNoRuntime" in document
+
+    @pytest.mark.parametrize("notebook", [True, False])
+    def test_every_plotly_auto_path_reports(self, monkeypatch, notebook) -> None:
+        document = self._rendered(monkeypatch, notebook=notebook)
+        called = document.replace("function reportNoRuntime(", "")
+        assert "reportNoRuntime(" in called
+
+    def test_the_iframe_path_reports_a_dead_relative_fallback(
+        self, monkeypatch
+    ) -> None:
+        """The branch that had no ``onerror`` at all."""
+        document = self._rendered(monkeypatch, notebook=False)
         assert "fb.onerror" in document
-        assert "reportNoRuntime(" in document.replace("function reportNoRuntime(", "")
+
+    def test_use_cdn_false_still_advises_init_notebook(self, monkeypatch) -> None:
+        """The two modes fail for different reasons and need different advice.
+
+        A caller who already passed ``use_cdn=False`` is not helped by being
+        told to pass ``use_cdn=False``; what they need is
+        ``init_notebook()``. Sharing one message would have cost them that.
+        """
+        px = pytest.importorskip("plotly.express")
+        monkeypatch.setattr(
+            "maidr.util.environment.Environment.is_notebook", lambda: True
+        )
+        monkeypatch.setattr(
+            "maidr.util.environment.Environment.is_shiny", lambda: False
+        )
+        document = str(
+            maidr.render(px.bar(x=["a"], y=[1]), use_cdn=False).get_html_string()
+        )
+        assert "init_notebook()" in document
 
     def test_both_renderers_say_the_same_thing(self, monkeypatch) -> None:
         """One failure, one wording -- the point of sharing the constant.
@@ -153,5 +197,5 @@ class TestThePlotlyRenderReportsToo:
         """
         marker = "The chart loaded but its runtime did not"
         assert marker in _OFFLINE_FALLBACK_REPORT
-        assert marker in self._plotly_iframe(monkeypatch)
+        assert marker in self._rendered(monkeypatch, notebook=False)
         assert marker in _rendered(monkeypatch, notebook=False)


### PR DESCRIPTION
## Description

Rebased onto `main` and cut down to the half that #468 did not cover.

#468 gave the **matplotlib** loader a `reportNoRuntime` for the case where neither the CDN nor the bundled fallback loads. The **Plotly** loader has the same shape and the same failure, and is still uncovered on `main`:

```js
s.onerror = function() {
    var fb = document.createElement('script');
    fb.src = '{bundled_js_rel}';
    document.head.appendChild(fb);      // no onerror at all
};
```

So a Plotly chart in a Shiny or Flask iframe with no network becomes an image with no MAIDR runtime — no sonification, no braille, no keyboard navigation — and says nothing. Exactly what #468 fixed, one file over.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Partially addresses #455, alongside #468.

## Changes Made

- **`maidr/util/dependencies.py`** — `_OFFLINE_FALLBACK_REPORT` moves here from `maidr/core/maidr.py` as `OFFLINE_FALLBACK_REPORT`. Both renderers already import from this module; leaving it beside one of them would mean the Plotly path importing from `maidr.core` for a JS string, or a second wording.
- **`maidr/plotly/plotly_maidr.py`** — defines the reporter in its loader and calls it from a new `fb.onerror`.
- **`maidr/core/maidr.py`** — import site only; the emitted script is byte-identical.

Verified both renderers now define the helper, call it, and say the same thing.

### What changed since the first version of this PR

The original also patched `maidr/core/maidr.py` with a separately-worded `NO_RUNTIME_CONSOLE_ERROR`. #468 landed the same fix there ~5 hours before this PR was opened, and I had not re-checked `main` between filing #455 and starting. Merging that would have put **two differently-worded diagnostics** on one failure — the drift the second commit claimed to be preventing, reintroduced under another name. Both the matplotlib hunk and the second constant are gone.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable — no user-facing API changed.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

**Verification.** `uv run pytest` — 2198 passed (from 2194; 4 new). `ruff check` and `uv lock --check` clean.

Tests extend `tests/core/test_offline_fallback_report.py` rather than adding a parallel file, so the two renderers' coverage sits together. Removing the new `fb.onerror` fails `test_the_plotly_fallback_script_reports_on_error`, and `test_both_renderers_say_the_same_thing` asserts the shared constant's wording reaches *both* emitted documents — the drift check neither file could make on its own.

**Not verified in a browser.** The assertions are about emitted script text. That a 404 on a `<script>` fires `onerror` is the one behavioural assumption underneath this that nothing here proves.