### PR TITLE
refactor(util): give the shared warning policy its own module

### DIFF
--- a/maidr/util/bundle_capability.py
+++ b/maidr/util/bundle_capability.py
@@ -19,12 +19,8 @@ import threading
 import warnings
 from collections.abc import Iterable
 
-from maidr.util.dependencies import (
-    BUNDLE_WARNING_ENV_VAR,
-    _bundle_warning_enabled,
-    bundled_js_path,
-    maidr_js_version,
-)
+from maidr.util.dependencies import bundled_js_path, maidr_js_version
+from maidr.util.warn import BUNDLE_WARNING_ENV_VAR, bundle_warning_enabled
 
 _logger = logging.getLogger(__name__)
 
@@ -159,7 +155,7 @@ def warn_if_bundle_cannot_render(
     rendered in a loop says it once and a second unsupported type is not
     swallowed by the first.
     """
-    if not _bundle_warning_enabled():
+    if not bundle_warning_enabled():
         return
 
     known = bundle_trace_types()

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -60,6 +60,13 @@ from typing import NamedTuple
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
+from maidr.util.warn import (
+    BUNDLE_WARNING_ENV_VAR,
+    _MAX_WARNED_KEY_LEN,
+    bundle_warning_enabled,
+    warn_once,
+)
+
 
 _logger = logging.getLogger(__name__)
 
@@ -284,32 +291,17 @@ def _is_valid_version(candidate: str) -> bool:
     )
 
 
-# Keys of warnings already logged, so a bad pin is reported once instead
-# of on every URL build.  See :func:`_warn_once`.
-_warned_keys: set[str] = set()
-_warned_keys_lock = threading.Lock()
-
-# Ceilings on the above.  Normal use adds nothing or one entry; these
-# only matter for a process that programmatically cycles through many
-# distinct bad pins.  Both are needed for the bound to be real: capping
-# the entry count alone still lets one arbitrarily long pin become an
-# arbitrarily long key.
-# Note the guarantee this buys is "each distinct value warns, and
-# repeats stay quiet" rather than "exactly once, forever": eviction
-# clears the whole set, so a value that already warned can warn again
-# once 64 other distinct values have cycled through.
-_MAX_WARNED_KEYS = 64
-_MAX_WARNED_KEY_LEN = 200
 
 # Deliberately not guarded by ``_resolution_lock`` below: this is a lone
 # reference assignment, written only by an explicit
 # :func:`set_cdn_version` call.  The lock exists to stop concurrent
 # *lookups*, which are a compound read-modify-write, not to protect this.
 #
-# Unlike the compound update in :func:`_warn_once`, the reasoning here
-# does not depend on the GIL and so survives free-threaded builds (PEP
-# 703): storing a single object reference stays indivisible there, so a
-# reader sees either the old value or the new one, never a torn write.
+# Unlike the compound update in :func:`maidr.util.warn.warn_once`, the
+# reasoning here does not depend on the GIL and so survives free-threaded
+# builds (PEP 703): storing a single object reference stays indivisible
+# there, so a reader sees either the old value or the new one, never a
+# torn write.
 _cdn_version_override: str | None = None
 
 _resolved_cdn_version: str | None = None
@@ -649,7 +641,7 @@ def _offline_version() -> str:
     # Keyed on the unusable value, so a wheel whose VERSION is garbled
     # rather than absent says which -- and a second, differently broken
     # one is still audible.
-    _warn_once(
+    warn_once(
         f"unusable-bundled-version:{bundled}",
         "maidr: the bundled maidr.js version %s, so CDN URLs fall back to "
         "the mutable maidr@%s tag. jsDelivr serves that with a seven-day "
@@ -936,7 +928,7 @@ def _normalise_version_pin(pin: str) -> str | None:
         # lookup would betray that intent for someone who chose it to
         # avoid egress, so degrade to ``@latest`` — still a working URL,
         # still no request.
-        _warn_once(
+        warn_once(
             f"{BUNDLED_TAG}:{bundled}",
             "maidr: a %r CDN version pin was requested but the bundled "
             "VERSION is %r; falling back to the %r dist-tag without "
@@ -954,7 +946,7 @@ def _normalise_version_pin(pin: str) -> str | None:
         return candidate
     # Truncate for display too: the key is capped, but an oversized pin
     # would otherwise land in the log line at full length.
-    _warn_once(
+    warn_once(
         f"pin:{pin}",
         "maidr: ignoring invalid CDN version pin %r; expected a semver "
         "such as '3.74.0', %r, or %r.",
@@ -988,7 +980,7 @@ def _warn_if_pin_predates_stylesheet_split(version: str) -> None:
     split_key = _version_key(_STYLESHEET_SPLIT_VERSION)
     if key is None or split_key is None or key >= split_key:
         return
-    _warn_once(
+    warn_once(
         f"pre-split-pin:{version}",
         "maidr: CDN version pin %r predates maidr %s, where KaTeX moved out "
         "of maidr.css into maidr-math.css. py-maidr links no stylesheet, so "
@@ -1000,46 +992,6 @@ def _warn_if_pin_predates_stylesheet_split(version: str) -> None:
     )
 
 
-def _warn_once(key: str, message: str, *args: object) -> None:
-    """Log a warning the first time it is seen, then stay quiet about it.
-
-    :func:`_normalise_version_pin` runs on every URL build — twice per
-    figure in the CDN modes — so a single typo'd ``MAIDR_CDN_VERSION``
-    would otherwise log two lines per rendered plot for the life of the
-    process.  Deduplicating by ``key`` rather than warning once globally
-    keeps a *second*, differently-broken pin audible.
-
-    Parameters
-    ----------
-    key : str
-        Identity of this warning.  Include the offending value so that
-        changing the value re-warns.  Truncated to
-        :data:`_MAX_WARNED_KEY_LEN`, so two pins identical for that many
-        characters share one warning.
-    message : str
-        ``logging``-style format string.
-    *args : object
-        Arguments interpolated into ``message`` by the logger.
-    """
-    key = key[:_MAX_WARNED_KEY_LEN]
-    if key in _warned_keys:
-        return
-    # Claim the key under the lock.  Individual set operations being
-    # atomic would not be enough: the sequence below is compound, so two
-    # threads could both pass the size check and one's ``clear()`` would
-    # drop the key the other just added.  Leaning on the GIL for that
-    # would also stop holding under free-threaded builds (PEP 703).  The
-    # membership test above keeps the lock off the common path.
-    with _warned_keys_lock:
-        if key in _warned_keys:
-            return
-        if len(_warned_keys) >= _MAX_WARNED_KEYS:
-            # Start over rather than grow without bound.  A process
-            # churning through this many distinct bad pins will see the
-            # occasional repeat, which is a fair trade for fixed memory.
-            _warned_keys.clear()
-        _warned_keys.add(key)
-    _logger.warning(message, *args)
 
 
 def _cdn_timeout() -> float:
@@ -1076,7 +1028,7 @@ def _cdn_timeout() -> float:
     try:
         timeout = float(raw)
     except ValueError:
-        _warn_once(
+        warn_once(
             f"timeout-nan:{raw}",
             "maidr: ignoring non-numeric %s=%r; using the %ss default.",
             CDN_TIMEOUT_ENV_VAR,
@@ -1090,7 +1042,7 @@ def _cdn_timeout() -> float:
         # guard and reach ``urlopen`` — which raises, gets swallowed by
         # the broad handler there, and silently disables resolution with
         # nothing logged.  ``inf`` would hang instead of being clamped.
-        _warn_once(
+        warn_once(
             f"timeout-nonfinite:{raw}",
             "maidr: %s=%s is not a finite number; using the %ss default.",
             CDN_TIMEOUT_ENV_VAR,
@@ -1102,7 +1054,7 @@ def _cdn_timeout() -> float:
         # Say so rather than silently substituting the default: `0` most
         # plausibly means "don't look up", and the user should learn that
         # it doesn't rather than wonder where the wait came from.
-        _warn_once(
+        warn_once(
             f"timeout-nonpositive:{raw}",
             "maidr: %s=%s is not a valid budget, so the %ss default applies. "
             "To skip the lookup entirely, set %s=%s.",
@@ -1114,7 +1066,7 @@ def _cdn_timeout() -> float:
         )
         return _DEFAULT_CDN_TIMEOUT
     if timeout < _MIN_CDN_TIMEOUT:
-        _warn_once(
+        warn_once(
             f"timeout-tiny:{raw}",
             "maidr: %s=%s is below the %ss floor and was clamped. The value "
             "is in seconds; a budget that small times out on every attempt "
@@ -1126,7 +1078,7 @@ def _cdn_timeout() -> float:
         )
         return _MIN_CDN_TIMEOUT
     if timeout > _MAX_CDN_TIMEOUT:
-        _warn_once(
+        warn_once(
             f"timeout:{raw}",
             "maidr: %s=%s exceeds the %ss cap and was clamped. The value is "
             "in seconds; a lookup needing longer would fall back to the "
@@ -1349,9 +1301,6 @@ def _fetch_latest_version(budget: float) -> str | None:
 #: outruns py-maidr's releases.
 STALE_MINOR_GAP = 5
 
-#: Set to ``0`` / ``false`` / ``off`` to silence the staleness warning.
-BUNDLE_WARNING_ENV_VAR = "MAIDR_BUNDLE_STALE_WARNING"
-
 # Same grammar as :data:`_VERSION_RE`, with the parts named so
 # :func:`_version_key` can pull them out.  Kept deliberately in step with
 # it: a looser shape here would mean a version this module refuses to pin
@@ -1522,7 +1471,7 @@ def warn_bundle_unreadable() -> None:
     before it happens; the staleness warning fires from an explicit render
     call, where a filterable warning category is the better fit.
     """
-    _warn_once(
+    warn_once(
         "missing-bundle",
         "maidr: use_cdn=False was requested but the bundled maidr.js/css "
         "could not be read, so the notebook will load them from the CDN. "
@@ -1584,7 +1533,7 @@ def warn_if_bundle_is_stale(*, bundle_is_primary: bool = True) -> None:
     than about how it was called — the message stands alone without a
     call site.
     """
-    if bundle_is_primary in _bundle_warned or not _bundle_warning_enabled():
+    if bundle_is_primary in _bundle_warned or not bundle_warning_enabled():
         return
 
     status = bundle_status(resolve=False)
@@ -1619,12 +1568,6 @@ def warn_if_bundle_is_stale(*, bundle_is_primary: bool = True) -> None:
         _logger.warning("%s", message)
 
 
-def _bundle_warning_enabled() -> bool:
-    """Return whether the staleness warning is enabled (it is by default)."""
-    raw = os.environ.get(BUNDLE_WARNING_ENV_VAR)
-    if raw is None:
-        return True
-    return raw.strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _prerelease_key(prerelease: str) -> tuple[tuple[int, int, str], ...]:

--- a/maidr/util/warn.py
+++ b/maidr/util/warn.py
@@ -1,0 +1,93 @@
+"""Warning policy shared by everything that reports on the bundle.
+
+Split out of :mod:`maidr.util.dependencies` (#293).  Both halves of that
+module warn, and the split would otherwise have left one importing a
+private helper from the other across a module boundary -- a wart four
+reviews of #494 flagged in a row.
+
+Deliberately a leaf: nothing here imports another ``maidr`` module, so
+both sides can import it eagerly without the lazy-shim dance
+``bundle_capability`` needs.  Keep it that way; the moment this file
+imports back into the package, it stops being able to serve as the shared
+bottom of the stack.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+_logger = logging.getLogger(__name__)
+
+
+# Keys of warnings already logged, so a bad pin is reported once instead
+# of on every URL build.  See :func:`warn_once`.
+_warned_keys: set[str] = set()
+_warned_keys_lock = threading.Lock()
+
+# Ceilings on the above.  Normal use adds nothing or one entry; these
+# only matter for a process that programmatically cycles through many
+# distinct bad pins.  Both are needed for the bound to be real: capping
+# the entry count alone still lets one arbitrarily long pin become an
+# arbitrarily long key.
+# Note the guarantee this buys is "each distinct value warns, and
+# repeats stay quiet" rather than "exactly once, forever": eviction
+# clears the whole set, so a value that already warned can warn again
+# once 64 other distinct values have cycled through.
+_MAX_WARNED_KEYS = 64
+_MAX_WARNED_KEY_LEN = 200
+
+
+#: Set to ``0`` / ``false`` / ``off`` to silence the staleness warning.
+BUNDLE_WARNING_ENV_VAR = "MAIDR_BUNDLE_STALE_WARNING"
+
+
+def warn_once(key: str, message: str, *args: object) -> None:
+    """Log a warning the first time it is seen, then stay quiet about it.
+
+    :func:`_normalise_version_pin` runs on every URL build — twice per
+    figure in the CDN modes — so a single typo'd ``MAIDR_CDN_VERSION``
+    would otherwise log two lines per rendered plot for the life of the
+    process.  Deduplicating by ``key`` rather than warning once globally
+    keeps a *second*, differently-broken pin audible.
+
+    Parameters
+    ----------
+    key : str
+        Identity of this warning.  Include the offending value so that
+        changing the value re-warns.  Truncated to
+        :data:`_MAX_WARNED_KEY_LEN`, so two pins identical for that many
+        characters share one warning.
+    message : str
+        ``logging``-style format string.
+    *args : object
+        Arguments interpolated into ``message`` by the logger.
+    """
+    key = key[:_MAX_WARNED_KEY_LEN]
+    if key in _warned_keys:
+        return
+    # Claim the key under the lock.  Individual set operations being
+    # atomic would not be enough: the sequence below is compound, so two
+    # threads could both pass the size check and one's ``clear()`` would
+    # drop the key the other just added.  Leaning on the GIL for that
+    # would also stop holding under free-threaded builds (PEP 703).  The
+    # membership test above keeps the lock off the common path.
+    with _warned_keys_lock:
+        if key in _warned_keys:
+            return
+        if len(_warned_keys) >= _MAX_WARNED_KEYS:
+            # Start over rather than grow without bound.  A process
+            # churning through this many distinct bad pins will see the
+            # occasional repeat, which is a fair trade for fixed memory.
+            _warned_keys.clear()
+        _warned_keys.add(key)
+    _logger.warning(message, *args)
+
+
+def bundle_warning_enabled() -> bool:
+    """Return whether the staleness warning is enabled (it is by default)."""
+    raw = os.environ.get(BUNDLE_WARNING_ENV_VAR)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in {"0", "false", "no", "off"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from matplotlib import pyplot as plt
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.enum.library import Library
 from maidr.util import dependencies
+from maidr.util import warn as warn_module
 from tests.fixture.matplotlib_factory import MatplotlibFactory
 from tests.fixture.seaborn_factory import SeabornFactory
 
@@ -25,7 +26,7 @@ def offline_cdn_version(monkeypatch):
     """
     monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, dependencies.LATEST_TAG)
     monkeypatch.setattr(dependencies, "_bundle_warned", set())
-    monkeypatch.setattr(dependencies, "_warned_keys", set())
+    monkeypatch.setattr(warn_module, "_warned_keys", set())
 
     # Default-deny the network rather than relying on the pin above.
     # ``bundle_status()`` deliberately ignores pins when resolving the

--- a/tests/core/test_broken_bundle_version.py
+++ b/tests/core/test_broken_bundle_version.py
@@ -23,6 +23,7 @@ import logging
 import pytest
 
 from maidr.util import dependencies
+from maidr.util import warn as warn_module
 
 
 @pytest.fixture
@@ -31,7 +32,7 @@ def no_pin(monkeypatch):
     monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
     dependencies.set_cdn_version(None)
     dependencies.reset_cdn_version_cache()
-    dependencies._warned_keys.clear()
+    warn_module._warned_keys.clear()
     yield
     dependencies.set_cdn_version(None)
     dependencies.reset_cdn_version_cache()

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -26,6 +26,7 @@ import pytest
 
 import maidr
 from maidr.util import dependencies
+from maidr.util import warn as warn_module
 
 
 # `maidr_css_cdn_url` is deprecated (#333) and warns on every call. These tests
@@ -382,11 +383,11 @@ def test_warned_keys_stays_bounded(resolvable):
     asserted: the subject here is the *log* dedup set, and every one of
     these several hundred calls raises the same deprecation.
     """
-    for i in range(dependencies._MAX_WARNED_KEYS * 3):
+    for i in range(warn_module._MAX_WARNED_KEYS * 3):
         maidr.set_cdn_version(f"bad-{i}")
         dependencies.maidr_js_cdn_url()
 
-    assert len(dependencies._warned_keys) <= dependencies._MAX_WARNED_KEYS
+    assert len(warn_module._warned_keys) <= warn_module._MAX_WARNED_KEYS
 
 
 @pytest.mark.parametrize(
@@ -794,7 +795,7 @@ def test_concurrent_warn_once_emits_once(monkeypatch):
     this as a free-threading guard and a smoke test, not as evidence that
     the lock is load-bearing today.
     """
-    monkeypatch.setattr(dependencies, "_warned_keys", set())
+    monkeypatch.setattr(warn_module, "_warned_keys", set())
     emitted: list[tuple] = []
     emit_lock = threading.Lock()
 
@@ -802,9 +803,9 @@ def test_concurrent_warn_once_emits_once(monkeypatch):
         with emit_lock:
             emitted.append(args)
 
-    monkeypatch.setattr(dependencies._logger, "warning", record)
+    monkeypatch.setattr(warn_module._logger, "warning", record)
 
-    _run_concurrently(lambda: dependencies._warn_once("same-key", "msg"))
+    _run_concurrently(lambda: warn_module.warn_once("same-key", "msg"))
 
     assert len(emitted) == 1, f"emitted {len(emitted)} times, expected 1"
 

--- a/tests/core/test_pin_validation.py
+++ b/tests/core/test_pin_validation.py
@@ -22,6 +22,7 @@ import pytest
 
 import maidr
 from maidr.util import dependencies
+from maidr.util import warn as warn_module
 
 
 @pytest.fixture(autouse=True)
@@ -29,7 +30,7 @@ def clean():
     """No pin, no cached lookup, and a fresh log-dedup set."""
     dependencies.set_cdn_version(None)
     dependencies.reset_cdn_version_cache()
-    dependencies._warned_keys.clear()
+    warn_module._warned_keys.clear()
     yield
     dependencies.set_cdn_version(None)
     dependencies.reset_cdn_version_cache()

--- a/tests/util/test_warn_module.py
+++ b/tests/util/test_warn_module.py
@@ -1,0 +1,74 @@
+"""The shared warning policy, and the property that lets it be shared.
+
+``maidr.util.warn`` exists so the halves of the ``dependencies.py`` split
+(#293) can both warn without one importing a private helper from the
+other. That only works while it stays a leaf.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+from maidr.util import warn
+
+
+def test_the_warn_module_imports_nothing_from_maidr():
+    """It has to sit at the bottom of the stack, and stay there.
+
+    ``dependencies`` and ``bundle_capability`` both import this eagerly.
+    The moment it imports back into the package it becomes a cycle, and
+    the fix would be another lazy shim -- for a module whose whole purpose
+    is to be simple enough not to need one.
+
+    Asserted on the parse tree rather than on ``sys.modules``: importing
+    any submodule initialises the ``maidr`` package first, so at runtime
+    everything looks imported no matter what this file does.
+    """
+    tree = ast.parse(pathlib.Path(warn.__file__).read_text())
+
+    offenders = [
+        ast.unparse(node)
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        and "maidr" in ast.unparse(node)
+    ]
+
+    assert not offenders, (
+        f"maidr.util.warn imports from the package: {offenders}. It is the "
+        "shared bottom of the warning stack and has to stay a leaf."
+    )
+
+
+def test_warn_once_is_quiet_the_second_time(monkeypatch):
+    """The property every caller depends on."""
+    seen: list[str] = []
+    monkeypatch.setattr(warn, "_warned_keys", set())
+    monkeypatch.setattr(warn._logger, "warning", lambda msg, *a: seen.append(msg % a))
+
+    warn.warn_once("a-key", "%s happened", "something")
+    warn.warn_once("a-key", "%s happened", "something")
+
+    assert seen == ["something happened"]
+
+
+def test_a_different_key_still_warns(monkeypatch):
+    """Deduplication is per key, so a second distinct fault stays audible."""
+    seen: list[str] = []
+    monkeypatch.setattr(warn, "_warned_keys", set())
+    monkeypatch.setattr(warn._logger, "warning", lambda msg, *a: seen.append(msg % a))
+
+    warn.warn_once("first", "%s", "one")
+    warn.warn_once("second", "%s", "two")
+
+    assert seen == ["one", "two"]
+
+
+def test_the_env_var_silences_the_bundle_warning(monkeypatch):
+    """The other half of the shared policy."""
+    monkeypatch.delenv(warn.BUNDLE_WARNING_ENV_VAR, raising=False)
+    assert warn.bundle_warning_enabled()
+
+    for off in ("0", "false", "no", "off", "OFF"):
+        monkeypatch.setenv(warn.BUNDLE_WARNING_ENV_VAR, off)
+        assert not warn.bundle_warning_enabled(), off


### PR DESCRIPTION
## Description

Prerequisite for the next cut of #293, and a fix for the one thing four consecutive reviews of #494 flagged: `bundle_capability` imported the private `_bundle_warning_enabled` from `dependencies` across a module boundary, because the warning-suppression policy belongs to neither half.

`maidr/util/warn.py` now owns it — `warn_once` and its dedup bookkeeping, `bundle_warning_enabled`, and `BUNDLE_WARNING_ENV_VAR`.

## The property that makes this work

**It is a leaf: it imports nothing from the package.** That is why both halves can import it eagerly, with none of the lazy `__getattr__` machinery `bundle_capability` needed — `warn.py` cannot participate in a cycle it has no edge into.

`test_the_warn_module_imports_nothing_from_maidr` asserts it on the parse tree, and the reason it is not a runtime check is the same one from #494: importing any submodule initialises the `maidr` package first, so at runtime everything looks imported regardless. Mutation-checked by adding one import back:

```
maidr/util/dependencies.py:63: from maidr.util.warn import (
maidr/util/warn.py:20:        from maidr.util.dependencies import maidr_js_version
E   ImportError: cannot import name 'maidr_js_version' from partially
    initialized module 'maidr.util.dependencies' (circular import)
```

As with the shim guard, a live cycle announces itself at collection; the AST assertion is for the quiet case, and for naming the invariant.

## Not pure motion — one behaviour change

`warn_once` now logs through the **`maidr.util.warn`** logger rather than `maidr.util.dependencies`. Calling that out rather than burying it:

- Filtering or configuring on the `maidr` prefix — the common case — is unaffected.
- Only a filter naming `maidr.util.dependencies` exactly would stop seeing these lines.

I judged that acceptable for an internal module whose path appears nowhere in `docs/` or `README.md`, but it is a real difference and worth a maintainer's eye rather than my say-so alone. Keeping the old name would have meant a module lying about where its logging comes from.

The two names also lose their underscores — `_warn_once` → `warn_once`, `_bundle_warning_enabled` → `bundle_warning_enabled` — since crossing a module boundary on purpose is exactly what a leading underscore says you are not doing.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor

## Related Issues

Refs #293, which names this directly: *"`_warn_once` and its bookkeeping are shared by both the CDN and staleness sides, so it needs a deliberate home rather than being duplicated."*

## Changes Made

- `maidr/util/warn.py` — new leaf module.
- `maidr/util/dependencies.py` — 2090 → 2013 lines; imports the four names it still uses.
- `maidr/util/bundle_capability.py` — no longer reaches into `dependencies` for a private name.
- `tests/util/test_warn_module.py` — new: the leaf invariant, dedup-per-key, and the env-var switch.
- `tests/conftest.py` and three test files — repointed at the module that now owns the state.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — **2329 passed, 13 skipped** (2325 + the 4 new). `ruff check` unchanged from `main` at 6 pre-existing findings.

Two things this cost that are worth knowing before the freshness cut:

1. **`_MAX_WARNED_KEY_LEN` is used by callers, not just by `warn_once`** — ten sites truncate keys before calling. It is part of the shared contract rather than an implementation detail, so it moved too and is imported back.
2. **A single line in `tests/conftest.py` patches this state**, so getting it wrong fails the entire suite at collection rather than in one file. It looked like a 100-file blast radius and was one line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_