### PR TITLE
refactor(util): give CDN version resolution its own module

### DIFF
--- a/maidr/__init__.py
+++ b/maidr/__init__.py
@@ -218,21 +218,23 @@ from .util.bundle_freshness import (  # noqa: E402
     bundle_status,
     resolver_outcome,
 )
-from .util.dependencies import (  # noqa: E402
+from .util.cdn import (  # noqa: E402
     BUNDLED_TAG,
     CDN_TIMEOUT_ENV_VAR,
     CDN_VERSION_ENV_VAR,
     LATEST_TAG,
     ResolverOutcome,
+    get_cdn_version,
+    reset_cdn_version_cache,
+    set_cdn_version,
+)
+from .util.dependencies import (  # noqa: E402
     bundled_css_path,
     bundled_js_path,
     bundled_math_css_path,
-    read_bundled_math_css,
-    get_cdn_version,
     maidr_js_version,
     read_bundled_js,
-    reset_cdn_version_cache,
-    set_cdn_version,
+    read_bundled_math_css,
 )
 from .util.warn import BUNDLE_WARNING_ENV_VAR  # noqa: E402
 

--- a/maidr/altair/altair_maidr.py
+++ b/maidr/altair/altair_maidr.py
@@ -44,6 +44,8 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 
 from maidr.util.dependencies import (
     MAIDR_VEGALITE_FILENAME,
+)
+from maidr.util.cdn import (
     cdn_url,
 )
 from maidr.util.environment import Environment

--- a/maidr/altair/altair_maidr.py
+++ b/maidr/altair/altair_maidr.py
@@ -56,7 +56,7 @@ from maidr.util.iframe_utils import wrap_in_iframe_plotly
 # CDN configuration for the Altair adapter. The ``vegalite.js`` adapter
 # tracks the newest published ``maidr`` release, resolved to a concrete
 # version at render time by
-# :func:`maidr.util.dependencies.get_cdn_version` so browsers never replay a
+# :func:`maidr.util.cdn.get_cdn_version` so browsers never replay a
 # stale ``@latest`` response. Pin with ``MAIDR_CDN_VERSION`` when a specific
 # version is needed.
 # ---------------------------------------------------------------------------

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -248,6 +248,8 @@ def init_notebook(
         MAIDR_JS_FILENAME,
         read_bundled_js,
         read_bundled_math_css,
+    )
+    from maidr.util.cdn import (
         bundled_cdn_url,
     )
 

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -32,11 +32,13 @@ from maidr.util.bundle_freshness import warn_if_bundle_is_stale
 from maidr.util.dependencies import (
     MAIDR_JS_FILENAME,
     OFFLINE_FALLBACK_REPORT,
-    bundled_cdn_url,
     inline_bundle_tags,
     maidr_bundled_files_dependency,
     maidr_bundled_relative_dir,
     maidr_html_dependency,
+)
+from maidr.util.cdn import (
+    bundled_cdn_url,
     maidr_js_cdn_url,
 )
 from maidr.util.environment import Environment

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -43,11 +43,13 @@ from maidr.util.bundle_freshness import warn_if_bundle_is_stale
 from maidr.util.dependencies import (
     MAIDR_JS_FILENAME,
     OFFLINE_FALLBACK_REPORT,
-    bundled_cdn_url,
     inline_bundle_tags,
     maidr_bundled_files_dependency,
     maidr_bundled_relative_dir,
     maidr_html_dependency,
+)
+from maidr.util.cdn import (
+    bundled_cdn_url,
     maidr_js_cdn_url,
 )
 from maidr.util.environment import Environment

--- a/maidr/util/bundle_freshness.py
+++ b/maidr/util/bundle_freshness.py
@@ -20,10 +20,11 @@ import warnings
 from typing import NamedTuple
 
 from maidr.util import dependencies as _deps
+from maidr.util import cdn as _cdn
+from maidr.util.cdn import ResolverOutcome
 from maidr.util.dependencies import (
     _UNKNOWN_VERSION,
     _version_key,
-    ResolverOutcome,
 )
 from maidr.util.warn import (
     BUNDLE_WARNING_ENV_VAR,
@@ -138,7 +139,7 @@ def resolver_outcome() -> ResolverOutcome | None:
     >>> resolver_outcome()  # doctest: +SKIP
     ResolverOutcome(resolved='4.2.0', unreachable=(), answered_badly=())
     """
-    return _deps._resolver_outcome
+    return _cdn._resolver_outcome
 
 
 def bundle_status(*, resolve: bool = True) -> BundleStatus:
@@ -184,7 +185,7 @@ def bundle_status(*, resolve: bool = True) -> BundleStatus:
     looked up at call time, so real output tracks whatever is current.
     """
     bundled = _deps.maidr_js_version()
-    published = _deps._published_version(resolve=resolve)
+    published = _cdn._published_version(resolve=resolve)
 
     bundled_key = _version_key(bundled) if bundled != _UNKNOWN_VERSION else None
     published_key = _version_key(published) if published else None

--- a/maidr/util/cdn.py
+++ b/maidr/util/cdn.py
@@ -1,0 +1,1115 @@
+"""Resolving which published ``maidr.js`` a page should load.
+
+Split out of :mod:`maidr.util.dependencies` (#293), which keeps the other
+half: reaching the copy bundled inside this package. The direction is
+one-way -- this module imports ``dependencies`` for the asset names and
+the bundled version, and nothing there imports back.
+
+Reads that tests patch go through the module object rather than a
+from-import (``_deps._deps.maidr_js_version()``), because a from-import binds
+at import time and would silently stop receiving
+``monkeypatch.setattr(dependencies, ...)``.
+
+The same hazard is why the back-compat shim in ``dependencies`` cannot
+cover this module's *state*. It forwards attribute **reads**, so
+``dependencies.get_cdn_version`` still resolves; it cannot forward a
+**write**, so ``monkeypatch.setattr(dependencies, "urlopen", ...)`` would
+set an attribute nothing here reads. Tests patch ``cdn`` directly for
+that reason, and the shim's docstring says so.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import os
+import threading
+import time
+import warnings
+from typing import NamedTuple
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from maidr.util import dependencies as _deps
+from maidr.util.dependencies import (
+    MAIDR_CSS_FILENAME,
+    MAIDR_JS_FILENAME,
+    # Unused here, re-exported so `maidr_css_cdn_url`'s deprecation can tell
+    # people to call `cdn_url(MAIDR_MATH_CSS_FILENAME)` *from this module*
+    # and have both names resolve from it. `test_deprecation_names_only_
+    # importable_symbols` fails if advice names a symbol the reader cannot
+    # import where they were sent.
+    MAIDR_MATH_CSS_FILENAME,  # noqa: F401
+    _UNKNOWN_VERSION,
+    _is_valid_version,
+    _warn_placeholder_css,
+    _version_key,
+)
+from maidr.util.warn import _MAX_WARNED_KEY_LEN, warn_once
+
+_logger = logging.getLogger(__name__)
+
+
+#: The release that made the split above true.
+#:
+#: Before it, ``maidr.css`` carried KaTeX and had to be linked.  py-maidr
+#: links no stylesheet at all now, so pinning the CDN to anything older
+#: leaves LaTeX in AI chat responses unstyled -- everything else is
+#: unaffected, since the interface has been styled at runtime throughout.
+#: :func:`_warn_if_pin_predates_stylesheet_split` says so once rather than
+#: letting it be discovered.
+_STYLESHEET_SPLIT_VERSION = "3.75.1"
+
+
+_CDN_URL_TEMPLATE = "https://cdn.jsdelivr.net/npm/maidr@{version}/dist/{filename}"
+
+
+#: Version specifier meaning "emit the mutable ``@latest`` dist-tag and do
+#: not contact the network".  This is the pre-resolution behaviour.
+LATEST_TAG = "latest"
+
+
+#: Version specifier meaning "use the version of the bundle shipped inside
+#: this wheel", i.e. serve over the CDN exactly what the offline fallback
+#: would serve.
+BUNDLED_TAG = "bundled"
+
+
+#: Pin the CDN version without touching Python (``MAIDR_CDN_VERSION=3.74.0``,
+#: ``=bundled``, or ``=latest`` to opt out of resolution entirely).
+CDN_VERSION_ENV_VAR = "MAIDR_CDN_VERSION"
+
+
+#: Time budget, in seconds, shared across the whole version lookup rather
+#: than applied per request, so adding a fallback endpoint cannot multiply
+#: how long a first render blocks.  Approximate rather than a hard ceiling
+#: — see :func:`_fetch_latest_version`.
+CDN_TIMEOUT_ENV_VAR = "MAIDR_CDN_TIMEOUT"
+
+
+_DEFAULT_CDN_TIMEOUT = 3.0
+
+
+#: Ceiling on the above.  Far beyond any legitimate lookup, so a larger
+#: value indicates a mistake — most plausibly milliseconds — rather than
+#: an intent to wait that long before a plot appears.
+_MAX_CDN_TIMEOUT = 30.0
+
+
+#: Floor on the same value, for the mistake in the other direction.  A
+#: budget below this cannot complete a round trip, so every attempt times
+#: out, the failure is cached, and every render for the rest of the
+#: process emits ``@latest`` — silently reinstating the stale-cache bug
+#: this module exists to fix.  ``MAIDR_CDN_TIMEOUT=0.05`` from someone
+#: wanting the lookup to be fast is the plausible way to get there; the
+#: milliseconds misreading (``=100``) lands on the ceiling instead.
+_MIN_CDN_TIMEOUT = 0.1
+
+
+# Endpoints consulted, in order, to turn the mutable ``latest`` dist-tag
+# into a concrete version.  jsDelivr's data API comes first because it is
+# the authority on what ``cdn.jsdelivr.net`` will actually serve; the npm
+# registry's dist-tags endpoint is the backup.  Both return small JSON
+# documents, so the lookup costs one short round trip per process.
+_RESOLVER_ENDPOINTS: tuple[tuple[str, str], ...] = (
+    (
+        "https://data.jsdelivr.com/v1/packages/npm/maidr/resolved"
+        "?specifier=latest",
+        "version",
+    ),
+    ("https://registry.npmjs.org/-/package/maidr/dist-tags", "latest"),
+)
+
+
+# Cap on how much of a resolver response we read, so a hostile or broken
+# endpoint cannot stream an unbounded body into memory.
+_MAX_RESOLVER_BYTES = 64 * 1024
+
+
+class ResolverOutcome(NamedTuple):
+    """Why the last ``latest`` lookup ended the way it did.
+
+    :func:`_fetch_latest_version` collapses every failure into ``None``,
+    which is the right answer for a render -- there is nothing a chart can
+    do about it either way -- but it loses the one distinction a monitor
+    needs.  Two endpoints failing to answer is the network; two endpoints
+    answering with something unusable is *this code* being wrong about
+    their shape, and only the second should wake anyone up.
+
+    Kept separate from :class:`BundleStatus` rather than folded into it,
+    so the render path's answer to "how does my bundle compare?" stays the
+    two versions and the two flags it already is.
+
+    Attributes
+    ----------
+    resolved : str or None
+        The version the lookup settled on, if any.
+    unreachable : tuple of str
+        Endpoints that never answered: a timeout, a refused connection, a
+        name that would not resolve, a blocked socket.  Says nothing about
+        whether the resolver code is right, because nothing was read.
+    answered_badly : tuple of str
+        Endpoints that answered, in a way this code could not use: an HTTP
+        error status, a body that would not decode or parse, a payload
+        without the key, or a value that is not a version.  This is the
+        one worth failing a scheduled check over -- an API that changed
+        shape looks exactly like this and looks like nothing else.
+    """
+
+    resolved: str | None
+    unreachable: tuple[str, ...]
+    answered_badly: tuple[str, ...]
+
+
+def _unresolved_cdn_url(filename: str) -> str:
+    """Format the ``@latest`` URL for ``filename``.  See public wrapper."""
+    return _CDN_URL_TEMPLATE.format(version=LATEST_TAG, filename=filename)
+
+
+# Deliberately not guarded by ``_resolution_lock`` below: this is a lone
+# reference assignment, written only by an explicit
+# :func:`set_cdn_version` call.  The lock exists to stop concurrent
+# *lookups*, which are a compound read-modify-write, not to protect this.
+#
+# Unlike the compound update in :func:`maidr.util.warn.warn_once`, the
+# reasoning here does not depend on the GIL and so survives free-threaded
+# builds (PEP 703): storing a single object reference stays indivisible
+# there, so a reader sees either the old value or the new one, never a
+# torn write.
+_cdn_version_override: str | None = None
+
+
+_resolved_cdn_version: str | None = None
+
+
+_resolution_attempted: bool = False
+
+
+# Bumped by :func:`reset_cdn_version_cache`.  A fetch reads this before it
+# starts and refuses to publish if it changed meanwhile, so a reset issued
+# mid-request discards the in-flight answer instead of being silently
+# overwritten by it.  The reset cannot simply take ``_fetch_lock``: that
+# would make it block for the whole timeout budget behind the very lookup
+# it is trying to abandon.
+_resolution_generation: int = 0
+
+
+# Guards the three globals above and nothing else, so it is only ever held
+# for a few instructions.  Readers on the *offline* paths take it, and a
+# lock held across a network call would let one stalled lookup freeze an
+# unrelated ``use_cdn=False`` render for the whole timeout budget --
+# breaking the guarantee those paths advertise.
+_resolution_lock = threading.Lock()
+
+
+# Serialises the lookup itself, so concurrent first renders still make one
+# request between them.  Fetchers take this *then* ``_resolution_lock`` to
+# publish; readers never take it, so they cannot be blocked by a fetch.
+_fetch_lock = threading.Lock()
+
+
+# The last lookup's verdict, for :func:`resolver_outcome`.  A single
+# rebound reference like the globals above, so no lock is needed to read
+# it: a reader sees one whole outcome, never half of two.  ``None`` until
+# a lookup has run, which is what tells "not tried" from "tried and
+# reached nothing".
+_resolver_outcome: ResolverOutcome | None = None
+
+
+# Unresolved CDN URLs, kept only for backwards compatibility with
+# callers outside this package that imported them before version
+# resolution existed.  Nothing inside ``maidr/`` references them.
+#
+# DO NOT reference these from a render path.  ``@latest`` is the mutable
+# dist-tag whose seven-day cache lifetime is the bug this module exists to
+# fix, so emitting one into HTML silently reintroduces it.  Call
+# :func:`maidr_js_cdn_url` / :func:`maidr_css_cdn_url` / :func:`cdn_url`
+# instead — ``tests/core/test_cdn_version.py`` enforces this.
+#
+# Derived from :func:`unresolved_cdn_url` rather than formatting the
+# template again, so "the unresolved URL" is spelled out in exactly one
+# place and the constants cannot drift from the function.
+MAIDR_JS_CDN_URL = _unresolved_cdn_url(MAIDR_JS_FILENAME)
+
+
+MAIDR_CSS_CDN_URL = _unresolved_cdn_url(MAIDR_CSS_FILENAME)
+
+
+def set_cdn_version(version: str | None) -> None:
+    """Pin the ``maidr`` version referenced by emitted CDN URLs.
+
+    Parameters
+    ----------
+    version : str or None
+        A concrete version (``"3.74.0"``, optionally ``v``-prefixed),
+        :data:`BUNDLED_TAG` to mirror the version bundled in this wheel,
+        or :data:`LATEST_TAG` to emit the mutable ``@latest`` dist-tag and
+        skip the network lookup entirely.  ``None`` clears the pin and
+        discards any cached lookup so the next URL re-resolves.
+
+        Both tags keep the lookup offline: if the bundled ``VERSION`` is
+        missing or unparseable, :data:`BUNDLED_TAG` warns and degrades to
+        :data:`LATEST_TAG` rather than reaching for the network, since
+        asking for the installed copy implies staying local.
+
+    Notes
+    -----
+    A malformed concrete version is logged and then *ignored*, which
+    means the next URL resolves normally — one bounded lookup, exactly as
+    if no pin had been set.  That is deliberate: mistyping ``3.74.0`` as
+    ``3.74`` says "I wanted a particular version", not "I want to stay
+    off the network", so recovering to the current published version is
+    the closest thing to what was asked.  Contrast :data:`BUNDLED_TAG`,
+    which *does* imply staying local and therefore degrades to
+    :data:`LATEST_TAG` rather than resolving.  The supported ways to
+    forbid the lookup outright are ``MAIDR_CDN_VERSION=latest`` and
+    ``use_cdn=False``.
+
+    Process-wide, not per-session: this writes module-level state shared
+    by every caller in the interpreter, matching ``set_use_cdn``.  In a
+    server handling concurrent sessions (e.g. Shiny), one session calling
+    this changes what the others render — prefer ``MAIDR_CDN_VERSION`` at
+    startup, or an explicit ``use_cdn=`` per call.
+
+    Takes precedence over the ``MAIDR_CDN_VERSION`` environment variable.
+    A value that is neither a recognised tag nor a valid semver is
+    ignored (with a warning) in favour of the normal resolution path.
+
+    Warns
+    -----
+    FutureWarning
+        When ``version`` is unusable.  Today the pin is ignored and the
+        next URL resolves normally; a future major release will raise
+        :class:`ValueError` instead.
+
+        The leniency is right for ``MAIDR_CDN_VERSION`` -- ambient
+        configuration may be set by something outside the caller's
+        control, and crashing on it would be hostile.  It is wrong here:
+        this is an explicit call with a bad argument, which is the
+        textbook case for ``ValueError``, and the caller currently gets no
+        return value, no exception, and a *log* line they may never see.
+        So a typo does nothing, visibly (#294).
+
+        Raising outright would break a script that has been quietly
+        mistyping its pin and rendering fine, so it goes through a
+        deprecation the way :func:`bundled_css_path` did.  The warning is
+        the behaviour change; the raise is the next major's.
+    """
+    global _cdn_version_override
+    # A blank string is treated as ``None`` rather than as a malformed
+    # pin.  Otherwise it stores an empty override that later reads as
+    # "no pin" and falls through silently, while every *other* unusable
+    # value warns — an asymmetry with no reason behind it.
+    if version is None or not str(version).strip():
+        _cdn_version_override = None
+        reset_cdn_version_cache()
+        return
+
+    candidate = str(version).strip()
+    # Checked here as well as on every URL build, because the two
+    # answer different questions. `_normalise_version_pin` asks "can I
+    # use this?" every time it needs a URL, and logs. This asks "did the
+    # caller just make a mistake?", once, at the point they made it --
+    # which is the only moment a stack trace points anywhere useful.
+    if _normalise_version_pin(candidate) is None:
+        warnings.warn(
+            f"maidr.set_cdn_version({version!r}) was given something that is "
+            f"neither a semver such as '3.74.0' nor {BUNDLED_TAG!r} or "
+            f"{LATEST_TAG!r}. The pin is ignored and URLs resolve as if it "
+            "had not been set. A future major release will raise ValueError "
+            "here instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
+    _cdn_version_override = candidate
+
+
+def get_cdn_version() -> str:
+    """Return the ``maidr`` version to splice into CDN URLs.
+
+    Resolution order:
+
+    1. An explicit pin from :func:`set_cdn_version`.
+    2. The ``MAIDR_CDN_VERSION`` environment variable.
+    3. The version this wheel ships, when resolving would block an event
+       loop — see :func:`_resolution_would_block`, and the note below.
+    4. The ``latest`` dist-tag resolved over the network (once per
+       process, then cached).
+    5. The literal string ``"latest"`` when the lookup fails, which
+       reproduces the library's historical behaviour.
+
+    Returns
+    -------
+    str
+        A concrete version such as ``"3.74.0"``, or ``"latest"``.
+
+    Notes
+    -----
+    Step 5 is what makes this safe to call from a render path: an
+    unreachable, blocked, or malformed resolver degrades to ``"latest"``
+    rather than raising.  That guarantee rests on
+    :func:`_fetch_latest_version` honouring its own "never raises"
+    contract — it catches ``Exception`` around every fallible step for
+    exactly this reason.  Should something slip past it anyway, the
+    handler in :func:`_resolve_latest_version` caches the attempt (so the
+    failure is not retried on every later render) and re-raises, so the
+    exception surfaces from ``render()`` / ``save_html()``.  That is a
+    deliberate fail-fast for a bug in this module rather than a third
+    degradation path.
+
+    A ``KeyboardInterrupt`` is treated differently: it is not cached, so
+    interrupting one render does not leave the rest of the process
+    emitting ``@latest``.
+
+    Step 3 is the one that depends on where it is called from, and it is
+    a deliberate trade.  ``maidr.render()`` is synchronous and Shiny calls
+    it from ``render_maidr.render()``, which is ``async`` — so under the
+    default the first figure in an app performed a blocking ``urlopen`` on
+    the event loop, stalling every concurrent session behind it (#296).
+    The bundled version is a real published one, so the URL resolves and
+    is immutable; what is given up is picking up a release newer than the
+    wheel, automatically, in an async process.
+
+    That is the trade the docs already recommended making by hand:
+    ``MAIDR_CDN_VERSION=bundled`` was the advice for Shiny apps, and this
+    makes the default do it in exactly the context the advice was for.
+    Two things follow that are worth knowing rather than discovering:
+
+    * :func:`warn_if_bundle_is_stale` reads only an already-completed
+      lookup, so a process that never resolves never hears it.
+    * Calling this once from synchronous code at start-up caches the
+      answer, after which every async render uses the resolved version --
+      which is how an app that wants the newer release gets it without
+      any render paying for the request.
+
+    Synchronous callers are unaffected, including threads: they still
+    resolve once per process and queue on ``_fetch_lock`` while the first
+    of them does.  That queueing is not fixed here; it is the event loop
+    specifically that must not be made to wait.
+    """
+    pin = _version_pin()
+    if pin is not None:
+        return pin
+    if _resolution_would_block():
+        return _offline_version()
+    # A lookup that failed falls back to the bundled version, not to
+    # `@latest`.  `@latest` is the mutable dist-tag whose seven-day
+    # `Cache-Control` is the whole of #290 -- so degrading to it meant the
+    # fix stopped applying in precisely the case it was meant to survive,
+    # and an offline browser could still replay a week-old build (#295).
+    #
+    # The bundled version is a real published one, immutable, and is the
+    # copy this wheel would have served anyway had the CDN been declined.
+    # What it costs is that a network hiccup pins the page to a possibly
+    # older release -- quieter, but staler. That trade was argued the
+    # other way when this fallback was written, on the grounds that
+    # `@latest` is byte-for-byte what users had before version resolution
+    # existed and so nobody ends up worse off. Three other paths have
+    # since moved to the bundled answer, and being the last one left
+    # emitting the mutable tag is not a place worth defending.
+    return _resolve_latest_version() or _offline_version()
+
+
+def _version_pin() -> str | None:
+    """Return the normalised explicit pin, or ``None`` if there is none."""
+    pin = _cdn_version_override
+    if pin is None:
+        pin = os.environ.get(CDN_VERSION_ENV_VAR)
+    if pin is None:
+        return None
+    return _normalise_version_pin(pin)
+
+
+def _published_version(*, resolve: bool) -> str | None:
+    """Return the version npm has actually published, ignoring any pin.
+
+    A pin answers "which version should we serve?", which is a different
+    question from "which version is current?".  Feeding a pin into the
+    staleness comparison would let ``set_cdn_version("4.0.0")`` — pinning
+    an unreleased build to test it — report 4.0.0 as *published* and
+    advise upgrading, and would let a backwards pin mask a genuinely old
+    bundle.  Only a real lookup answers the published question.
+
+    Parameters
+    ----------
+    resolve : bool
+        Whether to perform the lookup when the answer is not already
+        cached.  ``False`` keeps the caller offline and accepts ``None``.
+
+    Returns
+    -------
+    str or None
+        A concrete version, or ``None`` when it is unknown.
+    """
+    if resolve:
+        return _resolve_latest_version()
+    return _cached_resolution()
+
+
+def _resolution_state() -> tuple[bool, str | None]:
+    """Return ``(attempted, value)`` for the cached lookup, atomically.
+
+    Reads both globals under the lock so a caller cannot observe the flag
+    without the value it refers to.  Returned as a pair because ``None``
+    is ambiguous on its own: it means both "no lookup yet" and "the lookup
+    failed", and the two need different handling.
+
+    The lock is held for these two reads only — never across a network
+    call — so an offline caller is never delayed by someone else's lookup.
+    """
+    with _resolution_lock:
+        return _resolution_attempted, _resolved_cdn_version
+
+
+def _cached_resolution() -> str | None:
+    """Return the resolved version if a lookup has completed, else ``None``."""
+    attempted, value = _resolution_state()
+    return value if attempted else None
+
+
+def _offline_version() -> str:
+    """Return the best version available without making a request.
+
+    The order is the same question asked three ways, cheapest first: what
+    did the caller ask for, what did an earlier lookup establish, and what
+    shipped in this wheel.  Only when none of those is usable does this
+    fall back to :data:`LATEST_TAG`, the mutable dist-tag this module
+    exists to stop emitting.
+
+    Both offline callers read it from here rather than each spelling it
+    out, because when they disagreed the result was one page loading two
+    different builds of ``maidr.js`` -- an iframe on the pinned version
+    and its host on the bundled one.
+
+    The last step warns, because there are two roads to ``latest`` and
+    only one of them is normal.  A lookup that failed is a routine
+    operating condition -- offline, blocked, a malformed response -- and
+    is documented as the safe degradation; it stays quiet.  A bundled
+    version that will not read is a broken install, nobody but the user
+    can fix it, and the page still works, so without a word the only
+    symptom is someone occasionally being served a week-old ``maidr.js``
+    for reasons nothing in the output explains (#364).
+
+    Returns
+    -------
+    str
+        A concrete version, or ``latest`` when there is no better answer.
+    """
+    pin = _version_pin()
+    if pin is not None:
+        return pin
+
+    resolved = _cached_resolution()
+    if resolved is not None and _is_valid_version(resolved):
+        return resolved
+
+    bundled = _deps.maidr_js_version()
+    if _is_valid_version(bundled) and bundled != _UNKNOWN_VERSION:
+        return bundled
+
+    # The two faults read differently, and the point of speaking at all is
+    # to be read: an absent VERSION reported as `is unreadable ('0.0.0')`
+    # says the file contains those characters, which is the one thing it
+    # does not. `maidr_js_version` returns the sentinel for missing,
+    # empty and unreadable alike, so that is as far as the distinction
+    # goes -- but it is the distinction someone chasing this needs first.
+    if bundled == _UNKNOWN_VERSION:
+        detail = "cannot be read (the VERSION file is missing or empty)"
+    else:
+        # Truncated for the same reason `_normalise_version_pin` truncates
+        # its pin: nothing bounds the length of a garbled file, and a log
+        # line is not where a megabyte belongs.
+        detail = f"is not a version ({bundled[:_MAX_WARNED_KEY_LEN]!r})"
+
+    # Keyed on the unusable value, so a wheel whose VERSION is garbled
+    # rather than absent says which -- and a second, differently broken
+    # one is still audible.
+    warn_once(
+        f"unusable-bundled-version:{bundled}",
+        "maidr: the bundled maidr.js version %s, so CDN URLs fall back to "
+        "the mutable maidr@%s tag. jsDelivr serves that with a seven-day "
+        "cache lifetime, so a browser may replay an old bundle. Reinstall "
+        "py-maidr, or pin a version with maidr.set_cdn_version().",
+        detail,
+        LATEST_TAG,
+    )
+    return LATEST_TAG
+
+
+def _resolution_would_block() -> bool:
+    """Report whether resolving now would stall an event loop.
+
+    ``_resolve_latest_version`` makes a blocking ``urlopen`` call, holding
+    ``_fetch_lock`` across it.  On a thread running an event loop -- which
+    is where ``maidr.render()`` is called from in a Shiny app, through
+    ``render_maidr.render()`` -- that stalls every other session in the
+    process for up to :data:`MAIDR_CDN_TIMEOUT`, and that budget is only
+    approximate: ``urlopen``'s timeout applies per socket operation and
+    does not reliably cover ``getaddrinfo``, so a broken resolver can
+    exceed it (#296).
+
+    A lookup that has already completed costs nothing, so it is not
+    blocking and this says so -- which is what makes the answer stable
+    rather than context-dependent after the first resolution anywhere in
+    the process.  Resolving once from synchronous code at start-up is
+    therefore the way to have an async app serve the resolved version.
+
+    Returns
+    -------
+    bool
+        ``True`` only when a lookup would have to be performed *and* this
+        thread is running an event loop.
+    """
+    attempted, _ = _resolution_state()
+    if attempted:
+        return False
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+def unresolved_cdn_url(filename: str) -> str:
+    """Return the ``@latest`` CDN URL without resolving a version.
+
+    The last resort, reached only when no concrete version is available:
+    :func:`bundled_cdn_url` falls back here when the bundled ``VERSION``
+    is unusable, and :func:`get_cdn_version` returns ``latest`` when a
+    lookup fails.  Prefer :func:`cdn_url` or :func:`bundled_cdn_url` —
+    ``@latest`` is the mutable dist-tag this module exists to stop
+    emitting.
+
+    Parameters
+    ----------
+    filename : str
+        Asset name under the package's ``dist/`` directory.
+
+    Returns
+    -------
+    str
+        A jsDelivr URL pinned to the ``latest`` dist-tag.
+    """
+    return _unresolved_cdn_url(filename)
+
+
+def reset_cdn_version_cache() -> None:
+    """Discard the cached ``latest`` lookup so the next URL re-resolves.
+
+    Both successful and failed lookups are cached for the lifetime of the
+    process — the failure case deliberately so, because an offline
+    notebook must not stall on a doomed request for every figure it
+    renders.  Long-lived processes that want to pick up a newer release
+    can call this to force one more attempt.
+
+    Does not re-arm the one-shot staleness warning from
+    :func:`warn_if_bundle_is_stale`, which stays spent for the life of
+    the process regardless of how often the version is re-resolved.
+
+    Clears :func:`resolver_outcome` too.  It describes the lookup this
+    call is discarding, and leaving it behind would let a monitor read a
+    stale verdict as the current one -- reporting an endpoint as broken
+    after a successful re-resolution, or the reverse.
+
+    Returns without waiting on a lookup already in flight — it does not
+    take ``_fetch_lock``, which would make the reset itself block for the
+    whole budget behind the request it is abandoning.  That is a promise
+    about *this* call, not about the next one: a caller that needs a
+    version afterwards still queues on ``_fetch_lock`` behind the
+    abandoned request, and only then makes its own.  What the generation
+    counter guarantees is that the abandoned answer is discarded rather
+    than published over the reset.
+    """
+    global _resolved_cdn_version, _resolution_attempted, _resolution_generation
+    global _resolver_outcome
+    with _resolution_lock:
+        _resolved_cdn_version = None
+        _resolution_attempted = False
+        _resolver_outcome = None
+        # Invalidate any lookup already in flight, so its result cannot
+        # land after this call and quietly undo it.
+        _resolution_generation += 1
+
+
+def cdn_url(filename: str) -> str:
+    """Return the jsDelivr URL for a ``dist/`` asset at the resolved version.
+
+    Parameters
+    ----------
+    filename : str
+        Asset name under the package's ``dist/`` directory, e.g.
+        ``"maidr.js"``.  Trusted input: unlike the version, it is not
+        validated, because every call site passes one of this module's
+        ``MAIDR_*_FILENAME`` constants.  Validate it here first if that
+        ever stops being true.
+
+    Returns
+    -------
+    str
+        A fully qualified jsDelivr URL.
+    """
+    return _CDN_URL_TEMPLATE.format(version=get_cdn_version(), filename=filename)
+
+
+def bundled_cdn_url(filename: str) -> str:
+    """Return the CDN URL pinned to the version shipped in this wheel.
+
+    For code that must emit a CDN reference without making a request.
+    The bundled version came from the registry at release time, so it is
+    a real published version and the URL resolves — while being
+    immutable, and therefore free of the seven-day cache lifetime that
+    ``@latest`` carries.
+
+    Honours an explicit pin first, then a version an already-completed
+    lookup established, so these tags stay on the same version anything
+    else in the page loads.  Falls back to :data:`LATEST_TAG` only when
+    none of those is usable, where there is no better answer available
+    offline.
+
+    Parameters
+    ----------
+    filename : str
+        Asset name under the package's ``dist/`` directory.
+
+    Returns
+    -------
+    str
+        A jsDelivr URL at the bundled version, or at ``latest`` when that
+        version is unknown.
+    """
+    # A pin first, then a version an earlier lookup already established,
+    # then the bundled one -- see `_offline_version`, which is the same
+    # order `get_cdn_version` falls back to on an event loop, written once
+    # so the two cannot answer differently. When they did, a pinned
+    # session emitted the *bundled* version here while every iframe
+    # emitted the pinned one, and one page loaded two builds of maidr.js.
+    #
+    # A LATEST_TAG pin lands there too and yields the ``@latest`` URL,
+    # which is what that pin asks for and what the render paths emit.
+    return _CDN_URL_TEMPLATE.format(version=_offline_version(), filename=filename)
+
+
+def maidr_js_cdn_url() -> str:
+    """Return the CDN URL for ``maidr.js`` at the resolved version.
+
+    Returns
+    -------
+    str
+        A fully qualified jsDelivr URL.
+    """
+    return cdn_url(MAIDR_JS_FILENAME)
+
+
+
+
+def maidr_css_cdn_url() -> str:
+    """Return the CDN URL for ``maidr.css`` at the resolved version.
+
+    .. deprecated::
+        Linking this buys nothing and will be removed, along with
+        ``maidr.css`` itself, in the next major release.  If what you
+        wanted was the stylesheet that carries rules, and you want it from
+        the CDN as this function returns it, call
+        ``cdn_url(MAIDR_MATH_CSS_FILENAME)`` -- both from this module, which
+        is also the only place this function itself is importable from.
+        :func:`bundled_math_css_path` is the local-file counterpart, and is
+        re-exported as ``maidr.bundled_math_css_path``.  Or link nothing at
+        all -- MAIDR styles its interface at runtime.
+
+    Nothing in ``maidr/`` emits this any more.  From maidr 3.75.1 the file
+    it points at is a placeholder with no rules in it, published only so
+    that ``<link>`` tags written before the split keep resolving; linking
+    it costs a request and buys nothing.  Kept for callers outside this
+    package that already build their own HTML around it.
+
+    Returns
+    -------
+    str
+        A fully qualified jsDelivr URL.
+
+    Warns
+    -----
+    FutureWarning
+        Always.  See :func:`_warn_placeholder_css` for why this category.
+    """
+    _warn_placeholder_css(
+        "maidr.util.cdn.maidr_css_cdn_url",
+        "cdn_url(MAIDR_MATH_CSS_FILENAME) from maidr.util.cdn",
+    )
+    return cdn_url(MAIDR_CSS_FILENAME)
+
+
+def _normalise_version_pin(pin: str) -> str | None:
+    """Turn a user-supplied version specifier into a URL-safe string.
+
+    Parameters
+    ----------
+    pin : str
+        Raw specifier from :func:`set_cdn_version` or the environment.
+
+    Returns
+    -------
+    str or None
+        The version to use, or ``None`` when the specifier is empty or
+        unusable and the caller should fall through to network
+        resolution.
+    """
+    candidate = pin.strip()
+    if not candidate:
+        return None
+    if candidate.lower() == LATEST_TAG:
+        return LATEST_TAG
+    if candidate.lower() == BUNDLED_TAG:
+        bundled = _deps.maidr_js_version()
+        if _is_valid_version(bundled) and bundled != _UNKNOWN_VERSION:
+            return bundled
+        # Asking for ``bundled`` is a request to serve what is installed,
+        # which implies staying local.  Falling through to a network
+        # lookup would betray that intent for someone who chose it to
+        # avoid egress, so degrade to ``@latest`` — still a working URL,
+        # still no request.
+        warn_once(
+            f"{BUNDLED_TAG}:{bundled}",
+            "maidr: a %r CDN version pin was requested but the bundled "
+            "VERSION is %r; falling back to the %r dist-tag without "
+            "resolving. Reinstall py-maidr to repair the bundle.",
+            BUNDLED_TAG,
+            bundled,
+            LATEST_TAG,
+        )
+        return LATEST_TAG
+    # Accept a leading ``v`` (``v3.74.0``) since that is how the version
+    # is written in git tags and release notes.
+    candidate = candidate[1:] if candidate.startswith(("v", "V")) else candidate
+    if _is_valid_version(candidate):
+        _warn_if_pin_predates_stylesheet_split(candidate)
+        return candidate
+    # Truncate for display too: the key is capped, but an oversized pin
+    # would otherwise land in the log line at full length.
+    warn_once(
+        f"pin:{pin}",
+        "maidr: ignoring invalid CDN version pin %r; expected a semver "
+        "such as '3.74.0', %r, or %r.",
+        pin[:_MAX_WARNED_KEY_LEN],
+        BUNDLED_TAG,
+        LATEST_TAG,
+    )
+    return None
+
+
+def _warn_if_pin_predates_stylesheet_split(version: str) -> None:
+    """Warn once when a pin names a maidr from before the KaTeX split.
+
+    py-maidr emits no stylesheet link, because from
+    :data:`_STYLESHEET_SPLIT_VERSION` the published ``maidr.css`` is a
+    placeholder and ``maidr.js`` fetches the maths stylesheet itself.  An
+    older version has neither that runtime fetch nor rules anywhere else,
+    so LaTeX in AI chat responses renders unstyled.
+
+    The failure is narrow and silent — no other part of the interface
+    changes, and a page whose chat is never opened looks perfectly fine —
+    which is exactly why pinning backwards deserves a sentence rather
+    than a discovery.
+
+    Parameters
+    ----------
+    version : str
+        A pin that has already passed :func:`_is_valid_version`.
+    """
+    key = _version_key(version)
+    split_key = _version_key(_STYLESHEET_SPLIT_VERSION)
+    if key is None or split_key is None or key >= split_key:
+        return
+    warn_once(
+        f"pre-split-pin:{version}",
+        "maidr: CDN version pin %r predates maidr %s, where KaTeX moved out "
+        "of maidr.css into maidr-math.css. py-maidr links no stylesheet, so "
+        "LaTeX in AI chat responses will render unstyled at that version; "
+        "everything else is unaffected. Pin %s or newer to style it.",
+        version,
+        _STYLESHEET_SPLIT_VERSION,
+        _STYLESHEET_SPLIT_VERSION,
+    )
+
+
+def _cdn_timeout() -> float:
+    """Return the total time budget for the version lookup, in seconds.
+
+    Notes
+    -----
+    A non-numeric or non-positive ``MAIDR_CDN_TIMEOUT`` (including ``0``)
+    falls back to the default budget rather than meaning "no budget" or
+    "skip the lookup" — ``MAIDR_CDN_VERSION=latest`` is the supported way
+    to opt out of resolving entirely.
+
+    Values above :data:`_MAX_CDN_TIMEOUT` are clamped, with a warning so
+    the clamp is visible rather than silent.  Honouring an arbitrarily
+    large value would respect the letter of the configuration at the cost
+    of a render that appears to hang: ``MAIDR_CDN_TIMEOUT=3000`` meant as
+    milliseconds would block for fifty minutes.  Nothing legitimate needs
+    longer than the cap to fetch a sub-kilobyte JSON document, and a
+    lookup that slow degrades to the ``@latest`` URL anyway.
+
+    Values below :data:`_MIN_CDN_TIMEOUT` are clamped for the mirror-image
+    reason, and it is the more damaging mistake: a budget like ``0.05``,
+    set by someone who wanted the lookup to be quick, is positive and so
+    passes every other guard, yet no round trip can finish inside it.
+    Every attempt times out, the failure is cached once, and every render
+    for the rest of the process quietly emits ``@latest`` — the exact bug
+    this module exists to fix, arrived at through configuration rather
+    than through code.  A render that waits a tenth of a second and then
+    gives up is the better failure.
+    """
+    raw = os.environ.get(CDN_TIMEOUT_ENV_VAR)
+    if raw is None:
+        return _DEFAULT_CDN_TIMEOUT
+    try:
+        timeout = float(raw)
+    except ValueError:
+        warn_once(
+            f"timeout-nan:{raw}",
+            "maidr: ignoring non-numeric %s=%r; using the %ss default.",
+            CDN_TIMEOUT_ENV_VAR,
+            raw[:_MAX_WARNED_KEY_LEN],
+            _DEFAULT_CDN_TIMEOUT,
+        )
+        return _DEFAULT_CDN_TIMEOUT
+    if not math.isfinite(timeout):
+        # ``float("nan")`` parses, and NaN compares False against both
+        # the floor and the ceiling below, so it would sail through every
+        # guard and reach ``urlopen`` — which raises, gets swallowed by
+        # the broad handler there, and silently disables resolution with
+        # nothing logged.  ``inf`` would hang instead of being clamped.
+        warn_once(
+            f"timeout-nonfinite:{raw}",
+            "maidr: %s=%s is not a finite number; using the %ss default.",
+            CDN_TIMEOUT_ENV_VAR,
+            raw[:_MAX_WARNED_KEY_LEN],
+            _DEFAULT_CDN_TIMEOUT,
+        )
+        return _DEFAULT_CDN_TIMEOUT
+    if timeout <= 0:
+        # Say so rather than silently substituting the default: `0` most
+        # plausibly means "don't look up", and the user should learn that
+        # it doesn't rather than wonder where the wait came from.
+        warn_once(
+            f"timeout-nonpositive:{raw}",
+            "maidr: %s=%s is not a valid budget, so the %ss default applies. "
+            "To skip the lookup entirely, set %s=%s.",
+            CDN_TIMEOUT_ENV_VAR,
+            raw[:_MAX_WARNED_KEY_LEN],
+            _DEFAULT_CDN_TIMEOUT,
+            CDN_VERSION_ENV_VAR,
+            LATEST_TAG,
+        )
+        return _DEFAULT_CDN_TIMEOUT
+    if timeout < _MIN_CDN_TIMEOUT:
+        warn_once(
+            f"timeout-tiny:{raw}",
+            "maidr: %s=%s is below the %ss floor and was clamped. The value "
+            "is in seconds; a budget that small times out on every attempt "
+            "and silently reinstates the '%s' dist-tag.",
+            CDN_TIMEOUT_ENV_VAR,
+            raw[:_MAX_WARNED_KEY_LEN],
+            _MIN_CDN_TIMEOUT,
+            LATEST_TAG,
+        )
+        return _MIN_CDN_TIMEOUT
+    if timeout > _MAX_CDN_TIMEOUT:
+        warn_once(
+            f"timeout:{raw}",
+            "maidr: %s=%s exceeds the %ss cap and was clamped. The value is "
+            "in seconds; a lookup needing longer would fall back to the "
+            "'%s' dist-tag regardless.",
+            CDN_TIMEOUT_ENV_VAR,
+            raw[:_MAX_WARNED_KEY_LEN],
+            _MAX_CDN_TIMEOUT,
+            LATEST_TAG,
+        )
+        return _MAX_CDN_TIMEOUT
+    return timeout
+
+
+def _resolve_latest_version() -> str | None:
+    """Return the cached ``latest`` version, resolving it on first use.
+
+    Returns
+    -------
+    str or None
+        The concrete version behind the ``latest`` dist-tag, or ``None``
+        when it could not be resolved (offline, blocked, or malformed
+        response).
+
+    Notes
+    -----
+    A :func:`reset_cdn_version_cache` call that lands while this lookup is
+    in flight wins: the result is returned to *this* caller but not
+    cached, so the next render re-resolves rather than seeing the answer
+    the reset asked to discard.
+    """
+    global _resolved_cdn_version, _resolution_attempted
+    attempted, value = _resolution_state()
+    if attempted:
+        return value
+
+    with _fetch_lock:
+        # Re-check: another fetcher may have finished while we queued.
+        attempted, value = _resolution_state()
+        if attempted:
+            return value
+
+        with _resolution_lock:
+            generation = _resolution_generation
+
+        # Deliberately outside ``_resolution_lock``.  The offline paths
+        # read that lock, so holding it here would make a stalled lookup
+        # block a render that promised to make no request at all.
+        try:
+            result = _fetch_latest_version(_cdn_timeout())
+        except Exception:
+            # ``_fetch_latest_version`` is written not to raise, but if it
+            # ever does, record the attempt so the failure is cached
+            # rather than retried on every later render.
+            #
+            # Deliberately ``Exception`` and not ``BaseException``: a
+            # ``KeyboardInterrupt`` landing mid-lookup is the user
+            # interrupting, not a resolver that cannot be reached, and
+            # caching it would poison resolution for the life of the
+            # process -- every later render would silently emit
+            # ``@latest``, which is the bug this module exists to fix.
+            # Letting it propagate un-cached means the next render simply
+            # tries again.
+            with _resolution_lock:
+                if generation == _resolution_generation:
+                    _resolution_attempted = True
+            raise
+
+        with _resolution_lock:
+            # Drop the result if a reset intervened -- it asked for this
+            # answer to be discarded, and publishing it now would silently
+            # undo the reset.
+            if generation == _resolution_generation:
+                _resolved_cdn_version = result
+                _resolution_attempted = True
+        return result
+
+
+def _fetch_latest_version(budget: float) -> str | None:
+    """Query the resolver endpoints for the concrete ``latest`` version.
+
+    Parameters
+    ----------
+    budget : float
+        Total seconds allowed for the whole lookup.  Each attempt gets
+        whatever is left, so trying a second endpoint cannot double how
+        long the caller blocks.
+
+    Returns
+    -------
+    str or None
+        A validated semver string, or ``None`` if every endpoint failed.
+
+    Notes
+    -----
+    Never raises: a version lookup failing must degrade to the ``@latest``
+    URL, not break rendering.
+
+    The budget is approximate, not a hard ceiling.  It is enforced by
+    handing each attempt the remaining time as its socket timeout, and
+    ``urlopen`` applies that per blocking socket operation — connect, TLS
+    handshake, read — rather than to the call as a whole.  An endpoint
+    that stalls just under the limit at each step in turn can therefore
+    overrun the budget by a small multiple.  Name resolution is a further
+    gap: ``getaddrinfo`` is not reliably covered by a socket timeout on
+    every platform, so a broken resolver can stall past the budget before
+    any of those steps begins.
+
+    What it does bound reliably is the failure mode that actually bites:
+    a firewall blackholing packets, where each attempt would otherwise
+    burn a full timeout, and where the number of endpoints would multiply
+    the wait.  Hard-capping the total would need a watchdog thread, which
+    is not worth it for two endpoints returning sub-kilobyte payloads.
+    """
+    global _resolver_outcome
+
+    deadline = time.monotonic() + budget
+    unreachable: list[str] = []
+    answered_badly: list[str] = []
+    resolved: str | None = None
+
+    for url, key in _RESOLVER_ENDPOINTS:
+        timeout = deadline - time.monotonic()
+        if timeout <= 0:
+            _logger.debug(
+                "maidr: CDN version lookup budget spent before trying %s", url
+            )
+            # Never asked, so neither bucket: recording it as unreachable
+            # would report a spent budget as a network fault, and as
+            # answering badly would blame this code for a question it did
+            # not put. The endpoints before it already carry the verdict.
+            break
+        try:
+            # ``url`` is one of the hard-coded https:// endpoints above, never
+            # anything caller-supplied, so there is no scheme to smuggle here.
+            request = Request(
+                url,
+                headers={"Accept": "application/json", "User-Agent": "py-maidr"},
+            )
+            with urlopen(request, timeout=timeout) as response:
+                payload = json.loads(
+                    response.read(_MAX_RESOLVER_BYTES).decode("utf-8")
+                )
+        except HTTPError:
+            # The server answered; the status was one we cannot use. That
+            # is the endpoint telling us something -- a moved path, a
+            # removed package, a rate limit -- and it is a different fact
+            # from not having reached it at all.
+            _logger.debug("maidr: CDN version lookup rejected at %s", url,
+                          exc_info=True)
+            answered_badly.append(url)
+            continue
+        except (ValueError, UnicodeDecodeError):
+            # Bytes arrived and would not become JSON, or would not decode.
+            # Reached, and unusable.
+            _logger.debug("maidr: unparseable CDN version response from %s", url,
+                          exc_info=True)
+            answered_badly.append(url)
+            continue
+        except Exception:
+            # Deliberately broad, and deliberately last.  The obvious
+            # failures are OSError and HTTPException, but the contract
+            # above is that a lookup failure degrades to the ``@latest``
+            # URL rather than breaking rendering — and an exception this
+            # list did not anticipate would break it.  Sandboxes make that
+            # concrete: pytest-socket raises SocketBlockedError, which
+            # derives from Exception, not OSError, and would otherwise
+            # propagate out of render().
+            #
+            # Counted as unreachable rather than as a bad answer, because
+            # that is the safe direction: an unrecognised failure calling
+            # itself "this code is wrong" would redden a scheduled check
+            # for a network condition nobody can fix.
+            _logger.debug("maidr: CDN version lookup failed at %s", url, exc_info=True)
+            unreachable.append(url)
+            continue
+
+        candidate = payload.get(key) if isinstance(payload, dict) else None
+        if isinstance(candidate, str) and _is_valid_version(candidate.strip()):
+            resolved = candidate.strip()
+            break
+        # Answered, parsed, and said something this code cannot read: the
+        # payload has no such key, or the value is not a version. An
+        # endpoint that changed shape looks exactly like this.
+        _logger.debug("maidr: unusable CDN version %r from %s", candidate, url)
+        answered_badly.append(url)
+
+    _resolver_outcome = ResolverOutcome(
+        resolved=resolved,
+        unreachable=tuple(unreachable),
+        answered_badly=tuple(answered_badly),
+    )
+    return resolved

--- a/maidr/util/dependencies.py
+++ b/maidr/util/dependencies.py
@@ -44,21 +44,12 @@ part of the answer.
 
 from __future__ import annotations
 
-import asyncio
-import json
 import logging
-import math
-import os
 import re
-import threading
-import time
 import warnings
 from functools import lru_cache
 from importlib.resources import as_file, files
 from pathlib import Path
-from typing import NamedTuple
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
 
 # ``BUNDLE_WARNING_ENV_VAR`` is not used in this module; it is imported to
 # keep ``maidr.util.dependencies.BUNDLE_WARNING_ENV_VAR`` resolving, which it
@@ -94,15 +85,6 @@ MAIDR_CSS_FILENAME = "maidr.css"
 #: has to *be* in the same directory.
 MAIDR_MATH_CSS_FILENAME = "maidr-math.css"
 
-#: The release that made the split above true.
-#:
-#: Before it, ``maidr.css`` carried KaTeX and had to be linked.  py-maidr
-#: links no stylesheet at all now, so pinning the CDN to anything older
-#: leaves LaTeX in AI chat responses unstyled -- everything else is
-#: unaffected, since the interface has been styled at runtime throughout.
-#: :func:`_warn_if_pin_predates_stylesheet_split` says so once rather than
-#: letting it be discovered.
-_STYLESHEET_SPLIT_VERSION = "3.75.1"
 
 _VERSION_FILENAME = "VERSION"
 
@@ -115,103 +97,22 @@ _UNKNOWN_VERSION = "0.0.0"
 # CDN version resolution
 # ---------------------------------------------------------------------------
 
-_CDN_URL_TEMPLATE = "https://cdn.jsdelivr.net/npm/maidr@{version}/dist/{filename}"
 
 #: CDN-only asset: the Altair adapter loads it, but the wheel does not
 #: ship it, so it must never be passed to :func:`_bundled_asset_path`.
 MAIDR_VEGALITE_FILENAME = "vegalite.js"
 
-#: Version specifier meaning "emit the mutable ``@latest`` dist-tag and do
-#: not contact the network".  This is the pre-resolution behaviour.
-LATEST_TAG = "latest"
-
-#: Version specifier meaning "use the version of the bundle shipped inside
-#: this wheel", i.e. serve over the CDN exactly what the offline fallback
-#: would serve.
-BUNDLED_TAG = "bundled"
-
-#: Pin the CDN version without touching Python (``MAIDR_CDN_VERSION=3.74.0``,
-#: ``=bundled``, or ``=latest`` to opt out of resolution entirely).
-CDN_VERSION_ENV_VAR = "MAIDR_CDN_VERSION"
-
-#: Time budget, in seconds, shared across the whole version lookup rather
-#: than applied per request, so adding a fallback endpoint cannot multiply
-#: how long a first render blocks.  Approximate rather than a hard ceiling
-#: — see :func:`_fetch_latest_version`.
-CDN_TIMEOUT_ENV_VAR = "MAIDR_CDN_TIMEOUT"
-_DEFAULT_CDN_TIMEOUT = 3.0
-
-#: Ceiling on the above.  Far beyond any legitimate lookup, so a larger
-#: value indicates a mistake — most plausibly milliseconds — rather than
-#: an intent to wait that long before a plot appears.
-_MAX_CDN_TIMEOUT = 30.0
-
-#: Floor on the same value, for the mistake in the other direction.  A
-#: budget below this cannot complete a round trip, so every attempt times
-#: out, the failure is cached, and every render for the rest of the
-#: process emits ``@latest`` — silently reinstating the stale-cache bug
-#: this module exists to fix.  ``MAIDR_CDN_TIMEOUT=0.05`` from someone
-#: wanting the lookup to be fast is the plausible way to get there; the
-#: milliseconds misreading (``=100``) lands on the ceiling instead.
-_MIN_CDN_TIMEOUT = 0.1
-
-# Endpoints consulted, in order, to turn the mutable ``latest`` dist-tag
-# into a concrete version.  jsDelivr's data API comes first because it is
-# the authority on what ``cdn.jsdelivr.net`` will actually serve; the npm
-# registry's dist-tags endpoint is the backup.  Both return small JSON
-# documents, so the lookup costs one short round trip per process.
-_RESOLVER_ENDPOINTS: tuple[tuple[str, str], ...] = (
-    (
-        "https://data.jsdelivr.com/v1/packages/npm/maidr/resolved"
-        "?specifier=latest",
-        "version",
-    ),
-    ("https://registry.npmjs.org/-/package/maidr/dist-tags", "latest"),
-)
-
-# Cap on how much of a resolver response we read, so a hostile or broken
-# endpoint cannot stream an unbounded body into memory.
-_MAX_RESOLVER_BYTES = 64 * 1024
 
 
-class ResolverOutcome(NamedTuple):
-    """Why the last ``latest`` lookup ended the way it did.
-
-    :func:`_fetch_latest_version` collapses every failure into ``None``,
-    which is the right answer for a render -- there is nothing a chart can
-    do about it either way -- but it loses the one distinction a monitor
-    needs.  Two endpoints failing to answer is the network; two endpoints
-    answering with something unusable is *this code* being wrong about
-    their shape, and only the second should wake anyone up.
-
-    Kept separate from :class:`BundleStatus` rather than folded into it,
-    so the render path's answer to "how does my bundle compare?" stays the
-    two versions and the two flags it already is.
-
-    Attributes
-    ----------
-    resolved : str or None
-        The version the lookup settled on, if any.
-    unreachable : tuple of str
-        Endpoints that never answered: a timeout, a refused connection, a
-        name that would not resolve, a blocked socket.  Says nothing about
-        whether the resolver code is right, because nothing was read.
-    answered_badly : tuple of str
-        Endpoints that answered, in a way this code could not use: an HTTP
-        error status, a body that would not decode or parse, a payload
-        without the key, or a value that is not a version.  This is the
-        one worth failing a scheduled check over -- an API that changed
-        shape looks exactly like this and looks like nothing else.
-    """
-
-    resolved: str | None
-    unreachable: tuple[str, ...]
-    answered_badly: tuple[str, ...]
 
 
-def _unresolved_cdn_url(filename: str) -> str:
-    """Format the ``@latest`` URL for ``filename``.  See public wrapper."""
-    return _CDN_URL_TEMPLATE.format(version=LATEST_TAG, filename=filename)
+
+
+
+
+
+
+
 
 
 # Same intent as the guard in ``.github/scripts/fetch-maidr-bundle.sh``:
@@ -299,985 +200,54 @@ def _is_valid_version(candidate: str) -> bool:
 
 
 
-# Deliberately not guarded by ``_resolution_lock`` below: this is a lone
-# reference assignment, written only by an explicit
-# :func:`set_cdn_version` call.  The lock exists to stop concurrent
-# *lookups*, which are a compound read-modify-write, not to protect this.
-#
-# Unlike the compound update in :func:`maidr.util.warn.warn_once`, the
-# reasoning here does not depend on the GIL and so survives free-threaded
-# builds (PEP 703): storing a single object reference stays indivisible
-# there, so a reader sees either the old value or the new one, never a
-# torn write.
-_cdn_version_override: str | None = None
-
-_resolved_cdn_version: str | None = None
-_resolution_attempted: bool = False
-
-# Bumped by :func:`reset_cdn_version_cache`.  A fetch reads this before it
-# starts and refuses to publish if it changed meanwhile, so a reset issued
-# mid-request discards the in-flight answer instead of being silently
-# overwritten by it.  The reset cannot simply take ``_fetch_lock``: that
-# would make it block for the whole timeout budget behind the very lookup
-# it is trying to abandon.
-_resolution_generation: int = 0
-
-# Guards the three globals above and nothing else, so it is only ever held
-# for a few instructions.  Readers on the *offline* paths take it, and a
-# lock held across a network call would let one stalled lookup freeze an
-# unrelated ``use_cdn=False`` render for the whole timeout budget --
-# breaking the guarantee those paths advertise.
-_resolution_lock = threading.Lock()
-
-# Serialises the lookup itself, so concurrent first renders still make one
-# request between them.  Fetchers take this *then* ``_resolution_lock`` to
-# publish; readers never take it, so they cannot be blocked by a fetch.
-_fetch_lock = threading.Lock()
-
-# The last lookup's verdict, for :func:`resolver_outcome`.  A single
-# rebound reference like the globals above, so no lock is needed to read
-# it: a reader sees one whole outcome, never half of two.  ``None`` until
-# a lookup has run, which is what tells "not tried" from "tried and
-# reached nothing".
-_resolver_outcome: ResolverOutcome | None = None
-
-# Unresolved CDN URLs, kept only for backwards compatibility with
-# callers outside this package that imported them before version
-# resolution existed.  Nothing inside ``maidr/`` references them.
-#
-# DO NOT reference these from a render path.  ``@latest`` is the mutable
-# dist-tag whose seven-day cache lifetime is the bug this module exists to
-# fix, so emitting one into HTML silently reintroduces it.  Call
-# :func:`maidr_js_cdn_url` / :func:`maidr_css_cdn_url` / :func:`cdn_url`
-# instead — ``tests/core/test_cdn_version.py`` enforces this.
-#
-# Derived from :func:`unresolved_cdn_url` rather than formatting the
-# template again, so "the unresolved URL" is spelled out in exactly one
-# place and the constants cannot drift from the function.
-MAIDR_JS_CDN_URL = _unresolved_cdn_url(MAIDR_JS_FILENAME)
-MAIDR_CSS_CDN_URL = _unresolved_cdn_url(MAIDR_CSS_FILENAME)
-
-
-def set_cdn_version(version: str | None) -> None:
-    """Pin the ``maidr`` version referenced by emitted CDN URLs.
-
-    Parameters
-    ----------
-    version : str or None
-        A concrete version (``"3.74.0"``, optionally ``v``-prefixed),
-        :data:`BUNDLED_TAG` to mirror the version bundled in this wheel,
-        or :data:`LATEST_TAG` to emit the mutable ``@latest`` dist-tag and
-        skip the network lookup entirely.  ``None`` clears the pin and
-        discards any cached lookup so the next URL re-resolves.
-
-        Both tags keep the lookup offline: if the bundled ``VERSION`` is
-        missing or unparseable, :data:`BUNDLED_TAG` warns and degrades to
-        :data:`LATEST_TAG` rather than reaching for the network, since
-        asking for the installed copy implies staying local.
-
-    Notes
-    -----
-    A malformed concrete version is logged and then *ignored*, which
-    means the next URL resolves normally — one bounded lookup, exactly as
-    if no pin had been set.  That is deliberate: mistyping ``3.74.0`` as
-    ``3.74`` says "I wanted a particular version", not "I want to stay
-    off the network", so recovering to the current published version is
-    the closest thing to what was asked.  Contrast :data:`BUNDLED_TAG`,
-    which *does* imply staying local and therefore degrades to
-    :data:`LATEST_TAG` rather than resolving.  The supported ways to
-    forbid the lookup outright are ``MAIDR_CDN_VERSION=latest`` and
-    ``use_cdn=False``.
-
-    Process-wide, not per-session: this writes module-level state shared
-    by every caller in the interpreter, matching ``set_use_cdn``.  In a
-    server handling concurrent sessions (e.g. Shiny), one session calling
-    this changes what the others render — prefer ``MAIDR_CDN_VERSION`` at
-    startup, or an explicit ``use_cdn=`` per call.
-
-    Takes precedence over the ``MAIDR_CDN_VERSION`` environment variable.
-    A value that is neither a recognised tag nor a valid semver is
-    ignored (with a warning) in favour of the normal resolution path.
-
-    Warns
-    -----
-    FutureWarning
-        When ``version`` is unusable.  Today the pin is ignored and the
-        next URL resolves normally; a future major release will raise
-        :class:`ValueError` instead.
-
-        The leniency is right for ``MAIDR_CDN_VERSION`` -- ambient
-        configuration may be set by something outside the caller's
-        control, and crashing on it would be hostile.  It is wrong here:
-        this is an explicit call with a bad argument, which is the
-        textbook case for ``ValueError``, and the caller currently gets no
-        return value, no exception, and a *log* line they may never see.
-        So a typo does nothing, visibly (#294).
-
-        Raising outright would break a script that has been quietly
-        mistyping its pin and rendering fine, so it goes through a
-        deprecation the way :func:`bundled_css_path` did.  The warning is
-        the behaviour change; the raise is the next major's.
-    """
-    global _cdn_version_override
-    # A blank string is treated as ``None`` rather than as a malformed
-    # pin.  Otherwise it stores an empty override that later reads as
-    # "no pin" and falls through silently, while every *other* unusable
-    # value warns — an asymmetry with no reason behind it.
-    if version is None or not str(version).strip():
-        _cdn_version_override = None
-        reset_cdn_version_cache()
-        return
-
-    candidate = str(version).strip()
-    # Checked here as well as on every URL build, because the two
-    # answer different questions. `_normalise_version_pin` asks "can I
-    # use this?" every time it needs a URL, and logs. This asks "did the
-    # caller just make a mistake?", once, at the point they made it --
-    # which is the only moment a stack trace points anywhere useful.
-    if _normalise_version_pin(candidate) is None:
-        warnings.warn(
-            f"maidr.set_cdn_version({version!r}) was given something that is "
-            f"neither a semver such as '3.74.0' nor {BUNDLED_TAG!r} or "
-            f"{LATEST_TAG!r}. The pin is ignored and URLs resolve as if it "
-            "had not been set. A future major release will raise ValueError "
-            "here instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-
-    _cdn_version_override = candidate
-
-
-def get_cdn_version() -> str:
-    """Return the ``maidr`` version to splice into CDN URLs.
-
-    Resolution order:
-
-    1. An explicit pin from :func:`set_cdn_version`.
-    2. The ``MAIDR_CDN_VERSION`` environment variable.
-    3. The version this wheel ships, when resolving would block an event
-       loop — see :func:`_resolution_would_block`, and the note below.
-    4. The ``latest`` dist-tag resolved over the network (once per
-       process, then cached).
-    5. The literal string ``"latest"`` when the lookup fails, which
-       reproduces the library's historical behaviour.
-
-    Returns
-    -------
-    str
-        A concrete version such as ``"3.74.0"``, or ``"latest"``.
-
-    Notes
-    -----
-    Step 5 is what makes this safe to call from a render path: an
-    unreachable, blocked, or malformed resolver degrades to ``"latest"``
-    rather than raising.  That guarantee rests on
-    :func:`_fetch_latest_version` honouring its own "never raises"
-    contract — it catches ``Exception`` around every fallible step for
-    exactly this reason.  Should something slip past it anyway, the
-    handler in :func:`_resolve_latest_version` caches the attempt (so the
-    failure is not retried on every later render) and re-raises, so the
-    exception surfaces from ``render()`` / ``save_html()``.  That is a
-    deliberate fail-fast for a bug in this module rather than a third
-    degradation path.
-
-    A ``KeyboardInterrupt`` is treated differently: it is not cached, so
-    interrupting one render does not leave the rest of the process
-    emitting ``@latest``.
-
-    Step 3 is the one that depends on where it is called from, and it is
-    a deliberate trade.  ``maidr.render()`` is synchronous and Shiny calls
-    it from ``render_maidr.render()``, which is ``async`` — so under the
-    default the first figure in an app performed a blocking ``urlopen`` on
-    the event loop, stalling every concurrent session behind it (#296).
-    The bundled version is a real published one, so the URL resolves and
-    is immutable; what is given up is picking up a release newer than the
-    wheel, automatically, in an async process.
-
-    That is the trade the docs already recommended making by hand:
-    ``MAIDR_CDN_VERSION=bundled`` was the advice for Shiny apps, and this
-    makes the default do it in exactly the context the advice was for.
-    Two things follow that are worth knowing rather than discovering:
-
-    * :func:`warn_if_bundle_is_stale` reads only an already-completed
-      lookup, so a process that never resolves never hears it.
-    * Calling this once from synchronous code at start-up caches the
-      answer, after which every async render uses the resolved version --
-      which is how an app that wants the newer release gets it without
-      any render paying for the request.
-
-    Synchronous callers are unaffected, including threads: they still
-    resolve once per process and queue on ``_fetch_lock`` while the first
-    of them does.  That queueing is not fixed here; it is the event loop
-    specifically that must not be made to wait.
-    """
-    pin = _version_pin()
-    if pin is not None:
-        return pin
-    if _resolution_would_block():
-        return _offline_version()
-    # A lookup that failed falls back to the bundled version, not to
-    # `@latest`.  `@latest` is the mutable dist-tag whose seven-day
-    # `Cache-Control` is the whole of #290 -- so degrading to it meant the
-    # fix stopped applying in precisely the case it was meant to survive,
-    # and an offline browser could still replay a week-old build (#295).
-    #
-    # The bundled version is a real published one, immutable, and is the
-    # copy this wheel would have served anyway had the CDN been declined.
-    # What it costs is that a network hiccup pins the page to a possibly
-    # older release -- quieter, but staler. That trade was argued the
-    # other way when this fallback was written, on the grounds that
-    # `@latest` is byte-for-byte what users had before version resolution
-    # existed and so nobody ends up worse off. Three other paths have
-    # since moved to the bundled answer, and being the last one left
-    # emitting the mutable tag is not a place worth defending.
-    return _resolve_latest_version() or _offline_version()
-
-
-def _version_pin() -> str | None:
-    """Return the normalised explicit pin, or ``None`` if there is none."""
-    pin = _cdn_version_override
-    if pin is None:
-        pin = os.environ.get(CDN_VERSION_ENV_VAR)
-    if pin is None:
-        return None
-    return _normalise_version_pin(pin)
-
-
-def _published_version(*, resolve: bool) -> str | None:
-    """Return the version npm has actually published, ignoring any pin.
-
-    A pin answers "which version should we serve?", which is a different
-    question from "which version is current?".  Feeding a pin into the
-    staleness comparison would let ``set_cdn_version("4.0.0")`` — pinning
-    an unreleased build to test it — report 4.0.0 as *published* and
-    advise upgrading, and would let a backwards pin mask a genuinely old
-    bundle.  Only a real lookup answers the published question.
-
-    Parameters
-    ----------
-    resolve : bool
-        Whether to perform the lookup when the answer is not already
-        cached.  ``False`` keeps the caller offline and accepts ``None``.
-
-    Returns
-    -------
-    str or None
-        A concrete version, or ``None`` when it is unknown.
-    """
-    if resolve:
-        return _resolve_latest_version()
-    return _cached_resolution()
-
-
-def _resolution_state() -> tuple[bool, str | None]:
-    """Return ``(attempted, value)`` for the cached lookup, atomically.
-
-    Reads both globals under the lock so a caller cannot observe the flag
-    without the value it refers to.  Returned as a pair because ``None``
-    is ambiguous on its own: it means both "no lookup yet" and "the lookup
-    failed", and the two need different handling.
-
-    The lock is held for these two reads only — never across a network
-    call — so an offline caller is never delayed by someone else's lookup.
-    """
-    with _resolution_lock:
-        return _resolution_attempted, _resolved_cdn_version
-
-
-def _cached_resolution() -> str | None:
-    """Return the resolved version if a lookup has completed, else ``None``."""
-    attempted, value = _resolution_state()
-    return value if attempted else None
-
-
-def _offline_version() -> str:
-    """Return the best version available without making a request.
-
-    The order is the same question asked three ways, cheapest first: what
-    did the caller ask for, what did an earlier lookup establish, and what
-    shipped in this wheel.  Only when none of those is usable does this
-    fall back to :data:`LATEST_TAG`, the mutable dist-tag this module
-    exists to stop emitting.
-
-    Both offline callers read it from here rather than each spelling it
-    out, because when they disagreed the result was one page loading two
-    different builds of ``maidr.js`` -- an iframe on the pinned version
-    and its host on the bundled one.
-
-    The last step warns, because there are two roads to ``latest`` and
-    only one of them is normal.  A lookup that failed is a routine
-    operating condition -- offline, blocked, a malformed response -- and
-    is documented as the safe degradation; it stays quiet.  A bundled
-    version that will not read is a broken install, nobody but the user
-    can fix it, and the page still works, so without a word the only
-    symptom is someone occasionally being served a week-old ``maidr.js``
-    for reasons nothing in the output explains (#364).
-
-    Returns
-    -------
-    str
-        A concrete version, or ``latest`` when there is no better answer.
-    """
-    pin = _version_pin()
-    if pin is not None:
-        return pin
-
-    resolved = _cached_resolution()
-    if resolved is not None and _is_valid_version(resolved):
-        return resolved
-
-    bundled = maidr_js_version()
-    if _is_valid_version(bundled) and bundled != _UNKNOWN_VERSION:
-        return bundled
-
-    # The two faults read differently, and the point of speaking at all is
-    # to be read: an absent VERSION reported as `is unreadable ('0.0.0')`
-    # says the file contains those characters, which is the one thing it
-    # does not. `maidr_js_version` returns the sentinel for missing,
-    # empty and unreadable alike, so that is as far as the distinction
-    # goes -- but it is the distinction someone chasing this needs first.
-    if bundled == _UNKNOWN_VERSION:
-        detail = "cannot be read (the VERSION file is missing or empty)"
-    else:
-        # Truncated for the same reason `_normalise_version_pin` truncates
-        # its pin: nothing bounds the length of a garbled file, and a log
-        # line is not where a megabyte belongs.
-        detail = f"is not a version ({bundled[:_MAX_WARNED_KEY_LEN]!r})"
-
-    # Keyed on the unusable value, so a wheel whose VERSION is garbled
-    # rather than absent says which -- and a second, differently broken
-    # one is still audible.
-    warn_once(
-        f"unusable-bundled-version:{bundled}",
-        "maidr: the bundled maidr.js version %s, so CDN URLs fall back to "
-        "the mutable maidr@%s tag. jsDelivr serves that with a seven-day "
-        "cache lifetime, so a browser may replay an old bundle. Reinstall "
-        "py-maidr, or pin a version with maidr.set_cdn_version().",
-        detail,
-        LATEST_TAG,
-    )
-    return LATEST_TAG
-
-
-def _resolution_would_block() -> bool:
-    """Report whether resolving now would stall an event loop.
-
-    ``_resolve_latest_version`` makes a blocking ``urlopen`` call, holding
-    ``_fetch_lock`` across it.  On a thread running an event loop -- which
-    is where ``maidr.render()`` is called from in a Shiny app, through
-    ``render_maidr.render()`` -- that stalls every other session in the
-    process for up to :data:`MAIDR_CDN_TIMEOUT`, and that budget is only
-    approximate: ``urlopen``'s timeout applies per socket operation and
-    does not reliably cover ``getaddrinfo``, so a broken resolver can
-    exceed it (#296).
-
-    A lookup that has already completed costs nothing, so it is not
-    blocking and this says so -- which is what makes the answer stable
-    rather than context-dependent after the first resolution anywhere in
-    the process.  Resolving once from synchronous code at start-up is
-    therefore the way to have an async app serve the resolved version.
-
-    Returns
-    -------
-    bool
-        ``True`` only when a lookup would have to be performed *and* this
-        thread is running an event loop.
-    """
-    attempted, _ = _resolution_state()
-    if attempted:
-        return False
-
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return False
-    return True
-
-
-def unresolved_cdn_url(filename: str) -> str:
-    """Return the ``@latest`` CDN URL without resolving a version.
-
-    The last resort, reached only when no concrete version is available:
-    :func:`bundled_cdn_url` falls back here when the bundled ``VERSION``
-    is unusable, and :func:`get_cdn_version` returns ``latest`` when a
-    lookup fails.  Prefer :func:`cdn_url` or :func:`bundled_cdn_url` —
-    ``@latest`` is the mutable dist-tag this module exists to stop
-    emitting.
-
-    Parameters
-    ----------
-    filename : str
-        Asset name under the package's ``dist/`` directory.
-
-    Returns
-    -------
-    str
-        A jsDelivr URL pinned to the ``latest`` dist-tag.
-    """
-    return _unresolved_cdn_url(filename)
-
-
-def reset_cdn_version_cache() -> None:
-    """Discard the cached ``latest`` lookup so the next URL re-resolves.
-
-    Both successful and failed lookups are cached for the lifetime of the
-    process — the failure case deliberately so, because an offline
-    notebook must not stall on a doomed request for every figure it
-    renders.  Long-lived processes that want to pick up a newer release
-    can call this to force one more attempt.
-
-    Does not re-arm the one-shot staleness warning from
-    :func:`warn_if_bundle_is_stale`, which stays spent for the life of
-    the process regardless of how often the version is re-resolved.
-
-    Clears :func:`resolver_outcome` too.  It describes the lookup this
-    call is discarding, and leaving it behind would let a monitor read a
-    stale verdict as the current one -- reporting an endpoint as broken
-    after a successful re-resolution, or the reverse.
-
-    Returns without waiting on a lookup already in flight — it does not
-    take ``_fetch_lock``, which would make the reset itself block for the
-    whole budget behind the request it is abandoning.  That is a promise
-    about *this* call, not about the next one: a caller that needs a
-    version afterwards still queues on ``_fetch_lock`` behind the
-    abandoned request, and only then makes its own.  What the generation
-    counter guarantees is that the abandoned answer is discarded rather
-    than published over the reset.
-    """
-    global _resolved_cdn_version, _resolution_attempted, _resolution_generation
-    global _resolver_outcome
-    with _resolution_lock:
-        _resolved_cdn_version = None
-        _resolution_attempted = False
-        _resolver_outcome = None
-        # Invalidate any lookup already in flight, so its result cannot
-        # land after this call and quietly undo it.
-        _resolution_generation += 1
-
-
-def cdn_url(filename: str) -> str:
-    """Return the jsDelivr URL for a ``dist/`` asset at the resolved version.
-
-    Parameters
-    ----------
-    filename : str
-        Asset name under the package's ``dist/`` directory, e.g.
-        ``"maidr.js"``.  Trusted input: unlike the version, it is not
-        validated, because every call site passes one of this module's
-        ``MAIDR_*_FILENAME`` constants.  Validate it here first if that
-        ever stops being true.
-
-    Returns
-    -------
-    str
-        A fully qualified jsDelivr URL.
-    """
-    return _CDN_URL_TEMPLATE.format(version=get_cdn_version(), filename=filename)
-
-
-def bundled_cdn_url(filename: str) -> str:
-    """Return the CDN URL pinned to the version shipped in this wheel.
-
-    For code that must emit a CDN reference without making a request.
-    The bundled version came from the registry at release time, so it is
-    a real published version and the URL resolves — while being
-    immutable, and therefore free of the seven-day cache lifetime that
-    ``@latest`` carries.
-
-    Honours an explicit pin first, then a version an already-completed
-    lookup established, so these tags stay on the same version anything
-    else in the page loads.  Falls back to :data:`LATEST_TAG` only when
-    none of those is usable, where there is no better answer available
-    offline.
-
-    Parameters
-    ----------
-    filename : str
-        Asset name under the package's ``dist/`` directory.
-
-    Returns
-    -------
-    str
-        A jsDelivr URL at the bundled version, or at ``latest`` when that
-        version is unknown.
-    """
-    # A pin first, then a version an earlier lookup already established,
-    # then the bundled one -- see `_offline_version`, which is the same
-    # order `get_cdn_version` falls back to on an event loop, written once
-    # so the two cannot answer differently. When they did, a pinned
-    # session emitted the *bundled* version here while every iframe
-    # emitted the pinned one, and one page loaded two builds of maidr.js.
-    #
-    # A LATEST_TAG pin lands there too and yields the ``@latest`` URL,
-    # which is what that pin asks for and what the render paths emit.
-    return _CDN_URL_TEMPLATE.format(version=_offline_version(), filename=filename)
-
-
-def maidr_js_cdn_url() -> str:
-    """Return the CDN URL for ``maidr.js`` at the resolved version.
-
-    Returns
-    -------
-    str
-        A fully qualified jsDelivr URL.
-    """
-    return cdn_url(MAIDR_JS_FILENAME)
-
-
-def _warn_placeholder_css(name: str, instead: str) -> None:
-    """
-    Announce that a ``maidr.css`` accessor is going away.
-
-    ``FutureWarning`` rather than ``DeprecationWarning``, which is the more
-    usual category for an API removal. Python's own guidance splits them by
-    audience: ``DeprecationWarning`` is for warnings aimed at other library
-    authors, ``FutureWarning`` for those aimed at end users of applications
-    written in Python. Someone calling this is building a dashboard or a
-    report, not extending py-maidr.
-
-    The practical half matters more. ``DeprecationWarning`` is silenced by
-    default outside ``__main__``, so a caller inside a Shiny app or an
-    imported module would never see it and would meet the removal as a
-    breakage instead of a warning -- which is the one thing a deprecation
-    cycle exists to prevent.
-
-    Parameters
-    ----------
-    name : str
-        The function being called, spelled as a path that actually
-        imports, so the message names the caller's own call rather than
-        this helper.  Fully qualified rather than assumed: only one of
-        these two is re-exported from the top-level package, so a fixed
-        ``maidr.`` prefix would name a path that raises
-        :class:`AttributeError` for the other.
-    instead : str
-        What to call in its place, in the same form the caller wanted.  The
-        two accessors return different things -- a local :class:`Path` and a
-        remote URL -- so a single suggestion would hand one of them the
-        wrong type, which is the opposite of what a deprecation message is
-        for.
-    """
-    warnings.warn(
-        f"{name}() is deprecated and will be removed in the next major "
-        "release, along with the bundled maidr.css it resolves. That file has "
-        "carried no rules since maidr 3.75.1 and nothing in py-maidr links "
-        f"it. Use {instead} for the stylesheet that does carry rules, or link "
-        "no stylesheet at all -- MAIDR styles its interface at runtime.",
-        FutureWarning,
-        stacklevel=3,
-    )
-
-
-def maidr_css_cdn_url() -> str:
-    """Return the CDN URL for ``maidr.css`` at the resolved version.
-
-    .. deprecated::
-        Linking this buys nothing and will be removed, along with
-        ``maidr.css`` itself, in the next major release.  If what you
-        wanted was the stylesheet that carries rules, and you want it from
-        the CDN as this function returns it, call
-        ``cdn_url(MAIDR_MATH_CSS_FILENAME)`` -- both from this module, which
-        is also the only place this function itself is importable from.
-        :func:`bundled_math_css_path` is the local-file counterpart, and is
-        re-exported as ``maidr.bundled_math_css_path``.  Or link nothing at
-        all -- MAIDR styles its interface at runtime.
-
-    Nothing in ``maidr/`` emits this any more.  From maidr 3.75.1 the file
-    it points at is a placeholder with no rules in it, published only so
-    that ``<link>`` tags written before the split keep resolving; linking
-    it costs a request and buys nothing.  Kept for callers outside this
-    package that already build their own HTML around it.
-
-    Returns
-    -------
-    str
-        A fully qualified jsDelivr URL.
-
-    Warns
-    -----
-    FutureWarning
-        Always.  See :func:`_warn_placeholder_css` for why this category.
-    """
-    _warn_placeholder_css(
-        "maidr.util.dependencies.maidr_css_cdn_url",
-        "cdn_url(MAIDR_MATH_CSS_FILENAME) from maidr.util.dependencies",
-    )
-    return cdn_url(MAIDR_CSS_FILENAME)
-
-
-def _normalise_version_pin(pin: str) -> str | None:
-    """Turn a user-supplied version specifier into a URL-safe string.
-
-    Parameters
-    ----------
-    pin : str
-        Raw specifier from :func:`set_cdn_version` or the environment.
-
-    Returns
-    -------
-    str or None
-        The version to use, or ``None`` when the specifier is empty or
-        unusable and the caller should fall through to network
-        resolution.
-    """
-    candidate = pin.strip()
-    if not candidate:
-        return None
-    if candidate.lower() == LATEST_TAG:
-        return LATEST_TAG
-    if candidate.lower() == BUNDLED_TAG:
-        bundled = maidr_js_version()
-        if _is_valid_version(bundled) and bundled != _UNKNOWN_VERSION:
-            return bundled
-        # Asking for ``bundled`` is a request to serve what is installed,
-        # which implies staying local.  Falling through to a network
-        # lookup would betray that intent for someone who chose it to
-        # avoid egress, so degrade to ``@latest`` — still a working URL,
-        # still no request.
-        warn_once(
-            f"{BUNDLED_TAG}:{bundled}",
-            "maidr: a %r CDN version pin was requested but the bundled "
-            "VERSION is %r; falling back to the %r dist-tag without "
-            "resolving. Reinstall py-maidr to repair the bundle.",
-            BUNDLED_TAG,
-            bundled,
-            LATEST_TAG,
-        )
-        return LATEST_TAG
-    # Accept a leading ``v`` (``v3.74.0``) since that is how the version
-    # is written in git tags and release notes.
-    candidate = candidate[1:] if candidate.startswith(("v", "V")) else candidate
-    if _is_valid_version(candidate):
-        _warn_if_pin_predates_stylesheet_split(candidate)
-        return candidate
-    # Truncate for display too: the key is capped, but an oversized pin
-    # would otherwise land in the log line at full length.
-    warn_once(
-        f"pin:{pin}",
-        "maidr: ignoring invalid CDN version pin %r; expected a semver "
-        "such as '3.74.0', %r, or %r.",
-        pin[:_MAX_WARNED_KEY_LEN],
-        BUNDLED_TAG,
-        LATEST_TAG,
-    )
-    return None
-
-
-def _warn_if_pin_predates_stylesheet_split(version: str) -> None:
-    """Warn once when a pin names a maidr from before the KaTeX split.
-
-    py-maidr emits no stylesheet link, because from
-    :data:`_STYLESHEET_SPLIT_VERSION` the published ``maidr.css`` is a
-    placeholder and ``maidr.js`` fetches the maths stylesheet itself.  An
-    older version has neither that runtime fetch nor rules anywhere else,
-    so LaTeX in AI chat responses renders unstyled.
-
-    The failure is narrow and silent — no other part of the interface
-    changes, and a page whose chat is never opened looks perfectly fine —
-    which is exactly why pinning backwards deserves a sentence rather
-    than a discovery.
-
-    Parameters
-    ----------
-    version : str
-        A pin that has already passed :func:`_is_valid_version`.
-    """
-    key = _version_key(version)
-    split_key = _version_key(_STYLESHEET_SPLIT_VERSION)
-    if key is None or split_key is None or key >= split_key:
-        return
-    warn_once(
-        f"pre-split-pin:{version}",
-        "maidr: CDN version pin %r predates maidr %s, where KaTeX moved out "
-        "of maidr.css into maidr-math.css. py-maidr links no stylesheet, so "
-        "LaTeX in AI chat responses will render unstyled at that version; "
-        "everything else is unaffected. Pin %s or newer to style it.",
-        version,
-        _STYLESHEET_SPLIT_VERSION,
-        _STYLESHEET_SPLIT_VERSION,
-    )
-
-
-
-
-def _cdn_timeout() -> float:
-    """Return the total time budget for the version lookup, in seconds.
-
-    Notes
-    -----
-    A non-numeric or non-positive ``MAIDR_CDN_TIMEOUT`` (including ``0``)
-    falls back to the default budget rather than meaning "no budget" or
-    "skip the lookup" — ``MAIDR_CDN_VERSION=latest`` is the supported way
-    to opt out of resolving entirely.
-
-    Values above :data:`_MAX_CDN_TIMEOUT` are clamped, with a warning so
-    the clamp is visible rather than silent.  Honouring an arbitrarily
-    large value would respect the letter of the configuration at the cost
-    of a render that appears to hang: ``MAIDR_CDN_TIMEOUT=3000`` meant as
-    milliseconds would block for fifty minutes.  Nothing legitimate needs
-    longer than the cap to fetch a sub-kilobyte JSON document, and a
-    lookup that slow degrades to the ``@latest`` URL anyway.
-
-    Values below :data:`_MIN_CDN_TIMEOUT` are clamped for the mirror-image
-    reason, and it is the more damaging mistake: a budget like ``0.05``,
-    set by someone who wanted the lookup to be quick, is positive and so
-    passes every other guard, yet no round trip can finish inside it.
-    Every attempt times out, the failure is cached once, and every render
-    for the rest of the process quietly emits ``@latest`` — the exact bug
-    this module exists to fix, arrived at through configuration rather
-    than through code.  A render that waits a tenth of a second and then
-    gives up is the better failure.
-    """
-    raw = os.environ.get(CDN_TIMEOUT_ENV_VAR)
-    if raw is None:
-        return _DEFAULT_CDN_TIMEOUT
-    try:
-        timeout = float(raw)
-    except ValueError:
-        warn_once(
-            f"timeout-nan:{raw}",
-            "maidr: ignoring non-numeric %s=%r; using the %ss default.",
-            CDN_TIMEOUT_ENV_VAR,
-            raw[:_MAX_WARNED_KEY_LEN],
-            _DEFAULT_CDN_TIMEOUT,
-        )
-        return _DEFAULT_CDN_TIMEOUT
-    if not math.isfinite(timeout):
-        # ``float("nan")`` parses, and NaN compares False against both
-        # the floor and the ceiling below, so it would sail through every
-        # guard and reach ``urlopen`` — which raises, gets swallowed by
-        # the broad handler there, and silently disables resolution with
-        # nothing logged.  ``inf`` would hang instead of being clamped.
-        warn_once(
-            f"timeout-nonfinite:{raw}",
-            "maidr: %s=%s is not a finite number; using the %ss default.",
-            CDN_TIMEOUT_ENV_VAR,
-            raw[:_MAX_WARNED_KEY_LEN],
-            _DEFAULT_CDN_TIMEOUT,
-        )
-        return _DEFAULT_CDN_TIMEOUT
-    if timeout <= 0:
-        # Say so rather than silently substituting the default: `0` most
-        # plausibly means "don't look up", and the user should learn that
-        # it doesn't rather than wonder where the wait came from.
-        warn_once(
-            f"timeout-nonpositive:{raw}",
-            "maidr: %s=%s is not a valid budget, so the %ss default applies. "
-            "To skip the lookup entirely, set %s=%s.",
-            CDN_TIMEOUT_ENV_VAR,
-            raw[:_MAX_WARNED_KEY_LEN],
-            _DEFAULT_CDN_TIMEOUT,
-            CDN_VERSION_ENV_VAR,
-            LATEST_TAG,
-        )
-        return _DEFAULT_CDN_TIMEOUT
-    if timeout < _MIN_CDN_TIMEOUT:
-        warn_once(
-            f"timeout-tiny:{raw}",
-            "maidr: %s=%s is below the %ss floor and was clamped. The value "
-            "is in seconds; a budget that small times out on every attempt "
-            "and silently reinstates the '%s' dist-tag.",
-            CDN_TIMEOUT_ENV_VAR,
-            raw[:_MAX_WARNED_KEY_LEN],
-            _MIN_CDN_TIMEOUT,
-            LATEST_TAG,
-        )
-        return _MIN_CDN_TIMEOUT
-    if timeout > _MAX_CDN_TIMEOUT:
-        warn_once(
-            f"timeout:{raw}",
-            "maidr: %s=%s exceeds the %ss cap and was clamped. The value is "
-            "in seconds; a lookup needing longer would fall back to the "
-            "'%s' dist-tag regardless.",
-            CDN_TIMEOUT_ENV_VAR,
-            raw[:_MAX_WARNED_KEY_LEN],
-            _MAX_CDN_TIMEOUT,
-            LATEST_TAG,
-        )
-        return _MAX_CDN_TIMEOUT
-    return timeout
-
-
-def _resolve_latest_version() -> str | None:
-    """Return the cached ``latest`` version, resolving it on first use.
-
-    Returns
-    -------
-    str or None
-        The concrete version behind the ``latest`` dist-tag, or ``None``
-        when it could not be resolved (offline, blocked, or malformed
-        response).
-
-    Notes
-    -----
-    A :func:`reset_cdn_version_cache` call that lands while this lookup is
-    in flight wins: the result is returned to *this* caller but not
-    cached, so the next render re-resolves rather than seeing the answer
-    the reset asked to discard.
-    """
-    global _resolved_cdn_version, _resolution_attempted
-    attempted, value = _resolution_state()
-    if attempted:
-        return value
-
-    with _fetch_lock:
-        # Re-check: another fetcher may have finished while we queued.
-        attempted, value = _resolution_state()
-        if attempted:
-            return value
-
-        with _resolution_lock:
-            generation = _resolution_generation
-
-        # Deliberately outside ``_resolution_lock``.  The offline paths
-        # read that lock, so holding it here would make a stalled lookup
-        # block a render that promised to make no request at all.
-        try:
-            result = _fetch_latest_version(_cdn_timeout())
-        except Exception:
-            # ``_fetch_latest_version`` is written not to raise, but if it
-            # ever does, record the attempt so the failure is cached
-            # rather than retried on every later render.
-            #
-            # Deliberately ``Exception`` and not ``BaseException``: a
-            # ``KeyboardInterrupt`` landing mid-lookup is the user
-            # interrupting, not a resolver that cannot be reached, and
-            # caching it would poison resolution for the life of the
-            # process -- every later render would silently emit
-            # ``@latest``, which is the bug this module exists to fix.
-            # Letting it propagate un-cached means the next render simply
-            # tries again.
-            with _resolution_lock:
-                if generation == _resolution_generation:
-                    _resolution_attempted = True
-            raise
-
-        with _resolution_lock:
-            # Drop the result if a reset intervened -- it asked for this
-            # answer to be discarded, and publishing it now would silently
-            # undo the reset.
-            if generation == _resolution_generation:
-                _resolved_cdn_version = result
-                _resolution_attempted = True
-        return result
-
-
-def _fetch_latest_version(budget: float) -> str | None:
-    """Query the resolver endpoints for the concrete ``latest`` version.
-
-    Parameters
-    ----------
-    budget : float
-        Total seconds allowed for the whole lookup.  Each attempt gets
-        whatever is left, so trying a second endpoint cannot double how
-        long the caller blocks.
-
-    Returns
-    -------
-    str or None
-        A validated semver string, or ``None`` if every endpoint failed.
-
-    Notes
-    -----
-    Never raises: a version lookup failing must degrade to the ``@latest``
-    URL, not break rendering.
-
-    The budget is approximate, not a hard ceiling.  It is enforced by
-    handing each attempt the remaining time as its socket timeout, and
-    ``urlopen`` applies that per blocking socket operation — connect, TLS
-    handshake, read — rather than to the call as a whole.  An endpoint
-    that stalls just under the limit at each step in turn can therefore
-    overrun the budget by a small multiple.  Name resolution is a further
-    gap: ``getaddrinfo`` is not reliably covered by a socket timeout on
-    every platform, so a broken resolver can stall past the budget before
-    any of those steps begins.
-
-    What it does bound reliably is the failure mode that actually bites:
-    a firewall blackholing packets, where each attempt would otherwise
-    burn a full timeout, and where the number of endpoints would multiply
-    the wait.  Hard-capping the total would need a watchdog thread, which
-    is not worth it for two endpoints returning sub-kilobyte payloads.
-    """
-    global _resolver_outcome
-
-    deadline = time.monotonic() + budget
-    unreachable: list[str] = []
-    answered_badly: list[str] = []
-    resolved: str | None = None
-
-    for url, key in _RESOLVER_ENDPOINTS:
-        timeout = deadline - time.monotonic()
-        if timeout <= 0:
-            _logger.debug(
-                "maidr: CDN version lookup budget spent before trying %s", url
-            )
-            # Never asked, so neither bucket: recording it as unreachable
-            # would report a spent budget as a network fault, and as
-            # answering badly would blame this code for a question it did
-            # not put. The endpoints before it already carry the verdict.
-            break
-        try:
-            # ``url`` is one of the hard-coded https:// endpoints above, never
-            # anything caller-supplied, so there is no scheme to smuggle here.
-            request = Request(
-                url,
-                headers={"Accept": "application/json", "User-Agent": "py-maidr"},
-            )
-            with urlopen(request, timeout=timeout) as response:
-                payload = json.loads(
-                    response.read(_MAX_RESOLVER_BYTES).decode("utf-8")
-                )
-        except HTTPError:
-            # The server answered; the status was one we cannot use. That
-            # is the endpoint telling us something -- a moved path, a
-            # removed package, a rate limit -- and it is a different fact
-            # from not having reached it at all.
-            _logger.debug("maidr: CDN version lookup rejected at %s", url,
-                          exc_info=True)
-            answered_badly.append(url)
-            continue
-        except (ValueError, UnicodeDecodeError):
-            # Bytes arrived and would not become JSON, or would not decode.
-            # Reached, and unusable.
-            _logger.debug("maidr: unparseable CDN version response from %s", url,
-                          exc_info=True)
-            answered_badly.append(url)
-            continue
-        except Exception:
-            # Deliberately broad, and deliberately last.  The obvious
-            # failures are OSError and HTTPException, but the contract
-            # above is that a lookup failure degrades to the ``@latest``
-            # URL rather than breaking rendering — and an exception this
-            # list did not anticipate would break it.  Sandboxes make that
-            # concrete: pytest-socket raises SocketBlockedError, which
-            # derives from Exception, not OSError, and would otherwise
-            # propagate out of render().
-            #
-            # Counted as unreachable rather than as a bad answer, because
-            # that is the safe direction: an unrecognised failure calling
-            # itself "this code is wrong" would redden a scheduled check
-            # for a network condition nobody can fix.
-            _logger.debug("maidr: CDN version lookup failed at %s", url, exc_info=True)
-            unreachable.append(url)
-            continue
-
-        candidate = payload.get(key) if isinstance(payload, dict) else None
-        if isinstance(candidate, str) and _is_valid_version(candidate.strip()):
-            resolved = candidate.strip()
-            break
-        # Answered, parsed, and said something this code cannot read: the
-        # payload has no such key, or the value is not a version. An
-        # endpoint that changed shape looks exactly like this.
-        _logger.debug("maidr: unusable CDN version %r from %s", candidate, url)
-        answered_badly.append(url)
-
-    _resolver_outcome = ResolverOutcome(
-        resolved=resolved,
-        unreachable=tuple(unreachable),
-        answered_badly=tuple(answered_badly),
-    )
-    return resolved
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 # Same grammar as :data:`_VERSION_RE`, with the parts named so
@@ -1434,6 +404,54 @@ def _bundled_asset_path(filename: str) -> Path:
 def bundled_js_path() -> Path:
     """Return the filesystem path to the bundled ``maidr.js`` file."""
     return _bundled_asset_path(MAIDR_JS_FILENAME)
+
+
+# Shared: the placeholder is an *asset* concern, and both the bundled path
+# above and `cdn.maidr_css_cdn_url` point at the same 406-byte file. Kept
+# here rather than in `cdn` so the asset side does not import the CDN side
+# -- that would close the loop the split exists to open.
+def _warn_placeholder_css(name: str, instead: str) -> None:
+    """
+    Announce that a ``maidr.css`` accessor is going away.
+
+    ``FutureWarning`` rather than ``DeprecationWarning``, which is the more
+    usual category for an API removal. Python's own guidance splits them by
+    audience: ``DeprecationWarning`` is for warnings aimed at other library
+    authors, ``FutureWarning`` for those aimed at end users of applications
+    written in Python. Someone calling this is building a dashboard or a
+    report, not extending py-maidr.
+
+    The practical half matters more. ``DeprecationWarning`` is silenced by
+    default outside ``__main__``, so a caller inside a Shiny app or an
+    imported module would never see it and would meet the removal as a
+    breakage instead of a warning -- which is the one thing a deprecation
+    cycle exists to prevent.
+
+    Parameters
+    ----------
+    name : str
+        The function being called, spelled as a path that actually
+        imports, so the message names the caller's own call rather than
+        this helper.  Fully qualified rather than assumed: only one of
+        these two is re-exported from the top-level package, so a fixed
+        ``maidr.`` prefix would name a path that raises
+        :class:`AttributeError` for the other.
+    instead : str
+        What to call in its place, in the same form the caller wanted.  The
+        two accessors return different things -- a local :class:`Path` and a
+        remote URL -- so a single suggestion would hand one of them the
+        wrong type, which is the opposite of what a deprecation message is
+        for.
+    """
+    warnings.warn(
+        f"{name}() is deprecated and will be removed in the next major "
+        "release, along with the bundled maidr.css it resolves. That file has "
+        "carried no rules since maidr 3.75.1 and nothing in py-maidr links "
+        f"it. Use {instead} for the stylesheet that does carry rules, or link "
+        "no stylesheet at all -- MAIDR styles its interface at runtime.",
+        FutureWarning,
+        stacklevel=3,
+    )
 
 
 def bundled_css_path() -> Path:
@@ -1706,6 +724,34 @@ _MOVED_TO_BUNDLE_CAPABILITY = frozenset(
     }
 )
 
+#: Names that now live in :mod:`maidr.util.cdn` (#293).
+#:
+#: Only the public ones. The resolver's *state* is deliberately absent:
+#: the shim forwards attribute **reads**, and cannot forward a **write**,
+#: so ``monkeypatch.setattr(dependencies, "urlopen", ...)`` would set an
+#: attribute nothing in ``cdn`` reads -- a patch that silently does
+#: nothing rather than one that fails. Listing the private names here
+#: would make that trap look supported. Patch ``maidr.util.cdn``.
+_MOVED_TO_CDN = frozenset(
+    {
+        "BUNDLED_TAG",
+        "CDN_TIMEOUT_ENV_VAR",
+        "CDN_VERSION_ENV_VAR",
+        "LATEST_TAG",
+        "MAIDR_CSS_CDN_URL",
+        "MAIDR_JS_CDN_URL",
+        "ResolverOutcome",
+        "bundled_cdn_url",
+        "cdn_url",
+        "get_cdn_version",
+        "maidr_css_cdn_url",
+        "maidr_js_cdn_url",
+        "reset_cdn_version_cache",
+        "set_cdn_version",
+        "unresolved_cdn_url",
+    }
+)
+
 #: Names that now live in :mod:`maidr.util.bundle_freshness` (#293).
 _MOVED_TO_BUNDLE_FRESHNESS = frozenset(
     {
@@ -1741,7 +787,10 @@ def __dir__() -> list[str]:
         Everything defined here, plus the names that moved.
     """
     return sorted(
-        set(globals()) | _MOVED_TO_BUNDLE_CAPABILITY | _MOVED_TO_BUNDLE_FRESHNESS
+        set(globals())
+        | _MOVED_TO_CDN
+        | _MOVED_TO_BUNDLE_CAPABILITY
+        | _MOVED_TO_BUNDLE_FRESHNESS
     )
 
 
@@ -1770,6 +819,11 @@ def __getattr__(name: str) -> object:
     AttributeError
         For anything else, which is what Python expects here.
     """
+    if name in _MOVED_TO_CDN:
+        from maidr.util import cdn
+
+        return getattr(cdn, name)
+
     if name in _MOVED_TO_BUNDLE_CAPABILITY:
         from maidr.util import bundle_capability
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from matplotlib import pyplot as plt
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.enum.library import Library
 from maidr.util import bundle_freshness as freshness
-from maidr.util import dependencies
+from maidr.util import cdn
 from maidr.util import warn as warn_module
 from tests.fixture.matplotlib_factory import MatplotlibFactory
 from tests.fixture.seaborn_factory import SeabornFactory
@@ -25,7 +25,7 @@ def offline_cdn_version(monkeypatch):
     a warning raised by one test cannot suppress the same warning in the
     next.
     """
-    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, dependencies.LATEST_TAG)
+    monkeypatch.setenv(cdn.CDN_VERSION_ENV_VAR, cdn.LATEST_TAG)
     monkeypatch.setattr(freshness, "_bundle_warned", set())
     monkeypatch.setattr(warn_module, "_warned_keys", set())
 
@@ -36,12 +36,12 @@ def offline_cdn_version(monkeypatch):
     # quietly reach jsDelivr and depend on whatever is published today.
     # Tests that want a resolution replace this with their own stub.
     def _no_network(*_args, **_kwargs):
-        raise OSError("network disabled in tests; stub dependencies.urlopen")
+        raise OSError("network disabled in tests; stub cdn.urlopen")
 
-    monkeypatch.setattr(dependencies, "urlopen", _no_network)
-    dependencies.set_cdn_version(None)
+    monkeypatch.setattr(cdn, "urlopen", _no_network)
+    cdn.set_cdn_version(None)
     yield
-    dependencies.set_cdn_version(None)
+    cdn.set_cdn_version(None)
 
 
 # setup and teardown
@@ -80,17 +80,17 @@ def forbid_network():
     of these probes were silently vacuous for exactly that reason.
     """
     calls: list[str] = []
-    real_urlopen = dependencies.urlopen
+    real_urlopen = cdn.urlopen
 
     def recording(request, timeout=None):
         calls.append(getattr(request, "full_url", str(request)))
         raise OSError("network disabled in tests")
 
-    dependencies.urlopen = recording
+    cdn.urlopen = recording
     try:
         yield calls
     finally:
-        dependencies.urlopen = real_urlopen
+        cdn.urlopen = real_urlopen
     assert not calls, f"expected no network call, got: {calls}"
 
 

--- a/tests/core/test_broken_bundle_version.py
+++ b/tests/core/test_broken_bundle_version.py
@@ -22,6 +22,7 @@ import logging
 
 import pytest
 
+from maidr.util import cdn
 from maidr.util import dependencies
 from maidr.util import warn as warn_module
 
@@ -29,13 +30,13 @@ from maidr.util import warn as warn_module
 @pytest.fixture
 def no_pin(monkeypatch):
     """Clear every pin and cached lookup, and re-arm the one-shot warning."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
-    dependencies.reset_cdn_version_cache()
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
+    cdn.reset_cdn_version_cache()
     warn_module._warned_keys.clear()
     yield
-    dependencies.set_cdn_version(None)
-    dependencies.reset_cdn_version_cache()
+    cdn.set_cdn_version(None)
+    cdn.reset_cdn_version_cache()
     # `maidr_js_version` is not cleared here. `monkeypatch` tears down after
     # this fixture, so the name still points at `break_bundle`'s stand-in --
     # a plain function, with no `cache_clear` on it. `break_bundle` clears the
@@ -58,11 +59,11 @@ def test_an_unreadable_bundle_version_says_so(monkeypatch, caplog, no_pin) -> No
     break_bundle(monkeypatch)
 
     with caplog.at_level(logging.WARNING):
-        version = dependencies._offline_version()
+        version = cdn._offline_version()
 
-    assert version == dependencies.LATEST_TAG
+    assert version == cdn.LATEST_TAG
     assert "missing or empty" in caplog.text
-    assert dependencies.LATEST_TAG in caplog.text
+    assert cdn.LATEST_TAG in caplog.text
     assert "cache" in caplog.text
 
 
@@ -78,7 +79,7 @@ def test_a_garbled_version_is_named_in_the_warning(
     break_bundle(monkeypatch, "not-a-version")
 
     with caplog.at_level(logging.WARNING):
-        dependencies._offline_version()
+        cdn._offline_version()
 
     assert "not a version" in caplog.text
     assert "not-a-version" in caplog.text
@@ -94,7 +95,7 @@ def test_it_is_said_once_not_once_per_figure(monkeypatch, caplog, no_pin) -> Non
 
     with caplog.at_level(logging.WARNING):
         for _ in range(5):
-            dependencies._offline_version()
+            cdn._offline_version()
 
     assert caplog.text.count("maidr.js version") == 1
 
@@ -112,10 +113,10 @@ def test_a_failed_lookup_stays_quiet(monkeypatch, caplog, no_pin) -> None:
     it. The warning is about the broken install, not about being offline,
     and a healthy bundle is what keeps it quiet here.
     """
-    monkeypatch.setattr(dependencies, "_fetch_latest_version", lambda budget: None)
+    monkeypatch.setattr(cdn, "_fetch_latest_version", lambda budget: None)
 
     with caplog.at_level(logging.WARNING):
-        version = dependencies.get_cdn_version()
+        version = cdn.get_cdn_version()
 
     assert version == dependencies.maidr_js_version()
     assert "maidr.js version" not in caplog.text
@@ -124,7 +125,7 @@ def test_a_failed_lookup_stays_quiet(monkeypatch, caplog, no_pin) -> None:
 def test_a_working_bundle_stays_quiet(caplog, no_pin) -> None:
     """The control: the overwhelmingly common case says nothing."""
     with caplog.at_level(logging.WARNING):
-        version = dependencies._offline_version()
+        version = cdn._offline_version()
 
     assert version == dependencies.maidr_js_version()
     assert "maidr.js version" not in caplog.text
@@ -137,10 +138,10 @@ def test_a_pin_is_answered_before_the_bundle(monkeypatch, caplog, no_pin) -> Non
     install behind an explicit pin is not this warning's business.
     """
     break_bundle(monkeypatch)
-    dependencies.set_cdn_version("3.74.0")
+    cdn.set_cdn_version("3.74.0")
 
     with caplog.at_level(logging.WARNING):
-        version = dependencies._offline_version()
+        version = cdn._offline_version()
 
     assert version == "3.74.0"
     assert "maidr.js version" not in caplog.text

--- a/tests/core/test_bundle_capability.py
+++ b/tests/core/test_bundle_capability.py
@@ -496,7 +496,9 @@ def test_the_shim_must_stay_lazy():
     offenders = [
         (lineno, text)
         for lineno, text in imports
-        if "bundle_capability" in text or "bundle_freshness" in text
+        if "bundle_capability" in text
+        or "bundle_freshness" in text
+        or "cdn" in text
     ]
 
     assert not offenders, (

--- a/tests/core/test_bundle_freshness.py
+++ b/tests/core/test_bundle_freshness.py
@@ -24,6 +24,7 @@ import maidr
 import maidr.util.environment
 from maidr import api as maidr_api
 from maidr.util import bundle_freshness as freshness
+from maidr.util import cdn
 from maidr.util import dependencies
 from maidr.util import warn as warn_module
 
@@ -86,14 +87,14 @@ def published(monkeypatch):
     """
 
     def _set(version: str) -> None:
-        monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-        dependencies.set_cdn_version(None)
+        monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+        cdn.set_cdn_version(None)
 
         def fake_urlopen(request, timeout=None):
             payload = json.dumps({"version": version, "latest": version})
             return _FakeResponse(payload.encode("utf-8"))
 
-        monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+        monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
     return _set
 
@@ -162,7 +163,7 @@ def test_a_pin_does_not_stand_in_for_the_published_version(bundled, published):
 
     assert status.published == "3.74.0", "published must come from the lookup"
     # The pin still decides what the emitted URL serves.
-    assert "maidr@9.9.9/" in dependencies.maidr_js_cdn_url()
+    assert "maidr@9.9.9/" in cdn.maidr_js_cdn_url()
 
 
 def test_backwards_pin_cannot_conceal_a_stale_bundle(bundled, published):
@@ -187,8 +188,8 @@ def test_bundle_status_missing_bundle_is_not_reported_as_stale(bundled, publishe
 def test_bundle_status_resolve_false_never_hits_the_network(
     monkeypatch, bundled, forbid_network
 ):
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     bundled("3.66.1")
 
     status = maidr.bundle_status(resolve=False)
@@ -256,8 +257,8 @@ def test_env_var_silences_the_warning(disabled, monkeypatch, bundled, published)
 def test_warning_never_resolves_over_the_network(
     monkeypatch, bundled, forbid_network
 ):
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     bundled("3.66.1")
 
     with no_stale_bundle_warning():
@@ -425,8 +426,8 @@ def test_init_notebook_use_cdn_false_never_resolves_when_bundle_missing(
     works; building those URLs must not resolve a version, or an
     explicitly offline session pays for a lookup it opted out of.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     monkeypatch.setattr(
         maidr_api, "_NOTEBOOK_LOADED", False, raising=False
@@ -467,8 +468,8 @@ def test_offline_render_with_unknown_published_version_is_silent(
     bar_plot, monkeypatch, bundled, forbid_network
 ):
     """No network, nothing known: say nothing rather than guess."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     bundled("3.66.1")
 
     with no_stale_bundle_warning():
@@ -481,8 +482,8 @@ def test_init_notebook_makes_no_network_call(monkeypatch, forbid_network):
     Resolving here would put a blocking request inside ``import maidr``,
     before the user can apply any of the documented opt-outs.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     monkeypatch.setattr(maidr_api, "_NOTEBOOK_LOADED", False, raising=False)
     monkeypatch.setattr(
         maidr.util.environment.Environment, "is_notebook", staticmethod(lambda: True)

--- a/tests/core/test_cdn_event_loop.py
+++ b/tests/core/test_cdn_event_loop.py
@@ -27,6 +27,7 @@ import json
 
 import pytest
 
+from maidr.util import cdn
 from maidr.util import dependencies
 
 
@@ -47,9 +48,9 @@ def requests(monkeypatch):
     Yields the list of requested URLs, so a test can say "no request was
     made" as a fact about the network rather than about the clock.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
-    dependencies.reset_cdn_version_cache()
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
+    cdn.reset_cdn_version_cache()
 
     calls: list[str] = []
 
@@ -57,11 +58,11 @@ def requests(monkeypatch):
         calls.append(request.full_url)
         return _FakeResponse(json.dumps({"version": "9.9.9"}).encode("utf-8"))
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
     yield calls
 
-    dependencies.set_cdn_version(None)
-    dependencies.reset_cdn_version_cache()
+    cdn.set_cdn_version(None)
+    cdn.reset_cdn_version_cache()
 
 
 def in_loop(call):
@@ -80,7 +81,7 @@ def test_a_render_on_an_event_loop_makes_no_request(requests) -> None:
     what the user experiences, but the *cause* is the round trip, and that is
     the thing a test can state without measuring a shared CI runner.
     """
-    version = in_loop(dependencies.get_cdn_version)
+    version = in_loop(cdn.get_cdn_version)
 
     assert requests == []
     assert version == dependencies.maidr_js_version()
@@ -88,7 +89,7 @@ def test_a_render_on_an_event_loop_makes_no_request(requests) -> None:
 
 def test_a_synchronous_render_still_resolves(requests) -> None:
     """The control. Nothing outside an event loop changes."""
-    version = dependencies.get_cdn_version()
+    version = cdn.get_cdn_version()
 
     assert len(requests) == 1
     assert version == "9.9.9"
@@ -102,18 +103,18 @@ def test_the_version_emitted_on_a_loop_is_concrete(requests) -> None:
     can replay a week-old bundle. Declining to resolve must not quietly
     reintroduce it.
     """
-    url = in_loop(dependencies.maidr_js_cdn_url)
+    url = in_loop(cdn.maidr_js_cdn_url)
 
     assert requests == []
-    assert f"maidr@{dependencies.LATEST_TAG}/" not in url
+    assert f"maidr@{cdn.LATEST_TAG}/" not in url
     assert f"maidr@{dependencies.maidr_js_version()}/" in url
 
 
 def test_an_explicit_pin_still_wins_on_a_loop(requests) -> None:
     """A pin is the caller's own answer and costs no request either way."""
-    dependencies.set_cdn_version("3.74.0")
+    cdn.set_cdn_version("3.74.0")
 
-    assert in_loop(dependencies.get_cdn_version) == "3.74.0"
+    assert in_loop(cdn.get_cdn_version) == "3.74.0"
     assert requests == []
 
 
@@ -125,9 +126,9 @@ def test_a_completed_lookup_is_used_on_a_loop(requests) -> None:
     main thread agree. It is also the supported way for an async app to
     serve a release newer than its wheel.
     """
-    assert dependencies.get_cdn_version() == "9.9.9"
+    assert cdn.get_cdn_version() == "9.9.9"
 
-    assert in_loop(dependencies.get_cdn_version) == "9.9.9"
+    assert in_loop(cdn.get_cdn_version) == "9.9.9"
     assert len(requests) == 1
 
 
@@ -141,11 +142,11 @@ def test_a_cached_failure_is_not_retried_on_a_loop(monkeypatch, requests) -> Non
     agreeing is the point: after any resolution attempt, context stops
     mattering.
     """
-    monkeypatch.setattr(dependencies, "_fetch_latest_version", lambda budget: None)
+    monkeypatch.setattr(cdn, "_fetch_latest_version", lambda budget: None)
 
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
 
-    assert in_loop(dependencies.get_cdn_version) == dependencies.maidr_js_version()
+    assert in_loop(cdn.get_cdn_version) == dependencies.maidr_js_version()
     assert requests == []
 
 
@@ -166,7 +167,7 @@ def test_interleaved_renders_on_one_loop_all_return(requests) -> None:
 
     async def one_render():
         await asyncio.sleep(0)
-        return dependencies.get_cdn_version()
+        return cdn.get_cdn_version()
 
     async def main():
         return await asyncio.gather(*[one_render() for _ in range(4)])
@@ -186,18 +187,18 @@ def test_bundled_cdn_url_still_prefers_a_pin_then_a_lookup(requests) -> None:
     iframe emitted the pinned one, and one page loaded two builds of
     ``maidr.js``.
     """
-    dependencies.set_cdn_version("3.74.0")
-    assert "maidr@3.74.0/" in dependencies.bundled_cdn_url(
+    cdn.set_cdn_version("3.74.0")
+    assert "maidr@3.74.0/" in cdn.bundled_cdn_url(
         dependencies.MAIDR_JS_FILENAME
     )
 
-    dependencies.set_cdn_version(None)
-    assert dependencies.get_cdn_version() == "9.9.9"
-    assert "maidr@9.9.9/" in dependencies.bundled_cdn_url(
+    cdn.set_cdn_version(None)
+    assert cdn.get_cdn_version() == "9.9.9"
+    assert "maidr@9.9.9/" in cdn.bundled_cdn_url(
         dependencies.MAIDR_JS_FILENAME
     )
 
-    dependencies.reset_cdn_version_cache()
-    assert f"maidr@{dependencies.maidr_js_version()}/" in dependencies.bundled_cdn_url(
+    cdn.reset_cdn_version_cache()
+    assert f"maidr@{dependencies.maidr_js_version()}/" in cdn.bundled_cdn_url(
         dependencies.MAIDR_JS_FILENAME
     )

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -26,6 +26,7 @@ import pytest
 
 import maidr
 from maidr.util import bundle_freshness as freshness
+from maidr.util import cdn
 from maidr.util import dependencies
 from maidr.util import warn as warn_module
 
@@ -66,8 +67,8 @@ def resolvable(monkeypatch):
     Returns the list of requested URLs so tests can assert how many
     round trips actually happened.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     calls: list[str] = []
 
@@ -75,9 +76,9 @@ def resolvable(monkeypatch):
         calls.append(request.full_url)
         return _json_response({"version": "9.9.9", "latest": "9.9.9"})
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
     yield calls
-    dependencies.set_cdn_version(None)
+    cdn.set_cdn_version(None)
 
 
 class _FakeResponse(io.BytesIO):
@@ -101,13 +102,13 @@ def _json_response(payload: dict) -> _FakeResponse:
 
 def test_set_cdn_version_pins_concrete_version():
     maidr.set_cdn_version("3.74.0")
-    assert dependencies.get_cdn_version() == "3.74.0"
+    assert cdn.get_cdn_version() == "3.74.0"
     assert (
-        dependencies.maidr_js_cdn_url()
+        cdn.maidr_js_cdn_url()
         == "https://cdn.jsdelivr.net/npm/maidr@3.74.0/dist/maidr.js"
     )
     assert (
-        dependencies.maidr_css_cdn_url()
+        cdn.maidr_css_cdn_url()
         == "https://cdn.jsdelivr.net/npm/maidr@3.74.0/dist/maidr.css"
     )
     # No render path emits this one -- maidr.js resolves the maths
@@ -115,33 +116,33 @@ def test_set_cdn_version_pins_concrete_version():
     # has to name it for `window.maidrMathStylesheetUrl`, and it resolves
     # through the same helper as everything else.
     assert (
-        dependencies.cdn_url(dependencies.MAIDR_MATH_CSS_FILENAME)
+        cdn.cdn_url(dependencies.MAIDR_MATH_CSS_FILENAME)
         == "https://cdn.jsdelivr.net/npm/maidr@3.74.0/dist/maidr-math.css"
     )
 
 
 def test_set_cdn_version_accepts_v_prefix():
     maidr.set_cdn_version("v3.74.0")
-    assert dependencies.get_cdn_version() == "3.74.0"
+    assert cdn.get_cdn_version() == "3.74.0"
 
 
 def test_set_cdn_version_accepts_prerelease():
     maidr.set_cdn_version("3.74.0-beta.1")
-    assert dependencies.get_cdn_version() == "3.74.0-beta.1"
+    assert cdn.get_cdn_version() == "3.74.0-beta.1"
 
 
 def test_latest_tag_opts_out_of_resolution(forbid_network):
     """``latest`` keeps the legacy URL and makes no network request."""
     maidr.set_cdn_version("latest")
 
-    assert dependencies.get_cdn_version() == "latest"
-    assert dependencies.maidr_js_cdn_url() == dependencies.MAIDR_JS_CDN_URL
+    assert cdn.get_cdn_version() == "latest"
+    assert cdn.maidr_js_cdn_url() == cdn.MAIDR_JS_CDN_URL
 
 
 def test_bundled_tag_uses_shipped_version(forbid_network):
     maidr.set_cdn_version("bundled")
 
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
 
 
 def test_bundled_version_file_is_read_once(monkeypatch):
@@ -163,8 +164,8 @@ def test_bundled_version_file_is_read_once(monkeypatch):
     try:
         maidr.set_cdn_version("bundled")
         for _ in range(10):
-            dependencies.maidr_js_cdn_url()
-            dependencies.maidr_css_cdn_url()
+            cdn.maidr_js_cdn_url()
+            cdn.maidr_css_cdn_url()
         assert reads["n"] == 1, f"read VERSION {reads['n']} times, expected 1"
     finally:
         # Drop the value cached through the counting stub.
@@ -182,20 +183,20 @@ def test_bundled_tag_with_broken_version_stays_offline(monkeypatch, forbid_netwo
     )
     maidr.set_cdn_version("bundled")
 
-    assert dependencies.get_cdn_version() == dependencies.LATEST_TAG
-    assert dependencies.maidr_js_cdn_url() == dependencies.MAIDR_JS_CDN_URL
+    assert cdn.get_cdn_version() == cdn.LATEST_TAG
+    assert cdn.maidr_js_cdn_url() == cdn.MAIDR_JS_CDN_URL
 
 
 def test_env_var_pins_version(monkeypatch):
-    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, "3.70.1")
-    dependencies.set_cdn_version(None)
-    assert dependencies.get_cdn_version() == "3.70.1"
+    monkeypatch.setenv(cdn.CDN_VERSION_ENV_VAR, "3.70.1")
+    cdn.set_cdn_version(None)
+    assert cdn.get_cdn_version() == "3.70.1"
 
 
 def test_set_cdn_version_overrides_env_var(monkeypatch):
-    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, "3.70.1")
+    monkeypatch.setenv(cdn.CDN_VERSION_ENV_VAR, "3.70.1")
     maidr.set_cdn_version("3.74.0")
-    assert dependencies.get_cdn_version() == "3.74.0"
+    assert cdn.get_cdn_version() == "3.74.0"
 
 
 @pytest.mark.parametrize(
@@ -355,8 +356,8 @@ def test_invalid_pin_logs_once_not_once_per_render(resolvable, caplog):
 
     with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         for _ in range(5):
-            dependencies.maidr_js_cdn_url()
-            dependencies.maidr_css_cdn_url()
+            cdn.maidr_js_cdn_url()
+            cdn.maidr_css_cdn_url()
 
     complaints = [r for r in caplog.records if "invalid CDN version pin" in r.message]
     assert len(complaints) == 1, f"logged {len(complaints)} times, expected 1"
@@ -368,9 +369,9 @@ def test_a_second_bad_pin_still_warns(resolvable, caplog):
 
     with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         maidr.set_cdn_version("3.74")
-        dependencies.maidr_js_cdn_url()
+        cdn.maidr_js_cdn_url()
         maidr.set_cdn_version("nonsense")
-        dependencies.maidr_js_cdn_url()
+        cdn.maidr_js_cdn_url()
 
     complaints = [r for r in caplog.records if "invalid CDN version pin" in r.message]
     assert len(complaints) == 2
@@ -386,7 +387,7 @@ def test_warned_keys_stays_bounded(resolvable):
     """
     for i in range(warn_module._MAX_WARNED_KEYS * 3):
         maidr.set_cdn_version(f"bad-{i}")
-        dependencies.maidr_js_cdn_url()
+        cdn.maidr_js_cdn_url()
 
     assert len(warn_module._warned_keys) <= warn_module._MAX_WARNED_KEYS
 
@@ -411,7 +412,7 @@ def test_invalid_pin_never_reaches_the_url(hostile, resolvable):
     """
     with pytest.warns(FutureWarning, match="set_cdn_version"):
         maidr.set_cdn_version(hostile)
-    url = dependencies.maidr_js_cdn_url()
+    url = cdn.maidr_js_cdn_url()
 
     assert hostile not in url
     # Falls through to normal resolution, which the fixture stubs.
@@ -424,7 +425,12 @@ def test_no_render_path_references_the_unresolved_constants():
     ``MAIDR_JS_CDN_URL`` / ``MAIDR_CSS_CDN_URL`` are kept for backwards
     compatibility and as the lookup's fallback, but a render path that
     reaches for one silently reintroduces the stale-cache bug this module
-    exists to fix. Only ``dependencies.py`` itself may name them.
+    exists to fix. Only ``cdn.py``, which now owns them, and the shim in
+    ``dependencies.py`` that forwards them, may name them.
+
+    #293 recorded this exclusion as the thing that would need updating
+    once a module other than ``dependencies`` owned the constants; the
+    ``cdn.py`` cut is that moment, and this is that update.
 
     This is a text scan, not an import graph, so a mere *mention* — in a
     docstring or a comment — counts as a reference. That is deliberate
@@ -432,11 +438,16 @@ def test_no_render_path_references_the_unresolved_constants():
     means the failure is sometimes about prose rather than about a real
     call, which the message below says out loud.
     """
-    package_root = Path(dependencies.__file__).resolve().parent.parent
+    package_root = Path(cdn.__file__).resolve().parent.parent
+    # Two files may name them: ``cdn.py``, which owns them, and
+    # ``dependencies.py``, whose ``_MOVED_TO_CDN`` set lists them so the
+    # back-compat shim can forward the old import path. A forwarding list
+    # is not a render path, which is what this guard is about.
+    allowed = {Path(cdn.__file__).resolve(), Path(dependencies.__file__).resolve()}
     offenders = [
         path.relative_to(package_root).as_posix()
         for path in package_root.rglob("*.py")
-        if path.resolve() != Path(dependencies.__file__).resolve()
+        if path.resolve() not in allowed
         and re.search(r"MAIDR_(?:JS|CSS)_CDN_URL", path.read_text(encoding="utf-8"))
     ]
     assert not offenders, (
@@ -453,9 +464,9 @@ def test_no_render_path_references_the_unresolved_constants():
 
 
 def test_latest_is_resolved_to_a_concrete_version(resolvable):
-    assert dependencies.get_cdn_version() == "9.9.9"
+    assert cdn.get_cdn_version() == "9.9.9"
     assert (
-        dependencies.maidr_js_cdn_url()
+        cdn.maidr_js_cdn_url()
         == "https://cdn.jsdelivr.net/npm/maidr@9.9.9/dist/maidr.js"
     )
     assert len(resolvable) == 1, "resolution should need a single round trip"
@@ -463,23 +474,23 @@ def test_latest_is_resolved_to_a_concrete_version(resolvable):
 
 def test_resolution_is_cached_for_the_process(resolvable):
     for _ in range(5):
-        dependencies.maidr_js_cdn_url()
-        dependencies.maidr_css_cdn_url()
+        cdn.maidr_js_cdn_url()
+        cdn.maidr_css_cdn_url()
 
     assert len(resolvable) == 1, "version lookup must not repeat per render"
 
 
 def test_reset_cache_forces_a_new_lookup(resolvable):
-    dependencies.get_cdn_version()
-    dependencies.reset_cdn_version_cache()
-    dependencies.get_cdn_version()
+    cdn.get_cdn_version()
+    cdn.reset_cdn_version_cache()
+    cdn.get_cdn_version()
 
     assert len(resolvable) == 2
 
 
 def test_falls_back_to_npm_registry_when_jsdelivr_fails(monkeypatch):
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     calls: list[str] = []
 
     def fake_urlopen(request, timeout=None):
@@ -488,9 +499,9 @@ def test_falls_back_to_npm_registry_when_jsdelivr_fails(monkeypatch):
             raise OSError("jsDelivr unreachable")
         return _json_response({"latest": "4.1.0"})
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == "4.1.0"
+    assert cdn.get_cdn_version() == "4.1.0"
     assert len(calls) == 2
 
 
@@ -504,25 +515,25 @@ def test_offline_falls_back_to_the_bundled_version(monkeypatch):
     build (#295). The bundled version is immutable and is the copy this
     wheel would have served anyway.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     calls: list[str] = []
 
     def fake_urlopen(request, timeout=None):
         calls.append(request.full_url)
         raise OSError("network is unreachable")
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
-    assert dependencies.maidr_js_cdn_url() == (
+    assert cdn.maidr_js_cdn_url() == (
         "https://cdn.jsdelivr.net/npm/maidr@"
         f"{dependencies.maidr_js_version()}/dist/maidr.js"
     )
     # Failure is cached too, so an offline session does not stall on a
     # doomed request for every figure it renders.
-    dependencies.maidr_js_cdn_url()
-    dependencies.maidr_css_cdn_url()
-    assert len(calls) == len(dependencies._RESOLVER_ENDPOINTS)
+    cdn.maidr_js_cdn_url()
+    cdn.maidr_css_cdn_url()
+    assert len(calls) == len(cdn._RESOLVER_ENDPOINTS)
 
 
 def test_non_object_resolver_response_is_unusable(monkeypatch):
@@ -533,54 +544,54 @@ def test_non_object_resolver_response_is_unusable(monkeypatch):
     so the guard that keeps this a "no answer" rather than a traceback is
     worth pinning.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     def fake_urlopen(request, timeout=None):
         return _json_response([{"version": "9.9.9"}])
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
 
 
 def test_malformed_resolver_response_falls_back(monkeypatch):
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     def fake_urlopen(request, timeout=None):
         return _FakeResponse(b"<!DOCTYPE html><html>error</html>")
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
 
 
 def test_hostile_resolver_version_is_rejected(monkeypatch):
     """A compromised resolver cannot steer the URL at another path."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     def fake_urlopen(request, timeout=None):
         return _json_response({"version": "../../evil", "latest": "../../evil"})
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
-    assert "evil" not in dependencies.maidr_js_cdn_url()
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
+    assert "evil" not in cdn.maidr_js_cdn_url()
 
 
 def test_timeout_env_var_is_honoured(monkeypatch):
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, "0.25")
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, "0.25")
+    cdn.set_cdn_version(None)
     seen: list[float | None] = []
 
     def fake_urlopen(request, timeout=None):
         seen.append(timeout)
         return _json_response({"version": "9.9.9"})
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
-    dependencies.get_cdn_version()
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
+    cdn.get_cdn_version()
 
     assert len(seen) == 1
     assert 0 < seen[0] <= 0.25
@@ -588,9 +599,9 @@ def test_timeout_env_var_is_honoured(monkeypatch):
 
 def test_timeout_is_a_total_budget_across_endpoints(monkeypatch):
     """A fallback endpoint must not double how long a first render blocks."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, "2.0")
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, "2.0")
+    cdn.set_cdn_version(None)
     seen: list[float] = []
 
     def fake_urlopen(request, timeout=None):
@@ -599,11 +610,11 @@ def test_timeout_is_a_total_budget_across_endpoints(monkeypatch):
         time.sleep(0.2)
         raise OSError("unreachable")
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
 
-    assert len(seen) == len(dependencies._RESOLVER_ENDPOINTS)
+    assert len(seen) == len(cdn._RESOLVER_ENDPOINTS)
     # Each attempt gets only what is left of the budget, so the timeouts
     # shrink. This is the deterministic part of the guarantee; a
     # wall-clock assertion would add nothing but CI flakiness, since the
@@ -613,9 +624,9 @@ def test_timeout_is_a_total_budget_across_endpoints(monkeypatch):
 
 
 def test_budget_exhaustion_skips_remaining_endpoints(monkeypatch):
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, "0.15")
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, "0.15")
+    cdn.set_cdn_version(None)
     calls: list[str] = []
 
     def fake_urlopen(request, timeout=None):
@@ -623,16 +634,16 @@ def test_budget_exhaustion_skips_remaining_endpoints(monkeypatch):
         time.sleep(0.2)  # spends the whole budget on the first attempt
         raise OSError("unreachable")
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
     assert len(calls) == 1, "second endpoint should be skipped once spent"
 
 
 @pytest.mark.parametrize("bad", ["", "abc", "-1", "0", "nan", "inf", "-inf"])
 def test_invalid_timeout_falls_back_to_default(bad, monkeypatch):
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, bad)
-    assert dependencies._cdn_timeout() == dependencies._DEFAULT_CDN_TIMEOUT
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, bad)
+    assert cdn._cdn_timeout() == cdn._DEFAULT_CDN_TIMEOUT
 
 
 def test_oversized_timeout_is_clamped(monkeypatch, caplog):
@@ -641,10 +652,10 @@ def test_oversized_timeout_is_clamped(monkeypatch, caplog):
     ``MAIDR_CDN_TIMEOUT=3000`` read as seconds would block for fifty
     minutes before a plot appeared.
     """
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, "3000")
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, "3000")
 
     with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
-        assert dependencies._cdn_timeout() == dependencies._MAX_CDN_TIMEOUT
+        assert cdn._cdn_timeout() == cdn._MAX_CDN_TIMEOUT
 
     assert any("clamped" in r.message for r in caplog.records), (
         "clamping must be visible, not silent"
@@ -652,8 +663,8 @@ def test_oversized_timeout_is_clamped(monkeypatch, caplog):
 
 
 def test_timeout_just_under_the_cap_is_honoured(monkeypatch):
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, "29")
-    assert dependencies._cdn_timeout() == 29.0
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, "29")
+    assert cdn._cdn_timeout() == 29.0
 
 
 # ---------------------------------------------------------------------------
@@ -693,8 +704,8 @@ def test_save_html_use_cdn_auto_emits_versioned_url(bar_plot, tmp_path):
 
 def test_render_use_cdn_false_never_resolves(bar_plot, monkeypatch, forbid_network):
     """Offline rendering must not make a version-lookup request."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     maidr.render(bar_plot, use_cdn=False)
 
 
@@ -758,8 +769,8 @@ def test_concurrent_resolution_makes_one_lookup(monkeypatch):
     This one has teeth: with the lock removed, all 32 threads make their
     own request instead of one.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     calls: list[str] = []
     calls_lock = threading.Lock()
 
@@ -773,13 +784,13 @@ def test_concurrent_resolution_makes_one_lookup(monkeypatch):
         time.sleep(0.05)
         return _json_response({"version": "9.9.9", "latest": "9.9.9"})
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
     results: list[str] = []
     results_lock = threading.Lock()
 
     def resolve():
-        value = dependencies.get_cdn_version()
+        value = cdn.get_cdn_version()
         with results_lock:
             results.append(value)
 
@@ -820,8 +831,8 @@ def test_concurrent_staleness_warning_emits_once(monkeypatch):
     """
     monkeypatch.setattr(freshness, "_bundle_warned", set())
     monkeypatch.setattr(dependencies, "maidr_js_version", lambda: "3.66.1")
-    monkeypatch.setattr(dependencies, "_resolved_cdn_version", "3.74.0")
-    monkeypatch.setattr(dependencies, "_resolution_attempted", True)
+    monkeypatch.setattr(cdn, "_resolved_cdn_version", "3.74.0")
+    monkeypatch.setattr(cdn, "_resolution_attempted", True)
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -837,8 +848,8 @@ def test_blank_pin_clears_rather_than_falling_through(blank, resolvable):
     maidr.set_cdn_version("3.70.1")
     maidr.set_cdn_version(blank)
 
-    assert dependencies._cdn_version_override is None
-    assert dependencies.get_cdn_version() == "9.9.9"
+    assert cdn._cdn_version_override is None
+    assert cdn.get_cdn_version() == "9.9.9"
 
 
 def test_bundle_status_type_is_exported():
@@ -874,10 +885,10 @@ def test_build_metadata_is_ignored_for_precedence():
 @pytest.mark.parametrize("bad", ["abc", "-1", "0", "nan", "inf"])
 def test_unusable_timeout_is_reported_not_silently_replaced(bad, monkeypatch, caplog):
     """The clamp warns, so the other rejections should too."""
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, bad)
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, bad)
 
     with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
-        assert dependencies._cdn_timeout() == dependencies._DEFAULT_CDN_TIMEOUT
+        assert cdn._cdn_timeout() == cdn._DEFAULT_CDN_TIMEOUT
 
     assert caplog.records, f"{bad!r} was replaced with the default in silence"
 
@@ -899,21 +910,21 @@ def test_bundle_status_resolves_even_when_pinned_to_latest(monkeypatch):
     has no answer otherwise. Pin the behaviour so the docs and the code
     cannot drift apart.
     """
-    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, dependencies.LATEST_TAG)
-    dependencies.set_cdn_version(None)
+    monkeypatch.setenv(cdn.CDN_VERSION_ENV_VAR, cdn.LATEST_TAG)
+    cdn.set_cdn_version(None)
     calls: list[str] = []
 
     def fake_urlopen(request, timeout=None):
         calls.append(request.full_url)
         return _json_response({"version": "9.9.9", "latest": "9.9.9"})
 
-    monkeypatch.setattr(dependencies, "urlopen", fake_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", fake_urlopen)
 
     assert maidr.bundle_status().published == "9.9.9"
     assert calls, "bundle_status() should resolve despite the pin"
 
     # ...and resolve=False is the way to keep it quiet.
-    dependencies.reset_cdn_version_cache()
+    cdn.reset_cdn_version_cache()
     calls.clear()
     assert maidr.bundle_status(resolve=False).published is None
     assert not calls
@@ -926,10 +937,10 @@ def test_ordinary_timeout_passes_through_untouched(value, monkeypatch, caplog):
     The boundaries are covered elsewhere; this closes the loop by
     asserting the common case is neither clamped nor complained about.
     """
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, value)
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, value)
 
     with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
-        assert dependencies._cdn_timeout() == float(value)
+        assert cdn._cdn_timeout() == float(value)
 
     assert not caplog.records, f"{value!r} should be accepted silently"
 
@@ -957,8 +968,8 @@ def test_version_key_never_raises_on_a_shape_that_slips_through(monkeypatch):
 
 def test_resolver_response_read_is_capped(monkeypatch):
     """An oversized body must be truncated, not slurped whole."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     requested: list[int | None] = []
 
     class _HugeResponse(_FakeResponse):
@@ -968,12 +979,12 @@ def test_resolver_response_read_is_capped(monkeypatch):
 
     payload = b'{"version": "9.9.9", "pad": "' + b"x" * (256 * 1024) + b'"}'
     monkeypatch.setattr(
-        dependencies, "urlopen", lambda request, timeout=None: _HugeResponse(payload)
+        cdn, "urlopen", lambda request, timeout=None: _HugeResponse(payload)
     )
 
-    dependencies.get_cdn_version()
+    cdn.get_cdn_version()
 
-    assert requested and requested[0] == dependencies._MAX_RESOLVER_BYTES, (
+    assert requested and requested[0] == cdn._MAX_RESOLVER_BYTES, (
         f"read the body with size={requested[0]!r}, expected the cap"
     )
 
@@ -989,17 +1000,17 @@ def test_non_oserror_from_urlopen_does_not_escape(bar_plot, monkeypatch):
     class SocketBlockedError(Exception):
         pass
 
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     def blocked(*_args, **_kwargs):
         raise SocketBlockedError("network access blocked in this environment")
 
-    monkeypatch.setattr(dependencies, "urlopen", blocked)
+    monkeypatch.setattr(cdn, "urlopen", blocked)
 
     # Degrades to the bundled version rather than raising, and caches
     # the failure.
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
     maidr.render(bar_plot, use_cdn="auto")
 
 
@@ -1014,10 +1025,10 @@ def test_tiny_timeout_is_clamped_to_the_floor(raw, monkeypatch, caplog):
     mutable dist-tag: the bug this module exists to fix, reached through
     configuration rather than through code.
     """
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, raw)
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, raw)
 
     with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
-        assert dependencies._cdn_timeout() == dependencies._MIN_CDN_TIMEOUT
+        assert cdn._cdn_timeout() == cdn._MIN_CDN_TIMEOUT
 
     assert [r for r in caplog.records if "floor" in r.message], (
         "the clamp must be visible, like the ceiling's"
@@ -1026,17 +1037,17 @@ def test_tiny_timeout_is_clamped_to_the_floor(raw, monkeypatch, caplog):
 
 def test_the_floor_leaves_a_usable_budget_alone(monkeypatch):
     """Only values below the floor are clamped."""
-    monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, "0.5")
-    assert dependencies._cdn_timeout() == 0.5
+    monkeypatch.setenv(cdn.CDN_TIMEOUT_ENV_VAR, "0.5")
+    assert cdn._cdn_timeout() == 0.5
 
 
 def test_bundled_cdn_url_needs_no_lookup(monkeypatch, forbid_network):
     """``init_notebook`` depends on this being network-free."""
     # The suite pins ``latest`` by default; drop it so the bundled
     # version is what this exercises rather than the pin.
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
 
-    url = dependencies.bundled_cdn_url(dependencies.MAIDR_JS_FILENAME)
+    url = cdn.bundled_cdn_url(dependencies.MAIDR_JS_FILENAME)
 
     assert f"maidr@{dependencies.maidr_js_version()}/" in url
     assert "maidr@latest" not in url
@@ -1052,25 +1063,25 @@ def test_bundled_cdn_url_honours_an_explicit_pin(monkeypatch, forbid_network):
     two different builds of maidr.js in one page, and neither the version
     ``set_cdn_version`` documents.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version("3.74.0")
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version("3.74.0")
 
-    assert dependencies.bundled_cdn_url(dependencies.MAIDR_JS_FILENAME) == (
+    assert cdn.bundled_cdn_url(dependencies.MAIDR_JS_FILENAME) == (
         "https://cdn.jsdelivr.net/npm/maidr@3.74.0/dist/maidr.js"
     )
     # The two tag-emitting paths agree, which is the property that matters.
-    assert dependencies.bundled_cdn_url(
+    assert cdn.bundled_cdn_url(
         dependencies.MAIDR_JS_FILENAME
-    ) == dependencies.maidr_js_cdn_url()
+    ) == cdn.maidr_js_cdn_url()
 
 
 def test_bundled_cdn_url_under_a_latest_pin_emits_latest(monkeypatch, forbid_network):
     """``latest`` is a pin like any other: asked for it, emit it."""
-    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, dependencies.LATEST_TAG)
+    monkeypatch.setenv(cdn.CDN_VERSION_ENV_VAR, cdn.LATEST_TAG)
 
-    assert dependencies.bundled_cdn_url(
+    assert cdn.bundled_cdn_url(
         dependencies.MAIDR_JS_FILENAME
-    ) == dependencies.MAIDR_JS_CDN_URL
+    ) == cdn.MAIDR_JS_CDN_URL
 
 
 def test_pin_before_the_stylesheet_split_warns_once(monkeypatch, forbid_network, caplog):
@@ -1081,39 +1092,39 @@ def test_pin_before_the_stylesheet_split_warns_once(monkeypatch, forbid_network,
     An older version has neither, so LaTeX in AI chat responses renders
     unstyled while everything else looks fine.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
 
     with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
-        dependencies.set_cdn_version("3.74.0")
+        cdn.set_cdn_version("3.74.0")
         for _ in range(5):
-            dependencies.maidr_js_cdn_url()
+            cdn.maidr_js_cdn_url()
 
     complaints = [r for r in caplog.records if "predates maidr" in r.message]
     assert len(complaints) == 1, f"warned {len(complaints)} times, expected 1"
-    assert dependencies._STYLESHEET_SPLIT_VERSION in complaints[0].getMessage()
+    assert cdn._STYLESHEET_SPLIT_VERSION in complaints[0].getMessage()
 
 
 @pytest.mark.parametrize("pin", ["3.75.1", "3.76.0", "4.0.0", "3.75.2-rc.1"])
 def test_pin_at_or_after_the_split_is_silent(pin, monkeypatch, forbid_network, caplog):
     """The warning is about older versions only; newer ones carry the file."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
 
     with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
-        dependencies.set_cdn_version(pin)
-        dependencies.maidr_js_cdn_url()
+        cdn.set_cdn_version(pin)
+        cdn.maidr_js_cdn_url()
 
     assert not [r for r in caplog.records if "predates maidr" in r.message]
 
 
 def test_bundled_cdn_url_degrades_when_version_unknown(monkeypatch, forbid_network):
     """With no usable bundled VERSION there is no better offline answer."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
     monkeypatch.setattr(
         dependencies, "maidr_js_version", lambda: dependencies._UNKNOWN_VERSION
     )
-    assert dependencies.bundled_cdn_url(
+    assert cdn.bundled_cdn_url(
         dependencies.MAIDR_JS_FILENAME
-    ) == dependencies.MAIDR_JS_CDN_URL
+    ) == cdn.MAIDR_JS_CDN_URL
 
 
 def test_keyboard_interrupt_does_not_poison_resolution(monkeypatch):
@@ -1125,8 +1136,8 @@ def test_keyboard_interrupt_does_not_poison_resolution(monkeypatch):
     the process silently emitting ``@latest`` — the exact bug this module
     fixes — with nothing logged.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     calls: list[int] = []
 
@@ -1136,20 +1147,20 @@ def test_keyboard_interrupt_does_not_poison_resolution(monkeypatch):
             raise KeyboardInterrupt("user pressed Ctrl-C mid-lookup")
         return _json_response({"version": "9.9.9", "latest": "9.9.9"})
 
-    monkeypatch.setattr(dependencies, "urlopen", interrupt_then_succeed)
+    monkeypatch.setattr(cdn, "urlopen", interrupt_then_succeed)
 
     with pytest.raises(KeyboardInterrupt):
-        dependencies.get_cdn_version()
+        cdn.get_cdn_version()
 
-    assert dependencies.get_cdn_version() == "9.9.9", (
+    assert cdn.get_cdn_version() == "9.9.9", (
         "resolution stayed poisoned after Ctrl-C"
     )
 
 
 def test_a_real_failure_is_still_cached(monkeypatch):
     """The counterpart: an ordinary exception must not retry per render."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     calls: list[int] = []
 
@@ -1158,13 +1169,13 @@ def test_a_real_failure_is_still_cached(monkeypatch):
         raise RuntimeError("resolver is broken in an unexpected way")
 
     # Raise from the inner helper so the outer handler is what sees it.
-    monkeypatch.setattr(dependencies, "_fetch_latest_version", boom)
+    monkeypatch.setattr(cdn, "_fetch_latest_version", boom)
 
     with pytest.raises(RuntimeError):
-        dependencies.get_cdn_version()
+        cdn.get_cdn_version()
 
-    dependencies.maidr_js_cdn_url()
-    dependencies.maidr_js_cdn_url()
+    cdn.maidr_js_cdn_url()
+    cdn.maidr_js_cdn_url()
 
     assert len(calls) == 1, f"retried the failed lookup {len(calls)} times"
 
@@ -1177,8 +1188,8 @@ def test_reset_during_a_lookup_is_not_overwritten(monkeypatch):
     abandoning — so it bumps a generation counter instead and the fetcher
     declines to publish a result from a superseded generation.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
 
     in_flight = threading.Event()
     may_finish = threading.Event()
@@ -1191,26 +1202,26 @@ def test_reset_during_a_lookup_is_not_overwritten(monkeypatch):
             may_finish.wait(timeout=5)
         return _json_response({"version": version, "latest": version})
 
-    monkeypatch.setattr(dependencies, "urlopen", slow_urlopen)
+    monkeypatch.setattr(cdn, "urlopen", slow_urlopen)
 
     result: list[str] = []
     fetcher = threading.Thread(
-        target=lambda: result.append(dependencies.get_cdn_version())
+        target=lambda: result.append(cdn.get_cdn_version())
     )
     fetcher.start()
 
     assert in_flight.wait(timeout=5), "the lookup never started"
-    dependencies.reset_cdn_version_cache()
+    cdn.reset_cdn_version_cache()
     may_finish.set()
     fetcher.join(timeout=5)
 
     # The in-flight caller still gets its own answer...
     assert result == ["1.1.1"]
     # ...but it must not have been cached over the reset.
-    assert dependencies._cached_resolution() is None, (
+    assert cdn._cached_resolution() is None, (
         "the pre-reset result was published anyway, undoing the reset"
     )
-    assert dependencies.get_cdn_version() == "2.2.2", (
+    assert cdn.get_cdn_version() == "2.2.2", (
         "the reset did not force a re-lookup"
     )
 
@@ -1375,21 +1386,21 @@ def test_a_failed_lookup_never_emits_the_mutable_tag(monkeypatch):
     version is spliced in three places and a fallback that fixed one of
     them would look fixed.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
     monkeypatch.setattr(
-        dependencies, "urlopen", lambda *_a, **_k: (_ for _ in ()).throw(OSError())
+        cdn, "urlopen", lambda *_a, **_k: (_ for _ in ()).throw(OSError())
     )
 
     bundled = dependencies.maidr_js_version()
     urls = [
-        dependencies.maidr_js_cdn_url(),
-        dependencies.cdn_url(dependencies.MAIDR_MATH_CSS_FILENAME),
-        dependencies.bundled_cdn_url(dependencies.MAIDR_JS_FILENAME),
+        cdn.maidr_js_cdn_url(),
+        cdn.cdn_url(dependencies.MAIDR_MATH_CSS_FILENAME),
+        cdn.bundled_cdn_url(dependencies.MAIDR_JS_FILENAME),
     ]
 
     for url in urls:
-        assert f"maidr@{dependencies.LATEST_TAG}/" not in url, url
+        assert f"maidr@{cdn.LATEST_TAG}/" not in url, url
         assert f"maidr@{bundled}/" in url, url
 
 
@@ -1401,8 +1412,40 @@ def test_an_explicit_latest_pin_still_gets_the_mutable_tag(monkeypatch):
     and asking for the mutable tag, and #295 must not take that away --
     it is the documented way to keep the CDN without the lookup.
     """
-    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, "latest")
-    dependencies.set_cdn_version(None)
+    monkeypatch.setenv(cdn.CDN_VERSION_ENV_VAR, "latest")
+    cdn.set_cdn_version(None)
 
-    assert dependencies.get_cdn_version() == dependencies.LATEST_TAG
-    assert dependencies.maidr_js_cdn_url() == dependencies.MAIDR_JS_CDN_URL
+    assert cdn.get_cdn_version() == cdn.LATEST_TAG
+    assert cdn.maidr_js_cdn_url() == cdn.MAIDR_JS_CDN_URL
+
+
+def test_the_shim_forwards_reads_but_cannot_forward_a_patch():
+    """The one thing the back-compat shim does not cover, pinned.
+
+    ``dependencies.__getattr__`` resolves the moved names, so an old
+    ``dependencies.get_cdn_version`` still works and is the *same object*.
+    It cannot intercept an assignment: ``setattr`` writes straight to the
+    module dict, so ``monkeypatch.setattr(dependencies, "urlopen", ...)``
+    would set an attribute nothing in ``cdn`` reads -- a patch that
+    silently does nothing rather than one that fails.
+
+    That asymmetry is why the moved *state* is deliberately absent from
+    ``_MOVED_TO_CDN`` and why the suite patches ``cdn`` directly. Asserted
+    rather than described, so a future change that quietly starts
+    forwarding writes has to come and edit this.
+    """
+    assert dependencies.get_cdn_version is cdn.get_cdn_version, "reads forward"
+    assert "LATEST_TAG" in dir(dependencies), "and are advertised"
+
+    sentinel = object()
+    try:
+        dependencies.urlopen = sentinel
+        assert cdn.urlopen is not sentinel, (
+            "writing to `dependencies` reached `cdn`; if the shim has gained "
+            "write-forwarding, the private state can rejoin `_MOVED_TO_CDN` "
+            "and this test should say so instead"
+        )
+    finally:
+        del dependencies.urlopen
+
+    assert "urlopen" not in dependencies._MOVED_TO_CDN

--- a/tests/core/test_cdn_version.py
+++ b/tests/core/test_cdn_version.py
@@ -353,7 +353,7 @@ def test_invalid_pin_logs_once_not_once_per_render(resolvable, caplog):
     """
     maidr.set_cdn_version("3.74")  # missing patch component
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         for _ in range(5):
             dependencies.maidr_js_cdn_url()
             dependencies.maidr_css_cdn_url()
@@ -366,7 +366,7 @@ def test_invalid_pin_logs_once_not_once_per_render(resolvable, caplog):
 def test_a_second_bad_pin_still_warns(resolvable, caplog):
     """Deduplication is per value, so a new mistake stays audible."""
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         maidr.set_cdn_version("3.74")
         dependencies.maidr_js_cdn_url()
         maidr.set_cdn_version("nonsense")
@@ -643,7 +643,7 @@ def test_oversized_timeout_is_clamped(monkeypatch, caplog):
     """
     monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, "3000")
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         assert dependencies._cdn_timeout() == dependencies._MAX_CDN_TIMEOUT
 
     assert any("clamped" in r.message for r in caplog.records), (
@@ -876,7 +876,7 @@ def test_unusable_timeout_is_reported_not_silently_replaced(bad, monkeypatch, ca
     """The clamp warns, so the other rejections should too."""
     monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, bad)
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         assert dependencies._cdn_timeout() == dependencies._DEFAULT_CDN_TIMEOUT
 
     assert caplog.records, f"{bad!r} was replaced with the default in silence"
@@ -928,7 +928,7 @@ def test_ordinary_timeout_passes_through_untouched(value, monkeypatch, caplog):
     """
     monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, value)
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         assert dependencies._cdn_timeout() == float(value)
 
     assert not caplog.records, f"{value!r} should be accepted silently"
@@ -1016,7 +1016,7 @@ def test_tiny_timeout_is_clamped_to_the_floor(raw, monkeypatch, caplog):
     """
     monkeypatch.setenv(dependencies.CDN_TIMEOUT_ENV_VAR, raw)
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         assert dependencies._cdn_timeout() == dependencies._MIN_CDN_TIMEOUT
 
     assert [r for r in caplog.records if "floor" in r.message], (
@@ -1083,7 +1083,7 @@ def test_pin_before_the_stylesheet_split_warns_once(monkeypatch, forbid_network,
     """
     monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         dependencies.set_cdn_version("3.74.0")
         for _ in range(5):
             dependencies.maidr_js_cdn_url()
@@ -1098,7 +1098,7 @@ def test_pin_at_or_after_the_split_is_silent(pin, monkeypatch, forbid_network, c
     """The warning is about older versions only; newer ones carry the file."""
     monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
 
-    with caplog.at_level(logging.WARNING, logger=dependencies.__name__):
+    with caplog.at_level(logging.WARNING, logger=warn_module.__name__):
         dependencies.set_cdn_version(pin)
         dependencies.maidr_js_cdn_url()
 

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -12,6 +12,7 @@ import pytest
 
 import maidr
 from maidr import api as maidr_api
+from maidr.util import cdn
 from maidr.util import dependencies
 
 
@@ -519,12 +520,11 @@ def test_init_notebook_tag_matches_the_pin(mocker, reset_notebook_loaded, monkey
     """
     from unittest.mock import MagicMock
 
-    from maidr.util import dependencies
 
     mocker.patch(
         "maidr.util.environment.Environment.is_notebook", return_value=True
     )
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
     maidr.set_cdn_version("3.74.0")
     maidr_api._NOTEBOOK_LOADED = False
 
@@ -738,7 +738,7 @@ def test_placeholder_css_accessors_warn():
         ),
         (
             maidr_css_cdn_url,
-            "maidr.util.dependencies.maidr_css_cdn_url",
+            "maidr.util.cdn.maidr_css_cdn_url",
             "cdn_url(MAIDR_MATH_CSS_FILENAME)",
         ),
     ):

--- a/tests/core/test_pin_validation.py
+++ b/tests/core/test_pin_validation.py
@@ -21,19 +21,19 @@ import warnings
 import pytest
 
 import maidr
-from maidr.util import dependencies
+from maidr.util import cdn
 from maidr.util import warn as warn_module
 
 
 @pytest.fixture(autouse=True)
 def clean():
     """No pin, no cached lookup, and a fresh log-dedup set."""
-    dependencies.set_cdn_version(None)
-    dependencies.reset_cdn_version_cache()
+    cdn.set_cdn_version(None)
+    cdn.reset_cdn_version_cache()
     warn_module._warned_keys.clear()
     yield
-    dependencies.set_cdn_version(None)
-    dependencies.reset_cdn_version_cache()
+    cdn.set_cdn_version(None)
+    cdn.reset_cdn_version_cache()
 
 
 #: Values that are neither a semver nor a recognised tag. The last four are
@@ -75,7 +75,7 @@ def test_an_unusable_pin_is_still_ignored_for_now(value) -> None:
     with pytest.warns(FutureWarning, match="will raise ValueError"):
         maidr.set_cdn_version(value)
 
-    assert dependencies._version_pin() is None
+    assert cdn._version_pin() is None
 
 
 @pytest.mark.parametrize("value", USABLE)
@@ -106,14 +106,14 @@ def test_clearing_the_pin_is_silent(value, monkeypatch) -> None:
     correctly falls through to it -- so asserting on the *pin* rather
     than on the override would be measuring the fixture.
     """
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
 
     with warnings.catch_warnings(record=True) as records:
         warnings.simplefilter("always")
         maidr.set_cdn_version(value)
 
     assert [r for r in records if issubclass(r.category, FutureWarning)] == []
-    assert dependencies._version_pin() is None
+    assert cdn._version_pin() is None
 
 
 def test_the_environment_variable_stays_lenient(monkeypatch) -> None:
@@ -124,12 +124,12 @@ def test_the_environment_variable_stays_lenient(monkeypatch) -> None:
     cannot act on from inside their own code -- and certainly not, later,
     an exception.
     """
-    dependencies.set_cdn_version(None)
-    monkeypatch.setenv(dependencies.CDN_VERSION_ENV_VAR, "3.74")
+    cdn.set_cdn_version(None)
+    monkeypatch.setenv(cdn.CDN_VERSION_ENV_VAR, "3.74")
 
     with warnings.catch_warnings(record=True) as records:
         warnings.simplefilter("always")
-        resolved = dependencies._version_pin()
+        resolved = cdn._version_pin()
 
     assert resolved is None
     assert [r for r in records if issubclass(r.category, FutureWarning)] == []

--- a/tests/core/test_resolver_outcome.py
+++ b/tests/core/test_resolver_outcome.py
@@ -26,6 +26,7 @@ from urllib.error import HTTPError
 import pytest
 
 from maidr.util import bundle_freshness as freshness
+from maidr.util import cdn
 from maidr.util import dependencies
 
 
@@ -39,23 +40,23 @@ class _FakeResponse(io.BytesIO):
         self.close()
 
 
-ENDPOINT_COUNT = len(dependencies._RESOLVER_ENDPOINTS)
+ENDPOINT_COUNT = len(cdn._RESOLVER_ENDPOINTS)
 
 
 @pytest.fixture
 def clean(monkeypatch):
     """No pin, no cached lookup, no leftover outcome."""
-    monkeypatch.delenv(dependencies.CDN_VERSION_ENV_VAR, raising=False)
-    dependencies.set_cdn_version(None)
-    dependencies.reset_cdn_version_cache()
+    monkeypatch.delenv(cdn.CDN_VERSION_ENV_VAR, raising=False)
+    cdn.set_cdn_version(None)
+    cdn.reset_cdn_version_cache()
     yield
-    dependencies.set_cdn_version(None)
-    dependencies.reset_cdn_version_cache()
+    cdn.set_cdn_version(None)
+    cdn.reset_cdn_version_cache()
 
 
 def answer_with(monkeypatch, responder) -> None:
     """Make every resolver request go through ``responder``."""
-    monkeypatch.setattr(dependencies, "urlopen", responder)
+    monkeypatch.setattr(cdn, "urlopen", responder)
 
 
 def json_body(payload: dict):
@@ -81,7 +82,7 @@ def test_an_outage_is_reported_as_unreachable(monkeypatch, clean) -> None:
         lambda request, timeout=None: (_ for _ in ()).throw(TimeoutError()),
     )
 
-    assert dependencies._fetch_latest_version(3.0) is None
+    assert cdn._fetch_latest_version(3.0) is None
 
     outcome = freshness.resolver_outcome()
     assert len(outcome.unreachable) == ENDPOINT_COUNT
@@ -100,7 +101,7 @@ def test_an_http_error_is_an_answer(monkeypatch, clean) -> None:
 
     answer_with(monkeypatch, not_found)
 
-    assert dependencies._fetch_latest_version(3.0) is None
+    assert cdn._fetch_latest_version(3.0) is None
 
     outcome = freshness.resolver_outcome()
     assert len(outcome.answered_badly) == ENDPOINT_COUNT
@@ -116,7 +117,7 @@ def test_a_payload_without_the_key_is_an_answer(monkeypatch, clean) -> None:
     """
     answer_with(monkeypatch, json_body({"something_else": "4.2.0"}))
 
-    assert dependencies._fetch_latest_version(3.0) is None
+    assert cdn._fetch_latest_version(3.0) is None
     assert len(freshness.resolver_outcome().answered_badly) == ENDPOINT_COUNT
 
 
@@ -129,7 +130,7 @@ def test_a_value_that_is_not_a_version_is_an_answer(monkeypatch, clean) -> None:
         ),
     )
 
-    assert dependencies._fetch_latest_version(3.0) is None
+    assert cdn._fetch_latest_version(3.0) is None
     assert len(freshness.resolver_outcome().answered_badly) == ENDPOINT_COUNT
 
 
@@ -140,7 +141,7 @@ def test_a_body_that_will_not_parse_is_an_answer(monkeypatch, clean) -> None:
         lambda request, timeout=None: _FakeResponse(b"<html>proxy error</html>"),
     )
 
-    assert dependencies._fetch_latest_version(3.0) is None
+    assert cdn._fetch_latest_version(3.0) is None
     assert len(freshness.resolver_outcome().answered_badly) == ENDPOINT_COUNT
 
 
@@ -160,7 +161,7 @@ def test_an_unrecognised_failure_counts_as_unreachable(monkeypatch, clean) -> No
         lambda request, timeout=None: (_ for _ in ()).throw(Blocked()),
     )
 
-    assert dependencies._fetch_latest_version(3.0) is None
+    assert cdn._fetch_latest_version(3.0) is None
 
     outcome = freshness.resolver_outcome()
     assert len(outcome.unreachable) == ENDPOINT_COUNT
@@ -175,10 +176,10 @@ def test_a_success_reports_no_failures(monkeypatch, clean) -> None:
     """
     answer_with(monkeypatch, json_body({"version": "4.2.0"}))
 
-    assert dependencies._fetch_latest_version(3.0) == "4.2.0"
+    assert cdn._fetch_latest_version(3.0) == "4.2.0"
 
     outcome = freshness.resolver_outcome()
-    assert outcome == dependencies.ResolverOutcome("4.2.0", (), ())
+    assert outcome == cdn.ResolverOutcome("4.2.0", (), ())
 
 
 def test_a_fallback_records_the_endpoint_it_fell_back_from(
@@ -200,7 +201,7 @@ def test_a_fallback_records_the_endpoint_it_fell_back_from(
 
     answer_with(monkeypatch, first_down)
 
-    assert dependencies._fetch_latest_version(3.0) == "9.9.9"
+    assert cdn._fetch_latest_version(3.0) == "9.9.9"
 
     outcome = freshness.resolver_outcome()
     assert outcome.resolved == "9.9.9"
@@ -220,10 +221,10 @@ def test_a_reset_discards_the_verdict_with_the_lookup(monkeypatch, clean) -> Non
         raise HTTPError(request.full_url, 404, "Not Found", {}, None)
 
     answer_with(monkeypatch, not_found)
-    dependencies._fetch_latest_version(3.0)
+    cdn._fetch_latest_version(3.0)
     assert freshness.resolver_outcome().answered_badly
 
-    dependencies.reset_cdn_version_cache()
+    cdn.reset_cdn_version_cache()
 
     assert freshness.resolver_outcome() is None
 
@@ -240,5 +241,5 @@ def test_the_render_path_is_unchanged_by_any_of_it(monkeypatch, clean) -> None:
         lambda request, timeout=None: (_ for _ in ()).throw(TimeoutError()),
     )
 
-    assert dependencies.get_cdn_version() == dependencies.maidr_js_version()
+    assert cdn.get_cdn_version() == dependencies.maidr_js_version()
     assert freshness.bundle_status(resolve=False).published is None


### PR DESCRIPTION
## Description

The last half of #293's suggested shape. `maidr/util/cdn.py` takes the resolver — endpoints, timeout budget, semver pin handling, the `latest` lookup and its caching, and the URL builders.

`dependencies.py` goes **1781 → 835 lines** and is finally what the issue asked for: reaching the copy bundled inside the wheel.

| #293's concern | module | done |
|---|---|---|
| Bundled asset access | `dependencies.py` | ✅ |
| **CDN version resolution** | **`cdn.py`** | ✅ **this PR** |
| Bundled-copy freshness | `bundle_freshness.py` | ✅ #497 |
| *(not in the issue)* Bundled-copy capability | `bundle_capability.py` | ✅ #494 |
| *(the issue's third note)* Shared warning policy | `warn.py` | ✅ #496 |

## The shim is weaker here, and that changed the plan

The earlier cuts leaned on `dependencies.__getattr__` for back-compat. It forwards attribute **reads** — `dependencies.get_cdn_version` still resolves, to the same object. **It cannot forward a write**, because `setattr` goes straight to the module dict:

```
read-forward works                 : True
write to dependencies reaches cdn? : False
```

So `monkeypatch.setattr(dependencies, "urlopen", ...)` would set an attribute nothing in `cdn` reads — a patch that silently does nothing rather than one that fails. Since **18 tests patch `dependencies.urlopen`** and more patch `_fetch_latest_version` / `_resolved_cdn_version`, leaving them to the shim would have produced a green suite testing nothing.

Consequences, all deliberate:

- Only the **public** names are forwarded. The resolver's state is absent from `_MOVED_TO_CDN` on purpose — listing it would make the trap look supported.
- **266 test references** were repointed at `cdn` rather than left to the shim.
- `test_the_shim_forwards_reads_but_cannot_forward_a_patch` asserts the asymmetry, so a future change that starts forwarding writes has to come and edit it.

## Measured before moving, not after

The direction is one-way: **no asset-side function references a CDN name**, checked by walking the AST rather than by reading. So `cdn` imports `dependencies` and nothing imports back.

Three names stayed behind, for the reason #293 records after the first cut:

- **`_version_key`, `_UNKNOWN_VERSION`** — used by `bundle_freshness`, so they are shared *version* primitives rather than CDN ones. Moving them would have made freshness depend on the resolver to compare two local strings.
- **`_warn_placeholder_css`** — found later, by ruff: `bundled_css_path` calls it too. It is about the placeholder *asset*, not the CDN.

## Two tests needed real updates, both predicted

**`test_no_render_path_references_the_unresolved_constants`** is the exclusion #293's third note said would need repointing "to whichever module ends up owning them". It now allows the owner **and** the shim's forwarding list — `_MOVED_TO_CDN` names the constants so the old import path resolves, and a forwarding list is not a render path.

**`maidr_css_cdn_url`'s deprecation** named `cdn_url(MAIDR_MATH_CSS_FILENAME) from maidr.util.dependencies`, which after the move sent readers to a module where neither name lives:

```
AssertionError: the deprecation for maidr_css_cdn_url names symbols that
do not resolve: ['MAIDR_MATH_CSS_FILENAME']
```

`test_deprecation_names_only_importable_symbols` caught it. The advice now names `cdn`, and the filename is re-exported there so both halves resolve where the reader is sent.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor (no behaviour change)

## Related Issues

Closes #293 — with the caveat below.

## Changes Made

- `maidr/util/cdn.py` — new, 1115 lines.
- `maidr/util/dependencies.py` — 1781 → 835. Gains `_MOVED_TO_CDN` and a third shim branch; keeps the version primitives and `_warn_placeholder_css`.
- `maidr/util/bundle_freshness.py` — reads `_resolver_outcome` and `_published_version` through `_cdn.`, per the from-import trap #497 recorded.
- `maidr/__init__.py`, `api.py`, `core/maidr.py`, `plotly/plotly_maidr.py`, `altair/altair_maidr.py` — repointed at the canonical module.
- 8 test files + `conftest.py` — 266 references repointed, including every `setattr(dependencies, "<moved>", ...)`.
- `tests/core/test_bundle_capability.py` — the laziness guard covers `cdn`.

## Checklist

- [x] I have read the Contributor Guidelines.
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

`uv run pytest` — **2349 passed, 13 skipped**. `ruff check` unchanged at 6 pre-existing findings.

Verified rather than assumed:

- Identity preserved through the shim — `maidr.ResolverOutcome is cdn.ResolverOutcome` → `True`, which matters because `except` compares class objects.
- The write limitation reproduces exactly as documented (above).
- The laziness guard is **not vacuous**, though for this pair every module-scope import spelling fails loudly anyway (`cdn` from-imports `dependencies`, so the cycle raises `partially initialized module`). Checked directly, it flags `import maidr.util.cdn`, `from maidr.util import cdn`, and `from maidr.util.cdn import cdn_url` alike.

**On closing #293:** this completes the split it describes, but the issue named two modules and five exist. Worth a maintainer's eye on whether that shape is what was wanted before it closes — I have marked it `Closes` rather than `Refs` because the CDN cut was the last thing outstanding, not because the bookkeeping matches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_