### PR TITLE
refactor: drop the useless matplotlib guard in `_activate_backend`

### DIFF
--- a/maidr/__init__.py
+++ b/maidr/__init__.py
@@ -69,11 +69,7 @@ def _activate_backend() -> None:
     """
     global _original_backend, _backend_message_shown
 
-    try:
-        import matplotlib
-    except ImportError:
-        # matplotlib is not installed — nothing to activate.
-        return
+    import matplotlib
 
     # Save the original backend once, before we override it.
     # Guard against saving our own backend (could happen if _activate_backend


### PR DESCRIPTION
## Description

`_activate_backend` opened with:

```python
try:
    import matplotlib
except ImportError:
    # matplotlib is not installed — nothing to activate.
    return
```

The branch is reachable, and it cannot do what it says.

`_activate_backend()` is called twice. The first call is `maidr/__init__.py:192`, two lines before `from .api import (...)` at 194 — so with matplotlib missing it really does catch and return. Then line 194 runs, `maidr/api.py:8` imports `matplotlib.axes` at module scope, and `import maidr` fails anyway. All the guard buys is a traceback pointing at `api.py` rather than at the line that actually wanted matplotlib. By the second call (line 248) matplotlib is loaded and the branch is dead.

Since #474 matplotlib is a declared base dependency, so the configuration it defends against is not a supported one either.

The reason to remove it is the comment rather than the branch. It tells the next reader that maidr is built to run without matplotlib and degrade gracefully. Nothing in this codebase does: the model layer, `FigureManager` and nearly every module under `maidr/patch/` import it unconditionally. Anyone acting on that belief — adding a matching guard elsewhere, or looking for the code path that serves the matplotlib-less user — is working from a premise the guard invents.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor

## Related Issues

Closes #475. Raised in review of #474 and deliberately not bundled there: that commit is a `fix` and this is a `refactor`, and semantic-release reads the two differently.

## Changes Made

- `maidr/__init__.py` — five lines become one `import matplotlib`.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — 2205 passed, 1 skipped, including the four `tests/test_backend.py` tests that drive `_activate_backend` directly. `ruff check` clean on the edited file.

No test accompanies this. On any supported install nothing observable changes; the one difference is in an install that #474 made impossible, where the `ModuleNotFoundError` now names `maidr/__init__.py` instead of `maidr/api.py`. That is the point of the change rather than a side effect of it, and it is not a state a test can construct from inside a suite that has matplotlib installed.

The first revision of this PR claimed the branch was unreachable, having read only the second call site. It is reachable; it is merely useless. Corrected in `5268d5b` — the change is the same, the reason for it is not.