### PR TITLE
fix(pointplot): keep a hued point plot's confidence intervals

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -210,13 +210,9 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
         """
         axes_data = super()._extract_axes_data()
 
-        legend = self.ax.get_legend()
-        if legend is not None:
-            title = legend.get_title()
-            if title is not None:
-                z_label = title.get_text().strip()
-                if z_label:
-                    axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
+        z_label = self._legend_title()
+        if z_label:
+            axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
 
         return axes_data
 

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -115,6 +115,17 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         Shared rather than restated: ``MultiLinePlot`` and ``PointPlot`` both
         need it and would otherwise drift apart if the convention changed.
 
+        Read **live**, when the schema is built, while the group *names* are
+        captured once as the plotting call is patched. A caller who retitles
+        or relabels the legend in between can therefore make the two
+        disagree -- the points would carry the names the chart was drawn
+        with and the axis would carry the new title. Pre-existing, and
+        sharper for ``PointPlot`` than for ``MultiLinePlot`` because there
+        the divergence reaches per-point ``z`` values rather than one label.
+        Reconciling them means either freezing the title at registration or
+        re-reading the names at render, and both are changes to when a
+        layer decides what it says.
+
         Returns
         -------
         str

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -105,6 +105,30 @@ class MaidrPlot(ABC, FormatExtractorMixin):
 
         return maidr_schema
 
+    def _legend_title(self) -> str:
+        """
+        The grouping variable's name, as the legend titles it.
+
+        A ``hue`` split names its groups in the legend entries and names the
+        *variable* in the legend title, and the title is the only place that
+        name appears -- so this is what an ``axes.z`` label is read from.
+        Shared rather than restated: ``MultiLinePlot`` and ``PointPlot`` both
+        need it and would otherwise drift apart if the convention changed.
+
+        Returns
+        -------
+        str
+            The title, or an empty string when there is no legend or no
+            title on it.
+        """
+        legend = self.ax.get_legend()
+        if legend is None:
+            return ""
+        title = legend.get_title()
+        if title is None:
+            return ""
+        return title.get_text().strip()
+
     @staticmethod
     def _axis_config(
         label: str | None = None,

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -72,7 +72,10 @@ class MaidrPlotFactory:
             # the same layer; they differ only in what the library drew.
             # `Axes.errorbar` leaves a container, while seaborn's point plot
             # leaves the lines the patch resolved and hands them over here.
-            if isinstance(kwargs.get("estimate"), Line2D):
+            # `estimates` (plural) is the `hue`-split form, one line per
+            # group; `estimate` is the single-series one. Either says the
+            # lines came from seaborn.
+            if isinstance(kwargs.get("estimate"), Line2D) or kwargs.get("estimates"):
                 return PointPlot(single_ax, **kwargs)
             return ErrorBarPlot(single_ax, **kwargs)
         elif PlotType.HEAT == plot_type:

--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -101,6 +101,17 @@ class PointPlot(ErrorBarPlot):
         # the cursor was in the first.
         self._elements.clear()
 
+        # `_pairs_up` establishes that the intervals divide evenly among the
+        # estimates, and the patch will not construct this type unless it
+        # does. Checked here anyway: the invariant lives in another file, so
+        # a caller constructing `PointPlot` directly -- or a future change to
+        # the patch -- would otherwise mis-slice in silence, handing one
+        # group another's bounds. That is the exact failure the `line`
+        # fallback existed to prevent, and this module raises rather than
+        # guesses everywhere else.
+        if len(self._intervals) % len(self._estimates):
+            raise ExtractionError(self.type, self.ax)
+
         per_group = len(self._intervals) // len(self._estimates)
         # All the groups are named or none is, so a layer never declares an
         # `axes.z` that some of its series do not carry. `_extract_axes_data`

--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -102,11 +102,15 @@ class PointPlot(ErrorBarPlot):
         self._elements.clear()
 
         per_group = len(self._intervals) // len(self._estimates)
+        # All the groups are named or none is, so a layer never declares an
+        # `axes.z` that some of its series do not carry. `_extract_axes_data`
+        # reads the same predicate.
+        named = self._named_groups()
         series: list[list[dict]] = []
 
         for index, estimate in enumerate(self._estimates):
             intervals = self._intervals[index * per_group : (index + 1) * per_group]
-            group = self._groups[index] if index < len(self._groups) else ""
+            group = self._groups[index] if named else ""
             points = self._points_of(estimate, intervals, is_vertical, labels, group)
             if not points:
                 raise ExtractionError(self.type, self.ax)
@@ -246,6 +250,12 @@ class PointPlot(ErrorBarPlot):
         treatment says "Treatment" rather than "Group". Omitted for an
         ungrouped chart, which has nothing to name.
 
+        Also omitted when the groups themselves could not be named. The two
+        have to agree: declaring a ``z`` axis while some series carry no
+        ``z`` is a shape the consumer has no reading for, and it is reachable
+        whenever the legend does not list exactly one entry per drawn group.
+        Either the whole layer is grouped-and-named or none of it is.
+
         Returns
         -------
         dict
@@ -253,18 +263,25 @@ class PointPlot(ErrorBarPlot):
         """
         axes_data = super()._extract_axes_data()
 
-        if not self._estimates:
+        if not self._estimates or not self._named_groups():
             return axes_data
 
-        legend = self.ax.get_legend()
-        if legend is not None:
-            title = legend.get_title()
-            if title is not None:
-                z_label = title.get_text().strip()
-                if z_label:
-                    axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
+        z_label = self._legend_title()
+        if z_label:
+            axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
 
         return axes_data
+
+    def _named_groups(self) -> bool:
+        """
+        Whether every drawn group has a name to emit as ``z``.
+
+        Returns
+        -------
+        bool
+            True when the patch supplied one name per estimate.
+        """
+        return len(self._groups) == len(self._estimates) and all(self._groups)
 
     def _is_vertical(self) -> bool:
         """

--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -8,7 +8,7 @@ from matplotlib.axis import Axis
 from matplotlib.lines import Line2D
 
 from maidr.core.enum import MaidrKey
-from maidr.core.plot.errorbar import ErrorBarPlot
+from maidr.core.plot.errorbar import ErrorBarPlot, _is_drawn
 from maidr.exception import ExtractionError
 
 
@@ -54,15 +54,154 @@ class PointPlot(ErrorBarPlot):
     def __init__(self, ax: Axes, **kwargs) -> None:
         self._estimate: Line2D | None = kwargs.pop("estimate", None)
         self._intervals: list[Line2D] = list(kwargs.pop("intervals", []))
+        #: One estimate line per ``hue`` group, in the order seaborn drew
+        #: them. Empty for an ungrouped chart, which keeps ``_estimate``.
+        self._estimates: list[Line2D] = list(kwargs.pop("estimates", []))
+        #: The name of each group, from the legend, parallel to
+        #: ``_estimates``.
+        self._groups: list[str] = list(kwargs.pop("groups", []))
 
         super().__init__(ax, **kwargs)
 
-    def _extract_plot_data(self) -> list[dict]:
-        if self._estimate is None or not self._intervals:
+    def _extract_plot_data(self) -> list[dict] | list[list[dict]]:
+        if self._estimates:
+            return self._extract_grouped()
+        return self._extract_single()
+
+    def _extract_grouped(self) -> list[list[dict]]:
+        """
+        Describe a ``hue``-split chart as one series per group.
+
+        The grouped ``error_bar`` shape -- ``ErrorBarPoint[][]`` with a ``z``
+        on each point -- arrived in maidr 4.4.0 (xability/maidr#942). Before
+        it, the layer carried a single flat series with no field naming the
+        group, so a hued chart's intervals had nowhere to go and were dropped
+        rather than mis-assigned: the reader got the means of a chart drawn to
+        show the uncertainty around them (#462).
+
+        Seaborn draws the interval polylines **estimate-major** -- every
+        category of the first group, then every category of the second --
+        which is the order the consumer wants its rows in, so each group
+        takes a contiguous slice. Verified against the drawn geometry rather
+        than assumed: each estimate's value falls inside the span of the
+        interval its slice pairs it with.
+
+        Returns
+        -------
+        list of list of dict
+            A series per group, each point carrying ``z``.
+        """
+        is_vertical = self._is_vertical()
+        self._orientation = "vert" if is_vertical else "horz"
+        labels = self._category_labels(is_vertical)
+
+        # Cleared for the reason `_extract_single` records, and filled
+        # group-major so each group's rows take that group's slice. Handing
+        # every row the whole list would light a second group's whips while
+        # the cursor was in the first.
+        self._elements.clear()
+
+        per_group = len(self._intervals) // len(self._estimates)
+        series: list[list[dict]] = []
+
+        for index, estimate in enumerate(self._estimates):
+            intervals = self._intervals[index * per_group : (index + 1) * per_group]
+            group = self._groups[index] if index < len(self._groups) else ""
+            points = self._points_of(estimate, intervals, is_vertical, labels, group)
+            if not points:
+                raise ExtractionError(self.type, self.ax)
+            series.append(points)
+
+        if not series:
             raise ExtractionError(self.type, self.ax)
 
-        xs, ys = self._estimate.get_data()
-        if len(xs) != len(self._intervals):
+        if len(self._elements) != sum(len(points) for points in series):
+            # Same contract as the ungrouped path: one element per point or
+            # no selector at all.
+            self._elements.clear()
+            self._support_highlighting = False
+
+        return series
+
+    def _points_of(
+        self,
+        estimate: Line2D,
+        intervals: list[Line2D],
+        is_vertical: bool,
+        labels: dict[float, str],
+        group: str,
+    ) -> list[dict]:
+        """
+        Read one estimate line and the intervals drawn around it.
+
+        Split out of ``_extract_single`` so the grouped path reads each of
+        its series the same way rather than restating the pairing, the
+        category labelling and the dodge-rounding independently.
+
+        Parameters
+        ----------
+        estimate : Line2D
+            The line carrying this group's estimates.
+        intervals : list of Line2D
+            This group's interval polylines, in category order.
+        is_vertical : bool
+            Whether the categories run along x.
+        labels : dict
+            Category coordinate to drawn name.
+        group : str
+            The group's name, emitted as ``z``. Empty for an ungrouped
+            chart, which omits the key entirely.
+
+        Returns
+        -------
+        list of dict
+            One point per category.
+        """
+        xs, ys = estimate.get_data()
+        if len(xs) != len(intervals):
+            raise ExtractionError(self.type, self.ax)
+
+        # The category runs along the axis the intervals do NOT span. The
+        # schema names them `x` and `y` in both orientations and lets
+        # `orientation` say which is on screen where -- see `ErrorBarPlot`,
+        # whose docstring explains why this differs from how a bar travels.
+        categories, values = (xs, ys) if is_vertical else (ys, xs)
+
+        points = []
+        for category, value, interval in zip(categories, values, intervals):
+            coordinate = float(category)
+            bounds = self._interval_bounds(interval, is_vertical)
+            # Rounded as well as exact: a `dodge` shifts a group aside from
+            # the tick that names it, and the group is still that group.
+            label = labels.get(coordinate) or labels.get(float(round(coordinate)))
+            point = {
+                MaidrKey.X: label if label is not None else self._scalar(category),
+                # `None`, not the raw NaN, where seaborn padded a hue level
+                # missing from one category. The padding has a real position
+                # and no measurement, and `null` is how the core has said
+                # that since maidr 4.3.0 -- it sounds as the empty tone and
+                # announces as "missing". A bare NaN stops the chart
+                # initialising at all, since it is not JSON (#429), and a
+                # zero would claim a reading of zero. Same rule
+                # `MultiLinePlot._reading` applies, and this path inherited
+                # the case from it along with the intervals (#462).
+                MaidrKey.Y: self._scalar(value) if _is_drawn(value) else None,
+            }
+            if group:
+                point[MaidrKey.Z] = group
+            if bounds is not None:
+                point[MaidrKey.Y_MIN], point[MaidrKey.Y_MAX] = bounds
+                # Tag for highlighting only the intervals that produced a
+                # bound. One path per sample, in the order the points are
+                # emitted, which is the shape the consumer repeats across its
+                # three sections.
+                self._elements.append(interval)
+            points.append(point)
+
+        return points
+
+    def _extract_single(self) -> list[dict]:
+        if self._estimate is None or not self._intervals:
             raise ExtractionError(self.type, self.ax)
 
         is_vertical = self._is_vertical()
@@ -74,32 +213,10 @@ class PointPlot(ErrorBarPlot):
         # the consumer highlights the wrong group.
         self._elements.clear()
 
-        # The category runs along the axis the intervals do NOT span. The
-        # schema names them `x` and `y` in both orientations and lets
-        # `orientation` say which is on screen where -- see `ErrorBarPlot`,
-        # whose docstring explains why this differs from how a bar travels.
-        categories, values = (xs, ys) if is_vertical else (ys, xs)
         labels = self._category_labels(is_vertical)
-
-        data = []
-        for category, value, interval in zip(categories, values, self._intervals):
-            coordinate = float(category)
-            bounds = self._interval_bounds(interval, is_vertical)
-            # Rounded as well as exact: a `dodge` shifts a group aside from
-            # the tick that names it, and the group is still that group.
-            label = labels.get(coordinate) or labels.get(float(round(coordinate)))
-            point = {
-                MaidrKey.X: label if label is not None else self._scalar(category),
-                MaidrKey.Y: self._scalar(value),
-            }
-            if bounds is not None:
-                point[MaidrKey.Y_MIN], point[MaidrKey.Y_MAX] = bounds
-                # Tag for highlighting only the intervals that produced a
-                # bound. One path per sample, in the order the points are
-                # emitted, which is the shape the consumer repeats across its
-                # three sections.
-                self._elements.append(interval)
-            data.append(point)
+        data = self._points_of(
+            self._estimate, self._intervals, is_vertical, labels, ""
+        )
 
         if not data:
             raise ExtractionError(self.type, self.ax)
@@ -119,6 +236,35 @@ class PointPlot(ErrorBarPlot):
             self._support_highlighting = False
 
         return data
+
+    def _extract_axes_data(self) -> dict:
+        """
+        Add a ``z`` axis naming the grouping variable, when there is one.
+
+        Taken from the legend title, which is the ``hue`` column's name --
+        the same source ``MultiLinePlot`` uses, so a chart grouped by
+        treatment says "Treatment" rather than "Group". Omitted for an
+        ungrouped chart, which has nothing to name.
+
+        Returns
+        -------
+        dict
+            The per-axis ``AxisConfig`` mapping.
+        """
+        axes_data = super()._extract_axes_data()
+
+        if not self._estimates:
+            return axes_data
+
+        legend = self.ax.get_legend()
+        if legend is not None:
+            title = legend.get_title()
+            if title is not None:
+                z_label = title.get_text().strip()
+                if z_label:
+                    axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
+
+        return axes_data
 
     def _is_vertical(self) -> bool:
         """

--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -289,6 +289,13 @@ class PointPlot(ErrorBarPlot):
         """
         Whether every drawn group has a name to emit as ``z``.
 
+        Answers True vacuously when there are no groups at all, since
+        ``len([]) == len([])`` and ``all([])`` both hold. No caller reaches
+        it in that state -- ``_extract_axes_data`` returns early on an empty
+        ``_estimates`` and ``_extract_grouped`` runs only when it is
+        non-empty -- so the emptiness check lives in the callers rather than
+        here, and this answers the question it is named for.
+
         Returns
         -------
         bool

--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -127,9 +127,11 @@ class PointPlot(ErrorBarPlot):
                 raise ExtractionError(self.type, self.ax)
             series.append(points)
 
-        if not series:
-            raise ExtractionError(self.type, self.ax)
-
+        # No `if not series` guard here, deliberately: `_extract_plot_data`
+        # routes to this method only when `_estimates` is non-empty, and
+        # every iteration either appends or raises -- so an empty `series`
+        # has no way to occur. A check that cannot fire is worse than none;
+        # it sends a reader looking for the case that produces it.
         if len(self._elements) != sum(len(points) for points in series):
             # Same contract as the ungrouped path: one element per point or
             # no selector at all.

--- a/maidr/patch/pointplot.py
+++ b/maidr/patch/pointplot.py
@@ -95,7 +95,7 @@ def _register_point_layer(ax: Axes, existing: list[Line2D]) -> None:
         return
 
     paired = _pairs_up(estimates, intervals)
-    measured = any(_is_drawn(line.get_xydata()) for line in intervals)
+    measured = any(_has_drawn_segment(line.get_xydata()) for line in intervals)
 
     if paired and measured and len(estimates) == 1:
         FigureManager.create_maidr(
@@ -210,14 +210,14 @@ def _split(lines: list[Line2D]) -> tuple[list[Line2D], list[Line2D]]:
             # Kept whether or not it carries a bound. The list is read against
             # the estimates *by position*, so dropping the line a group with a
             # single observation leaves behind would shift every later group's
-            # interval onto the wrong estimate. `_is_drawn` decides what to do
-            # with it; it does not decide whether it is there.
+            # interval onto the wrong estimate. `_has_drawn_segment` decides
+            # what to do with it; it does not decide whether it is there.
             intervals.append(line)
 
     return estimates, intervals
 
 
-def _is_drawn(vertices: np.ndarray) -> bool:
+def _has_drawn_segment(vertices: np.ndarray) -> bool:
     """
     Check that a candidate interval is a shape the chart actually drew.
 

--- a/maidr/patch/pointplot.py
+++ b/maidr/patch/pointplot.py
@@ -145,9 +145,20 @@ def _group_labels(ax: Axes, count: int) -> list[str]:
     order, which is the order the groups were drawn in and so the order the
     estimates arrive in.
 
-    Returns fewer names than groups rather than guessing when the legend is
-    absent or short -- ``PointPlot`` omits ``z`` for a group it cannot name,
-    which reads as an unlabelled series rather than as a mislabelled one.
+    All the groups are named or none is. A legend that does not carry
+    exactly one entry per drawn group is not one this can read positionally,
+    and naming the groups it does cover would leave the layer declaring an
+    ``axes.z`` while some of its series carried no ``z`` at all -- a shape
+    the consumer has no reading for. Returning nothing instead gives the
+    clean fallback: an unlabelled grouped chart, which is what the old
+    ``line`` fallback produced anyway.
+
+    That count check is also the only guard on the assumption underneath
+    this: that seaborn lists its legend handles in the order it drew the
+    lines. The interval-to-estimate pairing is verified against the drawn
+    geometry (``_pairs_up``, and the bounds bracket their estimate); the
+    name-to-group pairing has no equivalent, because a name has no geometry
+    to check it against. A count mismatch is the one symptom available.
 
     Parameters
     ----------
@@ -159,12 +170,18 @@ def _group_labels(ax: Axes, count: int) -> list[str]:
     Returns
     -------
     list of str
-        The group names, in drawing order.
+        One name per group in drawing order, or empty when the legend
+        cannot be read as naming exactly those groups.
     """
     legend = ax.get_legend()
     if legend is None:
         return []
-    return [text.get_text() for text in legend.get_texts()][:count]
+
+    names = [text.get_text() for text in legend.get_texts()]
+    if len(names) != count:
+        return []
+
+    return names
 
 
 def _split(lines: list[Line2D]) -> tuple[list[Line2D], list[Line2D]]:

--- a/maidr/patch/pointplot.py
+++ b/maidr/patch/pointplot.py
@@ -103,13 +103,30 @@ def _register_point_layer(ax: Axes, existing: list[Line2D]) -> None:
         )
         return
 
+    if paired and measured:
+        # A `hue` split the chart into groups. This used to fall through to
+        # `line`, dropping the intervals rather than mis-assigning them,
+        # because the MAIDR error bar layer carried a single flat series with
+        # no field naming the group. maidr 4.4.0 gave it one --
+        # `ErrorBarPoint[][]` with a `z`, xability/maidr#942 -- so the
+        # intervals now have somewhere to go (#462).
+        #
+        # The estimates arrive one per group and the intervals estimate-major,
+        # which `PointPlot` slices; `_pairs_up` has already checked the counts
+        # divide evenly, so the slicing cannot straddle two groups.
+        FigureManager.create_maidr(
+            ax,
+            PlotType.ERRORBAR,
+            estimates=estimates,
+            intervals=intervals,
+            groups=_group_labels(ax, len(estimates)),
+        )
+        return
+
     # Everything else is a line chart. `errorbar=None` draws no intervals to
-    # carry, a chart whose every group holds one observation has none to draw,
-    # and more than one estimate means a `hue` split the chart into groups
-    # while the MAIDR error bar layer carries a single series -- so those
-    # intervals are dropped rather than mis-assigned. All three are still a
-    # repair over describing every drawn line, since the interval polylines no
-    # longer travel as series of their own.
+    # carry, and a chart whose every group holds one observation has none to
+    # draw. Both are still a repair over describing every drawn line, since
+    # the interval polylines no longer travel as series of their own.
     #
     # A chart where only *some* groups have an interval takes the branch above,
     # not this one: the undrawable lines stay in the list to hold their
@@ -117,6 +134,37 @@ def _register_point_layer(ax: Axes, existing: list[Line2D]) -> None:
     FigureManager.create_maidr(
         ax, PlotType.LINE, lines=estimates if paired else drawn
     )
+
+
+def _group_labels(ax: Axes, count: int) -> list[str]:
+    """
+    Name each ``hue`` group from the legend seaborn drew.
+
+    The estimate lines carry `_child`-prefixed labels rather than the group
+    names, so the legend is the only place the names appear. Read in legend
+    order, which is the order the groups were drawn in and so the order the
+    estimates arrive in.
+
+    Returns fewer names than groups rather than guessing when the legend is
+    absent or short -- ``PointPlot`` omits ``z`` for a group it cannot name,
+    which reads as an unlabelled series rather than as a mislabelled one.
+
+    Parameters
+    ----------
+    ax : Axes
+        The panel the point plot was drawn on.
+    count : int
+        How many groups were drawn.
+
+    Returns
+    -------
+    list of str
+        The group names, in drawing order.
+    """
+    legend = ax.get_legend()
+    if legend is None:
+        return []
+    return [text.get_text() for text in legend.get_texts()][:count]
 
 
 def _split(lines: list[Line2D]) -> tuple[list[Line2D], list[Line2D]]:

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -33,6 +33,7 @@ import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.core.plot.pointplot import PointPlot  # noqa: E402
+from maidr.patch.pointplot import _group_labels  # noqa: E402
 
 
 #: Three groups whose observations differ enough per group that the intervals
@@ -335,6 +336,80 @@ def test_three_groups_each_take_their_own_intervals():
     for series in schema["data"]:
         for point in series:
             assert point["yMin"] <= point["y"] <= point["yMax"]
+
+
+def test_a_legend_that_does_not_name_every_group_names_none():
+    """Either the whole layer is grouped-and-named or none of it is.
+
+    Naming only the groups the legend covers would leave the layer
+    declaring an ``axes.z`` while some of its series carried no ``z`` --
+    a shape the consumer has no reading for. The clean fallback is an
+    unlabelled grouped chart, which is what the old ``line`` path gave.
+
+    Driven through the guards directly rather than through a contrived
+    seaborn state. A legend short at *registration* time is the case this
+    protects against, and replacing the legend afterwards does not produce
+    it: the names are read while the call is being patched, so a later
+    ``ax.legend(...)`` leaves what was captured alone. Testing the guard is
+    honest; staging a chart seaborn may never draw is not.
+    """
+    frame = FRAME.assign(half=["x", "y"] * 9)
+
+    fig, ax = plt.subplots()
+    sns.pointplot(frame, x="group", y="value", hue="half", dodge=True, ax=ax)
+
+    # The reader: one name per drawn group, or nothing.
+    assert _group_labels(ax, 2) == ["x", "y"]
+    assert _group_labels(ax, 3) == []
+    assert _group_labels(ax, 1) == []
+
+    # The emitter, handed a short list: no `z` anywhere rather than on some
+    # series only, and no `axes.z` declaring one that is not there.
+    plot = _plots(fig)[0]
+    plot._groups = ["x"]
+    plot._schema = {}
+
+    schema = plot.render()
+
+    assert schema["type"] == PlotType.ERRORBAR.value
+    assert len(schema["data"]) == 2
+    assert "z" not in schema["axes"]
+    assert not any("z" in point for series in schema["data"] for point in series)
+    # The bounds are the point of the layer and survive the naming failure.
+    for series in schema["data"]:
+        for point in series:
+            assert point["yMin"] <= point["y"] <= point["yMax"]
+
+
+def test_a_group_whose_every_category_is_a_singleton_keeps_its_siblings():
+    """One group with no drawable interval must not cost the others theirs.
+
+    A hue level holding a single observation everywhere has nothing to
+    estimate an interval from, and seaborn renders that as a polyline whose
+    value coordinates are all NaN. The layer omits that group's bounds and
+    keeps the rest, rather than falling back for the whole chart.
+    """
+    frame = pd.DataFrame(
+        {
+            "g": ["a", "a", "a", "b", "b", "b"] * 2,
+            "half": ["x"] * 6 + ["y"] * 6,
+            "v": [1.0, 2.0, 3.0, 8.0, 9.0, 10.0, 5.0, 5.0, 5.0, 7.0, 7.0, 7.0],
+        }
+    )
+
+    fig, ax = plt.subplots()
+    sns.pointplot(frame, x="g", y="v", hue="half", dodge=True, ax=ax)
+
+    schema = _schema(fig)
+
+    assert schema["type"] == PlotType.ERRORBAR.value
+    assert len(schema["data"]) == 2
+    # Every point is still reported, with or without a bound.
+    assert all(len(series) == 2 for series in schema["data"])
+    # The group that has intervals keeps them.
+    assert any(
+        "yMin" in point for series in schema["data"] for point in series
+    )
 
 
 def test_a_dodged_group_is_still_named_by_its_tick():

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -437,6 +437,14 @@ def test_a_hue_level_with_no_drawable_interval_keeps_its_sibling_bounded():
     assert [point["x"] for point in unbounded] == ["a", "b"]
     assert all(point["y"] is not None for point in unbounded)
 
+    # The grouped path keeps the ungrouped contract: the consumer resolves
+    # the selector to one element per point and discards the result outright
+    # when the count disagrees, so a layer that cannot supply one for every
+    # point promises none at all rather than a selector that resolves short.
+    plot = _plots(fig)[0]
+    assert plot._support_highlighting is False
+    assert plot.elements == []
+
 
 def test_intervals_that_do_not_divide_among_the_groups_are_refused():
     """The counts are guaranteed by ``_pairs_up``, in another file.
@@ -470,6 +478,51 @@ def test_intervals_that_do_not_divide_among_the_groups_are_refused():
 
     with pytest.raises(ExtractionError):
         plot.render()
+
+
+def test_a_group_name_lands_on_that_group_s_own_values():
+    """The one assumption in the naming that geometry can be made to check.
+
+    Group names come from the legend and are matched to the estimate lines
+    positionally, so the whole thing rests on seaborn listing its legend
+    handles in draw order. Unlike the interval-to-estimate pairing, a name
+    has no geometry to verify it against -- ``_group_labels``'s count check
+    catches a legend of the wrong *size*, not one of the wrong *order*
+    (#502).
+
+    Made checkable by choosing hue levels whose names are recoverable from
+    their values: ``low`` sits near 1 and ``high`` near 100. A swapped
+    naming is then a visible mismatch rather than an invisible one, since
+    every other fixture in this file uses interchangeable levels (``x``/
+    ``y``, ``p``/``q``) where correct and swapped read identically.
+
+    Run with the default order and with ``hue_order`` reversed, because a
+    reversal is the cheapest way seaborn could plausibly diverge, and it is
+    the one a caller can trigger today.
+    """
+    frame = pd.DataFrame(
+        {
+            "g": list("abc") * 8,
+            "level": ["low"] * 12 + ["high"] * 12,
+            "v": [1.0, 2.0, 3.0] * 4 + [100.0, 101.0, 102.0] * 4,
+        }
+    )
+
+    for hue_order in (None, ["high", "low"]):
+        fig, ax = plt.subplots()
+        extra = {"hue_order": hue_order} if hue_order else {}
+        sns.pointplot(frame, x="g", y="v", hue="level", dodge=True, ax=ax, **extra)
+
+        schema = _schema(fig)
+        by_name = {
+            series[0]["z"]: [point["y"] for point in series]
+            for series in schema["data"]
+        }
+
+        assert set(by_name) == {"low", "high"}, hue_order
+        assert max(by_name["low"]) < 50, (hue_order, by_name["low"])
+        assert min(by_name["high"]) > 50, (hue_order, by_name["high"])
+        plt.close(fig)
 
 
 def test_a_dodged_group_is_still_named_by_its_tick():

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -33,6 +33,7 @@ import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.core.plot.pointplot import PointPlot  # noqa: E402
+from maidr.exception import ExtractionError  # noqa: E402
 from maidr.patch.pointplot import _group_labels  # noqa: E402
 
 
@@ -435,6 +436,40 @@ def test_a_hue_level_with_no_drawable_interval_keeps_its_sibling_bounded():
     assert all("yMin" not in point for point in unbounded)
     assert [point["x"] for point in unbounded] == ["a", "b"]
     assert all(point["y"] is not None for point in unbounded)
+
+
+def test_intervals_that_do_not_divide_among_the_groups_are_refused():
+    """The counts are guaranteed by ``_pairs_up``, in another file.
+
+    So the slicing checks them again rather than trusting a contract it
+    cannot see -- a caller constructing ``PointPlot`` directly, or a future
+    change to the patch, would otherwise mis-slice in silence.
+
+    The case is an interval **too many**, not one too few, and that is the
+    whole reason this test exists. A short list is already caught downstream
+    by ``_points_of``, whose ``len(xs) != len(intervals)`` raises when a
+    group's slice does not cover its categories. A long one is not: with 7
+    intervals over 2 estimates of 3 categories, ``per_group`` is 3, both
+    groups slice cleanly, and the extra interval is dropped without a word.
+    Measured both ways --
+
+        5 intervals: raises with or without the guard
+        7 intervals: raises only with it
+
+    -- because the first version of this test used the short list and
+    therefore passed with the guard removed.
+    """
+    frame = FRAME.assign(half=["x", "y"] * 9)
+
+    fig, ax = plt.subplots()
+    sns.pointplot(frame, x="group", y="value", hue="half", dodge=True, ax=ax)
+
+    plot = _plots(fig)[0]
+    plot._intervals.append(plot._intervals[0])  # 7 intervals across 2 estimates
+    plot._schema = {}
+
+    with pytest.raises(ExtractionError):
+        plot.render()
 
 
 def test_a_dodged_group_is_still_named_by_its_tick():

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -270,16 +270,21 @@ def test_a_point_plot_with_no_interval_stays_a_line():
     assert [point["x"] for point in schema["data"][0]] == ["a", "b", "c"]
 
 
-def test_a_hue_reads_as_the_multi_line_chart_it_is():
+def test_a_hue_keeps_its_intervals_as_a_grouped_error_bar():
     """
-    A ``hue`` splits the chart into groups, and the layer carries one series.
+    A ``hue`` splits the chart into groups, and each group keeps its bounds.
 
-    The intervals are dropped rather than mis-assigned -- carrying one group's
-    bounds under another's estimate would be worse than carrying none -- and a
-    follow-up covers giving the layer more than one series. What this pins is
-    that the interval polylines still do not travel as series of their own, and
-    that each remaining series is named after its hue level rather than after
-    whichever line index it happened to land on.
+    This replaces a test that pinned the gap. The layer used to fall back to
+    ``line``, dropping the intervals rather than mis-assigning them, because
+    the error bar layer carried a single flat series with no field naming the
+    group -- so a reader of a grouped point plot was handed the means of a
+    chart drawn to show the uncertainty around them. maidr 4.4.0 gave the
+    grammar a grouped shape (xability/maidr#942) and the fallback went with
+    it (#462).
+
+    What the old test pinned still holds and is still asserted: the interval
+    polylines do not travel as series of their own, and each series is named
+    after its hue level rather than after whichever line index it landed on.
     """
     fig, ax = plt.subplots()
     frame = FRAME.assign(half=["x", "y"] * 9)
@@ -287,9 +292,49 @@ def test_a_hue_reads_as_the_multi_line_chart_it_is():
 
     schema = _schema(fig)
 
-    assert schema["type"] == PlotType.LINE.value
+    assert schema["type"] == PlotType.ERRORBAR.value
     assert len(schema["data"]) == 2
     assert {point["z"] for series in schema["data"] for point in series} == {"x", "y"}
+
+    # The half the fallback used to lose. Every point carries a bound, and
+    # each bound belongs to the estimate it is emitted beside -- checked by
+    # containment rather than by position, since pairing the wrong group's
+    # interval to an estimate is the failure the fallback existed to avoid.
+    for series in schema["data"]:
+        for point in series:
+            assert point["yMin"] <= point["y"] <= point["yMax"]
+
+    # The grouping variable is named, so the reader hears "half" rather than
+    # an unlabelled third axis.
+    assert schema["axes"]["z"]["label"] == "half"
+
+
+def test_three_groups_each_take_their_own_intervals():
+    """Slicing the interval list per group has to generalise past two.
+
+    Seaborn draws the polylines estimate-major -- every category of the
+    first group, then of the second -- so each group takes a contiguous
+    slice. With two groups an off-by-one in that arithmetic still lands
+    inside the list and mis-pairs silently; a third group is what makes a
+    wrong stride reach the wrong bounds visibly.
+
+    Checked by containment rather than by index, because "did this group get
+    its own intervals" is the question, and the estimate falling inside the
+    bounds emitted beside it is what answers it.
+    """
+    frame = FRAME.assign(third=["x", "y", "z"] * 6)
+
+    fig, ax = plt.subplots()
+    sns.pointplot(frame, x="group", y="value", hue="third", dodge=True, ax=ax)
+
+    schema = _schema(fig)
+
+    assert schema["type"] == PlotType.ERRORBAR.value
+    assert len(schema["data"]) == 3
+    assert [series[0]["z"] for series in schema["data"]] == ["x", "y", "z"]
+    for series in schema["data"]:
+        for point in series:
+            assert point["yMin"] <= point["y"] <= point["yMax"]
 
 
 def test_a_dodged_group_is_still_named_by_its_tick():
@@ -455,12 +500,20 @@ def test_nothing_recognisable_still_describes_the_lines():
 
 def test_a_horizontal_dodge_names_its_groups():
     """
-    The categories are on y here, and they are named there (#353).
+    The categories are drawn on y here, and they are named (#353).
 
     This replaces a test that pinned the gap. ``-0.025`` and ``0.975`` are
     where two hue levels were shifted to make room for each other around the
     ticks the chart writes ``a`` and ``b`` on, so a reader was given the
     offsets and no way to reach the names.
+
+    The names moved from ``y`` to ``x`` when this chart stopped falling back
+    to ``line`` (#462), and that is a change of key rather than of behaviour:
+    an error bar layer carries the category as ``x`` in **both** orientations
+    and lets ``orientation`` say which is on screen where -- the convention
+    ``ErrorBarPlot`` documents and the single-series path has always used.
+    ``test_a_horizontal_chart_names_its_groups_without_a_dodge`` draws with
+    ``Axes.plot`` for exactly this reason.
     """
     frame = FRAME.assign(half=["x", "y"] * 9)
 
@@ -469,14 +522,15 @@ def test_a_horizontal_dodge_names_its_groups():
 
     schema = _schema(fig)
 
-    assert schema["type"] == PlotType.LINE.value
-    named = {point["y"] for series in schema["data"] for point in series}
+    assert schema["type"] == PlotType.ERRORBAR.value
+    assert schema["orientation"] == "horz"
+    named = {point["x"] for series in schema["data"] for point in series}
     assert named == set(FRAME["group"].unique())
 
     # The value axis is still numeric: only the axis carrying the categories
     # is named, and naming both would have made the measurement a string.
     assert all(
-        isinstance(point["x"], float)
+        isinstance(point["y"], float)
         for series in schema["data"]
         for point in series
     )
@@ -647,7 +701,7 @@ def test_a_hue_level_missing_a_category_does_not_break_the_pairing():
     schema = _schema(fig)
     data = schema["data"]
 
-    assert schema["type"] == PlotType.LINE.value
+    assert schema["type"] == PlotType.ERRORBAR.value
     # Two series, not two series plus six interval polylines.
     assert len(data) == 2
     assert all(len(series) == 3 for series in data)

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -381,19 +381,37 @@ def test_a_legend_that_does_not_name_every_group_names_none():
             assert point["yMin"] <= point["y"] <= point["yMax"]
 
 
-def test_a_group_whose_every_category_is_a_singleton_keeps_its_siblings():
-    """One group with no drawable interval must not cost the others theirs.
+def test_a_hue_level_with_no_drawable_interval_keeps_its_sibling_bounded():
+    """A whole hue level with nothing to estimate, across every category.
 
-    A hue level holding a single observation everywhere has nothing to
-    estimate an interval from, and seaborn renders that as a polyline whose
-    value coordinates are all NaN. The layer omits that group's bounds and
-    keeps the rest, rather than falling back for the whole chart.
+    Distinct from ``test_a_group_without_an_interval_does_not_cost_the
+    _others_theirs``, which is the ungrouped case: there a single *category*
+    lacks an interval inside one series. Here an entire *series* does, which
+    is the only version that exercises the per-group slicing.
+
+    A hue level holding a single observation in every category has no
+    interval to draw, and seaborn renders that as a polyline whose value
+    coordinates are all NaN. The layer omits that group's bounds and keeps
+    reporting both groups, rather than falling back for the whole chart.
+
+    An earlier version of this test used three *identical* observations,
+    calling it a singleton. Measured, that is not the same case at all --
+    seaborn's bootstrap over a zero-variance cell still produces a drawn
+    interval, so both groups came back bounded and the test passed without
+    ever reaching the branch it named:
+
+        zero-variance: group x ['bound', 'bound']  group y ['bound', 'bound']
+        true n=1:      group x ['bound', 'bound']  group y ['NO-bound', ...]
+
+    The assertions are per group rather than over the flattened schema, for
+    the same reason: an ``any(...)`` across every point is satisfied by the
+    sibling group alone and says nothing about the one under test.
     """
     frame = pd.DataFrame(
         {
-            "g": ["a", "a", "a", "b", "b", "b"] * 2,
-            "half": ["x"] * 6 + ["y"] * 6,
-            "v": [1.0, 2.0, 3.0, 8.0, 9.0, 10.0, 5.0, 5.0, 5.0, 7.0, 7.0, 7.0],
+            "g": ["a", "a", "a", "b", "b", "b", "a", "b"],
+            "half": ["x"] * 6 + ["y", "y"],
+            "v": [1.0, 2.0, 3.0, 8.0, 9.0, 10.0, 5.0, 7.0],
         }
     )
 
@@ -401,15 +419,22 @@ def test_a_group_whose_every_category_is_a_singleton_keeps_its_siblings():
     sns.pointplot(frame, x="g", y="v", hue="half", dodge=True, ax=ax)
 
     schema = _schema(fig)
+    bounded, unbounded = schema["data"]
 
     assert schema["type"] == PlotType.ERRORBAR.value
-    assert len(schema["data"]) == 2
-    # Every point is still reported, with or without a bound.
-    assert all(len(series) == 2 for series in schema["data"])
-    # The group that has intervals keeps them.
-    assert any(
-        "yMin" in point for series in schema["data"] for point in series
-    )
+    assert [series[0]["z"] for series in schema["data"]] == ["x", "y"]
+
+    # The sibling keeps every bound it drew.
+    assert all("yMin" in point for point in bounded)
+    for point in bounded:
+        assert point["yMin"] <= point["y"] <= point["yMax"]
+
+    # The singleton group is still announced -- estimate and category -- and
+    # simply carries no interval, which is the honest reading of a group
+    # that has none.
+    assert all("yMin" not in point for point in unbounded)
+    assert [point["x"] for point in unbounded] == ["a", "b"]
+    assert all(point["y"] is not None for point in unbounded)
 
 
 def test_a_dodged_group_is_still_named_by_its_tick():

--- a/tests/core/test_catplot_point.py
+++ b/tests/core/test_catplot_point.py
@@ -195,15 +195,17 @@ class TestWhatMustNotChange:
 
         assert layers(ax.get_figure()) == ["line"]
 
-    def test_a_hue_split_is_still_a_line(self):
-        # More than one estimate means a `hue` split the chart into groups,
-        # and the MAIDR error bar layer carries a single series -- so the
-        # intervals are dropped rather than mis-assigned. Unchanged here, and
-        # pinned so that moving registration does not quietly move it.
+    def test_a_hue_split_keeps_its_intervals(self):
+        # This used to pin the opposite -- `["line"]` -- because the error bar
+        # layer carried a single flat series with no field naming the group,
+        # so a hued chart's intervals were dropped rather than mis-assigned.
+        # maidr 4.4.0 gave the grammar a grouped shape and the fallback went
+        # with it (#462). Pinned here so that the registration `catplot`
+        # shares does not quietly diverge from the axes-level function's.
         _, ax = plt.subplots()
         sns.pointplot(frame(), x="g", y="v", hue="panel", ax=ax)
 
-        assert layers(ax.get_figure()) == ["line"]
+        assert layers(ax.get_figure()) == ["error_bar"]
 
     def test_a_point_plot_does_not_claim_lines_it_did_not_draw(self):
         # The per-panel snapshot. An estimate taken from another chart is


### PR DESCRIPTION
## Description

`sns.pointplot(..., hue=…)` read as a plain `line` layer. The estimates survived; the intervals did not — a reader of a grouped point plot was handed the means of a chart drawn to show the uncertainty around them.

That was the right call at the time, and #462 says so: the error bar layer carried a single flat series with no field naming the group, so pairing *n* groups' interval lines onto it would have attached one group's bound to another's estimate. Omitting them was the lesser harm.

**maidr 4.4.0 removed the constraint.** `ErrorBarPoint[][]` with a `z` landed in xability/maidr#943, closing xability/maidr#942, and it is in the bundle this package ships:

```
py-maidr bundles maidr.js: 4.4.0
```

So the intervals now have somewhere to go.

## It works against the real bundle, not just on paper

Driven in Chromium against the bundled `maidr.js`, arrowing up from the first category:

```
g is a, value v is 0.82, grp is p
g is a, upper bound v is 1.15, grp is p
g is a, lower bound v is 0.77, grp is q
g is a, value v is 1.06, grp is q
g is a, upper bound v is 1.35, grp is q
```

`p`'s upper bound (1.15) and `q`'s lower (0.77) are **adjacent moves**, so a reader hears directly that the two intervals overlap — the comparison a point plot exists to support, and the group-major ordering xability/maidr#943 designed for. No page errors, and the highlight resolves.

Worth checking rather than assuming: emitting a shape the grammar documents is not the same as the shipped bundle reading it.

## How the pairing is established

Seaborn draws the interval polylines **estimate-major** — every category of the first group, then every category of the second. Measured, not assumed:

```
estimate 0: x=[0, 1, 2] y=[0.817, 2.353, 2.924]
estimate 1: x=[0, 1, 2] y=[1.062, 2.249, 3.082]
interval 0: x~[0.0] yspan=0.463..1.171     <- estimate 0, category a
interval 1: x~[1.0] yspan=1.919..2.783
interval 2: x~[2.0] yspan=2.526..3.336
interval 3: x~[0.0] yspan=0.754..1.379     <- estimate 1, category a
interval 4: x~[1.0] yspan=1.764..2.730
interval 5: x~[2.0] yspan=2.658..3.464
```

Each estimate's value falls inside the span of the interval its slice pairs it with, which is the check the tests make too — containment rather than position, since mis-pairing is the exact failure the old fallback existed to avoid.

Group names come from the legend, the only place they appear (the estimate lines carry `_child`-prefixed labels). The legend title becomes `axes.z`, so a chart grouped by treatment says "Treatment" rather than "Group". A group that cannot be named omits `z` rather than guessing.

## One regression the suite caught

A hue level missing from one category is NaN-padded by seaborn so the estimate lines stay the same length. The new path emitted that NaN straight into the JSON — which is not JSON, and stopped the chart initialising (#429). `tests/core/plot/test_non_finite_coordinates.py::test_the_payload_is_loadable` is what said so, via `parse_constant`. It now emits `null`, the same rule `MultiLinePlot._reading` applies.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Closes #462. Depends on xability/maidr#942 / xability/maidr#943, both merged and released in v4.4.0.

## Changes Made

- `maidr/core/plot/pointplot.py` — `_extract_grouped` alongside `_extract_single`, with the per-group read factored into `_points_of` so both paths share the pairing, category labelling and dodge-rounding. `_extract_axes_data` adds `z` from the legend title, the same source `MultiLinePlot` uses. `_elements` is filled group-major so each group's rows take that group's slice.
- `maidr/patch/pointplot.py` — the multi-estimate case emits a grouped `error_bar` instead of falling through to `line`; `_group_labels` reads the legend.
- `maidr/core/plot/maidr_plot_factory.py` — dispatches on `estimates` (plural) as well as `estimate`.
- Tests — four that pinned the old fallback now pin the new behaviour, each keeping its original subject, plus a three-group case.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — **2344 passed, 13 skipped**. `ruff check` unchanged at the 6 pre-existing findings.

**The ungrouped path is untouched** and still emits the flat form — asserted directly, since xability/maidr#943 is explicit that a single-series chart must not have to wrap itself in an array.

`test_a_horizontal_dodge_names_its_groups` moved its assertion from `y` to `x`. That is a change of key rather than of behaviour: an error bar layer carries the category as `x` in **both** orientations and lets `orientation` say which is on screen where — the convention `ErrorBarPlot` documents and the single-series path has always used. `test_a_horizontal_chart_names_its_groups_without_a_dodge` draws with `Axes.plot` for exactly this reason, and its docstring says so.

Falsified, each mutation failing only its own tests:

| mutation | tests that fail |
|---|---|
| revert to the `line` fallback | **5** |
| wrong stride slicing intervals per group | **2** |
| emit NaN instead of `null` for a padded sample | **3** |

The three-group test exists because a two-group off-by-one still lands inside the interval list and mis-pairs silently; a third group is what makes a wrong stride reach visibly wrong bounds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_