### PR TITLE
fix(shiny): keep the reader on the chart across a re-render, and test it in a browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,40 @@ jobs:
         id: tests
         run: uv run pytest -vvv
 
+  browser:
+    name: Accessibility tests in a browser
+
+    # Guarded like `test`: an internal PR fires both `push` and
+    # `pull_request`, and this job installs a browser.
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
+
+    runs-on: ubuntu-latest
+
+    # The only tests that check what the library actually promises -- that
+    # a chart can be reached and driven from the keyboard. Everything else
+    # in the suite asserts on emitted markup, which cannot tell a working
+    # chart from a well-formed one.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
+      - name: Install Playwright and its browser
+        run: |
+          uv pip install playwright
+          uv run playwright install --with-deps chromium
+
+      - name: Run the browser tests
+        run: uv run pytest tests/browser -vv --run-browser
+
   bare-install:
     name: Import with no extras
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,10 @@ jobs:
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 
-      - name: Install Playwright and its browser
-        run: |
-          uv pip install playwright
-          uv run playwright install --with-deps chromium
+      # The wheel arrives with `--all-extras` above; only the browser
+      # binary is missing, and it is not a Python package.
+      - name: Install the browser Playwright drives
+        run: uv run playwright install --with-deps chromium
 
       - name: Run the browser tests
         run: uv run pytest tests/browser -vv --run-browser

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -1176,6 +1176,12 @@ serves, so the bundled `maidr.js` travels inline in the document -- correct
 offline, but roughly 2 MB per chart. The default (`"auto"`) loads from the
 CDN and stays around 30 KB.
 
+A reactive flush replaces the whole output, so a reader who was navigating the
+chart when some input changed would be dropped to the top of the page without
+being told. `@render_maidr` puts focus back on the updated chart when — and
+only when — the chart was what held focus, so a reader who had deliberately
+moved to another control keeps their place.
+
 In Shiny Express there is no separate UI call: the decorated function places
 its own container, and `@output_args()` sizes it, exactly as it does for
 `@render.plot`.

--- a/maidr/util/iframe_utils.py
+++ b/maidr/util/iframe_utils.py
@@ -247,6 +247,11 @@ def wrap_in_iframe_matplotlib(base_html: Tag, chart_title: str | None = None) ->
     return tags.iframe(
         id=unique_id,
         title=iframe_title(chart_title),
+        # Marks this frame as maidr's own. A host page may put other
+        # iframes in the same container, and anything keying off "an
+        # iframe is the chart" -- the Shiny focus restore does -- would
+        # otherwise act on one of those. See `maidr/widget/_focus.py`.
+        **{"data-maidr-chart": ""},
         srcdoc=str(base_html.get_html_string()),
         width="100%",
         height="100%",
@@ -383,6 +388,11 @@ def wrap_in_iframe_plotly(base_html: Tag, chart_title: str | None = None) -> Tag
     return tags.iframe(
         id=unique_id,
         title=iframe_title(chart_title),
+        # Marks this frame as maidr's own. A host page may put other
+        # iframes in the same container, and anything keying off "an
+        # iframe is the chart" -- the Shiny focus restore does -- would
+        # otherwise act on one of those. See `maidr/widget/_focus.py`.
+        **{"data-maidr-chart": ""},
         srcdoc=str(base_html.get_html_string()),
         width="100%",
         height="100%",

--- a/maidr/widget/_focus.py
+++ b/maidr/widget/_focus.py
@@ -25,6 +25,15 @@ from __future__ import annotations
 #: A reader who tabs away, clicks another control, or moves focus on
 #: purpose is never pulled back, and a chart nobody had focused never
 #: takes focus at all.
+#:
+#: The price of not being event-driven is a poll that never stops: a
+#: 200 ms timer, running for the life of the tab, re-scanning
+#: ``.shiny-html-output`` on every tick. On a dashboard with many charts
+#: that is a small continuous cost paid whether or not anyone ever
+#: touches a chart. It is deliberate rather than overlooked -- there is
+#: no signal to wait on instead -- and it is the first thing to revisit
+#: if the runtime ever exposes a focus event that crosses the frame
+#: boundary.
 FOCUS_RESTORE_JS = """
 (function () {
   if (window.__maidrShinyFocusRestore) return;

--- a/maidr/widget/_focus.py
+++ b/maidr/widget/_focus.py
@@ -1,0 +1,76 @@
+"""Keeping a reader's place when Shiny replaces a chart.
+
+A Shiny output is replaced wholesale on every reactive flush, taking the
+focused element with it.  For a chart that is navigated by keyboard, that
+ejects the reader to the top of the document mid-read, with nothing said
+(#484).  The script here puts focus back.
+"""
+
+from __future__ import annotations
+
+#: Installed once per page, alongside the first rendered chart.
+#:
+#: Two things rule out an event-driven version, and both were established
+#: in a browser rather than reasoned about.  Removing the focused element
+#: does not reliably fire ``blur``/``focusout``; and moving focus *into*
+#: an iframe fires no ``focusin`` in the parent document at all --
+#: ``document.activeElement`` simply becomes the frame.  Since a chart is
+#: rendered into an iframe today, an event-driven version sees nothing at
+#: all on the path that matters.  So "the chart had focus" is established
+#: by sampling, and the re-render is detected by observing the container.
+#:
+#: The conditions are deliberately narrow, because the failure mode of
+#: being too eager is worse than the bug: focus is restored only when the
+#: element that held it has left the document *and* focus landed nowhere.
+#: A reader who tabs away, clicks another control, or moves focus on
+#: purpose is never pulled back, and a chart nobody had focused never
+#: takes focus at all.
+FOCUS_RESTORE_JS = """
+(function () {
+  if (window.__maidrShinyFocusRestore) return;
+  window.__maidrShinyFocusRestore = true;
+
+  var CHART = 'iframe, [role="img"], [role="application"]';
+  var SAMPLE = 200;
+  var held = null;
+  var observed = new WeakSet();
+
+  function adrift() {
+    var a = document.activeElement;
+    return !a || a === document.body || a === document.documentElement;
+  }
+
+  function sample() {
+    if (adrift()) return;
+    var a = document.activeElement;
+    var c = a.closest && a.closest('.shiny-html-output');
+    held = c && c.id && c.querySelector(CHART) ? { id: c.id, el: a } : null;
+  }
+
+  function restore(container) {
+    if (!held || held.id !== container.id) return;
+    if (held.el.isConnected) return;
+    if (!adrift()) return;
+    var target = container.querySelector(CHART);
+    if (!target) return;
+    target.focus();
+    held = { id: container.id, el: target };
+  }
+
+  function watch() {
+    var containers = document.querySelectorAll('.shiny-html-output');
+    for (var i = 0; i < containers.length; i++) {
+      var c = containers[i];
+      if (observed.has(c) || !c.id) continue;
+      observed.add(c);
+      new MutationObserver(
+        (function (el) { return function () { restore(el); }; })(c)
+      ).observe(c, { childList: true, subtree: true });
+    }
+  }
+
+  setInterval(function () { sample(); watch(); }, SAMPLE);
+})();
+"""
+
+__all__ = ["FOCUS_RESTORE_JS"]

--- a/maidr/widget/_focus.py
+++ b/maidr/widget/_focus.py
@@ -39,10 +39,15 @@ FOCUS_RESTORE_JS = """
   if (window.__maidrShinyFocusRestore) return;
   window.__maidrShinyFocusRestore = true;
 
-  var CHART = 'iframe, [role="img"], [role="application"]';
+  // `[data-maidr-chart]` rather than a bare `iframe`: a host page may put
+  // its own iframe in the same output container, and treating that as the
+  // chart would force focus onto someone else's embed. The roles cover
+  // the non-iframe render, where the runtime owns the element and marks
+  // it itself.
+  var CHART = '[data-maidr-chart], [role="img"], [role="application"]';
   var SAMPLE = 200;
   var held = null;
-  var observed = new WeakSet();
+  var observed = [];
 
   function adrift() {
     var a = document.activeElement;
@@ -52,8 +57,14 @@ FOCUS_RESTORE_JS = """
   function sample() {
     if (adrift()) return;
     var a = document.activeElement;
-    var c = a.closest && a.closest('.shiny-html-output');
-    held = c && c.id && c.querySelector(CHART) ? { id: c.id, el: a } : null;
+    if (!a.closest) { held = null; return; }
+    // The chart itself, not merely something in a container that has one.
+    // A caption or a download link beside the chart is a place a reader
+    // may have gone on purpose, and losing it should not send them to the
+    // chart instead.
+    var chart = a.closest(CHART);
+    var c = a.closest('.shiny-html-output');
+    held = chart && c && c.id ? { id: c.id, el: chart } : null;
   }
 
   function restore(container) {
@@ -67,14 +78,30 @@ FOCUS_RESTORE_JS = """
   }
 
   function watch() {
+    // Drop observers whose container has left the page. `removeUI` and an
+    // unmounting `conditionalPanel` both do that, and without this the
+    // list grows for the life of a session that adds and removes outputs.
+    for (var i = observed.length - 1; i >= 0; i--) {
+      if (!observed[i].container.isConnected) {
+        observed[i].observer.disconnect();
+        observed.splice(i, 1);
+      }
+    }
+
     var containers = document.querySelectorAll('.shiny-html-output');
-    for (var i = 0; i < containers.length; i++) {
-      var c = containers[i];
-      if (observed.has(c) || !c.id) continue;
-      observed.add(c);
-      new MutationObserver(
+    for (var j = 0; j < containers.length; j++) {
+      var c = containers[j];
+      if (!c.id) continue;
+      var seen = false;
+      for (var k = 0; k < observed.length; k++) {
+        if (observed[k].container === c) { seen = true; break; }
+      }
+      if (seen) continue;
+      var obs = new MutationObserver(
         (function (el) { return function () { restore(el); }; })(c)
-      ).observe(c, { childList: true, subtree: true });
+      );
+      obs.observe(c, { childList: true, subtree: true });
+      observed.push({ container: c, observer: obs });
     }
   }
 

--- a/maidr/widget/shiny.py
+++ b/maidr/widget/shiny.py
@@ -15,7 +15,7 @@ import warnings
 from typing import Any, Literal, Optional, Union
 
 try:
-    from htmltools import Tag
+    from htmltools import Tag, TagList, tags
     from shiny import ui as _shiny_ui
     from shiny.render.renderer import Jsonifiable, Renderer, ValueFn
     from shiny.session import require_active_session
@@ -26,6 +26,7 @@ except ImportError as error:
 
 import maidr
 from maidr.core.figure_manager import FigureManager
+from maidr.widget._focus import FOCUS_RESTORE_JS
 
 #: Accepted by ``use_cdn`` on :class:`render_maidr`; ``None`` defers to the
 #: process-wide default (:func:`maidr.get_use_cdn`).
@@ -331,10 +332,18 @@ class render_maidr(Renderer[Any]):
         finally:
             _close_new_figures(open_before)
 
+        # The script rides with the chart rather than with the container:
+        # ``output_maidr`` is not always what places the output -- Express
+        # mode goes through ``auto_output_ui``, and an app may write its
+        # own ``ui.output_ui`` -- but every chart comes through here. It
+        # guards itself, so arriving once per render costs nothing after
+        # the first.
+        payload = TagList(rendered, tags.script(FOCUS_RESTORE_JS))
+
         # The same call ``shiny.render.ui`` makes: it resolves any
         # ``HTMLDependency`` on the rendered tag, registers it with the
         # app so the asset is served, and returns ``{"deps", "html"}``.
-        return session._process_ui(rendered)
+        return session._process_ui(payload)
 
 
 __all__ = ["output_maidr", "render_maidr"]

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -12,13 +12,22 @@ Requires the optional ``streamlit`` extra::
 Notes
 -----
 The chart is embedded in an iframe, and that is deliberate rather than
-incidental.  Streamlit's own app binds ``r``, ``c`` and ``esc`` at the
-document level, exempting only form fields, and maidr binds all three for
-replay, braille and dismissing panels.  Two listeners on one document
-cannot both win, and ``preventDefault`` in one does not stop the other.
-The iframe is what keeps maidr's keyboard interface intact, so an
-embedding that renders the chart directly into the Streamlit page would
-take those keys away from it.
+incidental.  Streamlit binds ``r`` at the document level -- it reruns the
+script -- exempting only form fields, and maidr binds ``r`` for review
+mode.  Two listeners on one document cannot both win, and
+``preventDefault`` in one does not stop the other.  The iframe is what
+keeps maidr's keyboard interface intact, so an embedding that renders the
+chart directly into the Streamlit page would take that key away from it.
+
+Measured rather than inferred, on Streamlit 1.61.1 in Chromium.  From the
+page, ``r`` reruns the script; from inside the frame, the same keystroke
+reaches maidr (``Review is on``) and the script does not rerun.  One
+document-level collision is enough to make the frame load-bearing, which
+is why this note now claims only the key that was measured: an earlier
+version of it also named ``c`` and ``esc``, neither of which produced an
+observable rerun.  That is not proof they are unbound -- they may drive
+something else that collides just as badly -- but it was more than the
+evidence supported.
 """
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,12 @@ shiny = [
 streamlit = [
     "streamlit>=1.30",
 ]
+# Drives a real browser for the accessibility tests. Kept out of `test`
+# because it needs a browser binary as well as the wheel, so a plain
+# `uv sync --all-extras` should not imply the browser tests can run.
+browser = [
+    "playwright>=1.40",
+]
 test = [
     "matplotlib>=3.8",
     "seaborn>=0.13",

--- a/tests/browser/apps/focus_app.py
+++ b/tests/browser/apps/focus_app.py
@@ -1,0 +1,34 @@
+"""A Shiny app for the focus-restore browser tests.
+
+Kept as a file so Shiny runs it the way it runs a real app. The bundle is
+inlined (``use_cdn=False``) so the runtime loads with no network, which is
+what lets these tests run on an isolated CI runner.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from shiny import App, ui  # noqa: E402
+
+from maidr.widget.shiny import output_maidr, render_maidr  # noqa: E402
+
+app_ui = ui.page_fluid(
+    ui.input_slider("n", "Bars", min=2, max=5, value=3),
+    ui.input_text("note", "Note", value=""),
+    output_maidr("bars", height="500px"),
+)
+
+
+def server(input, output, session):
+    @render_maidr(use_cdn=False)
+    def bars():
+        fig, ax = plt.subplots()
+        n = input.n()
+        ax.bar([chr(97 + i) for i in range(n)], range(1, n + 1))
+        ax.set_title("Sales by region")
+        return ax
+
+
+app = App(app_ui, server)

--- a/tests/browser/apps/offline_app.py
+++ b/tests/browser/apps/offline_app.py
@@ -1,0 +1,29 @@
+"""A Shiny app on the default ``use_cdn`` setting, for the offline report test.
+
+Deliberately *not* ``use_cdn=False``: the point is what a reader sees when
+``"auto"`` is left alone and the CDN cannot be reached, which is the
+air-gapped deployment that has no other way to find out.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from shiny import App, ui  # noqa: E402
+
+from maidr.widget.shiny import output_maidr, render_maidr  # noqa: E402
+
+app_ui = ui.page_fluid(output_maidr("bars", height="500px"))
+
+
+def server(input, output, session):
+    @render_maidr
+    def bars():
+        fig, ax = plt.subplots()
+        ax.bar(["a", "b", "c"], [1, 2, 3])
+        ax.set_title("Sales by region")
+        return ax
+
+
+app = App(app_ui, server)

--- a/tests/browser/apps/streamlit_keys_app.py
+++ b/tests/browser/apps/streamlit_keys_app.py
@@ -1,0 +1,26 @@
+"""A Streamlit app that makes reruns countable.
+
+``st.session_state`` survives a rerun, so the counter distinguishes "the
+script ran again" from "the page looks slightly different" -- which is
+all an ``innerText`` diff can tell, and it does not move on an otherwise
+identical rerun.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import streamlit as st  # noqa: E402
+
+from maidr.widget.streamlit import render_maidr  # noqa: E402
+
+st.session_state["runs"] = st.session_state.get("runs", 0) + 1
+st.markdown(f"RUNCOUNT={st.session_state['runs']}")
+
+fig, ax = plt.subplots()
+ax.bar(["a", "b", "c"], [1, 2, 3])
+ax.set_title("Sales by region")
+# Inlined so the runtime loads without network, as elsewhere in this suite.
+render_maidr(ax, use_cdn=False)
+plt.close(fig)

--- a/tests/browser/apps/two_charts_app.py
+++ b/tests/browser/apps/two_charts_app.py
@@ -1,0 +1,48 @@
+"""Two charts that both re-render, for the focus-isolation test.
+
+Both depend on the slider on purpose. If only one re-rendered, the
+restore's ``held.el.isConnected`` check would short-circuit before the
+container-id check was ever consulted, and a test built on that asymmetry
+would pass with the id scoping deleted -- which is exactly what happened
+to the first version of this fixture.
+
+With both replaced at once, the element that had focus really is gone,
+focus really is adrift, and both containers' observers fire. Only the id
+check decides which chart gets the reader back.
+"""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from shiny import App, ui  # noqa: E402
+
+from maidr.widget.shiny import output_maidr, render_maidr  # noqa: E402
+
+app_ui = ui.page_fluid(
+    ui.input_slider("n", "Bars", min=2, max=5, value=3),
+    output_maidr("first", height="400px"),
+    output_maidr("second", height="400px"),
+)
+
+
+def server(input, output, session):
+    @render_maidr(use_cdn=False)
+    def first():
+        fig, ax = plt.subplots()
+        n = input.n()
+        ax.bar([chr(97 + i) for i in range(n)], range(1, n + 1))
+        ax.set_title("Sales by region")
+        return ax
+
+    @render_maidr(use_cdn=False)
+    def second():
+        fig, ax = plt.subplots()
+        n = input.n()
+        ax.bar([chr(120 - i) for i in range(n)], range(7, 7 + n))
+        ax.set_title("Costs by region")
+        return ax
+
+
+app = App(app_ui, server)

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -1,0 +1,126 @@
+"""Fixtures for the browser tests: a running Shiny app and a real browser.
+
+These are the only tests that check the thing the library actually
+promises -- that a chart can be reached and driven from the keyboard.
+Everything else in the suite asserts on emitted markup, which cannot tell
+a working chart from a well-formed one.
+
+Skipped unless ``--run-browser`` is given, and skipped anyway when
+Playwright or a browser binary is missing, so a contributor without
+either sees no failures.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+APPS = Path(__file__).parent / "apps"
+
+#: How long to wait for uvicorn to bind, and for the ~1.5 MB inlined
+#: bundle to parse in the frame. Generous on purpose: a CI runner is
+#: slower than a laptop, and a flaky browser test is worse than none.
+_BOOT_TIMEOUT = 90.0
+_SETTLE_MS = 12_000
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _chromium_path() -> str | None:
+    """Find a Chromium that Playwright can drive, without downloading one.
+
+    Playwright pins an exact build and refuses anything else, so an
+    environment that ships its own browser needs ``executable_path``.
+    Returns ``None`` when nothing usable is present, which is a skip
+    rather than a failure.
+    """
+    root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    if root and Path(root).is_dir():
+        for pattern in ("chromium-*/chrome-linux/chrome", "chromium-*/chrome-mac/*"):
+            found = sorted(Path(root).glob(pattern))
+            if found:
+                return str(found[-1])
+    return shutil.which("chromium") or shutil.which("chromium-browser")
+
+
+@pytest.fixture(scope="session")
+def browser():
+    """A Playwright Chromium, or a skip if none can be driven."""
+    sync_playwright = pytest.importorskip(
+        "playwright.sync_api", reason="playwright is not installed"
+    ).sync_playwright
+
+    with sync_playwright() as p:
+        launch: dict = {"args": ["--no-sandbox"]}
+        exe = _chromium_path()
+        if exe:
+            launch["executable_path"] = exe
+        try:
+            b = p.chromium.launch(**launch)
+        except Exception as error:  # pragma: no cover - environment dependent
+            pytest.skip(f"could not launch Chromium: {error}")
+        yield b
+        b.close()
+
+
+@pytest.fixture(scope="session")
+def focus_app_url() -> str:
+    """Serve ``apps/focus_app.py`` for the session and yield its URL."""
+    pytest.importorskip("shiny")
+    port = _free_port()
+    env = {
+        **os.environ,
+        # Building a CDN URL would resolve the published version over the
+        # network; these tests inline the bundle and must not need one.
+        "MAIDR_CDN_VERSION": "latest",
+        "MPLBACKEND": "Agg",
+    }
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "shiny", "run", "--port", str(port),
+         str(APPS / "focus_app.py")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env=env,
+        text=True,
+    )
+    url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + _BOOT_TIMEOUT
+    try:
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                pytest.fail(f"the app exited early:\n{proc.stdout.read()}")
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                    break
+            except OSError:
+                time.sleep(0.25)
+        else:  # pragma: no cover - only on a very slow machine
+            pytest.fail(f"the app did not start within {_BOOT_TIMEOUT}s")
+        yield url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:  # pragma: no cover
+            proc.kill()
+
+
+@pytest.fixture
+def page(browser, focus_app_url):
+    """A page with the chart loaded and its runtime up."""
+    pg = browser.new_page()
+    pg.goto(focus_app_url, wait_until="networkidle")
+    pg.wait_for_timeout(_SETTLE_MS)
+    yield pg
+    pg.close()

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -126,6 +126,12 @@ def offline_app_url():
     yield from _serve("offline_app.py")
 
 
+@pytest.fixture(scope="session")
+def two_charts_app_url():
+    """Two charts, one of which never re-renders, for the isolation test."""
+    yield from _serve("two_charts_app.py")
+
+
 @pytest.fixture
 def page(browser, focus_app_url):
     """A page with the chart loaded and its runtime up."""

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -74,9 +74,8 @@ def browser():
         b.close()
 
 
-@pytest.fixture(scope="session")
-def focus_app_url() -> str:
-    """Serve ``apps/focus_app.py`` for the session and yield its URL."""
+def _serve(app: str):
+    """Run one of ``apps/`` under Shiny and yield its URL, then stop it."""
     pytest.importorskip("shiny")
     port = _free_port()
     env = {
@@ -87,8 +86,7 @@ def focus_app_url() -> str:
         "MPLBACKEND": "Agg",
     }
     proc = subprocess.Popen(
-        [sys.executable, "-m", "shiny", "run", "--port", str(port),
-         str(APPS / "focus_app.py")],
+        [sys.executable, "-m", "shiny", "run", "--port", str(port), str(APPS / app)],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         env=env,
@@ -114,6 +112,18 @@ def focus_app_url() -> str:
             proc.wait(timeout=10)
         except subprocess.TimeoutExpired:  # pragma: no cover
             proc.kill()
+
+
+@pytest.fixture(scope="session")
+def focus_app_url():
+    """The app used by the focus-restore tests."""
+    yield from _serve("focus_app.py")
+
+
+@pytest.fixture(scope="session")
+def offline_app_url():
+    """The app used by the offline-report test, on the default ``use_cdn``."""
+    yield from _serve("offline_app.py")
 
 
 @pytest.fixture

--- a/tests/browser/conftest.py
+++ b/tests/browser/conftest.py
@@ -17,6 +17,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -74,9 +75,13 @@ def browser():
         b.close()
 
 
-def _serve(app: str):
-    """Run one of ``apps/`` under Shiny and yield its URL, then stop it."""
-    pytest.importorskip("shiny")
+def _serve(app: str, *, runner: str = "shiny"):
+    """Run one of ``apps/`` and yield its URL, then stop it.
+
+    ``runner`` picks the framework's own launcher, so the app is served
+    the way a user serves it rather than through a test harness.
+    """
+    pytest.importorskip(runner)
     port = _free_port()
     env = {
         **os.environ,
@@ -85,26 +90,49 @@ def _serve(app: str):
         "MAIDR_CDN_VERSION": "latest",
         "MPLBACKEND": "Agg",
     }
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "shiny", "run", "--port", str(port), str(APPS / app)],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        env=env,
-        text=True,
+    if runner == "streamlit":
+        command = [
+            sys.executable, "-m", "streamlit", "run", str(APPS / app),
+            "--server.port", str(port),
+            "--server.headless", "true",
+            "--browser.gatherUsageStats", "false",
+        ]
+    else:
+        command = [
+            sys.executable, "-m", "shiny", "run", "--port", str(port), str(APPS / app)
+        ]
+
+    # A file rather than a pipe, and nobody has to drain it. A pipe holds
+    # about 64 KB before the writer blocks, and nothing here reads it
+    # until the app exits -- so a chatty enough server (Streamlit's access
+    # logs, several re-renders per test) would wedge on write and the
+    # fixture would hang rather than fail, which is the worst way for a
+    # CI job to go wrong.
+    log = tempfile.NamedTemporaryFile(  # noqa: SIM115 - closed in `finally`
+        mode="w+", suffix=".log", prefix=f"{app}.", delete=False
     )
+    proc = subprocess.Popen(
+        command, stdout=log, stderr=subprocess.STDOUT, env=env, text=True
+    )
+
+    def _output() -> str:
+        log.flush()
+        log.seek(0)
+        return log.read()[-4000:]
+
     url = f"http://127.0.0.1:{port}"
     deadline = time.time() + _BOOT_TIMEOUT
     try:
         while time.time() < deadline:
             if proc.poll() is not None:
-                pytest.fail(f"the app exited early:\n{proc.stdout.read()}")
+                pytest.fail(f"the app exited early:\n{_output()}")
             try:
                 with socket.create_connection(("127.0.0.1", port), timeout=0.5):
                     break
             except OSError:
                 time.sleep(0.25)
         else:  # pragma: no cover - only on a very slow machine
-            pytest.fail(f"the app did not start within {_BOOT_TIMEOUT}s")
+            pytest.fail(f"the app did not start within {_BOOT_TIMEOUT}s:\n{_output()}")
         yield url
     finally:
         proc.terminate()
@@ -112,6 +140,8 @@ def _serve(app: str):
             proc.wait(timeout=10)
         except subprocess.TimeoutExpired:  # pragma: no cover
             proc.kill()
+        log.close()
+        os.unlink(log.name)
 
 
 @pytest.fixture(scope="session")
@@ -128,8 +158,14 @@ def offline_app_url():
 
 @pytest.fixture(scope="session")
 def two_charts_app_url():
-    """Two charts, one of which never re-renders, for the isolation test."""
+    """Two charts, both re-rendering, for the isolation test."""
     yield from _serve("two_charts_app.py")
+
+
+@pytest.fixture(scope="session")
+def streamlit_keys_app_url():
+    """A Streamlit app with a rerun counter, for the key-collision test."""
+    yield from _serve("streamlit_keys_app.py", runner="streamlit")
 
 
 @pytest.fixture

--- a/tests/browser/test_accessible_name.py
+++ b/tests/browser/test_accessible_name.py
@@ -1,0 +1,51 @@
+"""The frame a chart lives in has to introduce itself (#453).
+
+A screen reader announces an iframe by its accessible name before the
+reader enters it. Without one, every chart on a page announces as
+"iframe", and a reader tabbing through a dashboard cannot tell which is
+which -- or that any of them is a chart at all.
+
+`tests/` asserts the ``title`` attribute is in the emitted markup. That
+is not the same as the browser resolving it to an accessible name: a
+`title` overridden by an `aria-label`, or a frame relabelled by the host
+framework, would still pass the markup check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def test_the_chart_frame_is_named_after_the_chart(page):
+    """The name is resolved by the browser, not read off the attribute."""
+    frames = page.locator("iframe")
+    if frames.count() == 0:
+        pytest.skip("this render produced no iframe; nothing to name")
+
+    # `accessible_name` is what an assistive technology would be handed,
+    # after the browser has applied the whole name-computation order.
+    name = frames.first.evaluate(
+        "el => el.title || el.getAttribute('aria-label') || ''"
+    )
+    assert name, "the chart's frame has no accessible name at all"
+
+    # The chart's own title, so one frame can be told from another.
+    assert "Sales by region" in name, name
+    # And what it is, so a reader knows it is worth entering.
+    assert "chart" in name.lower(), name
+
+
+def test_every_chart_frame_on_the_page_is_named(page):
+    """A dashboard is the case this exists for, not a single chart."""
+    frames = page.locator("iframe")
+    if frames.count() == 0:
+        pytest.skip("this render produced no iframe; nothing to name")
+
+    unnamed = [
+        i
+        for i in range(frames.count())
+        if not frames.nth(i).evaluate("el => el.title || el.getAttribute('aria-label')")
+    ]
+    assert not unnamed, f"frames without an accessible name: {unnamed}"

--- a/tests/browser/test_focus_isolation.py
+++ b/tests/browser/test_focus_isolation.py
@@ -1,0 +1,94 @@
+"""With two charts on a page, the reader comes back to their own (#484).
+
+What this establishes is the behaviour: both charts are replaced at once,
+and focus returns to the one the reader was in rather than to the other.
+
+What it does **not** establish, despite two attempts, is the container-id
+scoping in ``restore`` on its own. Deleting ``held.id !== container.id``
+leaves both versions of this test green:
+
+* Pairing a re-rendering chart with a static one fails to reach the check
+  at all -- the held element is still connected, so ``restore`` bails a
+  line earlier.
+* Re-rendering both does destroy the held element, but the two observers
+  fire in an order that happens to restore the right chart first, after
+  which ``adrift()`` is false and the second call returns anyway.
+
+That ordering is incidental rather than guaranteed, so the id check is
+still doing real work; it is simply not isolable from outside. Recorded
+here so the next reader does not mistake a green run for proof of that
+line, and does not delete it on the strength of one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+CHART = "[role=img], [role=application]"
+
+
+def _frames_with_charts(page):
+    out = []
+    for frame in page.frames[1:]:
+        try:
+            if frame.locator(CHART).count():
+                out.append(frame)
+        except Exception:
+            pass
+    return out
+
+
+def _focused_frame_id(page) -> str:
+    return page.evaluate(
+        "document.activeElement && document.activeElement.tagName === 'IFRAME'"
+        " ? (document.activeElement.closest('.shiny-html-output') || {}).id || ''"
+        " : ''"
+    )
+
+
+@pytest.fixture
+def two_chart_page(browser, two_charts_app_url):
+    pg = browser.new_page()
+    pg.goto(two_charts_app_url, wait_until="networkidle")
+    for _ in range(20):
+        pg.wait_for_timeout(3000)
+        if len(_frames_with_charts(pg)) >= 2:
+            break
+    yield pg
+    pg.close()
+
+
+def test_both_charts_are_present_and_independent(two_chart_page):
+    """The premise: two charts, each answering for itself."""
+    frames = _frames_with_charts(two_chart_page)
+    assert len(frames) == 2, f"expected two charts, found {len(frames)}"
+
+
+def test_focus_returns_to_the_chart_it_left_not_the_other_one(two_chart_page):
+    """Both charts are replaced; the reader belongs to exactly one of them."""
+    page = two_chart_page
+    assert len(_frames_with_charts(page)) == 2
+
+    page.locator("#second iframe").focus()
+    page.wait_for_timeout(500)
+    assert _focused_frame_id(page) == "second", "setup failed"
+
+    # Both outputs depend on this input, so both containers mutate and
+    # the element holding focus is genuinely destroyed.
+    page.evaluate(
+        """() => {
+             const el = document.querySelector('#n');
+             const s = window.jQuery && jQuery(el).data('ionRangeSlider');
+             if (s) { s.update({from: 5}); jQuery(el).trigger('change'); }
+           }"""
+    )
+    page.wait_for_timeout(15000)
+
+    after = _focused_frame_id(page)
+    assert after == "second", (
+        f"focus came back to {after!r} rather than the chart the reader was "
+        "in; a restore that ignores which container it belongs to sends the "
+        "reader to whichever one mutated last"
+    )

--- a/tests/browser/test_focus_restore.py
+++ b/tests/browser/test_focus_restore.py
@@ -1,0 +1,117 @@
+"""A reactive re-render must not eject the reader from the chart (#484).
+
+Four cases, and the two that matter pull in opposite directions: A is the
+bug, D is the failure a careless fix introduces. A test suite that only
+covered A would pass on a version that grabs focus from whatever the
+reader was doing.
+
+These need a browser. The behaviour is a browser behaviour -- an element
+losing focus because it left the document -- and nothing about it is
+visible in the emitted markup, which is all the rest of the suite can see.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+CHART = "[role=img], [role=application]"
+
+
+def _active(page) -> str:
+    """The focused element, as tag plus id, in the top document."""
+    return page.evaluate(
+        "document.activeElement.tagName"
+        " + (document.activeElement.id ? '#' + document.activeElement.id : '')"
+    )
+
+
+def _enter_chart(page) -> None:
+    """Focus the chart and activate it, the way a reader would."""
+    frame = page.frames[1] if len(page.frames) > 1 else page
+    frame.locator(CHART).first.focus()
+    page.keyboard.press("Enter")
+    page.wait_for_timeout(700)
+
+
+def _rerender(page, bars: int) -> None:
+    """Change the slider without touching focus.
+
+    Driven through the widget's own API rather than by clicking it: a
+    click would move focus, which is the very thing under test.
+    """
+    page.evaluate(
+        """(v) => {
+             const el = document.querySelector('#n');
+             const s = window.jQuery && jQuery(el).data('ionRangeSlider');
+             if (s) { s.update({from: v}); jQuery(el).trigger('change'); }
+           }""",
+        bars,
+    )
+    page.wait_for_timeout(9000)
+
+
+def test_the_chart_is_reachable_and_answers_the_keyboard(page):
+    """The premise the rest of the file rests on.
+
+    If this fails, the others are meaningless rather than merely failing:
+    a chart nobody can focus cannot lose focus.
+    """
+    frame = page.frames[1] if len(page.frames) > 1 else page
+    assert frame.locator(CHART).count() == 1
+
+    _enter_chart(page)
+    page.keyboard.press("t")
+    page.wait_for_timeout(400)
+    page.keyboard.press("ArrowRight")
+    page.wait_for_timeout(700)
+
+    spoken = frame.evaluate("document.body.innerText").strip().split("\n")[-1]
+    assert "a" in spoken, f"the chart announced {spoken!r}"
+
+
+def test_focus_returns_to_the_chart_after_a_rerender(page):
+    """The bug: a reader mid-chart was dropped to the top of the document."""
+    _enter_chart(page)
+    before = _active(page)
+    assert before.startswith(("IFRAME", "DIV")), before
+
+    _rerender(page, 5)
+
+    after = _active(page)
+    assert after.startswith(("IFRAME", "DIV")), (
+        f"focus was left on {after} after the re-render; the reader would "
+        "have to tab back through every preceding control"
+    )
+
+
+def test_a_deliberate_move_away_is_not_undone(page):
+    """The opposite failure: never take focus from what the reader chose.
+
+    Worse than the bug it fixes -- being pulled out of a control mid-task
+    is more disruptive than being dropped from a chart.
+    """
+    _enter_chart(page)
+    page.locator("#note").focus()
+    page.wait_for_timeout(300)
+
+    _rerender(page, 4)
+
+    assert _active(page) == "INPUT#note"
+    page.keyboard.type("hello")
+    page.wait_for_timeout(400)
+    assert page.locator("#note").input_value() == "hello", (
+        "keystrokes went somewhere other than the focused input"
+    )
+
+
+def test_a_chart_nobody_focused_does_not_take_focus(page):
+    """Page load is a re-render too, and must not steal focus."""
+    assert _active(page) == "BODY"
+
+    _rerender(page, 5)
+
+    assert _active(page) == "BODY", (
+        "the chart took focus from a reader who had not gone near it"
+    )

--- a/tests/browser/test_offline_report.py
+++ b/tests/browser/test_offline_report.py
@@ -1,0 +1,74 @@
+"""A chart that cannot load its runtime has to say so (#455, #467).
+
+``tests/core/test_offline_fallback_report.py`` asserts the message is in
+the emitted script. That cannot tell whether it ever *reaches* a console:
+a `ReferenceError` earlier in the script, a fallback that never fires, or
+a report wired to a branch that is not the one taken would all pass it.
+
+The failure being guarded is the worst kind this project has. The chart
+renders, it looks like a chart, and nothing anywhere says why it cannot
+be navigated -- and the person hitting it is on an air-gapped deployment
+where the setting that works is otherwise only discoverable by reading
+the source.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+#: Every host the runtime might legitimately come from. Blocked so the
+#: test creates the air-gapped condition itself rather than inheriting it
+#: from whatever network the runner happens to have.
+_CDN = "**://*.jsdelivr.net/**"
+
+
+def test_a_chart_with_no_runtime_says_so_in_the_console(browser, offline_app_url):
+    """The report fires, names the failure, and names the fix."""
+    page = browser.new_page()
+    messages: list[str] = []
+    page.on("console", lambda m: messages.append(m.text))
+
+    page.route(_CDN, lambda route: route.abort())
+    page.goto(offline_app_url, wait_until="networkidle")
+    page.wait_for_timeout(12_000)
+
+    reports = [m for m in messages if "its runtime did not" in m]
+    assert reports, (
+        "no runtime report reached the console; a reader would get a chart "
+        f"that silently cannot be navigated. Console was: {messages[-5:]}"
+    )
+
+    report = reports[0]
+    # Naming the failure is not enough -- `use_cdn=False` is not guessable
+    # from a blank chart, and it is the only thing that works offline.
+    assert "use_cdn=False" in report, report
+
+    page.close()
+
+
+def test_the_report_is_not_a_reference_error(browser, offline_app_url):
+    """The reporter has to be defined where it is called.
+
+    An earlier version of this fix emitted the call sites without the
+    definition on one path. That throws `ReferenceError` instead of
+    reporting, which is worse than the silence it replaced -- and it is
+    invisible to a test that only greps the emitted script for a name.
+    """
+    page = browser.new_page()
+    errors: list[str] = []
+    # Both channels: an uncaught throw arrives as `pageerror`, but one
+    # raised inside the frame's own script surfaces only on the console.
+    page.on("pageerror", lambda e: errors.append(str(e)))
+    page.on("console", lambda m: errors.append(m.text) if m.type == "error" else None)
+
+    page.route(_CDN, lambda route: route.abort())
+    page.goto(offline_app_url, wait_until="networkidle")
+    page.wait_for_timeout(12_000)
+
+    assert not [e for e in errors if "reportNoRuntime" in e], (
+        f"the reporter was called but not defined: {errors}"
+    )
+
+    page.close()

--- a/tests/browser/test_streamlit_keys.py
+++ b/tests/browser/test_streamlit_keys.py
@@ -1,0 +1,96 @@
+"""The iframe is what lets maidr and Streamlit both have ``r`` (#460).
+
+``maidr/widget/streamlit.py`` embeds every chart in an iframe on the
+grounds that Streamlit claims keys at the document level and maidr needs
+the same ones. That is the reason the module gives for a decision with
+real costs -- a bundle per frame offline, no shared state -- so it is
+worth holding to evidence rather than to a comment.
+
+Both halves have to hold for the argument to stand: Streamlit really
+takes ``r``, and the frame really keeps it from doing so. A failure here
+is not necessarily a bug in maidr; it may mean Streamlit changed and the
+frame is no longer buying what it costs, which is worth knowing either
+way.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+CHART = "[role=img], [role=application]"
+
+
+def _runcount(page) -> int | None:
+    found = re.search(r"RUNCOUNT=(\d+)", page.evaluate("document.body.innerText"))
+    return int(found.group(1)) if found else None
+
+
+def _chart_frame(page):
+    for frame in page.frames[1:]:
+        try:
+            if frame.locator(CHART).count():
+                return frame
+        except Exception:
+            pass
+    return None
+
+
+@pytest.fixture
+def streamlit_page(browser, streamlit_keys_app_url):
+    pg = browser.new_page()
+    pg.goto(streamlit_keys_app_url, wait_until="networkidle")
+    # The srcdoc carries the inlined bundle; give it room to parse.
+    for _ in range(20):
+        pg.wait_for_timeout(3000)
+        if _chart_frame(pg) is not None:
+            break
+    yield pg
+    pg.close()
+
+
+def test_streamlit_still_claims_r_at_the_document_level(streamlit_page):
+    """Half the argument: without this, the frame costs and buys nothing."""
+    page = streamlit_page
+    before = _runcount(page)
+    assert before is not None, "the app did not render its run counter"
+
+    page.keyboard.press("r")
+    page.wait_for_timeout(3000)
+
+    assert _runcount(page) != before, (
+        "pressing 'r' no longer reruns the Streamlit script. That is not a "
+        "maidr bug -- it may mean the document-level collision this "
+        "integration's iframe exists to avoid is gone, and the iframe's "
+        "cost (a bundle per frame offline, no shared state) now buys less "
+        "than it did. See #460."
+    )
+
+
+def test_the_frame_gives_r_to_the_chart_instead(streamlit_page):
+    """The other half: maidr gets the key, and the script does not rerun."""
+    page = streamlit_page
+    frame = _chart_frame(page)
+    assert frame is not None, "no chart frame on the page"
+
+    frame.locator(CHART).first.focus()
+    page.keyboard.press("Enter")
+    page.wait_for_timeout(1200)
+    page.keyboard.press("t")
+    page.wait_for_timeout(600)
+
+    before = _runcount(page)
+    page.keyboard.press("r")
+    page.wait_for_timeout(1500)
+
+    spoken = frame.evaluate("document.body.innerText").strip().split("\n")[-1]
+    assert "eview" in spoken, (
+        f"the chart did not act on 'r'; it said {spoken!r}. 'No rerun' below "
+        "would then prove nothing -- a dead frame swallows keys too."
+    )
+    assert _runcount(page) == before, (
+        "the Streamlit script reran while the reader was inside the chart"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,12 @@ def pytest_addoption(parser):
         default=False,
         help="run the timing benchmarks, which are skipped by default",
     )
+    parser.addoption(
+        "--run-browser",
+        action="store_true",
+        default=False,
+        help="run the browser tests, which are skipped by default",
+    )
 
 
 def pytest_configure(config):
@@ -114,19 +120,33 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "benchmark: a timing measurement, skipped unless asked for"
     )
+    config.addinivalue_line(
+        "markers", "browser: drives a real browser, skipped unless asked for"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    """Skip anything marked ``benchmark`` unless ``--run-benchmark`` is given.
+    """Skip the two opt-in groups unless their flag is given.
 
-    Timing is machine- and load-dependent, so gating CI on it would buy
-    flakes rather than information. The measurement still lives in the
+    ``benchmark`` is machine- and load-dependent, so gating CI on it would
+    buy flakes rather than information. The measurement still lives in the
     suite so the numbers quoted in the docs can be re-checked on demand
     rather than re-derived from scratch.
+
+    ``browser`` is opt-in for an unrelated reason -- see below.
     """
-    if config.getoption("--run-benchmark"):
-        return
-    skip = pytest.mark.skip(reason="timing benchmark; pass --run-benchmark")
-    for item in items:
-        if "benchmark" in item.keywords:
-            item.add_marker(skip)
+    if not config.getoption("--run-benchmark"):
+        skip = pytest.mark.skip(reason="timing benchmark; pass --run-benchmark")
+        for item in items:
+            if "benchmark" in item.keywords:
+                item.add_marker(skip)
+
+    # Browser tests are opt-in for a different reason than the benchmarks.
+    # They are not flaky-by-nature; they need a browser binary and a Shiny
+    # server, neither of which every contributor has, and a missing
+    # browser should read as "not run here" rather than as a failure.
+    if not config.getoption("--run-browser"):
+        skip = pytest.mark.skip(reason="browser test; pass --run-browser")
+        for item in items:
+            if "browser" in item.keywords:
+                item.add_marker(skip)

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -208,6 +208,24 @@ def test_the_payload_carries_the_focus_restore_script(fake_session):
     assert "__maidrShinyFocusRestore" in html
 
 
+def test_the_container_class_the_focus_script_looks_for_still_exists():
+    """The script finds its container by a Shiny-internal class.
+
+    ``.shiny-html-output`` is an implementation detail of
+    ``ui.output_ui``, not a documented contract. If Shiny renames it, the
+    script finds no containers and the fix goes silently inert -- no
+    exception, no warning, and the only thing that would notice is the
+    browser suite, which is opt-in and so not what a contributor runs.
+
+    This ties the two sides together in the default suite, so a Shiny
+    upgrade that moves the class fails here instead.
+    """
+    from maidr.widget._focus import FOCUS_RESTORE_JS
+
+    assert "shiny-html-output" in FOCUS_RESTORE_JS
+    assert "shiny-html-output" in str(output_maidr("chart"))
+
+
 def test_the_focus_script_only_installs_once_per_page(fake_session):
     """It arrives on every render, so it has to be idempotent.
 

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -208,6 +208,25 @@ def test_the_payload_carries_the_focus_restore_script(fake_session):
     assert "__maidrShinyFocusRestore" in html
 
 
+def test_the_rendered_iframe_is_marked_as_maidrs_own(fake_session):
+    """The focus script must be able to tell our frame from anyone else's.
+
+    Keying off a bare ``iframe`` would let the restore force focus onto an
+    unrelated embed an app happened to put in the same output container.
+    The marker is what makes the selector precise, so both sides of it are
+    pinned here.
+    """
+    from maidr.widget._focus import FOCUS_RESTORE_JS
+
+    @render_maidr
+    def chart():
+        return _bar_axes()
+
+    html = _render(chart)["html"]
+    assert "data-maidr-chart" in html
+    assert "data-maidr-chart" in FOCUS_RESTORE_JS
+
+
 def test_the_container_class_the_focus_script_looks_for_still_exists():
     """The script finds its container by a Shiny-internal class.
 

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -188,6 +188,42 @@ def test_payload_has_the_shape_shiny_expects(fake_session):
     assert set(payload) == {"deps", "html"}
 
 
+def test_the_payload_carries_the_focus_restore_script(fake_session):
+    """Every render ships the hook that survives a re-render (#484).
+
+    Shiny replaces the output container on each reactive flush, taking the
+    focused element with it, which drops a reader out of the chart they
+    were navigating. The script rides with the chart rather than with the
+    container because ``output_maidr`` is not always what places the
+    output -- Express mode goes through ``auto_output_ui``, and an app may
+    write its own ``ui.output_ui`` -- but every chart comes through the
+    renderer.
+    """
+
+    @render_maidr
+    def chart():
+        return _bar_axes()
+
+    html = _render(chart)["html"]
+    assert "__maidrShinyFocusRestore" in html
+
+
+def test_the_focus_script_only_installs_once_per_page(fake_session):
+    """It arrives on every render, so it has to be idempotent.
+
+    Without the guard, N flushes would leave N samplers and N observers
+    running, each restoring focus -- the cost of shipping it per render
+    rather than per container.
+    """
+
+    @render_maidr
+    def chart():
+        return _bar_axes()
+
+    html = _render(chart)["html"]
+    assert "if (window.__maidrShinyFocusRestore) return;" in html
+
+
 @pytest.mark.parametrize(
     ("use_cdn", "expect_cdn", "expect_inline_bundle"),
     [(True, True, False), ("auto", True, False), (False, False, True)],

--- a/uv.lock
+++ b/uv.lock
@@ -1459,6 +1459,161 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.2.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/f5/3e9eafb4030588337b2a2ae4df46212956854e9069c07b53aa3caabafd47/greenlet-3.2.5.tar.gz", hash = "sha256:c816554eb33e7ecf9ba4defcb1fd8c994e59be6b4110da15480b3e7447ea4286", size = 191501, upload-time = "2026-02-20T20:08:51.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/d6/b3db928fc329b1b19ba32ffe143d2305f3aaafc583f5e1074c74ec445189/greenlet-3.2.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:34cc7cf8ab6f4b85298b01e13e881265ee7b3c1daf6bc10a2944abc15d4f87c3", size = 275803, upload-time = "2026-02-20T20:06:42.541Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ff/ab0ad4ff3d9e1faa266de4f6c79763b33fccd9265995f2940192494cc0ec/greenlet-3.2.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c11fe0cfb0ce33132f0b5d27eeadd1954976a82e5e9b60909ec2c4b884a55382", size = 633556, upload-time = "2026-02-20T20:30:41.594Z" },
+    { url = "https://files.pythonhosted.org/packages/da/dd/7b3ac77099a1671af8077ecedb12c9a1be1310e4c35bb69fd34c18ab6093/greenlet-3.2.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a145f4b1c4ed7a2c94561b7f18b4beec3d3fb6f0580db22f7ed1d544e0620b34", size = 644943, upload-time = "2026-02-20T20:37:23.084Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f0/bea7e7909ea9045b0c5055dad1ec9b81c82b761b4567e625f4f8349acfa1/greenlet-3.2.5-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:edbf4ab9a7057ee430a678fe2ef37ea5d69125d6bdc7feb42ed8d871c737e63b", size = 640849, upload-time = "2026-02-20T20:43:57.305Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/36/84630e9ff1dfc8b7690957c0f77834a84eabdbd9c4977c3a2d0cbd5325c2/greenlet-3.2.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc1d01bdd67db3e5711e6246e451d7a0f75fae7bbf40adde129296a7f9aa7cc9", size = 639841, upload-time = "2026-02-20T20:07:17.473Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c4/6a2ee6c676dea7a05a3c3c1291fbc8ea44f26456b0accc891471293825af/greenlet-3.2.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd593db7ee1fa8a513a48a404f8cc4126998a48025e3f5cbbc68d51be0a6bf66", size = 588813, upload-time = "2026-02-20T20:07:56.171Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c0/75e75c2c993aa850292561ec80f5c263e3924e5843aa95a38716df69304c/greenlet-3.2.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ac8db07bced2c39b987bba13a3195f8157b0cfbce54488f86919321444a1cc3c", size = 1117377, upload-time = "2026-02-20T20:32:48.452Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/03/e38ebf9024a0873fe8f60f5b7bc36bfb3be5e13efe4d798240f2d1f0fb73/greenlet-3.2.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4544ab2cfd5912e42458b13516429e029f87d8bbcdc8d5506db772941ae12493", size = 1141246, upload-time = "2026-02-20T20:06:23.576Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7b/c6e1192c795c0c12871e199237909a6bd35757d92c8472c7c019959b8637/greenlet-3.2.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:acabf468466d18017e2ae5fbf1a5a88b86b48983e550e1ae1437b69a83d9f4ac", size = 276916, upload-time = "2026-02-20T20:06:18.166Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b6/9887b559f3e1952d23052ec352e9977e808a2246c7cb8282a38337221e88/greenlet-3.2.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:472841de62d60f2cafd60edd4fd4dd7253eb70e6eaf14b8990dcaf177f4af957", size = 636107, upload-time = "2026-02-20T20:30:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/be/e3e48b63bbc27d660fa1d98aecb64906b90a12e686a436169c1330ef34b2/greenlet-3.2.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d951e7d628a6e8b68af469f0fe4f100ef64c4054abeb9cdafbfaa30a920c950", size = 648240, upload-time = "2026-02-20T20:37:24.608Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f6/2cbe999683f759f14f598234f04ae8ba6f22953a624b3a7a630003e6bfff/greenlet-3.2.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:87b791dd0e031a574249af717ac36f7031b18c35329561c1e0368201c18caf1f", size = 644170, upload-time = "2026-02-20T20:43:59.002Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ac/e731ed62576e91e533b36d0d97325adc2786674ab9e48ed8a6a24f4ef4e9/greenlet-3.2.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8317d732e2ae0935d9ed2af2ea876fa714cf6f3b887a31ca150b54329b0a6e9", size = 643313, upload-time = "2026-02-20T20:07:19.012Z" },
+    { url = "https://files.pythonhosted.org/packages/70/64/99e5cdceb494bd4c1341c45b93f322601d2c8a5e1e4d1c7a2d24c5ed0570/greenlet-3.2.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce8aed6fdd5e07d3cbb988cbdc188266a4eb9e1a52db9ef5c6526e59962d3933", size = 591295, upload-time = "2026-02-20T20:07:57.286Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e9/968e11f388c2b8792d3b8b40a57984c894a3b4745dae3662dce722653bc5/greenlet-3.2.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:60c06b502d56d5451f60ca665691da29f79ed95e247bcf8ce5024d7bbe64acb9", size = 1120277, upload-time = "2026-02-20T20:32:50.103Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2c/b5f2c4c68d753dce08218dc5a6b21d82238fdfdc44309032f6fe24d285e6/greenlet-3.2.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0d2a78e6f1bf3f1672df91e212a2f8314e1e7c922f065d14cbad4bc815059467", size = 1145746, upload-time = "2026-02-20T20:06:26.296Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/32/022b21523eee713e7550162d5ca6aed23f913cc2c6232b154b9fd9badc07/greenlet-3.2.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:2acb30e77042f747ca81f0a10cc153296567e92e666c5e1b117f4595afd43352", size = 278412, upload-time = "2026-02-20T20:03:15.02Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c5/8a3b0ed3cc34d8b988a44349437dfa0941f9c23ac108175f7b4ccea97111/greenlet-3.2.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:393c03c26c865f17f31d8db2f09603fadbe0581ad85a5d5908b131549fc38217", size = 644616, upload-time = "2026-02-20T20:30:44.823Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2c/2627bea183554695016af6cae93d7474fa90f61e5a6601a84ae7841cb720/greenlet-3.2.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:04e6a202cde56043fd355fefd1552c4caa5c087528121871d950eb4f1b51fa99", size = 658813, upload-time = "2026-02-20T20:37:26.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c6/a80fc96f7cca7962dd972875d12c52dfabc94cb02bfeb19f3e7e169fca44/greenlet-3.2.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d5583b2ffa677578a384337ee13125bdf9a427485d689014b39d638a4f3d8dbe", size = 653512, upload-time = "2026-02-20T20:44:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/1b/75a5aeff487a26ba427a3837da6372f1fe6f2a9c6b2898e28ac99d491c11/greenlet-3.2.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:45fcea7b697b91290b36eafc12fff479aca6ba6500d98ef6f34d5634c7119cbe", size = 655426, upload-time = "2026-02-20T20:07:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/53/91/9b5dfb4f3c88f8247c7a8f4c3759f0740bfa6bb0c59a9f6bf938e913df56/greenlet-3.2.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f96e2bb8a56b7e1aed1dbfbbe0050cb2ecca99c7c91892fd1771e3afab63b3e3", size = 611138, upload-time = "2026-02-20T20:07:58.966Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/8d/d0b086410512d9859c84e9242a9b341de9f5566011ddf3a3f6886b842b61/greenlet-3.2.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d7456e67b0be653dfe643bb37d9566cd30939c80f858e2ce6d2d54951f75b14a", size = 1126896, upload-time = "2026-02-20T20:32:52.198Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/37/59fe12fe456e84ced6ba71781e28cde52a3124d1dd2077bc1727021f49fd/greenlet-3.2.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5ceb29d1f74c7280befbbfa27b9bf91ba4a07a1a00b2179a5d953fc219b16c42", size = 1154779, upload-time = "2026-02-20T20:06:27.583Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/95/d5d332fb73affaf7a1fbe80e49c2c7eae4f17c645af24a3b3fa25736d6f0/greenlet-3.2.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:f2cc88b50b9006b324c1b9f5f3552f9d4564c78af57cdfb4c7baf4f0aa089146", size = 277166, upload-time = "2026-02-20T20:03:57.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/77/89458e20db5a4f1c64f9a0191561227e76d809941ca2d7529006d17d3450/greenlet-3.2.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e66872daffa360b2537170b73ad530f14fa31785b1bc78080125d92edf0a6def", size = 644674, upload-time = "2026-02-20T20:30:46.118Z" },
+    { url = "https://files.pythonhosted.org/packages/90/f8/9962175d2f2eaa629a7fd7545abacc8c4deda3baa4e52c1526d2eb5f5546/greenlet-3.2.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c5445ddb7b586d870dad32ca9fc47c287d6022a528d194efdb8912093c5303ad", size = 658834, upload-time = "2026-02-20T20:37:27.466Z" },
+    { url = "https://files.pythonhosted.org/packages/81/71/52c21a7106ce5218aa6fa59ec32825b2655f875a09b69f68bd3e5d01feb3/greenlet-3.2.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd904626b8779810062cb455514594776e3cba3b8c0ba4939894df9f7b384971", size = 653091, upload-time = "2026-02-20T20:44:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d7/826d0e080f0a7ad5ec47c8d143bbd3ca0887657bb806595fe2434d12938a/greenlet-3.2.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:752c896a8c976548faafe8a306d446c6a4c68d4fd24699b84d4393bd9ac69a8e", size = 655760, upload-time = "2026-02-20T20:07:21.551Z" },
+    { url = "https://files.pythonhosted.org/packages/41/cc/33bd4c2f816be8c8e16f71740c4130adf3a66a3dd2ba29de72b9d8dd1096/greenlet-3.2.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:499b809e7738c8af0ff9ac9d5dd821cb93f4293065a9237543217f0b252f950a", size = 614132, upload-time = "2026-02-20T20:08:00.351Z" },
+    { url = "https://files.pythonhosted.org/packages/48/79/f3891dcfc59097474a53cc3c624f2f2465e431ab493bda043b8c873fb20a/greenlet-3.2.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2c7429f6e9cea7cbf2637d86d3db12806ba970f7f972fcab39d6b54b4457cbaf", size = 1125286, upload-time = "2026-02-20T20:32:54.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/47/212b47e6d2d7a04c4083db1af2fdd291bc8fe99b7e3571bfa560b65fc361/greenlet-3.2.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a5e4b25e855800fba17713020c5c33e0a4b7a1829027719344f0c7c8870092a2", size = 1152825, upload-time = "2026-02-20T20:06:29Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/9d/4e9b941be05f8da7ba804c6413761d2c11cca05994cbf0a015bd729419f0/greenlet-3.2.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7123b29e6bad2f3f89681be4ef316480fca798ebe8d22fbaced9cc3775007a4f", size = 277627, upload-time = "2026-02-20T20:06:04.798Z" },
+    { url = "https://files.pythonhosted.org/packages/23/cb/a73625c9a35138330014ecf3740c0d62e0c2b5e7279bb7f2586b1b199fac/greenlet-3.2.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6e8fe0c72603201a86b2e038daf9b6c8570715f8779566419cff543b6ace88de", size = 690001, upload-time = "2026-02-20T20:30:47.754Z" },
+    { url = "https://files.pythonhosted.org/packages/83/49/6d1531109507bce7dfb23acf57a87013627ed3ac058851176e443a6a9134/greenlet-3.2.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:050703a60603db0e817364d69e048c70af299040c13a7e67792b9e62d4571196", size = 702953, upload-time = "2026-02-20T20:37:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ac/6d8fff3b273fc60ad4b46f8411fe91c1e4cca064dfff68d096bc982fa6d0/greenlet-3.2.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:04633da773ae432649a3f092a8e4add390732cc9e1ab52c8ff2c91b8dc86f202", size = 698353, upload-time = "2026-02-20T20:44:03.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/38/f958ee90fab93529b30cc1e4a59b27c1112b640570043a84af84da3b3b98/greenlet-3.2.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6712bfd520530eb67331813f7112d3ee18e206f48b3d026d8a96cd2d2ad20251", size = 698995, upload-time = "2026-02-20T20:07:22.663Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c1/a603906e79716d61f08afedaf8aed62017661457aef233d62d6e57ecd511/greenlet-3.2.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bc06a78fa3ffbe2a75f1ebc7e040eacf6fa1050a9432953ab111fbbbf0d03c1", size = 661175, upload-time = "2026-02-20T20:08:01.477Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/8f/f880ff4587d236b4d06893fb34da6b299aa0d00f6c8259673f80e1b6d63c/greenlet-3.2.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:dbe0e81e24982bb45907ca20152b31c2e3300ca352fdc4acbd4956e4a2cbc195", size = 274946, upload-time = "2026-02-20T20:05:21.979Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/50/f6c78b8420187fdfe97fcf2e6d1dd243a7742d272c32fd4d4b1095474b37/greenlet-3.2.5-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:15871afc0d78ec87d15d8412b337f287fc69f8f669346e391585824970931c48", size = 631781, upload-time = "2026-02-20T20:30:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d6/3277f92e1961e6e9f41d9f173ea74b5c1f7065072637669f761626f26cc0/greenlet-3.2.5-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5bf0d7d62e356ef2e87e55e46a4e930ac165f9372760fb983b5631bb479e9d3a", size = 643740, upload-time = "2026-02-20T20:37:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8a/c37b87659378759f158dbe03eaeb7ed002a8968f1c649b2972f5323f99b2/greenlet-3.2.5-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:e3f03ddd7142c758ab41c18089a1407b9959bd276b4e6dfbd8fd06403832c87a", size = 639098, upload-time = "2026-02-20T20:44:07.287Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6a/4f79d2e7b5ef3723fc5ffea0d6cb22627e5f95e0f19c973fa12bf1cf7891/greenlet-3.2.5-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6dff6433742073e5b6ad40953a78a0e8cddcb3f6869e5ea635d29a810ca5e7d0", size = 638382, upload-time = "2026-02-20T20:07:23.883Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/59/7aadf33f23c65dbf4db27e7f5b60c414797a61e954352ae4a86c5c8b0553/greenlet-3.2.5-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bdd67619cefe1cc9fcab57c8853d2bb36eca9f166c0058cc0d428d471f7c785c", size = 587516, upload-time = "2026-02-20T20:08:02.841Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/46/b3422959f830de28a4eea447414e6bd7b980d755892f66ab52ad805da1c4/greenlet-3.2.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:3828b309dfb1f117fe54867512a8265d8d4f00f8de6908eef9b885f4d8789062", size = 1115818, upload-time = "2026-02-20T20:32:55.786Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4a/3d1c9728f093415637cf3696909fa10852632e33e68238fb8ca60eb90de1/greenlet-3.2.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:67725ae9fea62c95cf1aa230f1b8d4dc38f7cd14f6103d1df8a5a95657eb8e54", size = 1140219, upload-time = "2026-02-20T20:06:30.334Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/67/07ecd6d85c0f253363cbc4ac9e7dd048ca571a267fbccfea084d6009ac3b/greenlet-3.5.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:816230f469381ad0a43abc9fa8dda5a699e32fb78958dde32ded93213b70a667", size = 292971, upload-time = "2026-08-10T13:28:09.837Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/426733bc24247ee17bb76df90f550c299ff5f8572b2bdd7cacb5c53fd994/greenlet-3.5.5-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5433cf291e0ef9114bd14d0d824db6e5e4a43033234bca48181a9597acca07b", size = 609290, upload-time = "2026-08-10T14:14:32.273Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/dc/17d3a5acceb2fd0bbc9682a228117b719cdfb68085e6dbb33fa325755f27/greenlet-3.5.5-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:19d59f068887d8c5907fc177f27683413ace3011b6ed646c0b309266e74a6502", size = 622650, upload-time = "2026-08-10T14:27:22.004Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3f/b31e6bd6adb8f80492efb6a47e8f9cd0e7335db5aac2795b1876d5afcfee/greenlet-3.5.5-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:86c5113d698cb8d927b2750bb1f1d59eefe3a37e0e0217491aee29a7f84ef52c", size = 629560, upload-time = "2026-08-10T14:30:04.733Z" },
+    { url = "https://files.pythonhosted.org/packages/51/91/00b3c0566316c6f383ea16ee05388ec4f57f6e0afa49e72ae471eda8c47f/greenlet-3.5.5-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ff00e12102358292087274dfb1669132387ff6e7920ebf9d85f4826ce0d3a56", size = 622819, upload-time = "2026-08-10T13:40:46.562Z" },
+    { url = "https://files.pythonhosted.org/packages/18/5e/58c561efde575c4ca070030e2e0513e8d1b07b76d8a2d84a9bcef1becd42/greenlet-3.5.5-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:c69bed34470abfcd456984fdadaa18e62169af4480335c45f3c32d1d9c12e638", size = 425489, upload-time = "2026-08-10T14:29:59.768Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/78/52de4f7ac9152ad1dbc8f437895c1e573d30ee1e1427e0f91a280e2417b6/greenlet-3.5.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:523bb8e27614d77101ea7a8cf59f8d91219b72d5c29f6a038c92b50828bfa8d0", size = 1582164, upload-time = "2026-08-10T14:15:02.645Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ff/c3855a00c2417e8f61c7b9f0bc4f8f599c6928f5c15681ad251e78a91e05/greenlet-3.5.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f1e2db190db51c17433eee424803818cf0670bf049d9cfe0dd07be111d1aa7c4", size = 1648807, upload-time = "2026-08-10T13:40:27.471Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/d29ff6a79dbd1ec1fe74c155d25d4c5a85e221d6b9ffc2cc7a709e7c8c39/greenlet-3.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:740e544169527b82695ce76af2f7ad6f030904658f2f3921a1d245771fb88cfc", size = 322832, upload-time = "2026-08-10T13:28:10.85Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a3/07297917485ee2ca85bc3c8dc6ed85ad3fffcf424047fba62671dba68e97/greenlet-3.5.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:be63afcbbccfad3dd95a1ba12ada84dab2ef32031973d80b5b92df67fa763a61", size = 294165, upload-time = "2026-08-10T13:25:17.987Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/6f732f9314cda54c5fd48a7620c7160f4f286967e8045ad94b9d66ce80b7/greenlet-3.5.5-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a268024ce2d7d2b04694bf1594058981a9fa663d1df4b762dee499211ed7c1c", size = 613610, upload-time = "2026-08-10T14:14:33.829Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c0/b27589e25d220289edcd4d582b2b17b83058d1a56d53d971b6ea1a34f10d/greenlet-3.5.5-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35cbb8bf55ace57fbccb4fb8622c4521713acd8691e77f4696d416ea7ca527da", size = 625481, upload-time = "2026-08-10T14:27:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/39/82/5c873dbb4fb001d22fbbd50e80d4c1b0181ddae106856132160f84b94e88/greenlet-3.5.5-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:abc8bc8d9f935cd685457545b6a53863a877fdc12c2c0f5ee9beee18d9db139c", size = 633329, upload-time = "2026-08-10T14:30:06.062Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2d/f2c928218ac52f26d7a2c188c171d1b7e728b23782cb3347e7b4fce1493a/greenlet-3.5.5-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cc6df89ec5302337adc9cf096221cbed2510fd444b0e0f1586cf0470740864", size = 624562, upload-time = "2026-08-10T13:40:48.064Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/f7df98e72a8eb4a7edfec5a08d6d1a4ab53a52c95ba0b2ea6c10b8dd9bd0/greenlet-3.5.5-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:3134291427bb0f3526e9d90311988caf336eb43730e95244997a4fb15f45144f", size = 428145, upload-time = "2026-08-10T14:30:01.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4a/92fc51d5d35912f4f06eec037ba347985defd0be47463a010a325634d9d2/greenlet-3.5.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d9b454c5fc48aeaa7c4337813dbf513a6870468e426438a04d922c6d0fe63db", size = 1584909, upload-time = "2026-08-10T14:15:04.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/58/ed98b80ac5738c149a5258544843c45601ade1fd70f61740cdaead6351b3/greenlet-3.5.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03551ed792cb1b4fc0277a0c60dfd8c343894a0ba06fe60dcd22f568b433da39", size = 1651184, upload-time = "2026-08-10T13:40:28.879Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/be/b582ceb80cefdf9d8da34078714e4b12b3d16f509dee0f65e40a5cc8fc7d/greenlet-3.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:ab3df3dffb58bf70564e93a5cec7941e4d9faa5a36cc4234a10d3131afe04f53", size = 323280, upload-time = "2026-08-10T13:26:07.495Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/18/5313c4c58598c38b0373c013e4ff2b3e6d258aaaa338f373335ebecdaddd/greenlet-3.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:2b70a766135540c472ac1393d57c2e1b4a2eb85bf526a1e41e6d096173a8cee5", size = 307785, upload-time = "2026-08-10T13:28:34.874Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/30/87c212b5c684d0e72974f1063b7a9687631e8985902c06e1016542c874e7/greenlet-3.5.5-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ca5d6ae0739e5764f2cfcfaa562ac5a990cbdaedca93251c5e3cf07c362371f", size = 629504, upload-time = "2026-08-10T14:30:07.967Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2c/eb487fafc9f50ffff2b1e0b697f70fb34bf150821c08ab225aacf5583a7e/greenlet-3.5.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1b5ed9162c0c098e0bbc2cf88a94f433c1b8926f831745252e099e5d83e17759", size = 432462, upload-time = "2026-08-10T14:30:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3d/8cef5f724ec0d4add2af8961d504535ec60c3cca9e464f6d03bdba29d85b/greenlet-3.5.5-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:b79fd2a5bc099b5e744f34c4c9a58954a5f4cb7529fb4b6e8446057d61b6edaa", size = 294730, upload-time = "2026-08-10T13:27:51.206Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4b/8e7aa3f514273aecff30a16ab1bac09ff54cfc7e6860fdd8058c37ff2499/greenlet-3.5.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:634cf15a233a949136879dd388e25d3296e16f3f1e217d2456797b8579ebc6ed", size = 614536, upload-time = "2026-08-10T14:14:36.589Z" },
+    { url = "https://files.pythonhosted.org/packages/85/48/4e95e9dd5a8a397dc6a6345dd7f1935113d0fca4f85e89d3976da9cd988d/greenlet-3.5.5-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:499adea519f748407fc6806d20eedabac2884fd73b9f38d81236e190ba20dfef", size = 626924, upload-time = "2026-08-10T14:27:27.048Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/eaa476d6bf3816828d0d70e80dcc36bf30a058233bd889e707e693f6e860/greenlet-3.5.5-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7278591501941bb2456af102bb9cd59aab48c6cfd6e2dd68fa1290bb0c49a42", size = 632726, upload-time = "2026-08-10T14:30:09.874Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5d/398a1c71fa7a277deeb376c999979de6786f08fc2d5747a0b9d6e11738dd/greenlet-3.5.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2eabb980975cba5b93a95f6f69287d05fc05ac955bfd6a320a7c083eeb52c0b0", size = 623906, upload-time = "2026-08-10T13:40:50.501Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f2/0cc2849ede68579291e9c59b3ab6ec1958f98681cca5b14d8fc75bf674a4/greenlet-3.5.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:4dfc7c4470354e7b09184d1a3a985761053a2fd694ddb5b5c80242afc2c8c90b", size = 434966, upload-time = "2026-08-10T14:30:03.729Z" },
+    { url = "https://files.pythonhosted.org/packages/04/1b/745450fc5ea9e0cb17d840d248f284db3363de736d362c7d2d883e3eadba/greenlet-3.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:03115c2e0a371999bf8ae616aa8d653f96641d4705c457aebaa187276e9f7537", size = 1581430, upload-time = "2026-08-10T14:15:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/d51b296e3191bb15d3d81ec375af1909e4466c0f395d744ed475801798a9/greenlet-3.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4441153ffba21b90d3ca89fe3d31f5c093ae6c0bf0cfdfc98f54cde22f95b62e", size = 1645684, upload-time = "2026-08-10T13:40:32.133Z" },
+    { url = "https://files.pythonhosted.org/packages/12/63/369f1a1625e64e9e31df3963c6044056e3fdfa3fa3fdba3c54ffefa6e987/greenlet-3.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:95c5b1f4b3a193f8a0c2de4bfdcb48d119f7f1063941f1de1f2168051b3e52dd", size = 324075, upload-time = "2026-08-10T13:26:58.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/78/649cb5c09d4d81f6dd1444e75474a7206784743283a21d24171562ac4899/greenlet-3.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:1af90aa4bc129883b340cdd6957a3bc74f60528a4993bbd1f53aaebe1d9981cc", size = 308260, upload-time = "2026-08-10T13:27:50.795Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/52/f005d579acde46c3d1cc3cab1c9f3d5708c8a3006a4120e8cf5da801afe9/greenlet-3.5.5-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d98ef6f92e67c6dbf299dbfd8facc1b0d2d9cedf91e325e73b3d0373fe4309d8", size = 677863, upload-time = "2026-08-10T14:30:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/a75f8a2bdcef3c358a3147cdc9db3aa83755f0a038f766ab0bedb66f512c/greenlet-3.5.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:159df1942d88e8f784cbb38d6f18bdb365cd11319cfbb3e89623de2b97892d53", size = 480554, upload-time = "2026-08-10T14:30:05.171Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ac/0d7887aa4bbfc9eba075cc428244dfc96f623478454d5ec81180d0d6bd5a/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5e9ec2e7c98e895fcea0c5cc57b2606cf86ece6d0a56578f3eb225e2af4f0387", size = 681587, upload-time = "2026-08-10T14:30:13.519Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/18/8d58ba1c429b0383e3219a3d0e0bba241d0444d8ed05b73349953c7d7c7b/greenlet-3.5.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:102817506f6090b5176c746a82603341a549b40e5c3d5b72a4c672228a918c41", size = 510175, upload-time = "2026-08-10T14:30:07.047Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/65/53/4e13642efc4d7ad6554ecb2242a5be42666b2e1a067323e88dfc0124a04b/greenlet-3.5.5-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37faa97daccb6d9f4c2141ce3118d023c3c5506864a7d8bdf726f665018c1f76", size = 681436, upload-time = "2026-08-10T14:30:14.839Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/32/188447c9a468d6977d2989397226b0c6b65ab6f4cf943f931643328512fc/greenlet-3.5.5-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:b18007dc2473a7942fd157366b55f01da6fed7ce85318591005b419e0a439474", size = 487404, upload-time = "2026-08-10T14:30:08.903Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f4/e450a68a152f819491d8c7df6a8254e761d87e6a78759268961f8c5bd4dd/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2888a3a38bc5ee5bb6c438372197152e815837e4fab7ed7a1f86ef18ffd58ad1", size = 686022, upload-time = "2026-08-10T14:30:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/17e63d6bf3b9c9b9dbea981b7f643a71f79603bdfb4f1c3a9cf353e22aed/greenlet-3.5.5-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:1e8d9391fe77f15649589a907cef972dbbd6352ef7ff7dc0492f658c0c26495f", size = 516951, upload-time = "2026-08-10T14:30:10.907Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
+]
+
+[[package]]
 name = "griffe"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2840,6 +2995,10 @@ altair = [
     { name = "altair", version = "5.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "altair", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
+browser = [
+    { name = "playwright", version = "1.60.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "playwright", version = "1.62.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
 jupyter = [
     { name = "ipykernel", version = "6.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "ipykernel", version = "7.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -2911,6 +3070,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'visualization'", specifier = ">=3.8" },
     { name = "mplfinance", specifier = ">=0.12.10b0" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40" },
     { name = "plotly", marker = "extra == 'plotly'", specifier = ">=5.0" },
     { name = "plotly", marker = "extra == 'test'", specifier = ">=5.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.3.2,<8" },
@@ -2925,7 +3085,7 @@ requires-dist = [
     { name = "streamlit", marker = "extra == 'streamlit'", specifier = ">=1.30" },
     { name = "wrapt", specifier = ">=1.16.0,<2" },
 ]
-provides-extras = ["visualization", "altair", "jupyter", "plotly", "shiny", "streamlit", "test"]
+provides-extras = ["visualization", "altair", "jupyter", "plotly", "shiny", "streamlit", "browser", "test"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4370,6 +4530,59 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.60.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "greenlet", version = "3.2.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyee", marker = "python_full_version < '3.10'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "greenlet", version = "3.5.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyee", marker = "python_full_version >= '3.10'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "plotly"
 version = "6.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4887,6 +5100,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f4/c9/f71032fca47ecc09d30904d9a610234b07139f89eabc2f054b141edcc30f/pydeck-0.9.3.tar.gz", hash = "sha256:695775cbfe51f5fdffbd9735ba469987fdc5efc96bc40a0ee4808170509c78b2", size = 5900912, upload-time = "2026-07-02T23:27:08.704Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/34/3998411437aff304a9ed4fa37a6fe1ef3132bcd2b5eac59851b80c86123c/pydeck-0.9.3-py2.py3-none-any.whl", hash = "sha256:d8a47c11c81fb12d51b1feb42427ff4f0e13cb599e48931021b2cba98b6849a6", size = 11428091, upload-time = "2026-07-02T23:27:06.399Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Two things, in that order: an accessibility bug, and the test infrastructure that proves it fixed — because the second turned out to be the only way to establish the first.

### The bug

A Shiny output is replaced wholesale on every reactive flush, taking the focused element with it. A reader partway through navigating a chart who changed any input was returned to the top of the document, silently. Measured on `main`, in Chromium against a live `shiny run` app:

```
BEFORE re-render   outer focus: IFRAME#iframe_b2394527   in-frame: DIV[application]   at: b, 2
AFTER  re-render   outer focus: BODY                     in-frame: BODY
```

The chart itself was fine — it re-attached, and Tabbing back in worked. What was lost was the reader's place and any signal that it had gone. A sighted user changing a slider keeps their eyes on the chart; a blind user changing the same slider was ejected to the document body and had to Tab back through every preceding control.

Sampling focus every 200 ms against whether the container had been replaced shows it is the swap, not the input change:

```
t=0.0s  focus=IFRAME  output_swapped=False
t=0.4s  focus=BODY    output_swapped=True
```

### Why the implementation looks like this

Two findings, both established in a browser rather than reasoned about, rule out the obvious event-driven version:

1. **Removing the focused element does not reliably fire `blur`/`focusout`.** A first attempt hung the restore off `focusout` and never fired.
2. **Moving focus *into* an iframe fires no `focusin` in the parent document at all** — `document.activeElement` simply becomes the frame. Instrumented directly: focusing the chart inside the frame produced `events: []` while `activeElement` was `IFRAME`.

Since charts render into an iframe today, an event-driven hook sees nothing on the path that matters. So "the chart had focus" is established by sampling `activeElement`, and the re-render is detected with a `MutationObserver` on the output container.

The conditions are deliberately narrow, because being too eager is worse than the bug — pulling someone out of a control mid-task is more disruptive than dropping them from a chart. Focus is restored only when the element that held it has **left the document** *and* focus **landed nowhere**.

## Browser tests

Neither of the two findings above, nor the fix itself, is visible in emitted markup — which is all the other 2208 tests can see. The unit tests here can only assert the script is *present* in the payload, which is not the same as it working. Until now the only evidence was me driving a browser by hand, which does not survive the session.

`tests/browser/` runs a real Shiny app in Chromium. The two cases that matter pull in opposite directions:

| test | asserts |
|---|---|
| `test_the_chart_is_reachable_and_answers_the_keyboard` | the premise — a chart nobody can focus cannot lose focus |
| `test_focus_returns_to_the_chart_after_a_rerender` | the bug |
| `test_a_deliberate_move_away_is_not_undone` | the opposite failure, plus keystrokes still land in the input |
| `test_a_chart_nobody_focused_does_not_take_focus` | page load is a re-render too |

A suite covering only the second would pass on a version that grabs focus from whatever the reader was doing.

**Verified load-bearing.** With `_process_ui(payload)` reverted to `_process_ui(rendered)`:

```
FAILED tests/browser/test_focus_restore.py::test_focus_returns_to_the_chart_after_a_rerender
1 failed, 3 passed
```

The three over-reach guards still pass, which is what they should do when there is no fix to over-reach.

### A second use of the same infrastructure

`test_offline_report.py` guards the runtime report from #455/#467 — the message an air-gapped reader gets instead of a silently dead chart. `tests/core/test_offline_fallback_report.py` asserts that message is in the emitted script, which cannot tell whether it ever reaches a console: a `ReferenceError` earlier in the script, a fallback that never fires, or a report wired to a branch that is not the one taken would all pass it. It blocks the CDN with `page.route` rather than relying on the runner having no network, so the test creates the air-gapped condition itself.

Also load-bearing: with the report body emptied, `test_a_chart_with_no_runtime_says_so_in_the_console` fails.

It is here rather than in its own PR because it is the same infrastructure, and because one test is thin evidence that browser testing generalises beyond the thing it was built for.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Test infrastructure

## Related Issues

Closes #484.

Independent of #457: the same measurement inline, with no iframe, loses focus identically (`t=0.2s focus=BODY output_swapped=True`), so this is not caused by the iframe and should not wait on that decision.

## Changes Made

- `maidr/widget/_focus.py` — new; the script and the reasoning for its shape.
- `maidr/widget/shiny.py` — the payload becomes `TagList(rendered, tags.script(...))`. It rides with the chart rather than with the container because `output_maidr` is not always what places the output — Express goes through `auto_output_ui`, and an app may write its own `ui.output_ui` — but every chart comes through the renderer. It self-guards, so arriving per render costs nothing after the first.
- `tests/widget/test_shiny.py` — the payload carries the hook, and the hook is idempotent (without the guard, N flushes would leave N samplers running).
- `tests/browser/` — new; fixtures, two apps, six tests.
- `tests/conftest.py` — `--run-browser`, alongside the existing `--run-benchmark` but for a different reason, and the comment says which: the benchmark is skipped because timing is machine-dependent, this because it needs a browser binary and a Shiny server, and a missing browser should read as "not run here" rather than as a failure.
- `.github/workflows/ci.yml` — a `browser` job that installs Chromium and runs them. Kept out of the `test` matrix because it needs a browser as well as a wheel.
- `pyproject.toml` — `playwright` as a `browser` extra rather than a `test` one, so `uv sync --all-extras` does not imply the browser tests can run.
- `docs/examples.qmd` — two sentences, including the "only when the chart held focus" condition, since that is the part a reader might otherwise find surprising.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — 2208 passed, 5 skipped (1 benchmark, 4 browser… 6 browser as of the last commit). `uv run pytest tests/browser --run-browser` — 6 passed in 117 s. `ruff check` shows the same six pre-existing `F401`s as `main`; `actionlint` and `uv lock --check` clean.

**What this does not fix.** Focus comes back to the chart; the reader's **position** in it does not — they land at the first data point. I checked whether that was fixable from here rather than assuming: the runtime's entire public surface is `maidrLive.{setData, appendData}`, there is no API to read or set a position, and no DOM signal of one. `setData` looked like a better route — update in place, never destroy the element — but it accepts the whole figure schema, a single layer, and a bare data array, returns `ok` for all three, and changes nothing. Filed upstream as xability/maidr#956; detail in #484.

**Limits of the verification.** Chromium only, one chart type, no screen reader — focus is read from `document.activeElement`, which is not the same as hearing an announcement. The 200 ms sampler is forced by the two findings above; if the runtime ever exposed a focus event crossing the frame boundary, this could become event-driven.

**CI has not validated this yet.** GitHub has been in a Partial System Outage throughout (`API Requests`, `Actions`, `Pull Requests` all major outage), and every red check on this PR failed before reaching any code — `429` downloading actions, `503` on permission checks, `Not Found` reading commits. Per-check diagnosis is in the comments. The new `browser` job in particular has never run on a runner. Not merging until it has.