### PR TITLE
fix(patch): say which seaborn is installed when it is too old

### DIFF
--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -1,5 +1,12 @@
+# Before anything else: the modules below wrap seaborn internals by name,
+# and on a seaborn too old to have them `wrapt` raises an AttributeError
+# that names neither seaborn nor a version (#441).
+from ._seaborn_version import check_seaborn_version
+
+check_seaborn_version()
+
 # Import all patches to ensure they are applied
-from . import (  # noqa: F401
+from . import (  # noqa: E402, F401
     areaplot,
     barplot,
     boxenplot,

--- a/maidr/patch/_seaborn_version.py
+++ b/maidr/patch/_seaborn_version.py
@@ -1,0 +1,78 @@
+"""Fail understandably when seaborn is older than the patches expect.
+
+Nearly every module in this package wraps a seaborn internal by name, and
+the ones under ``_CategoricalPlotter`` and ``_DistributionPlotter``
+arrived with the categorical rewrite in seaborn **0.13**.  On an older
+seaborn ``wrapt`` cannot resolve the attribute and raises while
+``maidr.patch`` is being imported, so ``import maidr`` does not survive::
+
+    AttributeError: type object '_CategoricalPlotter' has no attribute 'plot_bars'
+
+Nothing in that names seaborn, names a version, or suggests what to do,
+and it arrives before any of the user's own code runs.  ``pyproject.toml``
+declares ``seaborn>=0.13``, so a resolver will not choose 0.12 on its own
+-- but `--no-deps`, a conflicting pin elsewhere in the environment, or an
+old lockfile all still land there, which is exactly the case #441 was
+filed about.
+
+This check does not make an old seaborn work.  It replaces an error that
+says nothing with one that says which version is installed, which is
+needed, and that the two do not match.
+"""
+
+from __future__ import annotations
+
+#: The release that introduced the internals the patches wrap.
+MIN_SEABORN = (0, 13)
+
+
+def _parse(version: str) -> tuple[int, ...]:
+    """Return the leading numeric components of a version string.
+
+    Deliberately tolerant: a version this cannot read must not become a
+    second, more confusing import failure than the one being replaced.
+    """
+    parts: list[int] = []
+    for chunk in version.split(".")[:2]:
+        digits = ""
+        for char in chunk:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def check_seaborn_version() -> None:
+    """Raise a readable ``ImportError`` on a seaborn the patches cannot wrap.
+
+    Raises
+    ------
+    ImportError
+        If the installed seaborn predates :data:`MIN_SEABORN`.
+    """
+    try:
+        import seaborn
+    except ImportError:
+        # Not our problem to report: seaborn is a declared dependency, and
+        # the import that needs it will say so plainly enough.
+        return
+
+    installed = getattr(seaborn, "__version__", "")
+    parsed = _parse(installed)
+    if not parsed or parsed >= MIN_SEABORN:
+        return
+
+    needed = ".".join(str(part) for part in MIN_SEABORN)
+    raise ImportError(
+        f"maidr requires seaborn >= {needed}, but seaborn {installed} is "
+        f"installed. maidr patches seaborn internals that arrived in "
+        f"{needed} (the categorical rewrite), so importing it against an "
+        f"older seaborn fails while those patches are applied. "
+        f"Upgrade with: pip install --upgrade 'seaborn>={needed}'"
+    )
+
+
+__all__ = ["MIN_SEABORN", "check_seaborn_version"]

--- a/tests/patch/test_seaborn_version.py
+++ b/tests/patch/test_seaborn_version.py
@@ -16,6 +16,7 @@ and cannot install an unsupported one to prove it.
 
 from __future__ import annotations
 
+import sys
 import types
 
 import pytest
@@ -58,7 +59,7 @@ class TestTheCheck:
         module = types.ModuleType("seaborn")
         if version is not None:
             module.__version__ = version
-        monkeypatch.setitem(__import__("sys").modules, "seaborn", module)
+        monkeypatch.setitem(sys.modules, "seaborn", module)
 
     def test_a_supported_seaborn_passes(self, monkeypatch):
         self._with_seaborn(monkeypatch, "0.13.2")

--- a/tests/util/test_seaborn_version.py
+++ b/tests/util/test_seaborn_version.py
@@ -1,0 +1,116 @@
+"""An unsupported seaborn must say so, not raise from inside wrapt (#441).
+
+The patches wrap seaborn internals by name, and the ones under
+``_CategoricalPlotter`` arrived in 0.13. On an older seaborn the failure
+used to be::
+
+    AttributeError: type object '_CategoricalPlotter' has no attribute 'plot_bars'
+
+raised while ``maidr.patch`` was being imported -- so before any of the
+user's own code ran, naming neither seaborn nor a version.
+
+Reproduced against a real seaborn 0.12.2 before this check existed; these
+tests drive the check itself, since the suite runs on a supported seaborn
+and cannot install an unsupported one to prove it.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from maidr.patch._seaborn_version import (
+    MIN_SEABORN,
+    _parse,
+    check_seaborn_version,
+)
+
+
+class TestParsingAVersion:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("0.13.2", (0, 13)),
+            ("0.12.2", (0, 12)),
+            ("1.0", (1, 0)),
+            ("0.14.0.dev0", (0, 14)),
+            ("0.13.2rc1", (0, 13)),
+        ],
+    )
+    def test_it_reads_the_leading_numbers(self, text, expected):
+        assert _parse(text) == expected
+
+    @pytest.mark.parametrize("text", ["", "unknown", "v0.13"])
+    def test_an_unreadable_version_yields_nothing(self, text):
+        """Tolerated rather than guessed at.
+
+        A version string this cannot read must not become a second, more
+        confusing import failure than the one being replaced -- so it
+        parses to nothing and the check lets the import proceed.
+        """
+        assert _parse(text) == ()
+
+
+class TestTheCheck:
+    @staticmethod
+    def _with_seaborn(monkeypatch, version):
+        module = types.ModuleType("seaborn")
+        if version is not None:
+            module.__version__ = version
+        monkeypatch.setitem(__import__("sys").modules, "seaborn", module)
+
+    def test_a_supported_seaborn_passes(self, monkeypatch):
+        self._with_seaborn(monkeypatch, "0.13.2")
+        check_seaborn_version()
+
+    def test_a_newer_seaborn_passes(self, monkeypatch):
+        self._with_seaborn(monkeypatch, "0.14.0")
+        check_seaborn_version()
+
+    def test_an_old_seaborn_raises(self, monkeypatch):
+        self._with_seaborn(monkeypatch, "0.12.2")
+        with pytest.raises(ImportError) as raised:
+            check_seaborn_version()
+
+        message = str(raised.value)
+        # What is installed, what is needed, and how to fix it -- the three
+        # things the AttributeError this replaces did not say.
+        assert "0.12.2" in message
+        assert "0.13" in message
+        assert "pip install" in message
+        assert "seaborn" in message
+
+    def test_an_unreadable_version_is_allowed_through(self, monkeypatch):
+        """Better a later, specific failure than a wrong early one.
+
+        Refusing to import on a version string we merely failed to parse
+        would break installs that work.
+        """
+        self._with_seaborn(monkeypatch, "not-a-version")
+        check_seaborn_version()
+
+    def test_a_seaborn_with_no_version_attribute_is_allowed_through(
+        self, monkeypatch
+    ):
+        self._with_seaborn(monkeypatch, None)
+        check_seaborn_version()
+
+
+def test_the_floor_matches_what_the_package_declares():
+    """The check and `pyproject.toml` have to agree.
+
+    Two floors that drift apart give the worst of both: a resolver that
+    installs a version the code then refuses, or the reverse.
+    """
+    import pathlib
+    import re
+
+    text = (pathlib.Path(__file__).parents[2] / "pyproject.toml").read_text()
+    declared = set(re.findall(r'"seaborn>=([0-9.]+)"', text))
+
+    expected = ".".join(str(part) for part in MIN_SEABORN)
+    assert declared == {expected}, (
+        f"pyproject declares seaborn floors {sorted(declared)}; the import "
+        f"check enforces {expected}"
+    )


### PR DESCRIPTION
## Description

#441 asked for one of two things. The floor half is done — `pyproject.toml` declares `seaborn>=0.13` and `maidr/patch/boxplot.py`'s wrong version branch is gone. This addresses what the issue said mattered *beyond* tidiness:

> Someone whose resolver lands on 0.12 — an older lockfile, a conflicting pin elsewhere in their environment — gets an `AttributeError` from `import maidr` with no indication that their seaborn version is the reason.

That is still true today. Reproduced on a real seaborn 0.12.2, following the issue's own steps:

```
AttributeError: type object '_CategoricalPlotter' has no attribute 'plot_bars'
```

Nothing there names seaborn, names a version, or says what to do, and it arrives while `maidr.patch` is being imported — before any of the user's own code runs.

**Note the attribute.** The issue reports `plot_boxes`; a real 0.12 install raises on **`plot_bars`**. The boxplot site had already been fixed, and four others had not. Five `_CategoricalPlotter` methods and two `_DistributionPlotter` ones are wrapped by name and all arrived in 0.13, so fixing them one at a time as they surface would be chasing a list.

Now:

```
ImportError: maidr requires seaborn >= 0.13, but seaborn 0.12.2 is installed.
maidr patches seaborn internals that arrived in 0.13 (the categorical
rewrite), so importing it against an older seaborn fails while those patches
are applied. Upgrade with: pip install --upgrade 'seaborn>=0.13'
```

### What this is not

It does **not** make seaborn 0.12 work — that is option 2 in the issue, still open, and it would need the boxen extraction to read 0.12's nested ladder as well. This replaces an error that says nothing with one that says which version is installed, which is needed, and how to fix it.

### Deliberately permissive

An unreadable or absent `__version__` is allowed through rather than treated as unsupported. Refusing to import on a version string we merely failed to parse would break installs that work, and the check exists to improve a failure — not to create one.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Refs #441 — the diagnosis half. Leaving the issue open for option 2 (making 0.12 genuinely work), which is a separate decision with the boxen work attached to it.

## Changes Made

- `maidr/patch/_seaborn_version.py` — new; the check, and why it is tolerant.
- `maidr/patch/__init__.py` — runs it before the patch modules are imported, which is the only point where it can precede the failure.
- `tests/util/test_seaborn_version.py` — 14 tests: version parsing including `.dev0` and `rc1` suffixes, the raise, both permissive paths, and that the check's floor and `pyproject.toml`'s agree, so the two cannot drift into a resolver installing a version the code then refuses.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — 2256 passed, 13 skipped. `ruff check` shows the same six pre-existing `F401`s as `main`.

Verified both directions against real installs rather than only against the mocked check:

```
seaborn 0.12.2  ->  ImportError, message above
seaborn 0.13.2  ->  import maidr OK
```

The unit tests drive the check with a stub module, since the suite runs on a supported seaborn and cannot install an unsupported one to prove it — the real 0.12.2 environment is what established that the check fires on the right thing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_