### PR TITLE
refactor(util): move bundle staleness reporting into its own module

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -362,6 +362,12 @@ It is only raised as a warning when the bundle genuinely runs
 (`use_cdn=False`). Under `use_cdn="auto"` the CDN copy normally loads
 instead, so the drift is reported to the logger rather than as a warning
 that could redden a test suite over code that never executed.
+
+That record comes from `maidr.util.bundle_freshness`, and the separate
+"bundle could not be read" record from `maidr.util.warn`. Both were
+emitted from `maidr.util.dependencies` in earlier releases, so filter on
+`maidr.util` — which has always caught both, and still will if they move
+again — rather than on a leaf module name.
 :::
 
 ::: {.callout-important}

--- a/maidr/__init__.py
+++ b/maidr/__init__.py
@@ -211,18 +211,20 @@ from .patch import (  # noqa: E402, F401
     violinplot,
 )
 from .util.bundle_capability import MaidrBundleTraceWarning  # noqa: E402
+from .util.bundle_freshness import (  # noqa: E402
+    STALE_MINOR_GAP,
+    BundleStatus,
+    MaidrBundleStaleWarning,
+    bundle_status,
+    resolver_outcome,
+)
+from .util.warn import BUNDLE_WARNING_ENV_VAR  # noqa: E402
 from .util.dependencies import (  # noqa: E402
-    BUNDLE_WARNING_ENV_VAR,
     BUNDLED_TAG,
     CDN_TIMEOUT_ENV_VAR,
     CDN_VERSION_ENV_VAR,
     LATEST_TAG,
-    STALE_MINOR_GAP,
-    BundleStatus,
     ResolverOutcome,
-    MaidrBundleStaleWarning,
-    bundle_status,
-    resolver_outcome,
     bundled_css_path,
     bundled_js_path,
     bundled_math_css_path,

--- a/maidr/__init__.py
+++ b/maidr/__init__.py
@@ -218,7 +218,6 @@ from .util.bundle_freshness import (  # noqa: E402
     bundle_status,
     resolver_outcome,
 )
-from .util.warn import BUNDLE_WARNING_ENV_VAR  # noqa: E402
 from .util.dependencies import (  # noqa: E402
     BUNDLED_TAG,
     CDN_TIMEOUT_ENV_VAR,
@@ -235,6 +234,7 @@ from .util.dependencies import (  # noqa: E402
     reset_cdn_version_cache,
     set_cdn_version,
 )
+from .util.warn import BUNDLE_WARNING_ENV_VAR  # noqa: E402
 
 # Second call: reclaim the backend after maidr's own imports.
 # NOTE: See the "Matplotlib backend activation" block at the top of this

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -240,13 +240,15 @@ def init_notebook(
         # IPython not importable — nothing to display into.
         return
 
+    from maidr.util.bundle_freshness import (
+        warn_bundle_unreadable,
+        warn_if_bundle_is_stale,
+    )
     from maidr.util.dependencies import (
         MAIDR_JS_FILENAME,
         read_bundled_js,
         read_bundled_math_css,
         bundled_cdn_url,
-        warn_bundle_unreadable,
-        warn_if_bundle_is_stale,
     )
 
     mode = _resolve_use_cdn(use_cdn)

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -24,11 +24,11 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.plot import MaidrPlot
 from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
-from maidr.util.bundle_freshness import warn_if_bundle_is_stale
 from maidr.util.bundle_capability import (
     schema_trace_types,
     warn_if_bundle_cannot_render,
 )
+from maidr.util.bundle_freshness import warn_if_bundle_is_stale
 from maidr.util.dependencies import (
     MAIDR_JS_FILENAME,
     OFFLINE_FALLBACK_REPORT,

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -24,6 +24,7 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.plot import MaidrPlot
 from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
+from maidr.util.bundle_freshness import warn_if_bundle_is_stale
 from maidr.util.bundle_capability import (
     schema_trace_types,
     warn_if_bundle_cannot_render,
@@ -37,7 +38,6 @@ from maidr.util.dependencies import (
     maidr_bundled_relative_dir,
     maidr_html_dependency,
     maidr_js_cdn_url,
-    warn_if_bundle_is_stale,
 )
 from maidr.util.environment import Environment
 from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_matplotlib

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -35,11 +35,11 @@ from maidr.plotly.step_shape import (
     is_step_trace,
     renders_through_webgl,
 )
-from maidr.util.bundle_freshness import warn_if_bundle_is_stale
 from maidr.util.bundle_capability import (
     schema_trace_types,
     warn_if_bundle_cannot_render,
 )
+from maidr.util.bundle_freshness import warn_if_bundle_is_stale
 from maidr.util.dependencies import (
     MAIDR_JS_FILENAME,
     OFFLINE_FALLBACK_REPORT,

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -35,6 +35,7 @@ from maidr.plotly.step_shape import (
     is_step_trace,
     renders_through_webgl,
 )
+from maidr.util.bundle_freshness import warn_if_bundle_is_stale
 from maidr.util.bundle_capability import (
     schema_trace_types,
     warn_if_bundle_cannot_render,
@@ -48,7 +49,6 @@ from maidr.util.dependencies import (
     maidr_bundled_relative_dir,
     maidr_html_dependency,
     maidr_js_cdn_url,
-    warn_if_bundle_is_stale,
 )
 from maidr.util.environment import Environment
 from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_plotly

--- a/maidr/util/bundle_freshness.py
+++ b/maidr/util/bundle_freshness.py
@@ -1,0 +1,314 @@
+"""How far the bundled ``maidr.js`` has drifted from what is published.
+
+Split out of :mod:`maidr.util.dependencies` (#293), which owned three
+separable concerns.  This is the one that answers "how old is the copy in
+this wheel" -- the coarse signal.  Whether that copy can actually draw a
+given chart is a different question, answered by
+:mod:`maidr.util.bundle_capability`, and the two are deliberately kept
+apart: "you are drifting" and "this chart will not draw" are different
+claims, and the second is the one worth acting on.
+
+Its tests live in ``tests/core/test_bundle_freshness.py``, which split
+along this line before the module did.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import warnings
+from typing import NamedTuple
+
+from maidr.util import dependencies as _deps
+from maidr.util.dependencies import (
+    _UNKNOWN_VERSION,
+    _version_key,
+    ResolverOutcome,
+)
+from maidr.util.warn import (
+    BUNDLE_WARNING_ENV_VAR,
+    bundle_warning_enabled,
+    warn_once,
+)
+
+_logger = logging.getLogger(__name__)
+
+#: Minor-version gap at which the bundled fallback stops being "a release
+#: or two behind" and starts being a copy users should know about.  The
+#: bug report that prompted this check cited a gap of 8.
+#:
+#: Picked without the release histories, then measured against them (#292).
+#: The question that decides it is not how fast upstream ships, it is how
+#: many minors accumulate between the py-maidr releases that refresh the
+#: bundle.  Over the seventeen cycles from 2026-01-31 to 2026-08-10:
+#:
+#:     median 1   mean 1.7   min 0   max 7
+#:     cycles reaching 3+:  6/17  (35%)
+#:     cycles reaching 5+:  1/17  (6%)
+#:     cycles reaching 8+:  0/17  (0%)
+#:
+#: So 5 fires on the one cycle in seventeen where the bundle genuinely
+#: fell behind -- a 68-day gap with nothing released -- and stays quiet
+#: otherwise.  3 would fire on a third of all cycles, which is how a
+#: warning becomes noise; 8 would not have fired even on that one.
+#:
+#: Recompute the *cycle* table, not upstream's cadence, if this is ever
+#: revisited: upstream shipping faster only matters here to the extent it
+#: outruns py-maidr's releases.
+STALE_MINOR_GAP = 5
+
+
+# Which severities have already spoken.  One shared flag would let the
+# quiet ``auto`` path -- the default, so almost always first -- consume the
+# single shot and leave the ``use_cdn=False`` warning permanently
+# unreachable, which is precisely the audience it exists for.
+_bundle_warned: set[bool] = set()
+_bundle_warning_lock = threading.Lock()
+
+
+class MaidrBundleStaleWarning(UserWarning):
+    """Raised as a warning when the bundled ``maidr.js`` has fallen behind.
+
+    A dedicated category so consumers running ``-W error`` or pytest's
+    ``filterwarnings = ["error"]`` can silence *this* advisory without
+    having to silence every ``UserWarning`` the stack emits.
+
+    Examples
+    --------
+    >>> import warnings
+    >>> warnings.filterwarnings(  # doctest: +SKIP
+    ...     "ignore", category=maidr.MaidrBundleStaleWarning
+    ... )
+    """
+
+
+class BundleStatus(NamedTuple):
+    """How the bundled ``maidr.js`` compares to the published release.
+
+    Attributes
+    ----------
+    bundled : str
+        Version of the copy shipped inside this wheel.
+    published : str or None
+        The version npm has published, or ``None`` when that is not
+        known.  Never what a pin says to serve — see
+        :func:`_published_version`.
+    is_behind : bool
+        ``True`` when the bundled copy is older than ``published``.
+    is_stale : bool
+        ``True`` when it is behind by at least a major version or
+        :data:`STALE_MINOR_GAP` minor versions — the threshold at which
+        :func:`warn_if_bundle_is_stale` speaks up.
+    """
+
+    bundled: str
+    published: str | None
+    is_behind: bool
+    is_stale: bool
+
+
+def resolver_outcome() -> ResolverOutcome | None:
+    """Report why the last ``latest`` lookup ended as it did.
+
+    For a monitor rather than for a render.  The scheduled freshness check
+    passes when the published version cannot be resolved, because a
+    resolver hiccup is not a drift signal and failing on one would train
+    maintainers to ignore the job.  That is right for a hiccup and wrong
+    for a persistent failure: if the resolver stays unreachable the job
+    stays green forever while checking nothing, and a green check that
+    verifies nothing is worse than a red one because it is
+    indistinguishable from a real pass (#298).
+
+    What separates the two is *how* it failed.  Endpoints that never
+    answered are the network, which nobody watching the job can fix.
+    Endpoints that answered with something this code could not use are
+    this code being wrong about their shape -- which is the most likely
+    long-lived cause, and the one worth waking someone for.
+
+    Returns
+    -------
+    ResolverOutcome or None
+        ``None`` when no lookup has run in this process, which is a
+        different thing from one that ran and reached nothing.  A pinned
+        or offline session never resolves, so the caller has to tell those
+        apart rather than reading an empty outcome as a verdict.
+
+    Examples
+    --------
+    >>> resolver_outcome()  # doctest: +SKIP
+    ResolverOutcome(resolved='4.2.0', unreachable=(), answered_badly=())
+    """
+    return _deps._resolver_outcome
+
+
+def bundle_status(*, resolve: bool = True) -> BundleStatus:
+    """Compare the bundled ``maidr.js`` against the published release.
+
+    Parameters
+    ----------
+    resolve : bool, default=True
+        Whether to look the published version up over the network when it
+        is not already cached.  Pass ``False`` on offline code paths: the
+        comparison then uses only an earlier lookup, and reports
+        ``published=None`` when none has happened.
+
+        Note that ``published`` always means "what npm published", never
+        "what we will serve" — a pin from :func:`set_cdn_version` or
+        ``MAIDR_CDN_VERSION`` does not stand in for it, so pinning
+        neither fakes staleness nor conceals it.
+
+    Returns
+    -------
+    BundleStatus
+        The two versions and how far apart they are.  Unparseable or
+        unknown versions yield ``is_behind=is_stale=False`` rather than a
+        guess.
+
+    Raises
+    ------
+    Exception
+        Only with ``resolve=True``, and only if the lookup itself fails
+        in a way it is written not to: unreachable endpoints, timeouts
+        and malformed responses are all handled internally and reported
+        as ``published=None``.  The re-raise exists so a genuine bug in
+        the resolver surfaces instead of being cached as "no answer", so
+        callers that must not fail -- a scheduled freshness check, say --
+        should still catch it.
+
+    Examples
+    --------
+    >>> bundle_status()  # doctest: +SKIP
+    BundleStatus(bundled='3.73.0', published='3.74.0', is_behind=True, is_stale=False)
+
+    The versions above are illustrative, not a fixture: ``published`` is
+    looked up at call time, so real output tracks whatever is current.
+    """
+    bundled = _deps.maidr_js_version()
+    published = _deps._published_version(resolve=resolve)
+
+    bundled_key = _version_key(bundled) if bundled != _UNKNOWN_VERSION else None
+    published_key = _version_key(published) if published else None
+    if bundled_key is None or published_key is None:
+        return BundleStatus(bundled, published, is_behind=False, is_stale=False)
+
+    is_behind = bundled_key < published_key
+    (bundled_major, bundled_minor, _), _, _ = bundled_key
+    (published_major, published_minor, _), _, _ = published_key
+    is_stale = is_behind and (
+        published_major > bundled_major
+        or published_minor - bundled_minor >= STALE_MINOR_GAP
+    )
+    return BundleStatus(bundled, published, is_behind, is_stale)
+
+
+def warn_bundle_unreadable() -> None:
+    """Warn that ``use_cdn=False`` had to reach for the CDN anyway.
+
+    Lives here rather than in :mod:`maidr.api` so the dedup bookkeeping
+    it relies on stays inside the module that owns it, and so every
+    statement about the bundled assets is made from one place.
+
+    Notes
+    -----
+    Uses ``logging`` where :func:`warn_if_bundle_is_stale` uses
+    ``warnings.warn``, which is deliberate rather than an oversight.  This
+    one can fire from ``init_notebook()`` during ``import maidr``, where a
+    ``UserWarning`` is awkward to attribute and impossible to filter
+    before it happens; the staleness warning fires from an explicit render
+    call, where a filterable warning category is the better fit.
+    """
+    warn_once(
+        "missing-bundle",
+        "maidr: use_cdn=False was requested but the bundled maidr.js/css "
+        "could not be read, so the notebook will load them from the CDN. "
+        "Reinstall py-maidr to repair the bundle for offline use.",
+    )
+
+
+def warn_if_bundle_is_stale(*, bundle_is_primary: bool = True) -> None:
+    """Warn once per process when the bundled fallback has drifted badly.
+
+    Intended for the render paths where the bundled copy can actually be
+    executed — ``use_cdn=False`` (it is the only source) and
+    ``use_cdn="auto"`` (it is the offline fallback).  Never issues a
+    network request of its own: it compares against the published version
+    only when that is already known, so an offline render stays offline
+    and simply says nothing.
+
+    That leaves a deliberate blind spot, and it is wider than it looks.
+    Only a real lookup arms this warning — and a pin *prevents* one,
+    because :func:`get_cdn_version` short-circuits on a pin before
+    resolution runs.  So a process pinned to any version, or using only
+    ``use_cdn=False``, stays silent however old its bundle is.  That is
+    precisely the air-gapped audience the warning is for.
+    Reaching them automatically would require the network request that
+    ``use_cdn=False`` exists to avoid, so this is a partial mitigation by
+    construction: :func:`bundle_status` (which does resolve) is the
+    explicit check for those users, and a release-time CI comparison is
+    the real answer.
+
+    Parameters
+    ----------
+    bundle_is_primary : bool, default True
+        Whether the bundled copy is what will actually run.  ``True`` for
+        ``use_cdn=False``, where it is the only source, and the drift is
+        raised as a :class:`MaidrBundleStaleWarning`.  ``False`` for
+        ``use_cdn="auto"``, where the CDN copy normally loads instead and
+        the drift goes to the logger rather than to a warning that could
+        fail a suite running ``-W error`` over code that never executed.
+
+    Notes
+    -----
+    Silenced by ``MAIDR_BUNDLE_STALE_WARNING=0``.
+
+    Emitted as a ``UserWarning``, so a caller running under ``-W error``
+    (or pytest's ``filterwarnings = ["error"]``) sees ``render()`` raise
+    rather than warn.  That is a real upgrade hazard for anyone treating
+    warnings as errors, which is why it is called out in the user guide
+    as well as here.
+
+    Fires at most once per process *per severity*, and neither
+    :func:`set_cdn_version` nor :func:`reset_cdn_version_cache` re-arms
+    it — so re-pinning in a REPL to watch it again will not produce a
+    second report.
+
+    ``stacklevel=2`` deliberately points at maidr's own render machinery
+    rather than the caller's ``render()`` / ``save_html()`` line.  The
+    depth from user code differs per entry point, so no fixed level
+    reaches it, and the warning is about the *installed package* rather
+    than about how it was called — the message stands alone without a
+    call site.
+    """
+    if bundle_is_primary in _bundle_warned or not bundle_warning_enabled():
+        return
+
+    status = bundle_status(resolve=False)
+    if not status.is_stale:
+        return
+
+    # Claim this severity's one report under a lock so concurrent first
+    # renders emit it once rather than racing between the check above and
+    # the set.  Latched per severity: a quiet ``auto`` report must not
+    # suppress a later ``use_cdn=False`` warning, where the bundle really
+    # is what runs.
+    with _bundle_warning_lock:
+        if bundle_is_primary in _bundle_warned:
+            return
+        _bundle_warned.add(bundle_is_primary)
+
+    message = (
+        f"maidr: the bundled copy of maidr.js is {status.bundled}, but the "
+        f"current published release is {status.published}. The bundle is "
+        f"what renders when the CDN is disabled (use_cdn=False) or "
+        f"unreachable (use_cdn='auto'), so those plots run the older "
+        f"build. Upgrade py-maidr to pick up a refreshed bundle. Set "
+        f"{BUNDLE_WARNING_ENV_VAR}=0 to silence this warning."
+    )
+    if bundle_is_primary:
+        warnings.warn(message, MaidrBundleStaleWarning, stacklevel=2)
+    else:
+        # Under ``use_cdn="auto"`` the CDN copy normally loads and the
+        # bundle never executes, so a warning here is about code that did
+        # not run -- and under ``-W error`` it would redden a downstream
+        # suite over it.  Report it, but to the logger.
+        _logger.warning("%s", message)

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -60,12 +60,7 @@ from typing import NamedTuple
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-from maidr.util.warn import (
-    BUNDLE_WARNING_ENV_VAR,
-    _MAX_WARNED_KEY_LEN,
-    bundle_warning_enabled,
-    warn_once,
-)
+from maidr.util.warn import _MAX_WARNED_KEY_LEN, warn_once
 
 
 _logger = logging.getLogger(__name__)
@@ -1273,34 +1268,6 @@ def _fetch_latest_version(budget: float) -> str | None:
     return resolved
 
 
-# ---------------------------------------------------------------------------
-# Bundled-copy freshness
-# ---------------------------------------------------------------------------
-
-#: Minor-version gap at which the bundled fallback stops being "a release
-#: or two behind" and starts being a copy users should know about.  The
-#: bug report that prompted this check cited a gap of 8.
-#:
-#: Picked without the release histories, then measured against them (#292).
-#: The question that decides it is not how fast upstream ships, it is how
-#: many minors accumulate between the py-maidr releases that refresh the
-#: bundle.  Over the seventeen cycles from 2026-01-31 to 2026-08-10:
-#:
-#:     median 1   mean 1.7   min 0   max 7
-#:     cycles reaching 3+:  6/17  (35%)
-#:     cycles reaching 5+:  1/17  (6%)
-#:     cycles reaching 8+:  0/17  (0%)
-#:
-#: So 5 fires on the one cycle in seventeen where the bundle genuinely
-#: fell behind -- a 68-day gap with nothing released -- and stays quiet
-#: otherwise.  3 would fire on a third of all cycles, which is how a
-#: warning becomes noise; 8 would not have fired even on that one.
-#:
-#: Recompute the *cycle* table, not upstream's cadence, if this is ever
-#: revisited: upstream shipping faster only matters here to the extent it
-#: outruns py-maidr's releases.
-STALE_MINOR_GAP = 5
-
 # Same grammar as :data:`_VERSION_RE`, with the parts named so
 # :func:`_version_key` can pull them out.  Kept deliberately in step with
 # it: a looser shape here would mean a version this module refuses to pin
@@ -1311,261 +1278,6 @@ _RELEASE_RE = re.compile(
     rf"(?P<prerelease>-{_PRERELEASE})?"
     rf"(?:\+{_BUILD})?\Z"
 )
-
-# Which severities have already spoken.  One shared flag would let the
-# quiet ``auto`` path -- the default, so almost always first -- consume the
-# single shot and leave the ``use_cdn=False`` warning permanently
-# unreachable, which is precisely the audience it exists for.
-_bundle_warned: set[bool] = set()
-_bundle_warning_lock = threading.Lock()
-
-
-class MaidrBundleStaleWarning(UserWarning):
-    """Raised as a warning when the bundled ``maidr.js`` has fallen behind.
-
-    A dedicated category so consumers running ``-W error`` or pytest's
-    ``filterwarnings = ["error"]`` can silence *this* advisory without
-    having to silence every ``UserWarning`` the stack emits.
-
-    Examples
-    --------
-    >>> import warnings
-    >>> warnings.filterwarnings(  # doctest: +SKIP
-    ...     "ignore", category=maidr.MaidrBundleStaleWarning
-    ... )
-    """
-
-
-class BundleStatus(NamedTuple):
-    """How the bundled ``maidr.js`` compares to the published release.
-
-    Attributes
-    ----------
-    bundled : str
-        Version of the copy shipped inside this wheel.
-    published : str or None
-        The version npm has published, or ``None`` when that is not
-        known.  Never what a pin says to serve — see
-        :func:`_published_version`.
-    is_behind : bool
-        ``True`` when the bundled copy is older than ``published``.
-    is_stale : bool
-        ``True`` when it is behind by at least a major version or
-        :data:`STALE_MINOR_GAP` minor versions — the threshold at which
-        :func:`warn_if_bundle_is_stale` speaks up.
-    """
-
-    bundled: str
-    published: str | None
-    is_behind: bool
-    is_stale: bool
-
-
-def resolver_outcome() -> ResolverOutcome | None:
-    """Report why the last ``latest`` lookup ended as it did.
-
-    For a monitor rather than for a render.  The scheduled freshness check
-    passes when the published version cannot be resolved, because a
-    resolver hiccup is not a drift signal and failing on one would train
-    maintainers to ignore the job.  That is right for a hiccup and wrong
-    for a persistent failure: if the resolver stays unreachable the job
-    stays green forever while checking nothing, and a green check that
-    verifies nothing is worse than a red one because it is
-    indistinguishable from a real pass (#298).
-
-    What separates the two is *how* it failed.  Endpoints that never
-    answered are the network, which nobody watching the job can fix.
-    Endpoints that answered with something this code could not use are
-    this code being wrong about their shape -- which is the most likely
-    long-lived cause, and the one worth waking someone for.
-
-    Returns
-    -------
-    ResolverOutcome or None
-        ``None`` when no lookup has run in this process, which is a
-        different thing from one that ran and reached nothing.  A pinned
-        or offline session never resolves, so the caller has to tell those
-        apart rather than reading an empty outcome as a verdict.
-
-    Examples
-    --------
-    >>> resolver_outcome()  # doctest: +SKIP
-    ResolverOutcome(resolved='4.2.0', unreachable=(), answered_badly=())
-    """
-    return _resolver_outcome
-
-
-def bundle_status(*, resolve: bool = True) -> BundleStatus:
-    """Compare the bundled ``maidr.js`` against the published release.
-
-    Parameters
-    ----------
-    resolve : bool, default=True
-        Whether to look the published version up over the network when it
-        is not already cached.  Pass ``False`` on offline code paths: the
-        comparison then uses only an earlier lookup, and reports
-        ``published=None`` when none has happened.
-
-        Note that ``published`` always means "what npm published", never
-        "what we will serve" — a pin from :func:`set_cdn_version` or
-        ``MAIDR_CDN_VERSION`` does not stand in for it, so pinning
-        neither fakes staleness nor conceals it.
-
-    Returns
-    -------
-    BundleStatus
-        The two versions and how far apart they are.  Unparseable or
-        unknown versions yield ``is_behind=is_stale=False`` rather than a
-        guess.
-
-    Raises
-    ------
-    Exception
-        Only with ``resolve=True``, and only if the lookup itself fails
-        in a way it is written not to: unreachable endpoints, timeouts
-        and malformed responses are all handled internally and reported
-        as ``published=None``.  The re-raise exists so a genuine bug in
-        the resolver surfaces instead of being cached as "no answer", so
-        callers that must not fail -- a scheduled freshness check, say --
-        should still catch it.
-
-    Examples
-    --------
-    >>> bundle_status()  # doctest: +SKIP
-    BundleStatus(bundled='3.73.0', published='3.74.0', is_behind=True, is_stale=False)
-
-    The versions above are illustrative, not a fixture: ``published`` is
-    looked up at call time, so real output tracks whatever is current.
-    """
-    bundled = maidr_js_version()
-    published = _published_version(resolve=resolve)
-
-    bundled_key = _version_key(bundled) if bundled != _UNKNOWN_VERSION else None
-    published_key = _version_key(published) if published else None
-    if bundled_key is None or published_key is None:
-        return BundleStatus(bundled, published, is_behind=False, is_stale=False)
-
-    is_behind = bundled_key < published_key
-    (bundled_major, bundled_minor, _), _, _ = bundled_key
-    (published_major, published_minor, _), _, _ = published_key
-    is_stale = is_behind and (
-        published_major > bundled_major
-        or published_minor - bundled_minor >= STALE_MINOR_GAP
-    )
-    return BundleStatus(bundled, published, is_behind, is_stale)
-
-
-def warn_bundle_unreadable() -> None:
-    """Warn that ``use_cdn=False`` had to reach for the CDN anyway.
-
-    Lives here rather than in :mod:`maidr.api` so the dedup bookkeeping
-    it relies on stays inside the module that owns it, and so every
-    statement about the bundled assets is made from one place.
-
-    Notes
-    -----
-    Uses ``logging`` where :func:`warn_if_bundle_is_stale` uses
-    ``warnings.warn``, which is deliberate rather than an oversight.  This
-    one can fire from ``init_notebook()`` during ``import maidr``, where a
-    ``UserWarning`` is awkward to attribute and impossible to filter
-    before it happens; the staleness warning fires from an explicit render
-    call, where a filterable warning category is the better fit.
-    """
-    warn_once(
-        "missing-bundle",
-        "maidr: use_cdn=False was requested but the bundled maidr.js/css "
-        "could not be read, so the notebook will load them from the CDN. "
-        "Reinstall py-maidr to repair the bundle for offline use.",
-    )
-
-
-def warn_if_bundle_is_stale(*, bundle_is_primary: bool = True) -> None:
-    """Warn once per process when the bundled fallback has drifted badly.
-
-    Intended for the render paths where the bundled copy can actually be
-    executed — ``use_cdn=False`` (it is the only source) and
-    ``use_cdn="auto"`` (it is the offline fallback).  Never issues a
-    network request of its own: it compares against the published version
-    only when that is already known, so an offline render stays offline
-    and simply says nothing.
-
-    That leaves a deliberate blind spot, and it is wider than it looks.
-    Only a real lookup arms this warning — and a pin *prevents* one,
-    because :func:`get_cdn_version` short-circuits on a pin before
-    resolution runs.  So a process pinned to any version, or using only
-    ``use_cdn=False``, stays silent however old its bundle is.  That is
-    precisely the air-gapped audience the warning is for.
-    Reaching them automatically would require the network request that
-    ``use_cdn=False`` exists to avoid, so this is a partial mitigation by
-    construction: :func:`bundle_status` (which does resolve) is the
-    explicit check for those users, and a release-time CI comparison is
-    the real answer.
-
-    Parameters
-    ----------
-    bundle_is_primary : bool, default True
-        Whether the bundled copy is what will actually run.  ``True`` for
-        ``use_cdn=False``, where it is the only source, and the drift is
-        raised as a :class:`MaidrBundleStaleWarning`.  ``False`` for
-        ``use_cdn="auto"``, where the CDN copy normally loads instead and
-        the drift goes to the logger rather than to a warning that could
-        fail a suite running ``-W error`` over code that never executed.
-
-    Notes
-    -----
-    Silenced by ``MAIDR_BUNDLE_STALE_WARNING=0``.
-
-    Emitted as a ``UserWarning``, so a caller running under ``-W error``
-    (or pytest's ``filterwarnings = ["error"]``) sees ``render()`` raise
-    rather than warn.  That is a real upgrade hazard for anyone treating
-    warnings as errors, which is why it is called out in the user guide
-    as well as here.
-
-    Fires at most once per process *per severity*, and neither
-    :func:`set_cdn_version` nor :func:`reset_cdn_version_cache` re-arms
-    it — so re-pinning in a REPL to watch it again will not produce a
-    second report.
-
-    ``stacklevel=2`` deliberately points at maidr's own render machinery
-    rather than the caller's ``render()`` / ``save_html()`` line.  The
-    depth from user code differs per entry point, so no fixed level
-    reaches it, and the warning is about the *installed package* rather
-    than about how it was called — the message stands alone without a
-    call site.
-    """
-    if bundle_is_primary in _bundle_warned or not bundle_warning_enabled():
-        return
-
-    status = bundle_status(resolve=False)
-    if not status.is_stale:
-        return
-
-    # Claim this severity's one report under a lock so concurrent first
-    # renders emit it once rather than racing between the check above and
-    # the set.  Latched per severity: a quiet ``auto`` report must not
-    # suppress a later ``use_cdn=False`` warning, where the bundle really
-    # is what runs.
-    with _bundle_warning_lock:
-        if bundle_is_primary in _bundle_warned:
-            return
-        _bundle_warned.add(bundle_is_primary)
-
-    message = (
-        f"maidr: the bundled copy of maidr.js is {status.bundled}, but the "
-        f"current published release is {status.published}. The bundle is "
-        f"what renders when the CDN is disabled (use_cdn=False) or "
-        f"unreachable (use_cdn='auto'), so those plots run the older "
-        f"build. Upgrade py-maidr to pick up a refreshed bundle. Set "
-        f"{BUNDLE_WARNING_ENV_VAR}=0 to silence this warning."
-    )
-    if bundle_is_primary:
-        warnings.warn(message, MaidrBundleStaleWarning, stacklevel=2)
-    else:
-        # Under ``use_cdn="auto"`` the CDN copy normally loads and the
-        # bundle never executes, so a warning here is about code that did
-        # not run -- and under ``-W error`` it would redden a downstream
-        # suite over it.  Report it, but to the logger.
-        _logger.warning("%s", message)
 
 
 
@@ -1921,6 +1633,11 @@ def inline_bundle_tags() -> "list | None":
         # truncated or corrupted asset raises out of ``read_text`` and which is
         # *not* an ``OSError`` -- so catching only file errors would let a
         # damaged bundle crash the render this exists to keep alive.
+        # Imported here rather than at module scope: `bundle_freshness`
+        # imports *this* module, so a top-level import would close the
+        # loop. This is the only call in the other direction.
+        from maidr.util.bundle_freshness import warn_bundle_unreadable
+
         warn_bundle_unreadable()
         return None
 
@@ -1977,6 +1694,20 @@ _MOVED_TO_BUNDLE_CAPABILITY = frozenset(
     }
 )
 
+#: Names that now live in :mod:`maidr.util.bundle_freshness` (#293).
+_MOVED_TO_BUNDLE_FRESHNESS = frozenset(
+    {
+        "BUNDLE_WARNING_ENV_VAR",
+        "BundleStatus",
+        "MaidrBundleStaleWarning",
+        "STALE_MINOR_GAP",
+        "bundle_status",
+        "resolver_outcome",
+        "warn_bundle_unreadable",
+        "warn_if_bundle_is_stale",
+    }
+)
+
 
 def __dir__() -> list[str]:
     """List the moved names alongside this module's own.
@@ -1998,7 +1729,9 @@ def __dir__() -> list[str]:
     list of str
         Everything defined here, plus the names that moved.
     """
-    return sorted(set(globals()) | _MOVED_TO_BUNDLE_CAPABILITY)
+    return sorted(
+        set(globals()) | _MOVED_TO_BUNDLE_CAPABILITY | _MOVED_TO_BUNDLE_FRESHNESS
+    )
 
 
 def __getattr__(name: str) -> object:
@@ -2030,4 +1763,8 @@ def __getattr__(name: str) -> object:
         from maidr.util import bundle_capability
 
         return getattr(bundle_capability, name)
+    if name in _MOVED_TO_BUNDLE_FRESHNESS:
+        from maidr.util import bundle_freshness
+
+        return getattr(bundle_freshness, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -60,7 +60,19 @@ from typing import NamedTuple
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-from maidr.util.warn import _MAX_WARNED_KEY_LEN, warn_once
+# ``BUNDLE_WARNING_ENV_VAR`` is not used in this module; it is imported to
+# keep ``maidr.util.dependencies.BUNDLE_WARNING_ENV_VAR`` resolving, which it
+# did before the name moved to ``warn`` in #496.  Straight from the owner
+# rather than through the ``__getattr__`` shim below: the shim would have
+# forwarded it to ``bundle_freshness``, which resolves only because *that*
+# module happens to import it for its own message text -- so a later cleanup
+# there would have broken an unrelated public path.  ``warn`` is a leaf, so
+# importing it eagerly raises none of the cycle questions the shim exists for.
+from maidr.util.warn import (  # noqa: F401
+    _MAX_WARNED_KEY_LEN,
+    BUNDLE_WARNING_ENV_VAR,
+    warn_once,
+)
 
 
 _logger = logging.getLogger(__name__)
@@ -1697,7 +1709,6 @@ _MOVED_TO_BUNDLE_CAPABILITY = frozenset(
 #: Names that now live in :mod:`maidr.util.bundle_freshness` (#293).
 _MOVED_TO_BUNDLE_FRESHNESS = frozenset(
     {
-        "BUNDLE_WARNING_ENV_VAR",
         "BundleStatus",
         "MaidrBundleStaleWarning",
         "STALE_MINOR_GAP",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from matplotlib import pyplot as plt
 
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.enum.library import Library
+from maidr.util import bundle_freshness as freshness
 from maidr.util import dependencies
 from maidr.util import warn as warn_module
 from tests.fixture.matplotlib_factory import MatplotlibFactory
@@ -25,7 +26,7 @@ def offline_cdn_version(monkeypatch):
     next.
     """
     monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, dependencies.LATEST_TAG)
-    monkeypatch.setattr(dependencies, "_bundle_warned", set())
+    monkeypatch.setattr(freshness, "_bundle_warned", set())
     monkeypatch.setattr(warn_module, "_warned_keys", set())
 
     # Default-deny the network rather than relying on the pin above.

--- a/tests/core/test_bundle_capability.py
+++ b/tests/core/test_bundle_capability.py
@@ -458,17 +458,21 @@ def test_the_shim_must_stay_lazy():
     source = pathlib.Path(dependencies.__file__).read_text()
     tree = ast.parse(source)
 
+    # Both halves of the split are checked here rather than only the one
+    # this file is named for: they share the shim, and a module-scope
+    # import of either closes the same loop.
     offenders = [
-        node.lineno
+        (node.lineno, ast.unparse(node))
         for node in tree.body  # module scope only; the shim's own import is nested
         if isinstance(node, (ast.Import, ast.ImportFrom))
-        and "bundle_capability" in ast.unparse(node)
+        and ("bundle_capability" in ast.unparse(node)
+             or "bundle_freshness" in ast.unparse(node))
     ]
 
     assert not offenders, (
-        "maidr.util.dependencies imports bundle_capability at module scope "
-        f"(line {offenders}); that makes the import cycle real. The shim has "
-        "to resolve it inside __getattr__ instead."
+        f"maidr.util.dependencies imports a split-out module at module scope "
+        f"({offenders}); that makes the import cycle real. The shim has to "
+        "resolve it inside __getattr__ instead."
     )
 
 

--- a/tests/core/test_bundle_capability.py
+++ b/tests/core/test_bundle_capability.py
@@ -461,12 +461,15 @@ def test_the_shim_must_stay_lazy():
     # Both halves of the split are checked here rather than only the one
     # this file is named for: they share the shim, and a module-scope
     # import of either closes the same loop.
-    offenders = [
+    imports = [
         (node.lineno, ast.unparse(node))
         for node in tree.body  # module scope only; the shim's own import is nested
         if isinstance(node, (ast.Import, ast.ImportFrom))
-        and ("bundle_capability" in ast.unparse(node)
-             or "bundle_freshness" in ast.unparse(node))
+    ]
+    offenders = [
+        (lineno, text)
+        for lineno, text in imports
+        if "bundle_capability" in text or "bundle_freshness" in text
     ]
 
     assert not offenders, (

--- a/tests/core/test_bundle_capability.py
+++ b/tests/core/test_bundle_capability.py
@@ -414,6 +414,33 @@ def test_the_shim_returns_the_object_rather_than_a_copy():
     assert viaShim is bundle_capability.MaidrBundleTraceWarning
 
 
+def test_the_env_var_resolves_to_one_object_from_every_path():
+    """``BUNDLE_WARNING_ENV_VAR`` must not come back through the shim.
+
+    It is public from ``maidr`` and from ``maidr.util.dependencies``, and
+    it is *owned* by ``maidr.util.warn`` (#496). For a while
+    ``dependencies`` resolved it through ``__getattr__`` to
+    ``bundle_freshness``, which had the name only because that module
+    imports it for its own message text -- so dropping what looks there
+    like an unused import would have broken an unrelated public path with
+    an ``AttributeError``.
+
+    Pinned by identity rather than by equality: both would pass on a
+    plain string today, and identity is what says the three names are one
+    constant rather than three that happen to agree.
+    """
+    from maidr.util import bundle_freshness, warn
+
+    assert dependencies.BUNDLE_WARNING_ENV_VAR is warn.BUNDLE_WARNING_ENV_VAR
+    assert maidr.BUNDLE_WARNING_ENV_VAR is warn.BUNDLE_WARNING_ENV_VAR
+
+    # The half that fails if the shim is put back in the path: this must
+    # hold whatever ``bundle_freshness`` does or does not import.
+    assert "BUNDLE_WARNING_ENV_VAR" not in dependencies._MOVED_TO_BUNDLE_FRESHNESS
+    assert "BUNDLE_WARNING_ENV_VAR" not in dependencies._MOVED_TO_BUNDLE_CAPABILITY
+    assert bundle_freshness.BUNDLE_WARNING_ENV_VAR is warn.BUNDLE_WARNING_ENV_VAR
+
+
 def test_an_unknown_attribute_still_raises_attribute_error():
     """The fallback branch has to keep failing.
 

--- a/tests/core/test_bundle_freshness.py
+++ b/tests/core/test_bundle_freshness.py
@@ -23,6 +23,7 @@ import pytest
 import maidr
 import maidr.util.environment
 from maidr import api as maidr_api
+from maidr.util import bundle_freshness as freshness
 from maidr.util import dependencies
 
 
@@ -206,7 +207,7 @@ def test_warning_names_both_versions(bundled, published):
     maidr.bundle_status()  # establish the published version by resolving
 
     with pytest.warns(UserWarning) as record:
-        dependencies.warn_if_bundle_is_stale()
+        freshness.warn_if_bundle_is_stale()
 
     message = str(record[0].message)
     assert "3.66.1" in message
@@ -223,10 +224,10 @@ def test_warning_is_emitted_once_per_process(bundled, published):
     maidr.bundle_status()  # establish the published version by resolving
 
     with pytest.warns(UserWarning):
-        dependencies.warn_if_bundle_is_stale()
+        freshness.warn_if_bundle_is_stale()
 
     with no_stale_bundle_warning():
-        dependencies.warn_if_bundle_is_stale()
+        freshness.warn_if_bundle_is_stale()
 
 
 def test_no_warning_for_normal_drift(bundled, published):
@@ -236,7 +237,7 @@ def test_no_warning_for_normal_drift(bundled, published):
     maidr.bundle_status()  # establish the published version
 
     with no_stale_bundle_warning():
-        dependencies.warn_if_bundle_is_stale()
+        freshness.warn_if_bundle_is_stale()
 
 
 @pytest.mark.parametrize("disabled", ["0", "false", "off", "no", "FALSE"])
@@ -248,7 +249,7 @@ def test_env_var_silences_the_warning(disabled, monkeypatch, bundled, published)
     maidr.bundle_status()  # establish the published version
 
     with no_stale_bundle_warning():
-        dependencies.warn_if_bundle_is_stale()
+        freshness.warn_if_bundle_is_stale()
 
 
 def test_warning_never_resolves_over_the_network(
@@ -259,7 +260,7 @@ def test_warning_never_resolves_over_the_network(
     bundled("3.66.1")
 
     with no_stale_bundle_warning():
-        dependencies.warn_if_bundle_is_stale()
+        freshness.warn_if_bundle_is_stale()
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +331,7 @@ def test_auto_render_first_does_not_swallow_a_later_offline_warning(
         "the auto render must have reported the drift to the logger"
     )
 
-    with pytest.warns(dependencies.MaidrBundleStaleWarning, match="3.66.1"):
+    with pytest.warns(freshness.MaidrBundleStaleWarning, match="3.66.1"):
         maidr.render(bar_plot, use_cdn=False)
 
 
@@ -346,7 +347,7 @@ def test_offline_render_first_does_not_swallow_a_later_auto_report(
     published("3.74.0")
     maidr.bundle_status()  # establish the published version by resolving
 
-    with pytest.warns(dependencies.MaidrBundleStaleWarning, match="3.66.1"):
+    with pytest.warns(freshness.MaidrBundleStaleWarning, match="3.66.1"):
         maidr.render(bar_plot, use_cdn=False)
 
     with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
@@ -506,11 +507,11 @@ def test_warning_uses_a_filterable_category(bundled, published):
     published("3.74.0")
     maidr.bundle_status()
 
-    with pytest.warns(dependencies.MaidrBundleStaleWarning):
-        dependencies.warn_if_bundle_is_stale(bundle_is_primary=True)
+    with pytest.warns(freshness.MaidrBundleStaleWarning):
+        freshness.warn_if_bundle_is_stale(bundle_is_primary=True)
 
-    assert issubclass(dependencies.MaidrBundleStaleWarning, UserWarning)
-    assert maidr.MaidrBundleStaleWarning is dependencies.MaidrBundleStaleWarning
+    assert issubclass(freshness.MaidrBundleStaleWarning, UserWarning)
+    assert maidr.MaidrBundleStaleWarning is freshness.MaidrBundleStaleWarning
 
 
 def test_auto_path_reports_drift_to_the_logger_not_as_a_warning(
@@ -527,7 +528,7 @@ def test_auto_path_reports_drift_to_the_logger_not_as_a_warning(
 
     with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
         with no_stale_bundle_warning():
-            dependencies.warn_if_bundle_is_stale(bundle_is_primary=False)
+            freshness.warn_if_bundle_is_stale(bundle_is_primary=False)
 
     assert any("bundled copy of maidr.js" in r.message for r in caplog.records), (
         "the drift must still be reported, just not as a warning"

--- a/tests/core/test_bundle_freshness.py
+++ b/tests/core/test_bundle_freshness.py
@@ -25,6 +25,7 @@ import maidr.util.environment
 from maidr import api as maidr_api
 from maidr.util import bundle_freshness as freshness
 from maidr.util import dependencies
+from maidr.util import warn as warn_module
 
 
 @contextlib.contextmanager
@@ -298,7 +299,7 @@ def test_use_cdn_auto_render_reports_to_the_logger(
     bundled("3.66.1")
     published("3.74.0")
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=freshness.__name__):
         with no_stale_bundle_warning():
             maidr.render(bar_plot, use_cdn="auto")
 
@@ -323,7 +324,7 @@ def test_auto_render_first_does_not_swallow_a_later_offline_warning(
     bundled("3.66.1")
     published("3.74.0")
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=freshness.__name__):
         with no_stale_bundle_warning():
             maidr.render(bar_plot, use_cdn="auto")
 
@@ -350,7 +351,7 @@ def test_offline_render_first_does_not_swallow_a_later_auto_report(
     with pytest.warns(freshness.MaidrBundleStaleWarning, match="3.66.1"):
         maidr.render(bar_plot, use_cdn=False)
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=freshness.__name__):
         with no_stale_bundle_warning():
             maidr.render(bar_plot, use_cdn="auto")
 
@@ -380,7 +381,7 @@ def test_plotly_auto_render_reports_to_the_logger(bundled, published, caplog):
     published("3.74.0")
     fig = go.Figure(data=[go.Bar(x=["A", "B"], y=[1, 2])])
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=freshness.__name__):
         with no_stale_bundle_warning():
             maidr.render(fig, use_cdn="auto")
 
@@ -445,7 +446,7 @@ def test_init_notebook_use_cdn_false_never_resolves_when_bundle_missing(
     fake_ipython.display = lambda html: displayed.setdefault("html", html)
     monkeypatch.setitem(sys.modules, "IPython.display", fake_ipython)
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         maidr.init_notebook(use_cdn=False)
 
     assert any("could not be read" in r.message for r in caplog.records), (
@@ -526,7 +527,7 @@ def test_auto_path_reports_drift_to_the_logger_not_as_a_warning(
     published("3.74.0")
     maidr.bundle_status()
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=freshness.__name__):
         with no_stale_bundle_warning():
             freshness.warn_if_bundle_is_stale(bundle_is_primary=False)
 

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -25,6 +25,7 @@ import matplotlib.pyplot as plt
 import pytest
 
 import maidr
+from maidr.util import bundle_freshness as freshness
 from maidr.util import dependencies
 from maidr.util import warn as warn_module
 
@@ -817,14 +818,14 @@ def test_concurrent_staleness_warning_emits_once(monkeypatch):
     sequence is too short for CPython to preempt, so this earns its keep
     on free-threaded builds rather than here.
     """
-    monkeypatch.setattr(dependencies, "_bundle_warned", set())
+    monkeypatch.setattr(freshness, "_bundle_warned", set())
     monkeypatch.setattr(dependencies, "maidr_js_version", lambda: "3.66.1")
     monkeypatch.setattr(dependencies, "_resolved_cdn_version", "3.74.0")
     monkeypatch.setattr(dependencies, "_resolution_attempted", True)
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        _run_concurrently(dependencies.warn_if_bundle_is_stale)
+        _run_concurrently(freshness.warn_if_bundle_is_stale)
 
     stale = [w for w in caught if "bundled copy of maidr.js" in str(w.message)]
     assert len(stale) == 1, f"warned {len(stale)} times, expected 1"
@@ -842,7 +843,7 @@ def test_blank_pin_clears_rather_than_falling_through(blank, resolvable):
 
 def test_bundle_status_type_is_exported():
     """The return type must be reachable for type hints and isinstance."""
-    assert maidr.BundleStatus is dependencies.BundleStatus
+    assert maidr.BundleStatus is freshness.BundleStatus
     assert "BundleStatus" in maidr.__all__
 
 

--- a/tests/core/test_resolver_outcome.py
+++ b/tests/core/test_resolver_outcome.py
@@ -25,6 +25,7 @@ from urllib.error import HTTPError
 
 import pytest
 
+from maidr.util import bundle_freshness as freshness
 from maidr.util import dependencies
 
 
@@ -70,7 +71,7 @@ def test_nothing_is_reported_before_a_lookup_runs(clean) -> None:
     A pinned or offline session never resolves. Reading an empty outcome as
     a verdict there would report every endpoint as fine, on no evidence.
     """
-    assert dependencies.resolver_outcome() is None
+    assert freshness.resolver_outcome() is None
 
 
 def test_an_outage_is_reported_as_unreachable(monkeypatch, clean) -> None:
@@ -82,7 +83,7 @@ def test_an_outage_is_reported_as_unreachable(monkeypatch, clean) -> None:
 
     assert dependencies._fetch_latest_version(3.0) is None
 
-    outcome = dependencies.resolver_outcome()
+    outcome = freshness.resolver_outcome()
     assert len(outcome.unreachable) == ENDPOINT_COUNT
     assert outcome.answered_badly == ()
 
@@ -101,7 +102,7 @@ def test_an_http_error_is_an_answer(monkeypatch, clean) -> None:
 
     assert dependencies._fetch_latest_version(3.0) is None
 
-    outcome = dependencies.resolver_outcome()
+    outcome = freshness.resolver_outcome()
     assert len(outcome.answered_badly) == ENDPOINT_COUNT
     assert outcome.unreachable == ()
 
@@ -116,7 +117,7 @@ def test_a_payload_without_the_key_is_an_answer(monkeypatch, clean) -> None:
     answer_with(monkeypatch, json_body({"something_else": "4.2.0"}))
 
     assert dependencies._fetch_latest_version(3.0) is None
-    assert len(dependencies.resolver_outcome().answered_badly) == ENDPOINT_COUNT
+    assert len(freshness.resolver_outcome().answered_badly) == ENDPOINT_COUNT
 
 
 def test_a_value_that_is_not_a_version_is_an_answer(monkeypatch, clean) -> None:
@@ -129,7 +130,7 @@ def test_a_value_that_is_not_a_version_is_an_answer(monkeypatch, clean) -> None:
     )
 
     assert dependencies._fetch_latest_version(3.0) is None
-    assert len(dependencies.resolver_outcome().answered_badly) == ENDPOINT_COUNT
+    assert len(freshness.resolver_outcome().answered_badly) == ENDPOINT_COUNT
 
 
 def test_a_body_that_will_not_parse_is_an_answer(monkeypatch, clean) -> None:
@@ -140,7 +141,7 @@ def test_a_body_that_will_not_parse_is_an_answer(monkeypatch, clean) -> None:
     )
 
     assert dependencies._fetch_latest_version(3.0) is None
-    assert len(dependencies.resolver_outcome().answered_badly) == ENDPOINT_COUNT
+    assert len(freshness.resolver_outcome().answered_badly) == ENDPOINT_COUNT
 
 
 def test_an_unrecognised_failure_counts_as_unreachable(monkeypatch, clean) -> None:
@@ -161,7 +162,7 @@ def test_an_unrecognised_failure_counts_as_unreachable(monkeypatch, clean) -> No
 
     assert dependencies._fetch_latest_version(3.0) is None
 
-    outcome = dependencies.resolver_outcome()
+    outcome = freshness.resolver_outcome()
     assert len(outcome.unreachable) == ENDPOINT_COUNT
     assert outcome.answered_badly == ()
 
@@ -176,7 +177,7 @@ def test_a_success_reports_no_failures(monkeypatch, clean) -> None:
 
     assert dependencies._fetch_latest_version(3.0) == "4.2.0"
 
-    outcome = dependencies.resolver_outcome()
+    outcome = freshness.resolver_outcome()
     assert outcome == dependencies.ResolverOutcome("4.2.0", (), ())
 
 
@@ -201,7 +202,7 @@ def test_a_fallback_records_the_endpoint_it_fell_back_from(
 
     assert dependencies._fetch_latest_version(3.0) == "9.9.9"
 
-    outcome = dependencies.resolver_outcome()
+    outcome = freshness.resolver_outcome()
     assert outcome.resolved == "9.9.9"
     assert len(outcome.unreachable) == 1
     assert outcome.answered_badly == ()
@@ -220,11 +221,11 @@ def test_a_reset_discards_the_verdict_with_the_lookup(monkeypatch, clean) -> Non
 
     answer_with(monkeypatch, not_found)
     dependencies._fetch_latest_version(3.0)
-    assert dependencies.resolver_outcome().answered_badly
+    assert freshness.resolver_outcome().answered_badly
 
     dependencies.reset_cdn_version_cache()
 
-    assert dependencies.resolver_outcome() is None
+    assert freshness.resolver_outcome() is None
 
 
 def test_the_render_path_is_unchanged_by_any_of_it(monkeypatch, clean) -> None:
@@ -240,4 +241,4 @@ def test_the_render_path_is_unchanged_by_any_of_it(monkeypatch, clean) -> None:
     )
 
     assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
-    assert dependencies.bundle_status(resolve=False).published is None
+    assert freshness.bundle_status(resolve=False).published is None


### PR DESCRIPTION
## Description

`maidr/util/bundle_freshness.py` takes staleness reporting — `bundle_status`, `BundleStatus`, `warn_if_bundle_is_stale`, `warn_bundle_unreadable`, `resolver_outcome`, `STALE_MINOR_GAP`, `MaidrBundleStaleWarning`.

`dependencies.py` goes **2033 → 1781 lines**.

| #293's concern | module | done |
|---|---|---|
| Bundled asset access | `dependencies.py` | ✅ stays put, as the issue intended |
| **Bundled-copy freshness** | **`bundle_freshness.py`** | ✅ **this PR** |
| CDN version resolution | `dependencies.py` | ❌ **not cut** — see below |
| *(not in the issue)* Bundled-copy capability | `bundle_capability.py` | ✅ #494 |
| *(the issue's third note)* Shared warning policy | `warn.py` | ✅ #496 |

**This does not finish #293, and an earlier revision of this description wrongly said it did.** The issue's suggested shape names *two* new modules, `cdn.py` and `bundle_freshness.py`. Only the second exists. `dependencies.py` is still 1781 lines because it holds asset access **and** the whole CDN resolver — the endpoints, the timeout budget, the semver guards — which is the concern the `cdn.py` half was for. Splitting that out is a separate PR, and I have not written it. #293 should stay open on those grounds specifically, not on the "four modules vs. two" bookkeeping I originally offered as the reason.

Two of the issue's three "notes for whoever picks it up" are settled: `api.py` is down from 8 imports to 4, and `_warn_once` got the deliberate home it asked for (`warn.py`, #496). The third — `test_no_render_path_references_the_unresolved_constants` needing its exclusion updated — needed no change, because `MAIDR_JS_CDN_URL` / `MAIDR_CSS_CDN_URL` never moved. It becomes live again if `cdn.py` is ever cut.

## Three things this cut needed that the first one did not

**1. `_RELEASE_RE` stays behind — again.** It sits inside the moved section, but `_version_key` uses it and it is a version-parsing primitive rather than a freshness one. I recorded this on #293 after the first cut as the thing to check before assuming a section is self-contained, and it caught itself here.

**2. There is an edge back into `dependencies`.** Unlike the capability cut, which was one-way, `inline_bundle_tags` calls `warn_bundle_unreadable`. Every other apparent reference turned out to be a docstring — the only real one is that single call, so it is imported inside the function and the module-scope dependency stays one-way.

**3. Reads that tests patch go through the module object.** `_deps.maidr_js_version()` and `_deps._published_version()` rather than from-imports:

```python
# tests/core/test_bundle_freshness.py
monkeypatch.setattr(dependencies, "maidr_js_version", lambda: version)
```

A from-import binds the function object at import time, so that patch would have silently stopped reaching this module — the fixture would set a version nothing read. **29 tests failed and said so**, which is the only reason I found it rather than shipping it.

## One observable change, not covered by "no behaviour change"

Moving the functions moves their `_logger`, so the log **records they emit now carry a different logger name**:

| record | before | after |
|---|---|---|
| `use_cdn="auto"` staleness drift | `maidr.util.dependencies` | `maidr.util.bundle_freshness` |
| bundle-unreadable (since #496) | `maidr.util.dependencies` | `maidr.util.warn` |

Message text, level, and the conditions that produce them are unchanged. This only matters to a caller that filters by logger name — e.g. `logging.getLogger("maidr.util.dependencies").setLevel(...)`, which would now silence nothing. `maidr.util` still catches everything, as before.

It also broke six tests without failing any of them — the same class of trap as point 3 above, applied to logger identity rather than a function reference. `test_bundle_freshness.py` had six `caplog.at_level(logging.WARNING, logger=dependencies.__name__)` calls left naming a logger that no longer emits. They kept passing because `caplog.records` collects by handler, not by name — the `logger=` argument only raises a level, and these records were already at WARNING. Idle today, and silently useless the first time a sub-WARNING record needs asserting on.

Which of the six belongs to which module was settled by spying on `logging.Logger.handle` while they ran, not by reading what each one calls:

```
test_use_cdn_auto_render_reports_to_the_logger              -> maidr.util.bundle_freshness
test_auto_render_first_does_not_swallow_a_later_offline_…   -> maidr.util.bundle_freshness
test_offline_render_first_does_not_swallow_a_later_auto_…   -> maidr.util.bundle_freshness
test_plotly_auto_render_reports_to_the_logger               -> maidr.util.bundle_freshness
test_init_notebook_use_cdn_false_never_resolves_when_…      -> maidr.util.warn
test_auto_path_reports_drift_to_the_logger_not_as_a_warning -> maidr.util.bundle_freshness
```

Worth doing that way: a first pass sorted them by call site and put the last one in `warn`, because `warn_if_bundle_is_stale` reaches `warn.py` on its *other* branch. The suite could not tell me, for the reason above.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor (behaviour unchanged except the logger names above)

## Related Issues

Refs #293 — advances it, does not close it. The `cdn.py` half is untouched; see the table at the top.

## Changes Made

- `maidr/util/bundle_freshness.py` — new, 314 lines.
- `maidr/util/dependencies.py` — the `__getattr__` shim gains a second set, `__dir__` covers both, one function-local import. `BUNDLE_WARNING_ENV_VAR` is imported straight from `warn` rather than forwarded through the shim, so the public path does not depend on what `bundle_freshness` happens to import (review point).
- `maidr/__init__.py`, `api.py`, `core/maidr.py`, `plotly/plotly_maidr.py` — repointed at the canonical module, so the shim stays the external back-compat surface rather than something first-party code leans on (the #494 review's point).
- `tests/conftest.py` and three test files — repointed at the module that owns the state.
- `tests/core/test_bundle_freshness.py` — the six `caplog` sites above.
- `tests/core/test_bundle_capability.py` — the laziness guard now covers **both** halves; they share the shim, so a module-scope import of either closes the same loop.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — **2329 passed, 13 skipped**, identical to `main`. `ruff check` unchanged at 6 pre-existing findings.

Verified rather than assumed:

- `_RELEASE_RE` occurs 3× in `dependencies.py` and 0× in the new module.
- Old import paths resolve, with identity preserved — `maidr.bundle_status is bundle_freshness.bundle_status` → `True`, which matters because `except MaidrBundleStaleWarning` compares class objects.
- Mutation-tested the widened laziness guard both ways: an eager `from … import` breaks the cycle live (`ImportError: … partially initialized module`), and a plain `import maidr.util.bundle_freshness` — which would *not* break — is caught by the AST assertion, which is the quiet case the guard exists for.
- Mutation-tested the `BUNDLE_WARNING_ENV_VAR` decoupling: with the name removed from `bundle_freshness` entirely, `dependencies.BUNDLE_WARNING_ENV_VAR` still resolves.
- The emitting logger for each repointed `caplog` site, per the table above.