### PR TITLE
refactor: drop the unreachable pyplot guard in `set_backend`

### DIFF
--- a/maidr/__init__.py
+++ b/maidr/__init__.py
@@ -155,11 +155,7 @@ def set_backend(use_maidr: bool = True) -> None:
     active backend.  ``set_backend`` only controls the behavior of
     ``plt.show()``.
     """
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError:
-        _logger.debug("matplotlib is not installed; cannot set backend.")
-        return
+    import matplotlib.pyplot as plt
 
     if use_maidr:
         plt.switch_backend("module://maidr.backend")


### PR DESCRIPTION
## Description

The public `set_backend()` opened with:

```python
try:
    import matplotlib.pyplot as plt
except ImportError:
    _logger.debug("matplotlib is not installed; cannot set backend.")
    return
```

`set_backend()` is reachable only after `import maidr` has succeeded, and `import maidr` loads pyplot on the way through — the "Matplotlib backend activation" block at the top of this same file exists to work around exactly that (`maidr.core.maidr` imports pyplot, which is why `_activate_backend()` has to be called twice). Verified:

```console
$ python -c "import sys; import maidr; print('matplotlib.pyplot' in sys.modules)"
True
```

So the `import` there is a `sys.modules` lookup and cannot raise `ImportError`.

Unlike the sibling guard removed in #476, this one is on public API, and the way it would fail is the reason it is worth removing rather than leaving alone: `return` is `set_backend`'s ordinary return, so a caller would get `None` back — indistinguishable from success — having changed no backend, told only at `DEBUG`, which is off by default. Silence is the worst available answer for a function whose entire job is a side effect.

`_activate_backend` already imports pyplot unguarded a few lines above (`maidr/__init__.py:91`), so this also makes the two agree.

Left alone: the `try`/`except ImportError` further down in `_activate_backend`, around the backend switch. That one guards a missing `maidr.backend` entry point, which is a different and still-reachable condition.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor

## Related Issues

Closes #477. Raised in review of #476 and kept out of it: that PR was scoped to an internal helper, and this touches public API.

## Changes Made

- `maidr/__init__.py` — five lines become one `import matplotlib.pyplot as plt`. `_logger` is still used elsewhere in the module, so the import stays.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — 2205 passed, 1 skipped. `ruff check` clean.

`tests/test_backend.py::TestSetBackend` covers the changed function directly — eight tests including both directions, a round trip, the idempotent repeat, and the Jupyter `%matplotlib inline` path.

No test is added. The removed branch cannot be entered, and a suite that can `import maidr` at all is a suite where pyplot is loaded — constructing the case would mean faking the very condition the change says is impossible.

*(An earlier revision of this section claimed `tests/test_backend.py` drives `_activate_backend` rather than `set_backend`, and offered a manual smoke test in place of coverage that already exists. It covers both; the smoke test was redundant, not a substitute.)*