### PR TITLE
ci: gate the release on the accessibility browser tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,62 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # `ci.yml` runs this before every install and `release.yml` never did.
+      # `uv sync --locked` below fails on a stale lockfile anyway, but with a
+      # resolver error rather than the sentence saying what to do about it --
+      # and this is the run that publishes, so the difference is worth the
+      # four lines.
+      - name: Check lockfile sync
+        run: |
+          if ! uv lock --check; then
+            echo "Error: Lockfile is out of sync with pyproject.toml"
+            echo "Please run 'uv lock' locally and commit the changes"
+            exit 1
+          fi
+
+      # Matches `ci.yml` rather than naming extras. A narrower install here
+      # silently skipped every test guarded by `importorskip` -- the whole
+      # Streamlit integration, because `streamlit` is deliberately not in the
+      # `test` extra -- so the release ran a weaker suite than the pull
+      # request that produced it.
       - name: Install the project
-        run: uv sync --locked --extra test --extra visualization
+        run: uv sync --locked --all-extras --dev
 
       - name: Run tests
         id: tests
         run: uv run pytest -vvv
+
+  browser:
+    name: Accessibility tests in a browser
+
+    runs-on: ubuntu-latest
+
+    # `release` needs this job, so a chart that cannot be driven from the
+    # keyboard blocks the publish. That is the point: everything else in
+    # the suite asserts on emitted markup, which cannot tell a working
+    # chart from a well-formed one, and the release refreshes the bundled
+    # `maidr.js` -- the change most able to break navigation while every
+    # markup assertion still passes.
+    #
+    # No `if:` guard, unlike `ci.yml`: this workflow runs only on a
+    # schedule or a manual dispatch, so there is no second event to
+    # deduplicate against.
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the project
+        run: uv sync --locked --all-extras --dev
+
+      - name: Install the browser Playwright drives
+        run: uv run playwright install --with-deps chromium
+
+      - name: Run the browser tests
+        run: uv run pytest tests/browser -vv --run-browser
 
   lint:
     runs-on: ubuntu-latest
@@ -75,7 +125,7 @@ jobs:
     name: Semantic Release
     runs-on: ubuntu-latest
     concurrency: release
-    needs: [test, lint]
+    needs: [test, lint, browser]
     if: github.repository == 'xability/py-maidr'
     environment:
       name: pypi


### PR DESCRIPTION
## Description

`release.yml` is the last gate before a version reaches PyPI, and it ran a strictly weaker suite than the CI that gates a pull request. Two gaps, both in checks on whether charts are actually accessible.

**The browser tests never ran.** `tests/browser/` is opt-in behind `--run-browser`. Only `ci.yml` passed it:

```yaml
# ci.yml
run: uv run pytest tests/browser -vv --run-browser

# release.yml
run: uv run pytest -vvv          # every browser test skips
```

**Streamlit was not installed, so its tests skipped too.** The release job installed `--extra test --extra visualization`, and `streamlit` is deliberately absent from the `test` extra, so every `pytest.importorskip("streamlit")` test skipped — including the real-`AppTest` run that #479 extended to cover the `components.v1.html` fallback.

Net: the release gate had never run a single browser test or a single Streamlit integration test.

That matters more than it sounds. The release job **refreshes the bundled `maidr.js` from npm at release time**, which is precisely the change able to break navigation or the offline report while every markup assertion still passes. The browser tests are the ones that would notice, and they were the ones not running.

## Changes Made

- `release.yml` `test` job installs `--all-extras --dev`, matching `ci.yml` rather than naming extras. Naming them is what let `streamlit` fall out silently.
- A `browser` job mirroring `ci.yml`'s, without the `if:` guard — this workflow runs only on a schedule or manual dispatch, so there is no second event to deduplicate against.
- `release` now `needs: [test, lint, browser]`.
- **A `Check lockfile sync` step on the `test` job.** `ci.yml` has it in two jobs and `release.yml` had it in none. `uv sync --locked` would already fail on a stale lockfile, so what this buys is the message: *"Lockfile is out of sync with pyproject.toml — run `uv lock` locally and commit the changes"* instead of a resolver error, on the run that publishes. Added in review, hence its absence from the first version of this list.

### On blocking

#490 asked whether a red browser test should block a release or merely report. **Blocking**, on the grounds that for a library whose purpose is that charts can be driven from the keyboard, shipping while that is unverified is the worse failure. The cost is real and worth naming: a flaky browser job now holds a release. The suite is 12 tests over ~3.5 minutes and has been green on every run so far, so this is a bet that it stays cheap — if it starts flaking, the fix is to stabilise it rather than to demote it, since a check that cannot block is not a gate.

A scheduled failure is also harder to notice than a PR failure — nobody is watching a Monday cron — which is an argument for keeping the job fast and boring rather than for letting it pass on red.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Closes #490. Introduced by #485, which added `tests/browser/` and the CI job without touching `release.yml` — found by auditing my own changes, not by anything failing.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`actionlint` clean. Parsed the result to confirm the wiring rather than eyeballing the YAML:

```
test    -> [checkout, setup-uv, Check lockfile sync, Install the project, Run tests]
browser -> [checkout, setup-uv, Install the project, Install the browser…, Run the browser tests]
release -> needs: ['test', 'lint', 'browser']
```

The browser suite was run locally exactly as the new job runs it — `pytest tests/browser -vv --run-browser` — **12 passed in 204 s**.

One thing this does not fix: `ci.yml` and `release.yml` still declare the same steps twice, which is how they drifted in the first place. #490 raised a composite action as the durable answer; that is a larger refactor of both files and is left out of a change whose point is to close the hole now. This PR adds one more duplicated block, which strengthens that case rather than weakening it.