### PR TITLE
docs: stop telling Shiny users their event loop is blocked

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -314,7 +314,21 @@ You give up picking up a release newer than your wheel, automatically, in an asy
 
 The same caching means this is not "async gets a different answer forever": after any resolution anywhere in the process, the loop and the main thread agree. It also means `warn_if_bundle_is_stale()` stays quiet in an app that never resolves, since it reads only an already-completed lookup.
 
-**The render itself still blocks, though.** The heading above is about the version *lookup*; do not read it as "nothing blocks the loop". `maidr.render()` is synchronous and CPU-bound — matplotlib's SVG writer, then lxml — so it runs on the event loop and every other session on that worker waits. It never awaits, so nothing preempts it: for as long as one render runs, the loop does not run at all. Measured on a trivial two-bar chart, one render holds the loop for about 55 ms, against 1.5 ms of ordinary scheduler jitter — every other session on that worker waits the whole time. A large scatter or heatmap is worse, and the cost is paid per session per input change. Re-run it with `uv run pytest tests/core/test_render_is_synchronous.py --run-benchmark`. Tracked in [#454](https://github.com/xability/py-maidr/issues/454).
+**The render no longer runs on the loop.** `maidr.render()` itself is synchronous and CPU-bound — matplotlib's SVG writer, then lxml — and it never awaits, so whoever calls it is stopped for its whole duration. `render_maidr` therefore does not call it on the loop: it hands the render to a worker thread, which works because the expensive part (`fig.savefig`, 87–88% of a render at every chart size) releases the GIL.
+
+Measured through the renderer on a 50-bar chart, longest gap between successive ticks of a 1 ms ticker:
+
+| | longest loop gap |
+|---|---|
+| idle, no rendering | 1.4 ms |
+| render on the loop, as it used to be | 609.3 ms |
+| render on a worker thread, as it is now | **12.5 ms** |
+
+Same throughput either way — the work did not get cheaper, it stopped being in everyone else's way.
+
+Two things this does not do. Renders of the **same figure** are serialised, because `savefig` writes `fig.dpi` for its duration and two concurrent writes leave one chart drawn at the other's scale; distinct figures, which is the usual per-session shape, run in parallel. And the chart still travels over the websocket on every flush — roughly 25 KB, or a couple of megabytes with `use_cdn=False`. That part is still open in [#454](https://github.com/xability/py-maidr/issues/454).
+
+`uv run pytest tests/core/test_render_is_synchronous.py --run-benchmark` re-measures the underlying `maidr.render()`, which is still synchronous and still blocks its caller — that is what makes moving it off the loop necessary rather than optional.
 :::
 
 `bundle_status()` is the one deliberate exception: it resolves even when pinned, because "how does my bundle compare to what's published?" has no answer otherwise. Pass `resolve=False` if you need it silent.

--- a/tests/core/test_render_is_synchronous.py
+++ b/tests/core/test_render_is_synchronous.py
@@ -90,13 +90,21 @@ async def _longest_gap_around_one_render() -> tuple[float, float]:
 
 @pytest.mark.benchmark
 def test_one_render_blocks_the_event_loop(monkeypatch) -> None:
-    """A render holds the loop for its whole duration.
+    """A render holds the loop of whoever calls it on one.
 
     ``maidr.render()`` is synchronous and never awaits, so nothing can
-    preempt it: for as long as it runs, every other session on that worker
-    is stopped. Asserted as "much larger than the baseline" rather than a
-    fixed millisecond count, which would fail on a loaded CI box while
-    telling nobody anything.
+    preempt it: for as long as it runs, that loop does not run at all.
+    Asserted as "much larger than the baseline" rather than a fixed
+    millisecond count, which would fail on a loaded CI box while telling
+    nobody anything.
+
+    Note what this does **not** say any more. It used to add "every other
+    session on that worker is stopped", which was true when ``render_maidr``
+    called this on the event loop. It no longer does -- the render is handed
+    to a worker thread -- so a Shiny app does not pay this, and measured
+    through the renderer the loop gap is 12.5 ms rather than 609 ms. What is
+    asserted here is the property of ``maidr.render()`` that makes moving it
+    off the loop necessary, not a description of what a Shiny app does.
     """
     # `_render_once` renders with `use_cdn=True`, and building that URL
     # would resolve the published version over the network. Pinning skips
@@ -116,7 +124,8 @@ def test_one_render_blocks_the_event_loop(monkeypatch) -> None:
 
     assert blocked * 1000 > _BLOCKED_MS, (
         f"one render held the loop for only {blocked * 1000:.1f} ms; if "
-        "rendering has stopped blocking, docs/index.qmd needs updating"
+        "`maidr.render` itself has stopped blocking its caller, both this "
+        "file and the async callout in docs/index.qmd need updating"
     )
     assert blocked > baseline * 5, (
         f"the render ({blocked * 1000:.1f} ms) is not clearly worse than "


### PR DESCRIPTION
## The defect

`docs/index.qmd`'s "Shiny and other async servers" callout still describes the state of things **before #504**:

> **The render itself still blocks, though.** … it runs on the event loop and every other session on that worker waits. It never awaits, so nothing preempts it: for as long as one render runs, the loop does not run at all. Measured … one render holds the loop for about 55 ms

#504 moved the render to a worker thread. That paragraph has been wrong since it landed — a reader today concludes their Shiny app stalls once per reactive flush, when it does not.

Found by checking the doc against the code, which is the only way this kind of staleness surfaces; nobody files a bug against documentation that is merely out of date.

## Re-measured through the shipped renderer

50-bar chart, longest gap between successive ticks of a 1 ms `asyncio` ticker, after a warm-up (the first render pays imports and the font cache — worth roughly thirty steady-state ones, and the reason an earlier measurement on #454 had to be retracted):

| | longest loop gap |
|---|---|
| idle, no rendering | 1.4 ms |
| render on the loop, as it used to be | 609.3 ms |
| render on a worker thread, as it is now | **12.5 ms** |

Same throughput either way — 9 vs 10 renders in the window. The work did not get cheaper; it stopped being in everyone else's way.

The 609.3 ms figure independently reproduces the 602.7 ms measured on [#454](https://github.com/xability/py-maidr/issues/454#issuecomment-5321960614) with a prototype, now through the shipped code path.

## What the callout now says it does *not* mean

Two limits, so the correction does not over-claim in the other direction:

- **Same-figure renders are still serialised.** `savefig` writes `fig.dpi` for its duration, so two concurrent renders of one figure leave one chart drawn at the other's scale. Distinct figures — the usual per-session shape — run in parallel. Pinned by `test_concurrent_renders_of_one_figure_agree` (#510).
- **The chart still crosses the websocket every flush**, ~25 KB or a couple of megabytes with `use_cdn=False`. That is #454's option 2 and is still open.

## The benchmark test

`tests/core/test_render_is_synchronous.py` keeps its assertion — the underlying `maidr.render()` *is* still synchronous, and that is exactly what makes moving it off the loop necessary rather than optional. What changed is its framing: it claimed "every other session on that worker is stopped", which was a statement about `render_maidr` rather than about the function it measures. Its failure message now names both files to update if `maidr.render` itself ever stops blocking its caller.

## Verification

**2382 passed, 13 skipped**, including the benchmark under `--run-benchmark`. `ruff check` unchanged at the 6 pre-existing findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_