### PR TITLE
fix(patch): forget a cleared axes' layers instead of appending beside them

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -299,9 +299,12 @@ class Maidr:
         same ``(row, col)``, and clearing one of a twinned pair must not
         take the other with it.
 
-        Idempotent: clearing an axes that holds no layers is a no-op, which
-        matters because ``Axes.clear`` and ``Axes.cla`` delegate to each
-        other and both are patched.
+        Idempotent: clearing an axes that holds no layers is a no-op. That
+        is not only about being called twice by a caller -- it is what makes
+        patching both ``Axes.clear`` and ``Axes.cla`` safe. The two delegate
+        to each other, and the inner call resolves to the *patched* method,
+        so a single ``ax.cla()`` fires the hook twice by construction. The
+        second firing has to find nothing left to do.
 
         Parameters
         ----------

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -274,7 +274,47 @@ class Maidr:
         return html.show(_renderer)
 
     def clear(self):
+        """Forget every layer on this figure.
+
+        ``selector_ids`` goes with them. It used to be left behind, and the
+        two lists are paired by index -- see ``_drop_superseded_layers`` for
+        the invariant -- so a figure cleared and then re-plotted tagged its
+        new layer's artists with the id minted for a layer that no longer
+        existed, and the new layer's own id was never used. Nothing raised
+        (#499).
+        """
         self._plots = []
+        self.selector_ids = []
+
+    def clear_axes(self, ax: Axes) -> None:
+        """Forget the layers drawn on one axes, keeping the rest.
+
+        ``clear()`` is right for ``Figure.clear``, where every layer is
+        going. It is too broad for ``Axes.clear``: on a figure with more
+        than one axes, clearing one must leave the others registered, or
+        redrawing a single panel silently unregisters its neighbours.
+
+        Keyed by ``_layer_axes_key`` rather than by grid position, for the
+        reason recorded there -- ``ax.twinx()`` puts a second axes at the
+        same ``(row, col)``, and clearing one of a twinned pair must not
+        take the other with it.
+
+        Idempotent: clearing an axes that holds no layers is a no-op, which
+        matters because ``Axes.clear`` and ``Axes.cla`` delegate to each
+        other and both are patched.
+
+        Parameters
+        ----------
+        ax : Axes
+            The axes whose layers should be forgotten.
+        """
+        kept = [
+            (plot, selector_id)
+            for plot, selector_id in zip(self._plots, self.selector_ids)
+            if self._layer_axes_key(plot) is not ax
+        ]
+        self._plots = [plot for plot, _ in kept]
+        self.selector_ids = [selector_id for _, selector_id in kept]
 
     def destroy(self) -> None:
         del self._plots

--- a/maidr/patch/clear.py
+++ b/maidr/patch/clear.py
@@ -6,6 +6,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from maidr.core.figure_manager import FigureManager
+from maidr.patch.lineplot import forget_axes_state
 
 
 @wrapt.patch_function_wrapper(Figure, "clear")
@@ -35,11 +36,25 @@ def _clear_axes(wrapped, instance, args, kwargs) -> None:
     Narrower than ``Figure.clear``'s ``maidr.clear()`` on purpose: on a
     figure with several axes, clearing one must leave the others registered.
 
+    Dropping the layers is not enough on its own. ``lineplot`` keeps its
+    own "already registered" latch on the axes, which matplotlib does not
+    reset because it does not own it -- so clearing the layers while
+    leaving the latch set makes the next ``ax.plot()`` register *nothing*,
+    and the chart goes from mis-described to undescribed. See
+    ``forget_axes_state``.
+
     Runs after ``wrapped``, matching the ``Figure.clear`` patch above -- the
     layers are dropped once matplotlib has actually removed the artists, not
     before.
     """
     wrapped(*args, **kwargs)
+
+    # Before the registration lookup, not after: this state lives on the
+    # axes and outlives any maidr entry. A figure closed with `maidr.close()`
+    # and then cleared would otherwise keep the latch set, and nothing drawn
+    # on it afterwards would register.
+    forget_axes_state(instance)
+
     figure = instance.get_figure()
     if figure is None:
         return

--- a/maidr/patch/clear.py
+++ b/maidr/patch/clear.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import wrapt
 
+from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from maidr.core.figure_manager import FigureManager
@@ -15,3 +16,44 @@ def clear(wrapped, instance, args, kwargs) -> None:
     except KeyError:
         return
     maidr.clear()
+
+
+def _clear_axes(wrapped, instance, args, kwargs) -> None:
+    """Drop the layers drawn on an axes when matplotlib clears it.
+
+    Only ``Figure.clear`` was patched, so re-plotting into a cleared axes
+    *appended* a layer rather than replacing one, and the reader was offered
+    a layer describing artists no longer drawn -- announced with confident
+    values, and with a highlight resolving to nothing because those artists
+    never reach ``HighlightContextManager``. It accumulated: five clear
+    cycles left six layers (#499).
+
+    ``ax.clear()`` is the ordinary way to redraw into a reused axes, so the
+    two spellings of the same intent behaved differently and the correct one
+    was the less common.
+
+    Narrower than ``Figure.clear``'s ``maidr.clear()`` on purpose: on a
+    figure with several axes, clearing one must leave the others registered.
+
+    Runs after ``wrapped``, matching the ``Figure.clear`` patch above -- the
+    layers are dropped once matplotlib has actually removed the artists, not
+    before.
+    """
+    wrapped(*args, **kwargs)
+    figure = instance.get_figure()
+    if figure is None:
+        return
+    try:
+        maidr = FigureManager.get_maidr(figure)
+    except KeyError:
+        return
+    maidr.clear_axes(instance)
+
+
+# Both spellings, because they delegate to each other depending on
+# ``Axes._subclass_uses_cla``: ``clear()`` may call ``cla()`` or vice versa.
+# Patching only one leaves the other reachable on a subclass that inverts
+# the delegation. When both fire for a single call the second finds nothing
+# left to drop, which is why ``clear_axes`` is idempotent.
+wrapt.wrap_function_wrapper(Axes, "clear", _clear_axes)
+wrapt.wrap_function_wrapper(Axes, "cla", _clear_axes)

--- a/maidr/patch/lineplot.py
+++ b/maidr/patch/lineplot.py
@@ -15,6 +15,39 @@ from maidr.util.step_utils import is_step_layer
 #: its own calls drew; see `line()` for what sweeping the axes collected.
 DRAWN_SERIES = "_maidr_line_series"
 
+#: The "this axes already has a layer" latch. Kept beside ``DRAWN_SERIES``
+#: because the two are reset together and nothing else may set either.
+PLOT_CREATED = "_maidr_plot_created"
+
+
+def forget_axes_state(ax: Axes) -> None:
+    """Drop the per-axes registration state this module stashes.
+
+    ``line()`` records two things directly on the ``Axes`` object: the
+    accumulated series, and a latch saying a layer already exists. Both are
+    plain instance attributes, so ``ax.clear()`` leaves them untouched --
+    matplotlib resets the state *it* owns, and knows nothing about these.
+
+    That makes them the one thing a clear has to be told about. Without
+    this, clearing an axes and drawing on it again finds the latch still
+    set, registers no layer at all, and leaves the chart **completely
+    undescribed** -- worse than the stale layer that clearing exists to
+    remove. It also leaves the series list holding ``Line2D`` objects that
+    were detached by the clear.
+
+    ``ax.containers``, which ``barplot`` gates on, needs none of this: it
+    belongs to matplotlib, which empties it on clear. This module is the
+    only one that keeps its own state on an axes.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes being cleared.
+    """
+    for attribute in (DRAWN_SERIES, PLOT_CREATED):
+        if hasattr(ax, attribute):
+            delattr(ax, attribute)
+
 
 def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
     """
@@ -159,7 +192,7 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
     series.extend(item for item in drawn if item not in series)
 
     # Check if a MAIDR plot already exists for this axes
-    if not hasattr(ax, "_maidr_plot_created"):
+    if not hasattr(ax, PLOT_CREATED):
         # Classify from the rendered artists: a layer is a step plot only when
         # every data-bearing line *it owns* is a step line.
         #
@@ -178,7 +211,7 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
             dict(kwargs, lines=series),
         )
         # Mark that a MAIDR plot has been created for this axes
-        setattr(ax, "_maidr_plot_created", True)
+        setattr(ax, PLOT_CREATED, True)
 
     return plot
 

--- a/tests/patch/test_clear.py
+++ b/tests/patch/test_clear.py
@@ -1,0 +1,184 @@
+"""Clearing an axes forgets the layers drawn on it, and nothing else.
+
+``Figure.clear`` was patched to drop a figure's registered layers;
+``Axes.clear`` was not. Re-plotting into a cleared axes therefore *appended*
+a layer, and the reader was offered one describing artists no longer drawn --
+announced with confident values, and with a highlight resolving to nothing
+because those artists never reach ``HighlightContextManager``. It accumulated:
+five clear cycles left six layers (#499).
+
+``ax.clear()`` is the ordinary way to redraw into a reused axes, so the two
+spellings of the same intent behaved differently, and the correct one was the
+less common for a single-axes figure.
+
+The tests assert on the emitted layer count rather than on ``_plots``, because
+the layer count is what a reader is offered. They also pin the neighbour cases
+-- a second panel, and a ``twinx`` twin at the same grid cell -- since the fix
+narrows ``clear()`` and the way to get that wrong is to take too much.
+
+``selector_ids`` is checked alongside, because it is paired with ``_plots`` by
+index in both directions and ``clear()`` used to empty only one of them. See
+``Maidr._drop_superseded_layers`` for the invariant.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def layer_count(maidr_obj) -> int:
+    """How many layers the emitted schema offers for the first subplot."""
+    schema = maidr_obj._flatten_maidr()
+    return len(schema["subplots"][0][0]["layers"])
+
+
+def paired(maidr_obj) -> bool:
+    """``_plots`` and ``selector_ids`` still line up by index."""
+    return len(maidr_obj._plots) == len(maidr_obj.selector_ids)
+
+
+@pytest.mark.parametrize("clear_it", [lambda ax: ax.clear(), lambda ax: plt.cla()])
+def test_replotting_a_cleared_axes_replaces_the_layer(clear_it):
+    """Both spellings reach the same ``Axes`` method and both were affected."""
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b", "c"], [1, 2, 3])
+    maidr_obj = FigureManager.get_maidr(fig)
+
+    clear_it(ax)
+    fig.gca().bar(["a", "b", "c"], [9, 9, 9])
+
+    assert layer_count(maidr_obj) == 1, (
+        "the cleared layer is still offered alongside the redrawn one"
+    )
+    layer = maidr_obj._flatten_maidr()["subplots"][0][0]["layers"][0]
+    assert [point["y"] for point in layer["data"]] == [9.0, 9.0, 9.0], (
+        "the surviving layer must be the redrawn one, not the discarded one"
+    )
+
+
+def test_repeated_clear_cycles_do_not_accumulate_layers():
+    """The count is the point: it grew by one per cycle, unbounded."""
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    maidr_obj = FigureManager.get_maidr(fig)
+
+    for i in range(5):
+        ax.clear()
+        ax.bar(["a", "b"], [i, i])
+
+    assert layer_count(maidr_obj) == 1
+    assert paired(maidr_obj)
+
+
+def test_clearing_one_panel_leaves_the_other_registered():
+    """``clear_axes`` is narrower than ``clear`` -- this is why."""
+    fig, (first, second) = plt.subplots(1, 2)
+    first.bar(["a", "b"], [1, 2])
+    second.bar(["c", "d"], [3, 4])
+    maidr_obj = FigureManager.get_maidr(fig)
+    assert len(maidr_obj._plots) == 2
+
+    first.clear()
+
+    assert [plot.ax for plot in maidr_obj._plots] == [second], (
+        "clearing one panel unregistered the other"
+    )
+    assert paired(maidr_obj)
+
+
+def test_clearing_a_twin_leaves_the_axes_it_was_twinned_from():
+    """``twinx`` puts a second axes at the same grid cell.
+
+    Keyed by position rather than by axes, this pair collapses -- the same
+    trap ``_layer_axes_key`` records for the supersede rules.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    twin = ax.twinx()
+    twin.plot([0, 1], [5, 6])
+    maidr_obj = FigureManager.get_maidr(fig)
+    assert len(maidr_obj._plots) == 2
+
+    twin.clear()
+
+    assert [plot.ax for plot in maidr_obj._plots] == [ax], (
+        "clearing the twin took the axes it was twinned from with it"
+    )
+    assert paired(maidr_obj)
+
+
+def test_clearing_an_axes_that_holds_no_layers_is_a_no_op():
+    """``Axes.clear`` and ``Axes.cla`` delegate to each other.
+
+    Both are patched, so a single call can fire the hook twice. The second
+    firing has to find nothing to do rather than disturb what the first left.
+    """
+    fig, (first, second) = plt.subplots(1, 2)
+    first.bar(["a", "b"], [1, 2])
+    maidr_obj = FigureManager.get_maidr(fig)
+    before = list(maidr_obj._plots)
+
+    second.clear()
+    second.clear()
+
+    assert maidr_obj._plots == before
+    assert paired(maidr_obj)
+
+
+def test_clearing_an_unregistered_figure_does_not_raise():
+    """A figure maidr never saw has no entry to drop."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])  # patched, but nothing registers a bare line here
+
+    ax.clear()  # must not raise
+    fig.clear()  # the pre-existing guard, kept
+
+
+def test_clear_drops_the_selector_ids_with_the_layers():
+    """The second half of #499, and the one that raised nothing.
+
+    ``clear()`` emptied ``_plots`` and left ``selector_ids`` behind. The two
+    are paired by index, so the next layer registered was tagged with the id
+    minted for a layer that no longer existed, and its own id was never used.
+
+    Called directly rather than through ``fig.clear()``, and that distinction
+    is the whole test. Going through the figure now reaches ``clear_axes``
+    first -- ``Figure.clear`` clears its axes, which is patched -- and that
+    drops both lists in step, so the figure route cannot fail even with this
+    line removed. It is a *public method* that can be called on its own, and
+    only calling it on its own pins what it does.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    maidr_obj = FigureManager.get_maidr(fig)
+    discarded = list(maidr_obj.selector_ids)
+    assert discarded, "the layer should have been registered with an id"
+
+    maidr_obj.clear()
+
+    assert maidr_obj._plots == []
+    assert maidr_obj.selector_ids == [], (
+        "the ids outlived the layers they were minted for"
+    )
+
+    ax.bar(["a", "b"], [9, 9])
+
+    assert paired(maidr_obj)
+    assert maidr_obj.selector_ids[0] not in discarded, (
+        "the re-plotted layer is wearing the discarded layer's selector id"
+    )

--- a/tests/patch/test_clear.py
+++ b/tests/patch/test_clear.py
@@ -262,48 +262,107 @@ def test_clear_drops_the_selector_ids_with_the_layers():
     )
 
 
-def test_lineplot_is_still_the_only_module_stashing_state_on_an_axes():
-    """``forget_axes_state`` only knows about the attributes it was told.
+def _maidr_state_stashed_in(source_file):
+    """Every place ``source_file`` puts maidr-owned state on another object.
 
-    Nothing makes a *future* patch module that reaches for
-    ``setattr(ax, ...)`` register its cleanup there, and the failure would
-    be the quiet one this file exists for: the layers are dropped, the new
-    module's latch survives, and the redraw registers nothing.
+    Yields ``(lineno, target, attribute)``. "maidr-owned" means the
+    attribute name starts with ``_maidr`` -- either written literally, or
+    named by a module-level constant holding such a string, which is how
+    ``lineplot`` spells ``DRAWN_SERIES`` and ``PLOT_CREATED``.
 
-    An AST guard rather than a grep, so a call spelled across several lines
-    or with a computed attribute name still counts. It fails on the module
-    that *adds* the state, which is where the fix belongs, rather than
-    later on a chart that stopped being described.
+    Both spellings of the assignment count: ``setattr(target, name, value)``
+    and ``target.attr = value``. An earlier version of this guard looked
+    only for ``setattr`` calls whose target was literally named ``ax`` or
+    ``axes``, which missed direct assignment entirely and missed every
+    module that binds its axes to ``instance`` or to a local of another
+    name. Both idioms are already used elsewhere in ``maidr/patch``.
     """
     import ast
+
+    tree = ast.parse(source_file.read_text())
+
+    # Module-level string constants, so `setattr(ax, DRAWN_SERIES, ...)`
+    # is read as the name it stands for rather than skipped.
+    constants = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        constants[target.id] = node.value.value
+
+    def resolve(node):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.Name):
+            return constants.get(node.id)
+        return None
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "setattr"
+            and len(node.args) >= 2
+        ):
+            name = resolve(node.args[1])
+            if name and name.startswith("_maidr"):
+                yield node.lineno, ast.unparse(node.args[0]), name
+
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if not isinstance(target, ast.Attribute):
+                    continue
+                if target.attr.startswith("_maidr"):
+                    yield node.lineno, ast.unparse(target.value), target.attr
+
+
+def test_no_new_module_stashes_maidr_state_on_an_axes():
+    """``forget_axes_state`` only knows about the attributes it was told.
+
+    Nothing makes a *future* patch module that stashes its own state on an
+    axes register the cleanup there, and the failure would be the quiet one
+    this file exists for: the layers are dropped, the new module's latch
+    survives the clear, and the redraw registers nothing at all.
+
+    Keyed on the *attribute* being maidr-owned rather than on the target
+    being named ``ax``, because the target's name is the part that varies
+    -- ``instance`` in a wrapt wrapper, or any local. What does not vary is
+    that maidr's own state is spelled ``_maidr...``.
+
+    State on an **artist** needs no cleanup: ``ax.clear()`` discards the
+    artists, so it goes with them. Only state on the axes survives, which
+    is what makes the target worth recording per entry.
+    """
     import pathlib
 
-    #: Modules known to keep their own state on an axes, and to have
-    #: registered its removal. Adding a name here means adding the cleanup.
-    allowed = {"lineplot.py"}
-
-    axes_like = {"ax", "axes"}
-    offenders: dict[str, list[int]] = {}
+    #: (module, target) -> why it is safe. A new entry is a decision:
+    #: on an axes, it must be removed in `forget_axes_state`; on an
+    #: artist, the clear discards it.
+    allowed = {
+        ("lineplot.py", "ax"): "latch and series; forget_axes_state removes both",
+        ("mplfinance.py", "line"): "on a Line2D; the clear discards the artist",
+    }
 
     patch_dir = pathlib.Path(__file__).resolve().parents[2] / "maidr" / "patch"
+    found = {}
     for source_file in sorted(patch_dir.glob("*.py")):
-        tree = ast.parse(source_file.read_text())
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            if not (isinstance(node.func, ast.Name) and node.func.id == "setattr"):
-                continue
-            if not node.args:
-                continue
-            target = node.args[0]
-            if isinstance(target, ast.Name) and target.id in axes_like:
-                if source_file.name not in allowed:
-                    offenders.setdefault(source_file.name, []).append(node.lineno)
+        for lineno, target, attribute in _maidr_state_stashed_in(source_file):
+            found.setdefault((source_file.name, target), []).append((lineno, attribute))
 
-    assert not offenders, (
-        f"{offenders} keeps its own state on an Axes. matplotlib does not "
-        "reset attributes it does not own, so clearing the axes leaves it "
-        "behind -- register its removal in "
-        "`maidr.patch.lineplot.forget_axes_state` and add the module to "
-        "`allowed` here. See #499."
+    unexpected = {key: sites for key, sites in found.items() if key not in allowed}
+
+    assert not unexpected, (
+        f"{unexpected} stashes maidr-owned state on another object. If the "
+        "target is an Axes, matplotlib will not reset it -- clearing the "
+        "axes leaves it behind, and the next draw registers nothing. "
+        "Remove it in `maidr.patch.lineplot.forget_axes_state` and add an "
+        "entry to `allowed` here saying so. If the target is an artist, the "
+        "clear discards it; add the entry saying that instead. See #499."
+    )
+
+    # The allowlist must not outlive what it describes: an entry for
+    # something no longer there would quietly widen the guard.
+    assert set(allowed) == set(found), (
+        f"`allowed` lists {set(allowed) - set(found)}, which no longer exists"
     )

--- a/tests/patch/test_clear.py
+++ b/tests/patch/test_clear.py
@@ -260,3 +260,50 @@ def test_clear_drops_the_selector_ids_with_the_layers():
     assert maidr_obj.selector_ids[0] not in discarded, (
         "the re-plotted layer is wearing the discarded layer's selector id"
     )
+
+
+def test_lineplot_is_still_the_only_module_stashing_state_on_an_axes():
+    """``forget_axes_state`` only knows about the attributes it was told.
+
+    Nothing makes a *future* patch module that reaches for
+    ``setattr(ax, ...)`` register its cleanup there, and the failure would
+    be the quiet one this file exists for: the layers are dropped, the new
+    module's latch survives, and the redraw registers nothing.
+
+    An AST guard rather than a grep, so a call spelled across several lines
+    or with a computed attribute name still counts. It fails on the module
+    that *adds* the state, which is where the fix belongs, rather than
+    later on a chart that stopped being described.
+    """
+    import ast
+    import pathlib
+
+    #: Modules known to keep their own state on an axes, and to have
+    #: registered its removal. Adding a name here means adding the cleanup.
+    allowed = {"lineplot.py"}
+
+    axes_like = {"ax", "axes"}
+    offenders: dict[str, list[int]] = {}
+
+    patch_dir = pathlib.Path(__file__).resolve().parents[2] / "maidr" / "patch"
+    for source_file in sorted(patch_dir.glob("*.py")):
+        tree = ast.parse(source_file.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not (isinstance(node.func, ast.Name) and node.func.id == "setattr"):
+                continue
+            if not node.args:
+                continue
+            target = node.args[0]
+            if isinstance(target, ast.Name) and target.id in axes_like:
+                if source_file.name not in allowed:
+                    offenders.setdefault(source_file.name, []).append(node.lineno)
+
+    assert not offenders, (
+        f"{offenders} keeps its own state on an Axes. matplotlib does not "
+        "reset attributes it does not own, so clearing the axes leaves it "
+        "behind -- register its removal in "
+        "`maidr.patch.lineplot.forget_axes_state` and add the module to "
+        "`allowed` here. See #499."
+    )

--- a/tests/patch/test_clear.py
+++ b/tests/patch/test_clear.py
@@ -234,12 +234,20 @@ def test_clear_drops_the_selector_ids_with_the_layers():
     are paired by index, so the next layer registered was tagged with the id
     minted for a layer that no longer existed, and its own id was never used.
 
-    Called directly rather than through ``fig.clear()``, and that distinction
-    is the whole test. Going through the figure now reaches ``clear_axes``
-    first -- ``Figure.clear`` clears its axes, which is patched -- and that
-    drops both lists in step, so the figure route cannot fail even with this
-    line removed. It is a *public method* that can be called on its own, and
-    only calling it on its own pins what it does.
+    Called directly rather than through ``fig.clear()``, because ``clear()``
+    is a *public method* that can be called on its own, and only calling it
+    on its own pins what it does.
+
+    That is the durable reason. There is also a version-dependent one: on
+    the matplotlib this was written against (3.10.9), ``Figure.clear``
+    clears its axes through ``Axes.clear``, which is patched, so the figure
+    route reaches ``clear_axes`` first and drops both lists in step --
+    measured, two axes giving two firings. Whether that holds is not a
+    thing to rely on: some matplotlib versions detach a figure's axes with
+    ``ax.remove()``, which would not route through the patch at all.
+    Correctness does not depend on it either way, since ``Figure.clear``'s
+    own patch calls ``maidr.clear()`` unconditionally -- but the test does,
+    which is why it does not go that way round.
     """
     fig, ax = plt.subplots()
     ax.bar(["a", "b"], [1, 2])
@@ -333,6 +341,15 @@ def test_no_new_module_stashes_maidr_state_on_an_axes():
     State on an **artist** needs no cleanup: ``ax.clear()`` discards the
     artists, so it goes with them. Only state on the axes survives, which
     is what makes the target worth recording per entry.
+
+    **Not a complete guarantee, and should not be leaned on as one.** It
+    sees an attribute stashed under a name it can read statically -- a
+    literal, or a module-level string constant. It does not see a name
+    built at runtime (an f-string, a ``getattr`` result), and it does not
+    see state kept *outside* the object at all, such as a module-level
+    ``WeakKeyDictionary`` keyed by axes. Those would need the same cleanup
+    and would pass here. What this catches is the shape the bug actually
+    took, which is the shape a future module is most likely to repeat.
     """
     import pathlib
 

--- a/tests/patch/test_clear.py
+++ b/tests/patch/test_clear.py
@@ -140,13 +140,91 @@ def test_clearing_an_axes_that_holds_no_layers_is_a_no_op():
     assert paired(maidr_obj)
 
 
-def test_clearing_an_unregistered_figure_does_not_raise():
-    """A figure maidr never saw has no entry to drop."""
-    fig, ax = plt.subplots()
-    ax.plot([0, 1], [0, 1])  # patched, but nothing registers a bare line here
+def test_clearing_a_brand_new_axes_does_not_raise():
+    """``Axes.__init__`` calls ``cla()``, so the hook fires before anything exists.
+
+    An earlier version of this test used ``ax.plot()`` and claimed nothing
+    was registered, which is wrong -- ``plot`` registers a LINE layer. The
+    guard being pinned here is the one that keeps every axes construction
+    from raising on a figure that has no maidr entry yet, so the test must
+    not draw anything at all.
+    """
+    fig = plt.figure()
+    ax = fig.add_subplot()  # `cla()` already fired here, unregistered
 
     ax.clear()  # must not raise
     fig.clear()  # the pre-existing guard, kept
+
+
+@pytest.mark.parametrize("draw", ["plot", "step"])
+def test_a_line_layer_is_registered_again_after_its_axes_is_cleared(draw):
+    """The regression this fix could have shipped, and the worse failure.
+
+    ``lineplot`` latches "this axes already has a layer" onto the axes
+    itself. matplotlib does not reset it -- it does not own it -- so
+    dropping the layers while leaving the latch set makes the redraw
+    register nothing, and the chart is **undescribed** rather than
+    mis-described: ``subplots: [[{}]]``.
+
+    Worth both spellings: ``ax.step`` delegates to ``Axes.plot`` and goes
+    through the same latch.
+    """
+    fig, ax = plt.subplots()
+    getattr(ax, draw)([0, 1, 2], [1, 2, 3])
+    maidr_obj = FigureManager.get_maidr(fig)
+    assert len(maidr_obj._plots) == 1
+
+    ax.clear()
+    getattr(ax, draw)([0, 1, 2], [9, 8, 7])
+
+    assert len(maidr_obj._plots) == 1, (
+        "the redrawn line registered no layer; the chart is undescribed"
+    )
+    assert layer_count(maidr_obj) == 1
+    assert paired(maidr_obj)
+
+
+def test_clearing_an_axes_drops_the_accumulated_line_series():
+    """The series list holds ``Line2D`` objects the clear detached.
+
+    Left in place they are both stale and unbounded -- a redraw appends to
+    the same list, so the layer would describe lines that are no longer
+    drawn alongside the ones that are.
+    """
+    from maidr.patch.lineplot import DRAWN_SERIES, PLOT_CREATED
+
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [1, 2])
+    assert len(getattr(ax, DRAWN_SERIES)) == 1
+    assert hasattr(ax, PLOT_CREATED)
+
+    ax.clear()
+
+    assert not hasattr(ax, DRAWN_SERIES)
+    assert not hasattr(ax, PLOT_CREATED)
+
+    ax.plot([0, 1], [5, 6])
+    assert len(getattr(ax, DRAWN_SERIES)) == 1, (
+        "the redrawn layer is carrying lines from before the clear"
+    )
+
+
+def test_figure_clear_empties_every_axes_on_a_multi_axes_figure():
+    """The cascade: ``Figure.clear`` clears its axes, and those are patched.
+
+    So ``clear_axes`` runs per axes *and* ``clear()`` runs at the figure
+    level. Both lists have to end up empty however the two interleave.
+    """
+    fig, (first, second) = plt.subplots(1, 2)
+    first.bar(["a", "b"], [1, 2])
+    second.bar(["c", "d"], [3, 4])
+    maidr_obj = FigureManager.get_maidr(fig)
+    assert len(maidr_obj._plots) == 2
+
+    fig.clear()
+
+    assert maidr_obj._plots == []
+    assert maidr_obj.selector_ids == []
 
 
 def test_clear_drops_the_selector_ids_with_the_layers():


### PR DESCRIPTION
## Description

`Figure.clear` was patched to drop a figure's registered layers. `Axes.clear` was not. Re-plotting into a cleared axes therefore **appended** a layer rather than replacing one, and the reader was offered a layer describing artists that are no longer drawn.

Same sequence — plot, render, clear, re-plot — through each spelling:

```
ax.clear()               layers=2  y per layer=[[1.0, 2.0, 3.0], [9.0, 9.0, 9.0]]
plt.cla()                layers=2  y per layer=[[1.0, 2.0, 3.0], [9.0, 9.0, 9.0]]
fig.clear() [patched]    layers=1  y per layer=[[9.0, 9.0, 9.0]]
```

The stale layer's artists are gone from the axes:

```
layer 0: 3 elements, still on axes: [False, False, False]
layer 1: 3 elements, still on axes: [True, True, True]
```

and nothing ever drops it — **five clear cycles left six layers**.

### Why this is the bad kind of bug

Not a crash and not a missing chart: a **complete, confident, wrong answer delivered only in the non-visual modality**. The phantom layer announces `1, 2, 3` for a chart displaying `9, 9, 9`, and its highlight resolves to nothing because artists that are no longer drawn never reach `HighlightContextManager`. A sighted reviewer looking at the figure sees one correct chart.

`ax.clear()` is ordinary matplotlib — the normal way to redraw into a reused axes, which is what an animation loop or a long-lived app does. So the two spellings of one intent behaved differently, and the correct one was the less common for a single-axes figure.

## A second defect in the same area

`Maidr.clear()` emptied `_plots` and left `selector_ids` behind:

```
before clear:      plots=1 selector_ids=1
after fig.clear(): plots=0 selector_ids=1
after re-plot:     plots=1 selector_ids=2   <- not aligned
```

The two are paired by index in both directions, and `_drop_superseded_layers` already documents exactly what that costs:

> dropping a layer without dropping its id hands every surviving layer its neighbour's, and the highlight lands on the wrong mark with nothing raised.

Measured consequence: the re-plotted layer's artists were tagged with `selector_ids[0]` — the id minted for the discarded layer — while the id minted for the new layer was never used. Nothing raised.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Closes #499. Found while investigating #498 (artist retention), checking what happens to retained artists when an axes is cleared while its figure survives.

## Changes Made

- `maidr/core/maidr.py` — new `clear_axes(ax)`, and `clear()` now drops `selector_ids` too.
  - `clear_axes` rather than reusing `clear()`: on a figure with several axes, clearing one must leave the others registered. Keyed by `_layer_axes_key`, so a `twinx` twin — a second axes at the same `(row, col)` — does not take the axes it was twinned from with it, which is the trap that helper already records for the supersede rules.
- `maidr/patch/clear.py` — patches **both** `Axes.clear` and `Axes.cla`. They delegate to each other depending on `Axes._subclass_uses_cla`, so patching one leaves the other reachable on a subclass that inverts the delegation. That can fire the hook twice for a single call, which is why `clear_axes` is idempotent. Runs after `wrapped`, matching the existing `Figure.clear` patch.
- `tests/patch/test_clear.py` — new; the clear patch had **no** coverage before this.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — **2338 passed, 13 skipped** (+8). `ruff check` unchanged at the 6 pre-existing findings; the new files are clean.

Every test was falsified against the code it pins, rather than trusted because it passed:

| mutation | tests that fail |
|---|---|
| `Axes.clear` / `cla` not patched | **5** |
| `clear_axes` drops every axes instead of one | **3** |
| `clear()` leaves `selector_ids` behind | **1** |

The last one is worth flagging, because **it initially passed under mutation** — a test that would have shipped asserting nothing. Going through `fig.clear()` now reaches `clear_axes` first (`Figure.clear` clears its axes, which is patched), and that drops both lists in step, so the figure route cannot fail even with the line removed. The test now calls the public `Maidr.clear()` directly, which is what that line actually guards. I only caught it because the mutation run reported `8 passed` where it should have reported a failure, and I checked that the mutation had really applied rather than assuming the test was fine.

Behaviour deliberately **not** changed: a figure whose layers are all cleared keeps its `FigureManager.figs` entry, exactly as the `Figure.clear` path already did. Dropping the entry is #456, and it has an open hazard (#452's cached-figure case) that this change should not quietly decide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_