### PR TITLE
test(streamlit): cover the `components.v1.html` fallback end to end

### DIFF
--- a/tests/widget/test_streamlit.py
+++ b/tests/widget/test_streamlit.py
@@ -406,20 +406,15 @@ def test_a_normal_render_is_recognised_as_having_a_runtime(bar_axes, use_cdn):
     assert not [w for w in caught if "no source for maidr.js" in str(w.message)]
 
 
-def test_a_real_streamlit_app_embeds_the_chart_as_srcdoc(monkeypatch):
-    """Drive the real Streamlit, not a stub, once end to end.
+def _run_smoke_app(monkeypatch):
+    """Run the smoke app under Streamlit's own script runner.
 
-    The stubbed dispatch tests assert which function is called with which
-    arguments; they cannot see what Streamlit then *does* with them. This
-    is the check that ``st.iframe``'s positional argument really carries a
-    self-contained document into the frame's ``srcdoc`` rather than being
-    treated as a URL -- a mistake that would raise nothing in Python and
-    show up only as a blank embed in a browser.
+    Returns the emitted ``IFrame`` proto.  Which of the two embedding APIs
+    produced it depends on the installed Streamlit, and deliberately is not
+    asserted here -- both marshal into the same proto, which is what lets
+    one set of assertions cover both.
     """
-    st = pytest.importorskip("streamlit")
-    if not hasattr(st, "iframe"):
-        pytest.skip("this Streamlit predates st.iframe; the fallback covers it")
-
+    pytest.importorskip("streamlit")
     from streamlit.testing.v1 import AppTest
 
     monkeypatch.setenv("MAIDR_CDN_VERSION", "latest")
@@ -428,12 +423,53 @@ def test_a_real_streamlit_app_embeds_the_chart_as_srcdoc(monkeypatch):
 
     assert list(at.exception) == []
 
-    proto = at.get("iframe")[0].proto
+    frames = at.get("iframe")
+    assert len(frames) == 1, f"expected one embed, got {len(frames)}"
+    return frames[0].proto
+
+
+def test_a_real_streamlit_app_embeds_the_chart_as_srcdoc(monkeypatch):
+    """Drive the real Streamlit, not a stub, once end to end.
+
+    The stubbed dispatch tests assert which function is called with which
+    arguments; they cannot see what Streamlit then *does* with them. This
+    is the check that the HTML really carries a self-contained document
+    into the frame's ``srcdoc`` rather than being treated as a URL -- a
+    mistake that would raise nothing in Python and show up only as a blank
+    embed in a browser.
+
+    Runs on whichever embedding API the installed Streamlit provides.
+    ``st.iframe`` arrived in 1.56, and the extra allows 1.30, so on an
+    older one this exercises the ``components.v1.html`` fallback instead --
+    the path every user on a pre-1.56 Streamlit takes, and the one that had
+    no end-to-end coverage at all while this test skipped itself there.
+    """
+    proto = _run_smoke_app(monkeypatch)
+
     assert not proto.src, "the HTML was treated as a URL, not as a document"
     assert proto.srcdoc, "no document reached the frame"
     # The chart and its runtime both have to survive the trip.
     assert "maidr=" in proto.srcdoc
     assert "cdn.jsdelivr" in proto.srcdoc
+
+
+def test_a_real_streamlit_app_leaves_tab_index_unset(monkeypatch):
+    """``tab_index=None`` has to reach the frame as *absent*, not as 0.
+
+    The two mean different things -- absent is the browser default, 0 makes
+    the frame itself a tab stop ahead of the chart inside it -- and a
+    protobuf scalar cannot tell them apart on its own. The field is
+    declared with explicit presence, so ``HasField`` can; a Streamlit that
+    dropped that would silently turn the default into an extra tab stop on
+    every chart.
+    """
+    proto = _run_smoke_app(monkeypatch)
+
+    assert proto.DESCRIPTOR.fields_by_name["tab_index"].has_presence, (
+        "IFrame.tab_index lost explicit presence; unset is now "
+        "indistinguishable from 0 and the default cannot be checked"
+    )
+    assert not proto.HasField("tab_index")
 
 
 def test_tab_index_support_is_detected_on_the_real_streamlit():


### PR DESCRIPTION
## Description

`test_a_real_streamlit_app_embeds_the_chart_as_srcdoc` — the only test that drives a real Streamlit rather than a stub — opened with:

```python
if not hasattr(st, "iframe"):
    pytest.skip("this Streamlit predates st.iframe; the fallback covers it")
```

Nothing covers it. The fallback has stub coverage only, and the stubs assert *which function is called with which arguments*, which is the one thing that cannot go wrong silently. What can go wrong silently is what Streamlit then does with the HTML — and that was checked on exactly one of the two paths.

It matters more than "an old Streamlit" suggests: the `streamlit` extra allows `>=1.30`, `st.iframe` arrived in 1.56, and **CI's own Python 3.9 job resolves streamlit 1.50** (`uv.lock`). So the job most likely to catch a version-sensitive break was the one job where this test skipped itself.

Both APIs marshal into the same `IFrame` proto, so the skip buys nothing. Removing it makes the 3.9 job exercise the fallback for real while 3.10–3.12 keep exercising `st.iframe`, from one set of assertions.

Verified on both, locally:

| Python | Streamlit | path taken | before | after |
|---|---|---|---|---|
| 3.9 | 1.50.0 | `components.v1.html` | `SKIPPED` | `passed` |
| 3.11 | 1.61.1 | `st.iframe` | passed | passed |

### A second assertion, on `tab_index`

`render_maidr`'s `tab_index` defaults to `None`, documented as the browser default, on the reasoning that an iframe's contents already take part in sequential focus navigation and maidr gives the chart its own tab stop — so `0` would put one extra Tab in front of every chart, announced with Streamlit's hardcoded frame name.

That default only holds if `None` reaches the frame as *absent*. A protobuf scalar cannot express absence on its own, and `IFrame.tab_index` reads as `0` when unset — the very value the default exists to avoid. It survives because the field is declared with explicit presence, so `HasField` can tell them apart. The new test asserts both: that presence is still tracked, and that nothing set the field.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Test coverage

## Changes Made

- `tests/widget/test_streamlit.py` — the skip becomes coverage; the app run moves into a `_run_smoke_app` helper, which also asserts exactly one embed is emitted; one new test for the `tab_index` default.

No production code changed.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — 2206 passed, 1 skipped. `ruff check` clean.

Confirmed the change is load-bearing rather than cosmetic: on Python 3.9 with streamlit 1.50, `main` reports

```
SKIPPED [1] tests/widget/test_streamlit.py:421: this Streamlit predates st.iframe; the fallback covers it
```

and this branch reports `3 passed`.

One thing a test cannot reach, so as not to imply it is covered: the fallback's `_LEGACY_FALLBACK_HEIGHT`. Streamlit carries width and height in the element's `LayoutConfig` rather than on the `IFrame` proto, and `AppTest` exposes only the proto — so whether the 600 px lands is still unverified here, as is anything about how the embed actually lays out.

Found while driving the #459 integration against a real Streamlit install for the first time, which also confirmed the pieces it rests on: `st.iframe` routes a raw HTML string to `srcdoc` rather than `src`, and `height="content"` measurement is available only on that srcdoc path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_