### PR TITLE
fix(shiny): let @output_args size a chart in Shiny Express

### DIFF
--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -1176,6 +1176,19 @@ serves, so the bundled `maidr.js` travels inline in the document -- correct
 offline, but roughly 2 MB per chart. The default (`"auto"`) loads from the
 CDN and stays around 30 KB.
 
+In Shiny Express there is no separate UI call: the decorated function places
+its own container, and `@output_args()` sizes it, exactly as it does for
+`@render.plot`.
+
+```python
+from shiny.express import output_args
+
+@output_args(width="600px")
+@render_maidr
+def bars():
+    ...
+```
+
 Check out [a reactive Shiny dashboard example with maidr](https://xabilitylab.shinyapps.io/a11y_dashboard/) and its source code is available on [GitHub](https://github.com/xability/a11y_dashboard).
 
 ### Streamlit

--- a/maidr/widget/shiny.py
+++ b/maidr/widget/shiny.py
@@ -273,9 +273,32 @@ class render_maidr(Renderer[Any]):
         self.use_cdn = use_cdn
         super().__init__(_fn)
 
-    def auto_output_ui(self) -> Tag:
-        """Return the container Shiny Express places for this output."""
-        return output_maidr(self.output_id, width=self.width, height=self.height)
+    def auto_output_ui(self, **kwargs: Any) -> Tag:
+        """Return the container Shiny Express places for this output.
+
+        Parameters
+        ----------
+        **kwargs : Any
+            Arguments for :func:`output_maidr`, supplied by
+            :func:`shiny.express.output_args` and taking precedence over
+            the ones given to the decorator.  Shiny splats
+            ``@output_args(...)`` into this method, so a renderer whose
+            signature takes nothing raises ``TypeError`` there --
+            ``shiny.render.plot`` accepts ``**kwargs`` here for the same
+            reason.
+
+        Returns
+        -------
+        htmltools.Tag
+            The output container.
+        """
+        # `setdefault` rather than Shiny's `set_kwargs_value` helper: that
+        # one exists to skip `MISSING`/`None` so an unset argument does not
+        # override the UI function's own default, and neither of these can
+        # be either.
+        kwargs.setdefault("width", self.width)
+        kwargs.setdefault("height", self.height)
+        return output_maidr(self.output_id, **kwargs)
 
     async def render(self) -> Optional[Jsonifiable]:
         """

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -125,6 +125,47 @@ def test_auto_output_ui_delegates_to_output_maidr(fake_session):
     assert "height: 7em" in rendered
 
 
+def test_output_args_reaches_the_container(fake_session):
+    """``@output_args`` is Shiny's documented way to size an Express output.
+
+    Shiny splats it into ``auto_output_ui``, so a renderer that takes no
+    keywords there raises ``TypeError`` -- which is what this one did, and
+    is why ``shiny.render.plot`` accepts ``**kwargs``.  Driven through
+    ``_render_auto_output_ui`` rather than ``auto_output_ui`` directly,
+    since that splat is the step being tested.
+    """
+    from shiny.express import output_args
+
+    @output_args(width="50%")
+    @render_maidr(width="42px", height="7em")
+    def sized():
+        return _bar_axes()
+
+    rendered = str(sized._render_auto_output_ui())
+    assert "width: 50%" in rendered
+    # Unmentioned arguments still come from the decorator: `@output_args`
+    # overrides, it does not reset.
+    assert "height: 7em" in rendered
+
+
+def test_an_unknown_output_arg_names_the_ui_function(fake_session):
+    """Forwarded rather than swallowed, so a typo is not silence.
+
+    ``output_maidr`` takes a deliberately narrow set of arguments, and a
+    keyword it does not know is a mistake worth raising -- an
+    ``**kwargs``-absorbing container would drop it on the floor.
+    """
+    from shiny.express import output_args
+
+    @output_args(not_an_argument=1)
+    @render_maidr
+    def sized():
+        return _bar_axes()
+
+    with pytest.raises(TypeError, match="output_maidr"):
+        sized._render_auto_output_ui()
+
+
 def test_output_maidr_applies_module_namespacing():
     """A module's output id is namespaced, so modules keep working."""
     with module.namespace_context("mod1"):


### PR DESCRIPTION
## Description

`shiny.express.output_args()` is Shiny's documented way to pass UI arguments to a renderer that places its own container. It works by splatting its keywords into the renderer's `auto_output_ui()`:

```python
# shiny/render/renderer/_renderer.py
def _render_auto_output_ui(self):
    with session_context(self._session):
        return self.auto_output_ui(
            # Pass the `@output_args(foo="bar")` kwargs through to the auto_output_ui function.
            **self._auto_output_ui_kwargs,
        )
```

`render_maidr.auto_output_ui()` took no keywords, so in Shiny Express:

```python
from shiny.express import output_args

@output_args(width="50%")
@render_maidr
def bars():
    ...
```

```
TypeError: render_maidr.auto_output_ui() got an unexpected keyword argument 'width'
```

`shiny.render.plot` accepts `**kwargs` there for exactly this reason — it is the precedent this integration was built against, and this is the piece of that contract it had missed.

### Precedence

`@output_args` overrides the decorator; it does not reset it. Given `@output_args(width="50%")` over `@render_maidr(width="42px", height="7em")`, the container is `width: 50%; height: 7em`.

Implemented with `kwargs.setdefault` rather than Shiny's `set_kwargs_value` helper. That helper exists to skip `MISSING`/`None` so an unset argument does not override the UI function's own default, and `render_maidr`'s `width`/`height` are plain strings that can be neither — the two behave identically here, and the simpler one does not reach into a private module.

### Unknown keywords

`output_maidr` keeps its narrow signature, so a keyword it does not know raises there:

```
TypeError: output_maidr() got an unexpected keyword argument 'bogus'
```

An `**kwargs`-absorbing container would have dropped a typo on the floor instead, which for a sizing argument means silently getting the wrong layout.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made

- `maidr/widget/shiny.py` — `auto_output_ui` accepts and forwards `**kwargs`.
- `tests/widget/test_shiny.py` — two tests, driven through `_render_auto_output_ui` since the splat is the step under test. Both fail on `main`.
- `docs/examples.qmd` — the Shiny section only showed Core mode; adds the Express spelling.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — 2205 passed, 1 skipped. `ruff check` clean.

Verified against py-shiny 1.6.1 by driving the real `_render_auto_output_ui` rather than a stand-in, so the test fails if upstream stops splatting.

Nothing here was checked in a browser: the assertions are on the emitted container markup, not on how it lays out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_