### PR TITLE
fix(core): stop retaining every figure for the life of the process

### DIFF
--- a/maidr/backend.py
+++ b/maidr/backend.py
@@ -87,9 +87,12 @@ def show(*args: Any, **kwargs: Any) -> None:
         else:
             # clear_fig=False because the backend handles figure cleanup.
             maidr_obj.show(clear_fig=False, use_cdn=use_cdn)
-            # Clean up maidr's own tracking to prevent memory leaks.
-            # Without this, FigureManager.figs grows unboundedly because
-            # clear_fig=False skips the plt.close() -> clear.py path.
+            # Drop maidr's record now rather than waiting for the figure to
+            # be collected: `clear_fig=False` skips the `plt.close()` ->
+            # `clear.py` path, and `Gcf.destroy` below is what actually
+            # releases the figure. Since #456 the record no longer outlives
+            # the figure on its own, so this is timeliness rather than the
+            # difference between bounded and unbounded.
             MaidrFigureManager.destroy(fig)
         Gcf.destroy(manager.num)
 

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -18,53 +18,49 @@ from maidr.exception.unsupported_plot_error import UnsupportedPlotError
 class _FigureRecords:
     """A mapping from ``Figure`` to ``Maidr`` that stores each entry on its key.
 
-    Behaves as the plain ``dict`` this replaced -- ``figs[fig]``, ``fig in
-    figs``, ``.get``, ``.pop``, ``.clear`` -- but the value is kept in the
-    figure's own ``__dict__`` rather than in a module-level table.
+    Reads as the plain ``dict`` this replaced -- ``figs[fig]``, ``fig in
+    figs``, ``.get``, ``.pop``, ``.clear``, iteration, ``len`` -- but the
+    value lives in the figure's own ``__dict__`` rather than in a
+    module-level table. A class-level dict kept every registered figure
+    reachable for the life of the process; storing the record on the figure
+    makes the whole graph one isolated cycle once the caller lets go, which
+    the collector reclaims (#456).
 
-    That is the whole point. A module-level dict is a strong reference from a
-    class attribute, so a figure stayed reachable for the life of the process
-    even after the application dropped it and matplotlib closed it (#456).
-    Registration happens when a chart is *plotted*, not when it is rendered,
-    so this applied to every supported figure -- and the ``plt.show()`` path
-    only escaped it because the backend calls :meth:`FigureManager.destroy`
-    explicitly. A Shiny or Streamlit render never goes through ``plt.show``.
+    Not a ``WeakKeyDictionary``: every value reaches its own key --
+    ``Maidr._fig``, ``MaidrPlot.ax``, and each subclass's artist handles --
+    so the entry would keep the figure alive and the weak key would never
+    die. #498 records that chain.
 
-    Storing the record on the figure makes the whole graph -- figure, its
-    ``Maidr``, its layers, and the artists those layers hold -- one isolated
-    reference cycle once the application lets go, which the cyclic collector
-    reclaims. Measured on a figure built, rendered and closed:
+    Invariants
+    ----------
+    A record belongs to a figure only if ``record.fig is fig``.
+        Every read goes through :meth:`_record`, which enforces it, and the
+        one write refuses a record that fails it. Without this a
+        ``copy.copy`` of a figure -- which copies ``__dict__`` entries by
+        reference -- would answer as registered and hand back the
+        *original's* chart.
 
-    ======================================  =========
-    registry                                collected
-    ======================================  =========
-    module-level dict                       no
-    record stored on the figure             yes
-    ======================================  =========
+    ``_seen`` holds every figure this mapping can enumerate.
+        It backs iteration, ``len`` and ``clear`` only, weakly, so it
+        retains nothing. :meth:`_record` adds to it, because ``deepcopy``
+        and ``pickle`` install a valid record without going through
+        :meth:`__setitem__`. **A read therefore mutates shared state**,
+        which is why every operation takes ``_guard``.
 
-    This is deliberately *not* a ``WeakKeyDictionary``, which was tried first
-    and freed nothing: every value reaches its own key -- ``Maidr._fig``,
-    ``MaidrPlot.ax``, and each subclass's own artist handles such as
-    ``BarPlot._own_bars`` -- so the entry keeps the figure alive and the weak
-    key never dies. #498 records that chain. Keeping the value *on* the key
-    sidesteps it entirely: a value that reaches its key is exactly what a
-    cycle is, and cycles are collectable as long as nothing outside points in.
+    Notes
+    -----
+    Reclamation is the cyclic collector's rather than refcounting's, so a
+    host running ``gc.disable()`` gets the growth back between collections.
+    In proportion: a bare matplotlib ``Figure`` is not refcount-reclaimable
+    either, since its artists refer back to it, so turning the collector off
+    leaks figures with or without this package.
 
-    Membership is by identity either way -- ``Figure`` inherits ``__hash__``
-    and ``__eq__`` from ``object``, so dict lookup was already identity.
-
-    ``_seen`` exists only so the mapping can be enumerated and cleared. It
-    holds weak references and no values, so it retains nothing.
-
-    Reclamation is therefore the cyclic collector's, not refcounting's --
-    so a host that runs with ``gc.disable()`` or ``gc.freeze()``, which
-    long-lived servers sometimes do for latency, gets the growth back
-    between explicit collections. Worth knowing, and worth keeping in
-    proportion: a matplotlib ``Figure`` has never been reclaimable by
-    refcount either, since its own artists refer back to it. Measured with
-    the collector off, a bare figure built and closed with no maidr
-    involvement at all is not collected. Turning the collector off leaks
-    figures whether or not this package is installed.
+    The approach leans on ``Figure`` accepting instance attributes and on
+    ``copy``/``deepcopy``/``pickle`` treating ``__dict__`` as they do today.
+    Neither is a contract matplotlib publishes. If either changes the
+    failure is quiet -- the attribute is simply absent and a figure reads as
+    unregistered -- so ``tests/core/test_figure_manager.py`` pins all three
+    behaviours rather than leaving them to be assumed.
     """
 
     #: Attribute the record is stored under on the figure.
@@ -75,60 +71,37 @@ class _FigureRecords:
 
     def __init__(self) -> None:
         self._seen: weakref.WeakSet = weakref.WeakSet()
-        # Reentrant because this class calls itself: `clear` walks `__iter__`,
-        # which asks `__contains__`, and pops as it goes.
+        # Its own lock, not `FigureManager._lock`: `figs` is reachable
+        # directly and a caller cannot be relied on to hold that one.
+        # Reentrant because `clear` walks `__iter__`, which asks
+        # `__contains__`.
         #
-        # Its own lock rather than `FigureManager._lock`, because a caller
-        # cannot be relied on to hold that one. `figs` is a public class
-        # attribute that reads like a dict, and `if fig in FigureManager.figs`
-        # is the natural thing to write -- but since the record moved onto the
-        # figure a lookup also updates `_seen`, so that apparently-read-only
-        # line races. Making each operation self-contained means the contract
-        # is enforced instead of documented.
+        # `FigureManager._lock` is still required for what this cannot do --
+        # spanning the check-then-act in `_get_maidr` and the paired append
+        # in `create_maidr`.
         #
-        # `FigureManager._lock` is still needed and still does something this
-        # cannot: it spans the *compound* operations -- the check-then-act in
-        # `_get_maidr`, and the paired append in `create_maidr` -- which no
-        # per-operation lock can make atomic.
-        #
-        # What goes wrong without this: threads adding and removing entries
-        # while others iterate raise `RuntimeError: Set changed size during
-        # iteration` out of `__iter__`. Reproduced 3 of 3 against a build
-        # with this lock removed, and 0 of 3 with it.
-        #
-        # Deliberately not covered by a test. Detection needs sustained
-        # contention -- a bounded version of that harness detected on only
-        # about half its runs, and raising the budget did not improve it,
-        # so the rate is thread-scheduling luck rather than duration. A
-        # coin-flip guard costing a busy-waiting second per suite run is
-        # worth less than this comment.
+        # Without this, concurrent add/remove during iteration raises
+        # `RuntimeError: Set changed size during iteration`. Untested here:
+        # provoking it needs sustained contention and detects about half the
+        # time. `test_one_thread_cannot_enter_the_registry_while_another_is_inside`
+        # asserts the exclusion this provides instead, deterministically.
         self._guard = threading.RLock()
 
     def _record(self, fig: Figure) -> Any:
         """This figure's own record, or ``_MISSING``.
 
-        The ownership check is not a formality. ``copy.copy`` on a ``Figure``
-        copies the ``__dict__`` entries themselves, so a shallow copy would
-        inherit the original's record and answer as registered -- handing
-        back a ``Maidr`` bound to a *different* figure, and rendering the
-        original's chart under the copy's name. The module-level dict could
-        not do that, because only the object actually inserted was ever a
-        key.
+        Returns
+        -------
+        Maidr or object
+            The record when ``record.fig is fig``, else the ``_MISSING``
+            sentinel. A missing attribute, a record naming another figure,
+            and a record whose ``Maidr`` has been destroyed (``Maidr.fig``
+            raising after ``Maidr.destroy``) are all "not registered" --
+            the last because a shallow copy can outlive the pop that
+            detached the original, and a membership test must answer a bool
+            rather than raise.
 
-        ``deepcopy`` and ``pickle`` are the opposite case and are left
-        working: both rebuild the record alongside the figure, so the copy's
-        record points at the copy and it is genuinely registered. Neither
-        goes through :meth:`__setitem__`, though -- they write ``__dict__``
-        directly -- so a legitimately owned record is added to ``_seen``
-        here. Without that a copied figure answered ``in`` but was missing
-        from ``list(figs)``, uncounted by ``len``, and survived ``clear()``.
-
-        The ``AttributeError`` guard covers a record whose ``Maidr`` has been
-        destroyed. ``FigureManager.destroy`` pops the record before calling
-        ``Maidr.destroy()``, which deletes ``_fig`` -- but it pops it off the
-        figure it was given, and a shallow copy taken beforehand still holds
-        the same object. Reading ``record.fig`` there raised out of a
-        membership test, which has to answer a bool.
+        Also brings ``_seen`` up to date, per the class's second invariant.
         """
         record = getattr(fig, self._ATTR, self._MISSING)
         if record is self._MISSING:
@@ -153,12 +126,9 @@ class _FigureRecords:
         return record
 
     def __setitem__(self, fig: Figure, maidr: Maidr) -> None:
-        # Refused rather than stored, because every read enforces ownership
-        # and a record naming another figure could not be read back: the
-        # write appeared to succeed, left the attribute set, and `figs[fig]`
-        # then raised `KeyError`. The dict this replaced would have stored
-        # and returned it. Raising puts the error at the mistake instead of
-        # at a lookup somewhere else.
+        # Upholds the ownership invariant at the one write, so the mapping
+        # cannot hold a record no read would return. The dict this replaced
+        # would have stored a mismatched record and handed it back.
         if maidr.fig is not fig:
             raise ValueError(
                 "a figure's record must be the Maidr for that figure; "
@@ -169,22 +139,17 @@ class _FigureRecords:
             self._seen.add(fig)
 
     def __delitem__(self, fig: Figure) -> None:
-        # Through `_record` like every other read, so that `del figs[fig]`
-        # and `figs.pop(fig)` agree about what is registered. Deleting
-        # straight off the attribute would succeed for a shallow copy that
-        # `pop` refuses -- two spellings of one operation disagreeing.
+        # Through `_record`, so `del figs[fig]` and `figs.pop(fig)` agree
+        # about what is registered.
         with self._guard:
             if self._record(fig) is self._MISSING:
                 raise KeyError(fig)
             self._delete(fig)
 
     def _delete(self, fig: Figure) -> None:
-        # `delattr` after a `_record` check is a check-then-act, where the
-        # dict operation it replaced was atomic. `FigureManager` holds
-        # `_lock` across both, but `figs` is reachable directly, so a caller
-        # that does not would otherwise get an `AttributeError` out of `pop`
-        # where the class promises a `KeyError` -- or nothing, since the
-        # entry it wanted gone is gone either way.
+        # Tolerant of a lost race: the entry the caller wanted gone is gone
+        # either way, and raising `AttributeError` where the class promises
+        # `KeyError` would be the wrong answer.
         with self._guard:
             try:
                 delattr(fig, self._ATTR)
@@ -193,9 +158,8 @@ class _FigureRecords:
             self._seen.discard(fig)
 
     def __len__(self) -> int:
-        # Not just for completeness: without it `if figs:` is always true,
-        # which is the one way a partial mapping fails *quietly* rather than
-        # with a `TypeError`.
+        # Without it `if figs:` is always true -- the one way a partial
+        # mapping fails quietly rather than with a `TypeError`.
         return sum(1 for _ in self)
 
     def __iter__(self):
@@ -219,26 +183,15 @@ class _FigureRecords:
             return maidr
 
     def clear(self) -> None:
-        """Drop every record this mapping knows about.
+        """Drop every record in ``_seen`` -- which is not quite every record.
 
-        "Knows about" is the caveat, and it is not fixable from here.
-        ``_seen`` learns of a figure when its record is written or read, and
-        ``deepcopy``/``pickle`` do neither -- they rebuild ``__dict__``
-        directly. A clone whose record has never been looked up is therefore
-        still registered afterwards:
-
-        ======================================  ==================
-        clone                                   dropped by clear
-        ======================================  ==================
-        read once before the clear              yes
-        never read                              no
-        ======================================  ==================
-
-        Closing it would need a hook on the copy itself, which means putting
-        registry knowledge into ``Maidr.__deepcopy__``/``__setstate__``.
-        Not worth it for what this costs: nothing outlives the clone, since
-        its record is reachable only through it, so this is an enumeration
-        gap rather than a leak. ``clear`` exists for test isolation.
+        A ``deepcopy``/``pickle`` clone enters ``_seen`` only when its record
+        is first read, so one that has never been looked up survives this.
+        Closing the gap would need a hook on the copy, meaning registry
+        knowledge inside ``Maidr.__deepcopy__``/``__setstate__``; not worth
+        it, since the clone's record is reachable only through the clone, so
+        this is an enumeration gap rather than a leak. ``clear`` exists for
+        test isolation.
         """
         with self._guard:
             for fig in self:

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -100,10 +100,13 @@ class _FigureRecords:
         self._seen.add(fig)
 
     def __delitem__(self, fig: Figure) -> None:
-        try:
-            delattr(fig, self._ATTR)
-        except AttributeError:
-            raise KeyError(fig) from None
+        # Through `_record` like every other read, so that `del figs[fig]`
+        # and `figs.pop(fig)` agree about what is registered. Deleting
+        # straight off the attribute would succeed for a shallow copy that
+        # `pop` refuses -- two spellings of one operation disagreeing.
+        if self._record(fig) is self._MISSING:
+            raise KeyError(fig)
+        delattr(fig, self._ATTR)
         self._seen.discard(fig)
 
     def __len__(self) -> int:

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+import weakref
 from typing import Any
 
 from matplotlib.artist import Artist
@@ -14,6 +15,106 @@ from maidr.core.plot import MaidrPlotFactory
 from maidr.exception.unsupported_plot_error import UnsupportedPlotError
 
 
+class _FigureRecords:
+    """A mapping from ``Figure`` to ``Maidr`` that stores each entry on its key.
+
+    Behaves as the plain ``dict`` this replaced -- ``figs[fig]``, ``fig in
+    figs``, ``.get``, ``.pop``, ``.clear`` -- but the value is kept in the
+    figure's own ``__dict__`` rather than in a module-level table.
+
+    That is the whole point. A module-level dict is a strong reference from a
+    class attribute, so a figure stayed reachable for the life of the process
+    even after the application dropped it and matplotlib closed it (#456).
+    Registration happens when a chart is *plotted*, not when it is rendered,
+    so this applied to every supported figure -- and the ``plt.show()`` path
+    only escaped it because the backend calls :meth:`FigureManager.destroy`
+    explicitly. A Shiny or Streamlit render never goes through ``plt.show``.
+
+    Storing the record on the figure makes the whole graph -- figure, its
+    ``Maidr``, its layers, and the artists those layers hold -- one isolated
+    reference cycle once the application lets go, which the cyclic collector
+    reclaims. Measured on a figure built, rendered and closed:
+
+    ======================================  =========
+    registry                                collected
+    ======================================  =========
+    module-level dict                       no
+    record stored on the figure             yes
+    ======================================  =========
+
+    This is deliberately *not* a ``WeakKeyDictionary``, which was tried first
+    and freed nothing: every value reaches its own key -- ``Maidr._fig``,
+    ``MaidrPlot.ax``, and each subclass's own artist handles such as
+    ``BarPlot._own_bars`` -- so the entry keeps the figure alive and the weak
+    key never dies. #498 records that chain. Keeping the value *on* the key
+    sidesteps it entirely: a value that reaches its key is exactly what a
+    cycle is, and cycles are collectable as long as nothing outside points in.
+
+    Membership is by identity either way -- ``Figure`` inherits ``__hash__``
+    and ``__eq__`` from ``object``, so dict lookup was already identity.
+
+    ``_seen`` exists only so the mapping can be enumerated and cleared. It
+    holds weak references and no values, so it retains nothing.
+    """
+
+    #: Attribute the record is stored under on the figure.
+    _ATTR = "_maidr_record"
+
+    #: Distinguishes "no default given" from a default of ``None``.
+    _MISSING = object()
+
+    def __init__(self) -> None:
+        self._seen: weakref.WeakSet = weakref.WeakSet()
+
+    def __contains__(self, fig: Figure) -> bool:
+        return hasattr(fig, self._ATTR)
+
+    def __getitem__(self, fig: Figure) -> Maidr:
+        try:
+            return getattr(fig, self._ATTR)
+        except AttributeError:
+            raise KeyError(fig) from None
+
+    def __setitem__(self, fig: Figure, maidr: Maidr) -> None:
+        setattr(fig, self._ATTR, maidr)
+        self._seen.add(fig)
+
+    def __delitem__(self, fig: Figure) -> None:
+        try:
+            delattr(fig, self._ATTR)
+        except AttributeError:
+            raise KeyError(fig) from None
+        self._seen.discard(fig)
+
+    def __len__(self) -> int:
+        # Not just for completeness: without it `if figs:` is always true,
+        # which is the one way a partial mapping fails *quietly* rather than
+        # with a `TypeError`.
+        return sum(1 for _ in self)
+
+    def __iter__(self):
+        # Over a snapshot: `_seen` is weak, so iterating it directly can drop
+        # members mid-loop when a figure is collected by another thread.
+        return iter([fig for fig in list(self._seen) if fig in self])
+
+    def get(self, fig: Figure, default: Any = None) -> Any:
+        return getattr(fig, self._ATTR, default)
+
+    def pop(self, fig: Figure, default: Any = _MISSING) -> Any:
+        maidr = getattr(fig, self._ATTR, self._MISSING)
+        if maidr is self._MISSING:
+            if default is self._MISSING:
+                raise KeyError(fig)
+            return default
+        delattr(fig, self._ATTR)
+        self._seen.discard(fig)
+        return maidr
+
+    def clear(self) -> None:
+        for fig in self:
+            self.pop(fig, None)
+
+
 class FigureManager:
     """
     Manages creation and retrieval of Maidr instances associated with figures.
@@ -23,9 +124,11 @@ class FigureManager:
 
     Attributes
     ----------
-    figs : dict
-        A dictionary that maps matplotlib Figure objects to their corresponding
-        Maidr instances.
+    figs : _FigureRecords
+        Maps matplotlib Figure objects to their corresponding Maidr instances.
+        Reads as a dict; each entry is stored on its own figure so that
+        registering a chart no longer keeps it alive for the life of the
+        process (#456). See :class:`_FigureRecords`.
 
         Reads reach worker threads since #504, which renders off the Shiny
         event loop. Both write paths -- :meth:`_get_maidr`'s insert and
@@ -46,7 +149,7 @@ class FigureManager:
         Recursively extracts Axes objects from the input artist or container.
     """
 
-    figs = {}
+    figs = _FigureRecords()
 
     _instance = None
     _lock = threading.Lock()
@@ -179,7 +282,9 @@ class FigureManager:
         # not a dict operation. That leaves one gap this does not close: a
         # `create_maidr` that took its reference just before the pop can
         # still append to an object no longer in `figs`. Its layers go
-        # nowhere, which is #456's territory rather than this lock's.
+        # nowhere. Independent of this lock, and unchanged by #456: the
+        # record moving onto the figure changes how long an entry lives,
+        # not who may be holding a reference to it mid-registration.
         maidr.destroy()
         del maidr
 

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -66,14 +66,34 @@ class _FigureRecords:
     def __init__(self) -> None:
         self._seen: weakref.WeakSet = weakref.WeakSet()
 
+    def _record(self, fig: Figure) -> Any:
+        """This figure's own record, or ``_MISSING``.
+
+        The ownership check is not a formality. ``copy.copy`` on a ``Figure``
+        copies the ``__dict__`` entries themselves, so a shallow copy would
+        inherit the original's record and answer as registered -- handing
+        back a ``Maidr`` bound to a *different* figure, and rendering the
+        original's chart under the copy's name. The module-level dict could
+        not do that, because only the object actually inserted was ever a
+        key.
+
+        ``deepcopy`` and ``pickle`` are the opposite case and are left
+        working: both rebuild the record alongside the figure, so the copy's
+        record points at the copy and it is genuinely registered.
+        """
+        record = getattr(fig, self._ATTR, self._MISSING)
+        if record is not self._MISSING and record.fig is not fig:
+            return self._MISSING
+        return record
+
     def __contains__(self, fig: Figure) -> bool:
-        return hasattr(fig, self._ATTR)
+        return self._record(fig) is not self._MISSING
 
     def __getitem__(self, fig: Figure) -> Maidr:
-        try:
-            return getattr(fig, self._ATTR)
-        except AttributeError:
-            raise KeyError(fig) from None
+        record = self._record(fig)
+        if record is self._MISSING:
+            raise KeyError(fig)
+        return record
 
     def __setitem__(self, fig: Figure, maidr: Maidr) -> None:
         setattr(fig, self._ATTR, maidr)
@@ -98,10 +118,11 @@ class _FigureRecords:
         return iter([fig for fig in list(self._seen) if fig in self])
 
     def get(self, fig: Figure, default: Any = None) -> Any:
-        return getattr(fig, self._ATTR, default)
+        record = self._record(fig)
+        return default if record is self._MISSING else record
 
     def pop(self, fig: Figure, default: Any = _MISSING) -> Any:
-        maidr = getattr(fig, self._ATTR, self._MISSING)
+        maidr = self._record(fig)
         if maidr is self._MISSING:
             if default is self._MISSING:
                 raise KeyError(fig)

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -55,6 +55,16 @@ class _FigureRecords:
 
     ``_seen`` exists only so the mapping can be enumerated and cleared. It
     holds weak references and no values, so it retains nothing.
+
+    Reclamation is therefore the cyclic collector's, not refcounting's --
+    so a host that runs with ``gc.disable()`` or ``gc.freeze()``, which
+    long-lived servers sometimes do for latency, gets the growth back
+    between explicit collections. Worth knowing, and worth keeping in
+    proportion: a matplotlib ``Figure`` has never been reclaimable by
+    refcount either, since its own artists refer back to it. Measured with
+    the collector off, a bare figure built and closed with no maidr
+    involvement at all is not collected. Turning the collector off leaks
+    figures whether or not this package is installed.
     """
 
     #: Attribute the record is stored under on the figure.

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -175,6 +175,27 @@ class _FigureRecords:
         return maidr
 
     def clear(self) -> None:
+        """Drop every record this mapping knows about.
+
+        "Knows about" is the caveat, and it is not fixable from here.
+        ``_seen`` learns of a figure when its record is written or read, and
+        ``deepcopy``/``pickle`` do neither -- they rebuild ``__dict__``
+        directly. A clone whose record has never been looked up is therefore
+        still registered afterwards:
+
+        ======================================  ==================
+        clone                                   dropped by clear
+        ======================================  ==================
+        read once before the clear              yes
+        never read                              no
+        ======================================  ==================
+
+        Closing it would need a hook on the copy itself, which means putting
+        registry knowledge into ``Maidr.__deepcopy__``/``__setstate__``.
+        Not worth it for what this costs: nothing outlives the clone, since
+        its record is reachable only through it, so this is an enumeration
+        gap rather than a leak. ``clear`` exists for test isolation.
+        """
         for fig in self:
             self.pop(fig, None)
 
@@ -201,6 +222,11 @@ class FigureManager:
         must stay index-aligned. Individual dict and list operations are
         atomic under the GIL; the lock is for the check-then-act and the
         paired write around them.
+
+        Every method above holds ``_lock``, and a direct caller of ``figs``
+        must too -- including for what look like reads. Since #456 a lookup
+        also updates the bookkeeping behind iteration, so ``in`` and
+        ``get`` mutate shared state rather than only observing it.
 
     Methods
     -------

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -65,6 +65,34 @@ class _FigureRecords:
 
     def __init__(self) -> None:
         self._seen: weakref.WeakSet = weakref.WeakSet()
+        # Reentrant because this class calls itself: `clear` walks `__iter__`,
+        # which asks `__contains__`, and pops as it goes.
+        #
+        # Its own lock rather than `FigureManager._lock`, because a caller
+        # cannot be relied on to hold that one. `figs` is a public class
+        # attribute that reads like a dict, and `if fig in FigureManager.figs`
+        # is the natural thing to write -- but since the record moved onto the
+        # figure a lookup also updates `_seen`, so that apparently-read-only
+        # line races. Making each operation self-contained means the contract
+        # is enforced instead of documented.
+        #
+        # `FigureManager._lock` is still needed and still does something this
+        # cannot: it spans the *compound* operations -- the check-then-act in
+        # `_get_maidr`, and the paired append in `create_maidr` -- which no
+        # per-operation lock can make atomic.
+        #
+        # What goes wrong without this: threads adding and removing entries
+        # while others iterate raise `RuntimeError: Set changed size during
+        # iteration` out of `__iter__`. Reproduced 3 of 3 against a build
+        # with this lock removed, and 0 of 3 with it.
+        #
+        # Deliberately not covered by a test. Detection needs sustained
+        # contention -- a bounded version of that harness detected on only
+        # about half its runs, and raising the budget did not improve it,
+        # so the rate is thread-scheduling luck rather than duration. A
+        # coin-flip guard costing a busy-waiting second per suite run is
+        # worth less than this comment.
+        self._guard = threading.RLock()
 
     def _record(self, fig: Figure) -> Any:
         """This figure's own record, or ``_MISSING``.
@@ -101,7 +129,8 @@ class _FigureRecords:
             return self._MISSING
         if owner is not fig:
             return self._MISSING
-        self._seen.add(fig)
+        with self._guard:
+            self._seen.add(fig)
         return record
 
     def __contains__(self, fig: Figure) -> bool:
@@ -125,17 +154,19 @@ class _FigureRecords:
                 "a figure's record must be the Maidr for that figure; "
                 f"{maidr!r} names a different one"
             )
-        setattr(fig, self._ATTR, maidr)
-        self._seen.add(fig)
+        with self._guard:
+            setattr(fig, self._ATTR, maidr)
+            self._seen.add(fig)
 
     def __delitem__(self, fig: Figure) -> None:
         # Through `_record` like every other read, so that `del figs[fig]`
         # and `figs.pop(fig)` agree about what is registered. Deleting
         # straight off the attribute would succeed for a shallow copy that
         # `pop` refuses -- two spellings of one operation disagreeing.
-        if self._record(fig) is self._MISSING:
-            raise KeyError(fig)
-        self._delete(fig)
+        with self._guard:
+            if self._record(fig) is self._MISSING:
+                raise KeyError(fig)
+            self._delete(fig)
 
     def _delete(self, fig: Figure) -> None:
         # `delattr` after a `_record` check is a check-then-act, where the
@@ -144,11 +175,12 @@ class _FigureRecords:
         # that does not would otherwise get an `AttributeError` out of `pop`
         # where the class promises a `KeyError` -- or nothing, since the
         # entry it wanted gone is gone either way.
-        try:
-            delattr(fig, self._ATTR)
-        except AttributeError:
-            pass
-        self._seen.discard(fig)
+        with self._guard:
+            try:
+                delattr(fig, self._ATTR)
+            except AttributeError:
+                pass
+            self._seen.discard(fig)
 
     def __len__(self) -> int:
         # Not just for completeness: without it `if figs:` is always true,
@@ -159,20 +191,22 @@ class _FigureRecords:
     def __iter__(self):
         # Over a snapshot: `_seen` is weak, so iterating it directly can drop
         # members mid-loop when a figure is collected by another thread.
-        return iter([fig for fig in list(self._seen) if fig in self])
+        with self._guard:
+            return iter([fig for fig in list(self._seen) if fig in self])
 
     def get(self, fig: Figure, default: Any = None) -> Any:
         record = self._record(fig)
         return default if record is self._MISSING else record
 
     def pop(self, fig: Figure, default: Any = _MISSING) -> Any:
-        maidr = self._record(fig)
-        if maidr is self._MISSING:
-            if default is self._MISSING:
-                raise KeyError(fig)
-            return default
-        self._delete(fig)
-        return maidr
+        with self._guard:
+            maidr = self._record(fig)
+            if maidr is self._MISSING:
+                if default is self._MISSING:
+                    raise KeyError(fig)
+                return default
+            self._delete(fig)
+            return maidr
 
     def clear(self) -> None:
         """Drop every record this mapping knows about.
@@ -196,8 +230,9 @@ class _FigureRecords:
         its record is reachable only through it, so this is an enumeration
         gap rather than a leak. ``clear`` exists for test isolation.
         """
-        for fig in self:
-            self.pop(fig, None)
+        with self._guard:
+            for fig in self:
+                self.pop(fig, None)
 
 
 class FigureManager:
@@ -330,9 +365,11 @@ class FigureManager:
         # between them. Two uncontended acquires per registered layer, counting the
         # paired append in `create_maidr`.
         with cls._lock:
-            if fig not in cls.figs:
-                cls.figs[fig] = Maidr(fig, plot_type)
-            return cls.figs[fig]
+            maidr = cls.figs.get(fig)
+            if maidr is None:
+                maidr = Maidr(fig, plot_type)
+                cls.figs[fig] = maidr
+            return maidr
 
     @classmethod
     def get_maidr(cls, fig: Figure) -> Maidr:
@@ -354,9 +391,10 @@ class FigureManager:
         # `UnsupportedPlotError` below into a bare `KeyError` -- losing the
         # message that is the whole point of raising it.
         with cls._lock:
-            if fig not in cls.figs:
+            maidr = cls.figs.get(fig)
+            if maidr is None:
                 raise UnsupportedPlotError(fig)
-            return cls.figs[fig]
+            return maidr
 
     @classmethod
     def destroy(cls, fig: Figure) -> None:

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -114,6 +114,17 @@ class _FigureRecords:
         return record
 
     def __setitem__(self, fig: Figure, maidr: Maidr) -> None:
+        # Refused rather than stored, because every read enforces ownership
+        # and a record naming another figure could not be read back: the
+        # write appeared to succeed, left the attribute set, and `figs[fig]`
+        # then raised `KeyError`. The dict this replaced would have stored
+        # and returned it. Raising puts the error at the mistake instead of
+        # at a lookup somewhere else.
+        if maidr.fig is not fig:
+            raise ValueError(
+                "a figure's record must be the Maidr for that figure; "
+                f"{maidr!r} names a different one"
+            )
         setattr(fig, self._ATTR, maidr)
         self._seen.add(fig)
 

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -79,11 +79,29 @@ class _FigureRecords:
 
         ``deepcopy`` and ``pickle`` are the opposite case and are left
         working: both rebuild the record alongside the figure, so the copy's
-        record points at the copy and it is genuinely registered.
+        record points at the copy and it is genuinely registered. Neither
+        goes through :meth:`__setitem__`, though -- they write ``__dict__``
+        directly -- so a legitimately owned record is added to ``_seen``
+        here. Without that a copied figure answered ``in`` but was missing
+        from ``list(figs)``, uncounted by ``len``, and survived ``clear()``.
+
+        The ``AttributeError`` guard covers a record whose ``Maidr`` has been
+        destroyed. ``FigureManager.destroy`` pops the record before calling
+        ``Maidr.destroy()``, which deletes ``_fig`` -- but it pops it off the
+        figure it was given, and a shallow copy taken beforehand still holds
+        the same object. Reading ``record.fig`` there raised out of a
+        membership test, which has to answer a bool.
         """
         record = getattr(fig, self._ATTR, self._MISSING)
-        if record is not self._MISSING and record.fig is not fig:
+        if record is self._MISSING:
             return self._MISSING
+        try:
+            owner = record.fig
+        except AttributeError:
+            return self._MISSING
+        if owner is not fig:
+            return self._MISSING
+        self._seen.add(fig)
         return record
 
     def __contains__(self, fig: Figure) -> bool:
@@ -106,7 +124,19 @@ class _FigureRecords:
         # `pop` refuses -- two spellings of one operation disagreeing.
         if self._record(fig) is self._MISSING:
             raise KeyError(fig)
-        delattr(fig, self._ATTR)
+        self._delete(fig)
+
+    def _delete(self, fig: Figure) -> None:
+        # `delattr` after a `_record` check is a check-then-act, where the
+        # dict operation it replaced was atomic. `FigureManager` holds
+        # `_lock` across both, but `figs` is reachable directly, so a caller
+        # that does not would otherwise get an `AttributeError` out of `pop`
+        # where the class promises a `KeyError` -- or nothing, since the
+        # entry it wanted gone is gone either way.
+        try:
+            delattr(fig, self._ATTR)
+        except AttributeError:
+            pass
         self._seen.discard(fig)
 
     def __len__(self) -> int:
@@ -130,8 +160,7 @@ class _FigureRecords:
             if default is self._MISSING:
                 raise KeyError(fig)
             return default
-        delattr(fig, self._ATTR)
-        self._seen.discard(fig)
+        self._delete(fig)
         return maidr
 
     def clear(self) -> None:

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -88,6 +88,20 @@ class Maidr:
         Saves the rendered HTML representation to a file.
     show(renderer='auto')
         Displays the rendered HTML content in the specified rendering context.
+
+    Notes
+    -----
+    Since #456 this object is stored on its own figure, so **everything held
+    here and on every :class:`~maidr.core.plot.MaidrPlot` participates in
+    that figure's pickle and deepcopy**. Before, the registry lived off the
+    figure and a figure was picklable regardless of maidr's state.
+
+    So an unpicklable attribute -- a lock, a generator, an open handle, a
+    closure kept on ``self`` rather than used within one call -- would break
+    ``pickle.dumps(fig)`` for a plain-looking figure that merely happens to
+    have been plotted through maidr, somewhere the user has no reason to
+    look. Nothing enforces this; ``tests/core/test_figure_manager.py``
+    round-trips a figure through both, which is what would notice.
     """
 
     def __init__(self, fig: Figure, plot_type: PlotType = PlotType.LINE) -> None:

--- a/maidr/widget/shiny.py
+++ b/maidr/widget/shiny.py
@@ -259,7 +259,7 @@ def _close_new_figures(before: set) -> None:
     only a warning on the server to show for it.
 
     ``FigureManager.figs`` therefore still keeps a record per figure --
-    which is correct, and no longer a leak.  The record is stored on the
+    which is correct, and no longer a leak. The record is stored on the
     figure itself (#456), so it lasts exactly as long as the application's
     own reference: a cached figure keeps its data across flushes, and a
     throwaway one is reclaimed with everything maidr extracted from it.

--- a/maidr/widget/shiny.py
+++ b/maidr/widget/shiny.py
@@ -258,11 +258,11 @@ def _close_new_figures(before: set) -> None:
     static image: an accessible chart quietly turning into a picture, with
     only a warning on the server to show for it.
 
-    ``FigureManager.figs`` therefore still retains an entry per figure.
-    That is pre-existing behaviour rather than something this introduces,
-    and it cannot be fixed from here: the entry's value is a
-    :class:`~maidr.core.maidr.Maidr` that holds the figure, so even a
-    weakly-keyed map would keep it reachable.
+    ``FigureManager.figs`` therefore still keeps a record per figure --
+    which is correct, and no longer a leak.  The record is stored on the
+    figure itself (#456), so it lasts exactly as long as the application's
+    own reference: a cached figure keeps its data across flushes, and a
+    throwaway one is reclaimed with everything maidr extracted from it.
 
     Parameters
     ----------

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -579,3 +579,50 @@ def test_a_record_naming_another_figure_is_refused_not_quietly_kept():
         for fig in (a, b):
             FigureManager.figs.pop(fig, None)
             plt.close(fig)
+
+
+def test_clear_drops_every_registered_figure():
+    """``clear`` is the suite's own isolation tool and nothing asserted it.
+
+    Called from ``tests/widget/test_shiny.py``'s fixture and nowhere else,
+    so a ``clear`` that silently dropped nothing would leak one test's
+    figures into the next rather than fail here. It is also the method most
+    exposed to the ``_seen`` bookkeeping, since it iterates and pops in the
+    same pass while ``_record`` is adding to the set it walks.
+
+    Includes a figure whose record arrived by ``deepcopy`` rather than
+    through ``__setitem__``, which was invisible to ``clear`` until
+    ``_record`` started keeping ``_seen`` current -- and, separately, one
+    that is *never looked up*, which ``clear`` still cannot see. That gap
+    is asserted rather than hidden: ``_seen`` learns of a figure only when
+    its record is written or read, and a clone does neither. See
+    ``_FigureRecords.clear`` for why closing it is not worth what it costs.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    other, other_ax = plt.subplots()
+    other_ax.bar(["c"], [3])
+    twin = copy.deepcopy(fig)
+    untouched = copy.deepcopy(fig)
+    try:
+        # Reading `twin` is what puts it within `clear`'s reach; `untouched`
+        # is deliberately not read, so the two differ only in that.
+        for registered in (fig, other, twin):
+            assert registered in FigureManager.figs
+
+        FigureManager.figs.clear()
+
+        for registered in (fig, other, twin):
+            assert registered not in FigureManager.figs
+        assert list(FigureManager.figs) == []
+        assert len(FigureManager.figs) == 0
+
+        assert untouched in FigureManager.figs, (
+            "a clone that was never looked up is expected to survive "
+            "`clear` -- if this now passes, the gap was closed and this "
+            "assertion is the thing to delete"
+        )
+    finally:
+        for f in (fig, other):
+            FigureManager.figs.pop(f, None)
+            plt.close(f)

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -552,3 +552,30 @@ def test_a_copied_figure_is_visible_to_enumeration_not_only_to_lookup(clone):
         FigureManager.figs.pop(fig, None)
         FigureManager.figs.pop(twin, None)
         plt.close(fig)
+
+
+def test_a_record_naming_another_figure_is_refused_not_quietly_kept():
+    """The one write path has to uphold what every read path enforces.
+
+    Storing a ``Maidr`` that names a different figure used to succeed, set
+    the attribute, and then read back as unregistered -- a write that did
+    not stick, leaving a stray attribute behind. The dict this replaced
+    would have stored and returned it, so this is a behaviour change, and a
+    deliberate one: the alternative is a silent disagreement discovered at
+    some later lookup rather than an error at the mistake.
+    """
+    a, ax_a = plt.subplots()
+    ax_a.bar(["a"], [1])
+    b, ax_b = plt.subplots()
+    ax_b.bar(["b"], [2])
+    try:
+        record_of_b = FigureManager.figs[b]
+        with pytest.raises(ValueError, match="names a different one"):
+            FigureManager.figs[a] = record_of_b
+
+        # And a's own record is untouched by the refusal.
+        assert FigureManager.figs[a].fig is a
+    finally:
+        for fig in (a, b):
+            FigureManager.figs.pop(fig, None)
+            plt.close(fig)

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -8,6 +8,8 @@ import matplotlib.pyplot as plt
 import pytest
 import seaborn as sns
 
+import maidr
+
 from maidr.core import Maidr
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.figure_manager import FigureManager
@@ -434,3 +436,57 @@ def test_del_and_pop_agree_about_what_is_registered():
     finally:
         FigureManager.figs.pop(fig, None)
         plt.close(fig)
+
+
+def test_a_cached_figure_keeps_its_chart_across_renders():
+    """#452's hazard, against #456's fix.
+
+    A figure built lazily and cached -- ``@reactive.calc``, any memoised
+    helper -- is closed by the render that opened it and is still the live
+    chart. Dropping its record there is what made every later render fall
+    back to a static image: an accessible chart quietly turning into a
+    picture. That is why #456 could not be fixed by dropping on
+    ``close_event``, and why a bounded cache would have carried the same
+    hazard in miniature.
+
+    Storing the record on the figure ties its lifetime to the caller's own
+    reference instead, so the cache holding the figure is exactly what keeps
+    the record. Both halves are asserted -- the record survives repeated
+    render-and-close cycles, *and* letting go really does reclaim it --
+    because a fix that never released anything would pass the first alone.
+
+    **What this does not detect.** It is not a guard against the
+    ``close_event`` design. Tried: dropping the record from a
+    ``close_event`` handler leaves this test passing, because under ``Agg``
+    ``plt.close()`` fires no ``close_event`` at all (measured: 0 callbacks).
+    That is worth knowing for its own sake -- it means that option would
+    also have been inert in a headless server, which is where the leak it
+    was meant to fix actually happens -- but it means the reclaim half is
+    the only part with a falsified detector behind it, against the plain
+    dict this replaced.
+    """
+    cache = {}
+
+    def cached_figure():
+        if "fig" not in cache:
+            fig, ax = plt.subplots()
+            ax.bar(["a", "b", "c"], [1, 2, 3])
+            cache["fig"] = fig
+        return cache["fig"]
+
+    for flush in range(3):
+        fig = cached_figure()
+        maidr.render(fig)
+        plt.close(fig)
+        gc.collect()
+        assert fig in FigureManager.figs, (
+            f"the cached figure lost its record on flush {flush}; every "
+            "later render would fall back to a static image"
+        )
+        assert len(FigureManager.figs[fig].plots) == 1
+
+    ref = weakref.ref(cache.pop("fig"))
+    del fig
+    gc.collect()
+    gc.collect()
+    assert ref() is None, "the cache let go but the figure was not reclaimed"

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -1,4 +1,6 @@
+import gc
 import threading
+import weakref
 
 import matplotlib.pyplot as plt
 import pytest
@@ -252,5 +254,93 @@ def test_a_layer_keeps_the_selector_id_minted_with_it(monkeypatch):
         )
     finally:
         second_done.set()
+        FigureManager.figs.pop(fig, None)
+        plt.close(fig)
+
+
+def test_a_closed_figure_is_not_kept_alive_by_having_been_registered():
+    """Registering a chart must not outlive the application's own reference.
+
+    Layers are registered when a chart is *plotted*, not when it is
+    rendered, so before #456 every supported figure entered a class-level
+    dict and stayed reachable for the life of the process -- long after the
+    application dropped it and matplotlib closed it. The ``plt.show()`` path
+    escaped it only because the backend calls ``destroy`` explicitly
+    (``maidr/backend.py``); a Shiny or Streamlit render never goes through
+    ``plt.show``, so a long-lived server accumulated one figure per render.
+
+    The record lives on the figure now, which makes the whole graph an
+    isolated cycle once the caller lets go.
+
+    Driven through ``ax.bar`` rather than ``_get_maidr`` directly, so that
+    the reference the extraction itself takes -- ``MaidrPlot.ax``,
+    ``_elements``, and ``BarPlot._own_bars`` -- are all present. Those are
+    what defeated the ``WeakKeyDictionary`` attempt recorded in #498: a
+    value that reaches its own key keeps a weak key alive forever. They are
+    harmless here precisely because they close a cycle rather than a chain.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    assert fig in FigureManager.figs, "the figure was never registered"
+
+    ref = weakref.ref(fig)
+    plt.close(fig)
+    del fig, ax
+    # Two passes: the first may only break the cycle, and matplotlib's
+    # artists refer to each other in both directions throughout.
+    gc.collect()
+    gc.collect()
+
+    assert ref() is None, (
+        "a registered figure survived the application dropping it; the "
+        "registry is holding it for the life of the process"
+    )
+
+
+def test_the_registry_reads_as_the_mapping_it_replaced():
+    """Storage moved onto the figure; the shape callers see did not.
+
+    ``figs`` is read directly across this suite and named in
+    ``FigureManager``'s own docstring, so the operations it supports are
+    part of what the move had to preserve -- including ``pop``'s two
+    signatures, which ``destroy`` and this file's cleanup rely on
+    differently.
+
+    Deliberately **not** a detector for the move itself: a plain dict
+    satisfies every assertion here, which is the whole point of preserving
+    the interface. ``test_a_closed_figure_is_not_kept_alive_by_having_been_registered``
+    is what tells the two apart. This one guards later edits to
+    ``_FigureRecords``.
+
+    Everything is asserted about *this* figure rather than about the
+    registry's total contents. An earlier draft asserted ``len(figs) == 1``,
+    which passed alone and failed in a full run -- other tests leave their
+    figures registered -- and would have passed or failed by collection
+    timing once they stopped doing so.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    try:
+        maidr = FigureManager.figs[fig]
+
+        assert fig in FigureManager.figs
+        assert FigureManager.figs.get(fig) is maidr
+        assert fig in list(FigureManager.figs)
+
+        assert FigureManager.figs.pop(fig) is maidr
+        assert fig not in FigureManager.figs
+        assert fig not in list(FigureManager.figs)
+        assert FigureManager.figs.get(fig) is None
+        assert FigureManager.figs.get(fig, "fallback") == "fallback"
+
+        # Absent: `pop` with no default raises, with one returns it. `destroy`
+        # catches the KeyError to mean "never registered", so a `pop` that
+        # answered `None` there would silently call `destroy` on nothing.
+        assert FigureManager.figs.pop(fig, None) is None
+        with pytest.raises(KeyError):
+            FigureManager.figs.pop(fig)
+        with pytest.raises(KeyError):
+            FigureManager.figs[fig]
+    finally:
         FigureManager.figs.pop(fig, None)
         plt.close(fig)

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -626,3 +626,82 @@ def test_clear_drops_every_registered_figure():
         for f in (fig, other):
             FigureManager.figs.pop(f, None)
             plt.close(f)
+
+
+def test_one_thread_cannot_enter_the_registry_while_another_is_inside(monkeypatch):
+    """The registry's own lock actually excludes, rather than merely existing.
+
+    ``figs`` is a public class attribute that reads like a dict, so
+    ``if fig in FigureManager.figs`` is the natural line for a future
+    contributor to write outside ``FigureManager``'s lock -- and since the
+    record moved onto the figure, a lookup also updates the bookkeeping
+    behind iteration, so that apparently-read-only line mutates shared
+    state. ``_FigureRecords`` therefore guards itself.
+
+    Asserted as **mutual exclusion**, which is what the lock promises, and
+    with an explicit handoff rather than a crowd. The failure it prevents
+    -- ``RuntimeError: Set changed size during iteration`` -- can only be
+    provoked by sustained contention, and a bounded harness for it detected
+    on roughly half its runs while a larger budget made it *worse*: 5 of 8
+    at 0.75s against 3 of 8 at 1.0s. That is scheduler luck, not a test.
+
+    Parking one thread inside the critical section and asking whether
+    another can get in needs no luck at all.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    try:
+        inside = threading.Event()
+        b_finished = threading.Event()
+        real_add = FigureManager.figs._seen.add
+        who = threading.local()
+
+        def parking_add(item):
+            """Park the holder inside the guard -- and only the holder.
+
+            Tagged per thread because `_seen.add` is on the enterer's path
+            too (`pop` establishes ownership before deleting). A version
+            without the tag parked *both* threads and passed with the guard
+            removed: neither could observe the other, so there was nothing
+            to detect.
+            """
+            if getattr(who, "tag", None) == "holder":
+                inside.set()
+                b_finished.wait(_HANDOFF_DEADLINE)
+            return real_add(item)
+
+        monkeypatch.setattr(FigureManager.figs._seen, "add", parking_add)
+        record = FigureManager.figs[fig]
+
+        def hold():
+            who.tag = "holder"
+            FigureManager.figs[fig] = record
+
+        def enter():
+            who.tag = "enterer"
+            inside.wait(5)
+            FigureManager.figs.pop(fig, None)
+            b_finished.set()
+
+        holder = threading.Thread(target=hold)
+        enterer = threading.Thread(target=enter)
+        holder.start()
+        enterer.start()
+
+        # The holder parks until the deadline because the enterer is blocked
+        # on the guard; unguarded, the enterer completes immediately and the
+        # holder is released early. The gap between those is the assertion.
+        entered_while_held = b_finished.wait(_HANDOFF_DEADLINE / 2)
+
+        for worker in (holder, enterer):
+            worker.join(timeout=10)
+            assert not worker.is_alive(), "the registry deadlocked"
+
+        assert not entered_while_held, (
+            "a second thread entered the registry while another was inside "
+            "its critical section; the guard is not excluding anything"
+        )
+    finally:
+        b_finished.set()
+        FigureManager.figs.pop(fig, None)
+        plt.close(fig)

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -1,4 +1,6 @@
+import copy
 import gc
+import pickle
 import threading
 import weakref
 
@@ -343,4 +345,65 @@ def test_the_registry_reads_as_the_mapping_it_replaced():
             FigureManager.figs[fig]
     finally:
         FigureManager.figs.pop(fig, None)
+        plt.close(fig)
+
+
+def test_a_shallow_copy_of_a_figure_is_not_its_original_s_chart():
+    """Storing the record on the figure means copies inherit the attribute.
+
+    ``copy.copy`` on a ``Figure`` copies the ``__dict__`` entries themselves,
+    so without a check the copy answers as registered and hands back a
+    ``Maidr`` bound to the *original* -- which would render the original's
+    chart, with the original's data, under the copy. The module-level dict
+    could not do that: only the object actually inserted was ever a key.
+
+    So the copy is treated as unregistered, which is what it is. Whoever
+    plots on it registers it.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    twin = copy.copy(fig)
+    try:
+        assert fig in FigureManager.figs
+        assert twin not in FigureManager.figs
+        assert FigureManager.figs.get(twin) is None
+        with pytest.raises(KeyError):
+            FigureManager.figs[twin]
+
+        # And asking about the copy must not take the original's record away.
+        assert FigureManager.figs.pop(twin, None) is None
+        assert fig in FigureManager.figs
+    finally:
+        FigureManager.figs.pop(fig, None)
+        plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    "clone",
+    [
+        pytest.param(copy.deepcopy, id="deepcopy"),
+        pytest.param(lambda fig: pickle.loads(pickle.dumps(fig)), id="pickle"),
+    ],
+)
+def test_a_figure_that_is_copied_wholesale_keeps_its_chart(clone):
+    """Unlike a shallow copy, these rebuild the record alongside the figure.
+
+    Both are new couplings: a figure's pickle now carries the ``Maidr`` and
+    every ``MaidrPlot`` under it, which it did not when the record lived in
+    a module-level dict. Pinned in both directions -- that the round trip
+    still *succeeds*, since anything unpicklable added to those classes
+    would now break pickling a plain figure, and that the copy's record
+    belongs to the copy rather than to the original, which is what
+    distinguishes this from the shallow case above.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    twin = clone(fig)
+    try:
+        assert twin in FigureManager.figs
+        assert FigureManager.figs[twin] is not FigureManager.figs[fig]
+        assert FigureManager.figs[twin].fig is twin
+    finally:
+        FigureManager.figs.pop(fig, None)
+        FigureManager.figs.pop(twin, None)
         plt.close(fig)

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -407,3 +407,30 @@ def test_a_figure_that_is_copied_wholesale_keeps_its_chart(clone):
         FigureManager.figs.pop(fig, None)
         FigureManager.figs.pop(twin, None)
         plt.close(fig)
+
+
+def test_del_and_pop_agree_about_what_is_registered():
+    """Two spellings of one operation must not disagree.
+
+    ``__delitem__`` originally deleted the attribute directly while ``pop``
+    went through the ownership check, so ``del figs[copy]`` succeeded on a
+    shallow copy that ``figs.pop(copy)`` refused. Nothing calls
+    ``__delitem__`` today, which is exactly why it would have gone unnoticed
+    until the first caller.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    twin = copy.copy(fig)
+    try:
+        with pytest.raises(KeyError):
+            FigureManager.figs.pop(twin)
+        with pytest.raises(KeyError):
+            del FigureManager.figs[twin]
+
+        del FigureManager.figs[fig]
+        assert fig not in FigureManager.figs
+        with pytest.raises(KeyError):
+            del FigureManager.figs[fig]
+    finally:
+        FigureManager.figs.pop(fig, None)
+        plt.close(fig)

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -490,3 +490,65 @@ def test_a_cached_figure_keeps_its_chart_across_renders():
     gc.collect()
     gc.collect()
     assert ref() is None, "the cache let go but the figure was not reclaimed"
+
+
+def test_a_stale_copy_of_a_destroyed_figure_answers_rather_than_raises():
+    """``Maidr.destroy()`` deletes ``_fig``, and a copy can still hold it.
+
+    ``FigureManager.destroy`` pops the record before tearing the ``Maidr``
+    down, which is why a *destroyed* record is unreachable -- from the
+    figure it was popped off. A shallow copy taken beforehand holds the same
+    object, and reading ``record.fig`` on it raised ``AttributeError`` out
+    of a membership test, which has to answer a bool.
+
+    Found in review after I had reasoned the case away as impossible: the
+    pop removes the record from the original, not from a copy that already
+    exists.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    twin = copy.copy(fig)
+    try:
+        maidr.close(ax)  # FigureManager.destroy -> Maidr.destroy
+
+        assert (twin in FigureManager.figs) is False
+        assert FigureManager.figs.get(twin) is None
+        with pytest.raises(KeyError):
+            FigureManager.figs[twin]
+        assert FigureManager.figs.pop(twin, None) is None
+    finally:
+        FigureManager.figs.pop(fig, None)
+        plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    "clone",
+    [
+        pytest.param(copy.deepcopy, id="deepcopy"),
+        pytest.param(lambda fig: pickle.loads(pickle.dumps(fig)), id="pickle"),
+    ],
+)
+def test_a_copied_figure_is_visible_to_enumeration_not_only_to_lookup(clone):
+    """A record that never went through ``__setitem__`` still has to count.
+
+    ``deepcopy`` and ``pickle`` rebuild ``__dict__`` directly, so nothing
+    adds the copy to ``_seen`` -- and ``_seen`` is what backs iteration,
+    ``len`` and ``clear``. The copy therefore answered ``in`` while being
+    absent from ``list(figs)``, uncounted, and immune to ``clear()``: a
+    mapping disagreeing with itself about what it holds.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    twin = clone(fig)
+    try:
+        assert twin in FigureManager.figs
+        assert twin in list(FigureManager.figs)
+
+        before = len(FigureManager.figs)
+        FigureManager.figs.pop(twin)
+        assert twin not in list(FigureManager.figs)
+        assert len(FigureManager.figs) == before - 1
+    finally:
+        FigureManager.figs.pop(fig, None)
+        FigureManager.figs.pop(twin, None)
+        plt.close(fig)

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -517,19 +517,18 @@ def test_an_unresolvable_figure_gets_a_fresh_lock_rather_than_a_shared_one():
 def test_the_lock_does_not_keep_a_closed_figure_alive():
     """The map is weak-keyed, so it adds no retention of its own (#498).
 
-    Worth pinning because ``FigureManager.figs`` already retains every
-    figure for the life of the process, and a second strong map keyed by
-    figure would be a new instance of a problem that is being worked on
-    rather than added to.
+    Worth pinning because a strong map keyed by figure is exactly the shape
+    that kept every registered figure alive for the life of the process
+    (#456), and this one is keyed the same way.
     """
     from matplotlib.figure import Figure
     from maidr.widget.shiny import _figure_lock
 
-    # A bare `Figure`, deliberately not `plt.subplots()`: pyplot registers
-    # with `FigureManager`, which retains every figure for the life of the
-    # process (#456). Through that, this assertion would fail for a reason
-    # that has nothing to do with the lock map -- which is exactly what the
-    # first version of this test did.
+    # A bare `Figure`, deliberately not `plt.subplots()`, so that nothing
+    # but the lock map can be the reason this passes or fails. When this was
+    # written `FigureManager` retained every figure and a pyplot figure
+    # failed here for that reason rather than the lock map's; that is fixed
+    # now, and the isolation is still worth keeping.
     figure = Figure()
     _figure_lock(figure)
     ref = weakref.ref(figure)


### PR DESCRIPTION
Closes #456.

## The defect

`FigureManager.figs` was a class-level `dict`, so a figure stayed reachable for the life of the process once maidr registered it.

Registration happens when a chart is **plotted**, not when it is rendered, so this applied to every supported figure — including ones never rendered at all. The `plt.show()` path escaped it only because `maidr/backend.py` calls `destroy` explicitly. A Shiny or Streamlit render never goes through `plt.show`, so a long-lived server accumulated one figure, and every artist maidr extracted from it, per render.

## Measured

25 renders, each building its own figure and calling `plt.close()`:

| chart | before | after |
|---|---|---|
| 10 bars | 17.65 MB, `figs` +25 | **0.26 MB, `figs` +0** |
| 200 bars | 177.80 MB, `figs` +25 | **2.30 MB, `figs` +0** |

The `after` column matches the control #498 established (drop the entry by hand: 0.27 MB / 1.32 MB), so what remains is baseline allocation rather than retention.

## The fix, and why it is none of the three options on #456

The record now lives on the figure itself rather than in a module-level table. That makes the whole graph — figure, its `Maidr`, its layers, and the artists those layers hold — **one isolated reference cycle** once the application lets go, which the cyclic collector reclaims.

| case | figure collected |
|---|---|
| module-level dict (today) | no |
| record stored on the figure | **yes** |

This is deliberately **not** a `WeakKeyDictionary`. That was option 1, it was tried, and it freed nothing — every value reaches its own key (`Maidr._fig`, `MaidrPlot.ax`, and each subclass's own artist handles such as `BarPlot._own_bars`), so the entry keeps the figure alive and the weak key never dies. Keeping the value *on* the key sidesteps that entirely, because a value that reaches its key is exactly what a cycle *is*, and cycles are collectable as long as nothing outside points in.

It also avoids what was wrong with the other two:

- **Option 2 (bounded LRU)** evicts entries for figures the app still re-renders, stripping a live chart of its data. Here lifetime is exactly the application's own reference, so there is no bound to tune and nothing to evict early.
- **Option 3 (drop on `close_event`)** is wrong per #452 — a figure built lazily and cached (`@reactive.calc`, any memoised helper) is closed by the render that opened it but is still the live chart. Here a cached figure keeps its record for as long as the cache holds it.

### It also corrects #498's premise

#498 says "no lifetime fix in `FigureManager` can work" because `MaidrPlot` holds live artists. Measurement says otherwise: popping the `figs` entry by hand frees the figure today, cycles and all. Those references are a barrier to a *weak key*, not to the *cyclic collector*. Posting the detail on #498 separately.

## Compatibility

`figs` keeps the mapping interface it had — `figs[fig]`, `fig in figs`, `.get`, `.pop` (both signatures), `.clear`, iteration, `len` — so its callers and the 25 places the suite reads it are unchanged. `pickle` and `deepcopy` of a figure carrying a record both still work (checked).

`__len__` is implemented rather than skipped for a specific reason: without it `if figs:` is always true, which is the one way a partial mapping fails quietly instead of with a `TypeError`.

## Verification

**2361 passed, 13 skipped.** `ruff check` unchanged at the 6 pre-existing findings.

The retention test was falsified against the previous implementation **in isolation** before being trusted — it fails on the plain dict and passes on the fix, run alone rather than only as part of the file.

Its neighbour, the mapping-contract test, is **not** a detector and no longer claims to be. An earlier draft of it asserted `len(figs) == 1`; that passed when run alone against the *old* dict and failed only in a full run, because other tests leave their figures registered. It was measuring suite state, not the contract. It now asserts only about its own figure, and its docstring says plainly that a plain dict satisfies every line of it.

Three stale comments that asserted the old behaviour as fact are corrected in the same change (`maidr/widget/shiny.py`, `maidr/backend.py`, `tests/widget/test_shiny.py`) rather than left to read as current.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_