### PR TITLE
test(shiny): pin what the per-figure lock actually prevents

### DIFF
--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -852,7 +852,10 @@ def test_concurrent_renders_of_one_figure_agree():
             start.wait(timeout=10)
             rendered = str(renderer._render_off_loop(ax))
             outputs.append(_VOLATILE_IN_SVG.sub("", rendered))
-        except BaseException as exc:  # reported below, not swallowed
+        except Exception as exc:  # reported below, not swallowed
+            # Narrow enough to cover everything expected --
+            # `BrokenBarrierError` is a `RuntimeError` -- while leaving
+            # `KeyboardInterrupt` and `SystemExit` free to end the thread.
             failures.append(exc)
 
     workers = [threading.Thread(target=render_once) for _ in range(racers)]

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -632,7 +632,10 @@ def test_two_renders_of_one_figure_do_not_overlap(monkeypatch):
         for worker in workers:
             worker.start()
         for worker in workers:
-            worker.join()
+            # Bounded: an unbounded join turns a broken lock into a hung
+            # suite rather than a failed test (#506).
+            worker.join(timeout=60)
+            assert not worker.is_alive(), "a render deadlocked on the lock"
     finally:
         plt.close(fig)
 
@@ -767,7 +770,8 @@ def test_two_different_figures_rendering_at_once_keep_their_selectors():
         for worker in workers:
             worker.start()
         for worker in workers:
-            worker.join()
+            worker.join(timeout=60)
+            assert not worker.is_alive(), "a render deadlocked"
 
         assert [together[i] for i in range(len(figures))] == alone, (
             "a concurrent render of another figure stripped this one's "
@@ -775,3 +779,75 @@ def test_two_different_figures_rendering_at_once_keep_their_selectors():
         )
     finally:
         plt.close("all")
+
+
+#: Attributes that differ between two renders of the same chart by design --
+#: fresh uuids per layer, and the timestamp matplotlib stamps into the SVG.
+_VOLATILE_IN_SVG = re.compile(
+    r'(id="[^"]*"|url\(#[^)]*\)|<dc:date>[^<]*</dc:date>'
+    r'|xlink:href="#[^"]*"|maidr="[^"]*")'
+)
+
+
+def test_concurrent_renders_of_one_figure_agree(monkeypatch):
+    """Concurrent renders of one figure must produce the same chart.
+
+    Narrower than it first looks, and worth stating plainly:
+    ``test_two_renders_of_one_figure_do_not_overlap`` above already fails
+    without the lock, so this is not filling an unguarded gap. That one
+    monkeypatches ``maidr.render`` to a sleeping stub, so it proves the
+    lock *excludes* but cannot see what the exclusion is protecting. This
+    runs the real render and asserts the consequence.
+
+    ``savefig`` writes ``fig.dpi`` for its duration and restores it
+    afterwards, so two renders of the **same** figure at once race on one
+    mutable attribute and the loser draws the whole chart at the other
+    call's dpi (#454). Distinct figures do not race; that is why the lock
+    is per figure rather than process-wide.
+
+    The failure is the kind this project treats as worst: not garbled
+    markup and not an exception, but a complete, well-formed SVG of the
+    same chart at the wrong size. Geometry is what the highlight overlay
+    and the tactile export are positioned against, so a chart rendered at
+    72% scale is wrong in the modality a sighted reviewer checks least.
+
+    Asserted as agreement between renders rather than against a fixed size,
+    since the wrong-dpi output is internally consistent -- it is only wrong
+    relative to what every other render produced.
+
+    Measured 10 of 10 runs mismatching with the lock stubbed out and 10 of
+    10 identical with it, so this runs in CI rather than under
+    ``--run-benchmark``.
+    """
+    fig, ax = plt.subplots()
+    ax.bar([str(i) for i in range(30)], list(range(30)))
+    renderer = render_maidr(lambda: ax)
+
+    outputs: list[str] = []
+    failures: list[BaseException] = []
+
+    def render_once():
+        try:
+            rendered = str(renderer._render_off_loop(ax))
+            outputs.append(_VOLATILE_IN_SVG.sub("", rendered))
+        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+            failures.append(exc)
+
+    workers = [threading.Thread(target=render_once) for _ in range(6)]
+    try:
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join(timeout=60)
+            assert not worker.is_alive(), "a render deadlocked on the lock"
+
+        assert not failures, f"a render raised: {failures[:2]}"
+        assert len(outputs) == len(workers)
+        assert len(set(outputs)) == 1, (
+            "concurrent renders of one figure disagreed; one of them drew "
+            "the chart at another render's dpi, which produces a valid SVG "
+            "at the wrong scale rather than an error"
+        )
+    finally:
+        FigureManager.figs.pop(fig, None)
+        plt.close(fig)

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -784,7 +784,7 @@ def test_two_different_figures_rendering_at_once_keep_their_selectors():
 #: Attributes that differ between two renders of the same chart by design --
 #: fresh uuids per layer, and the timestamp matplotlib stamps into the SVG.
 _VOLATILE_IN_SVG = re.compile(
-    r'(id="[^"]*"|url\(#[^)]*\)|<dc:date>[^<]*</dc:date>'
+    r'(\bid="[^"]*"|url\(#[^)]*\)|<dc:date>[^<]*</dc:date>'
     r'|xlink:href="#[^"]*"|maidr="[^"]*")'
 )
 
@@ -815,6 +815,13 @@ def test_concurrent_renders_of_one_figure_agree():
     since the wrong-dpi output is internally consistent -- it is only wrong
     relative to what every other render produced.
 
+    Scope: **geometry, not data.** ``_VOLATILE_IN_SVG`` strips every
+    ``maidr="..."`` attribute, and the one on the root ``<svg>`` carries
+    the whole embedded schema, so a race that scrambled the announced
+    values without moving a coordinate would pass this. The bug it guards
+    is about ``fig.dpi``, which lives entirely in the ``<path d="...">``
+    data the regex leaves alone.
+
     Measured 10 of 10 runs mismatching with the lock stubbed out and 10 of
     10 identical with it, so this runs in CI rather than under
     ``--run-benchmark``.
@@ -842,10 +849,10 @@ def test_concurrent_renders_of_one_figure_agree():
 
     def render_once():
         try:
-            start.wait(timeout=30)
+            start.wait(timeout=10)
             rendered = str(renderer._render_off_loop(ax))
             outputs.append(_VOLATILE_IN_SVG.sub("", rendered))
-        except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
+        except BaseException as exc:  # reported below, not swallowed
             failures.append(exc)
 
     workers = [threading.Thread(target=render_once) for _ in range(racers)]
@@ -853,7 +860,10 @@ def test_concurrent_renders_of_one_figure_agree():
         for worker in workers:
             worker.start()
         for worker in workers:
-            worker.join(timeout=60)
+            # Longer than the barrier's own deadline above, so a thread
+            # still legitimately waiting there is not reported as a
+            # deadlocked render. A healthy run of this test is ~1.7s.
+            worker.join(timeout=30)
             assert not worker.is_alive(), "a render deadlocked on the lock"
 
         assert not failures, f"a render raised: {failures[:2]}"

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -738,8 +738,6 @@ def test_two_different_figures_rendering_at_once_keep_their_selectors():
     Counts selectors rather than comparing whole documents, because ids
     are per-render uuids; the count is what goes missing.
     """
-    import re
-
     from maidr.core.figure_manager import FigureManager
 
     def build():
@@ -814,6 +812,14 @@ def test_concurrent_renders_of_one_figure_agree():
     Asserted as agreement between renders rather than against a fixed size,
     since the wrong-dpi output is internally consistent -- it is only wrong
     relative to what every other render produced.
+
+    The barrier synchronises the *start*, not the duration. On a runner
+    slow or oversubscribed enough that each ``savefig`` finishes before
+    the next thread is scheduled, this would pass with a broken lock --
+    a false negative rather than a flaky failure, so it would show up as
+    quietly reduced coverage rather than as CI noise. Measured 8 of 8
+    detections here with the lock removed; the sibling test above detects
+    overlap regardless of speed and is the one to trust on a bad day.
 
     Scope: **geometry, not data.** ``_VOLATILE_IN_SVG`` strips every
     ``maidr="..."`` attribute, and the one on the root ``<svg>`` carries

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -854,7 +854,7 @@ def test_concurrent_renders_of_one_figure_agree():
     # worker has been joined. Written down because this file documents its
     # other concurrency decisions.
     outputs: list[str] = []
-    failures: list[BaseException] = []
+    failures: list[Exception] = []
     # One constant for the barrier and the thread count, because they must
     # agree: a barrier expecting more arrivals than there are threads waits
     # forever (#506).

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -626,7 +626,11 @@ def test_two_renders_of_one_figure_do_not_overlap(monkeypatch):
     try:
         renderer = render_maidr(lambda: ax)
         workers = [
-            threading.Thread(target=renderer._render_off_loop, args=(ax,))
+            # Daemon, so that the deadlock this test exists to catch fails
+            # the test rather than wedging the interpreter at shutdown: a
+            # timed-out join leaves the thread alive and still holding the
+            # figure's lock.
+            threading.Thread(target=renderer._render_off_loop, args=(ax,), daemon=True)
             for _ in range(4)
         ]
         for worker in workers:
@@ -762,7 +766,7 @@ def test_two_different_figures_rendering_at_once_keep_their_selectors():
             together[index] = selectors(figure)
 
         workers = [
-            threading.Thread(target=render, args=(index, figure))
+            threading.Thread(target=render, args=(index, figure), daemon=True)
             for index, figure in enumerate(figures)
         ]
         for worker in workers:
@@ -845,6 +849,10 @@ def test_concurrent_renders_of_one_figure_agree():
     ax.bar([str(i) for i in range(30)], list(range(30)))
     renderer = render_maidr(lambda: ax)
 
+    # Appended from several threads without a lock, which is safe because
+    # `list.append` is atomic under the GIL, and read only after every
+    # worker has been joined. Written down because this file documents its
+    # other concurrency decisions.
     outputs: list[str] = []
     failures: list[BaseException] = []
     # One constant for the barrier and the thread count, because they must
@@ -864,7 +872,7 @@ def test_concurrent_renders_of_one_figure_agree():
             # `KeyboardInterrupt` and `SystemExit` free to end the thread.
             failures.append(exc)
 
-    workers = [threading.Thread(target=render_once) for _ in range(racers)]
+    workers = [threading.Thread(target=render_once, daemon=True) for _ in range(racers)]
     try:
         for worker in workers:
             worker.start()

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -789,7 +789,7 @@ _VOLATILE_IN_SVG = re.compile(
 )
 
 
-def test_concurrent_renders_of_one_figure_agree(monkeypatch):
+def test_concurrent_renders_of_one_figure_agree():
     """Concurrent renders of one figure must produce the same chart.
 
     Narrower than it first looks, and worth stating plainly:
@@ -818,6 +818,15 @@ def test_concurrent_renders_of_one_figure_agree(monkeypatch):
     Measured 10 of 10 runs mismatching with the lock stubbed out and 10 of
     10 identical with it, so this runs in CI rather than under
     ``--run-benchmark``.
+
+    The renders start from a barrier rather than from whenever each thread
+    happens to be scheduled. Review raised the right worry -- a quiet or
+    single-core runner could let six staggered renders complete without
+    ever landing inside each other's ``dpi`` window, which would reduce
+    this to a no-op that still passes. Raising the chart size does not
+    address that (detection was 8 of 8 at 30, 100 and 200 bars alike, so
+    the margin was never the variable); starting them together does,
+    because it does not depend on the scheduler being busy.
     """
     fig, ax = plt.subplots()
     ax.bar([str(i) for i in range(30)], list(range(30)))
@@ -825,15 +834,21 @@ def test_concurrent_renders_of_one_figure_agree(monkeypatch):
 
     outputs: list[str] = []
     failures: list[BaseException] = []
+    # One constant for the barrier and the thread count, because they must
+    # agree: a barrier expecting more arrivals than there are threads waits
+    # forever (#506).
+    racers = 6
+    start = threading.Barrier(racers)
 
     def render_once():
         try:
+            start.wait(timeout=30)
             rendered = str(renderer._render_off_loop(ax))
             outputs.append(_VOLATILE_IN_SVG.sub("", rendered))
         except BaseException as exc:  # noqa: BLE001 - reported, not swallowed
             failures.append(exc)
 
-    workers = [threading.Thread(target=render_once) for _ in range(6)]
+    workers = [threading.Thread(target=render_once) for _ in range(racers)]
     try:
         for worker in workers:
             worker.start()
@@ -849,5 +864,4 @@ def test_concurrent_renders_of_one_figure_agree(monkeypatch):
             "at the wrong scale rather than an error"
         )
     finally:
-        FigureManager.figs.pop(fig, None)
         plt.close(fig)


### PR DESCRIPTION
> **Correction, before anything else.** This PR's original description claimed "removing the lock left the suite green." **That is false.** `test_two_renders_of_one_figure_do_not_overlap` already exists in this same file and already fails without the lock. I asserted the gap without running the suite against a lock-free build — I only checked that my *own* new test failed. The verification note below is what I should have run first.

Follows up on [#454](https://github.com/xability/py-maidr/issues/454#issuecomment-5321960614), where I offered a regression test for finding 3 and did not write one.

## What was actually already covered

Running the whole file against a build with `_figure_lock` removed from `_render_off_loop`:

```
FAILED test_two_renders_of_one_figure_do_not_overlap
FAILED test_concurrent_renders_of_one_figure_agree   <- this PR
2 failed, 35 passed
```

So the lock **is** guarded today. The existing test asserts the *mechanism*: with `maidr.render` monkeypatched to a sleeping stub, no two renders of one figure are ever inside at once.

## What this adds, and it is narrower than I first said

The existing test replaces the render entirely, so it cannot observe what the lock is protecting — it proves exclusion, not that the output is right. This one runs the **real** render path (real `savefig`, real SVG) and asserts the user-visible consequence: six concurrent renders of one figure produce byte-identical markup once per-render uuids and matplotlib's `dc:date` are stripped.

That matters because the failure mode is a *valid* document at the wrong scale:

```
-L 640 345.6      ->  +L 460.8 345.6
-L 640 -134.4     ->  +L 460.8 0
```

`640 / (100/72) = 460.8` — `savefig` writes `fig.dpi` for its duration and restores it. Geometry is what the highlight overlay and the tactile export are positioned against, so this is wrong in the modality a sighted reviewer checks least. A future change that keeps renders from *overlapping* but reintroduces shared mutable state some other way would pass the existing test and fail this one.

Whether a second test earns its place on that argument alone is a fair question, and a reasonable answer is no. I would rather put the corrected reasoning up and let you judge than leave the original claim standing.

## Detection

| | result |
|---|---|
| lock stubbed out, standalone harness | 10/10 mismatched |
| lock in place, standalone harness | 10/10 identical |
| lock removed, through pytest | 6/6 failed |
| lock restored, through pytest | 6/6 passed |

## Verification

**2382 passed, 13 skipped.** `ruff check` unchanged at the 6 pre-existing findings; `ruff format` clean on the changed file apart from one pre-existing hunk elsewhere in it that this PR does not touch.