### PR TITLE
fix(core): stop reading a figure caption as every panel's x-axis label

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -772,11 +772,13 @@ class Maidr:
                 position_groups[pos] = []
             position_groups[pos].append(plot["schema"])
 
+        # One entry per position, because `position_groups` already gathered
+        # every layer that shares one -- a stacked bar, a violin's KDE and box
+        # halves. The branch that used to guard this assignment against an
+        # already-filled cell could not fire for that reason, and would have
+        # nested a list inside `layers` rather than extending it if it had.
         for (row, col), layers in position_groups.items():
-            if subplot_grid[row][col]:
-                subplot_grid[row][col]["layers"].append(layers)
-            else:
-                subplot_grid[row][col] = {"id": Maidr._unique_id(), "layers": layers}
+            subplot_grid[row][col] = {"id": Maidr._unique_id(), "layers": layers}
 
         # Backfill the positions no axes occupies. The grid is sized from the
         # largest row/col any layer reports, so a figure with a gap -- an axes

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -221,19 +221,61 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         """Return the CSS selector for highlighting elements."""
         return "g[maidr='true'] > path"
 
-    def extract_shared_xlabel(self, ax, y_threshold=0.2):
+    def extract_shared_xlabel(self, ax: Axes, y_threshold: float = 0.2) -> str:
+        """Recover an x-axis label shared across a ``sharex`` axes group.
+
+        A faceted figure often labels only one member of a shared-x group,
+        or labels the figure rather than any axes. Either way the sibling
+        axes report an empty ``get_xlabel()`` and would announce ``X``.
+
+        Three sources, in order of how plainly they say "this labels your
+        x axis": a sibling's own label, ``Figure.supxlabel``, and finally a
+        figure-level text sitting in the bottom margin.
+
+        Parameters
+        ----------
+        ax : Axes
+            The axes whose shared x-label should be recovered.
+        y_threshold : float, optional
+            Figure-fraction y-position below which a figure text is treated
+            as a bottom-margin (shared) x-label, by default 0.2.
+
+        Returns
+        -------
+        str
+            The recovered label, or ``""`` if none is found.
+
+        Notes
+        -----
+        The margin scan is reached only when this axes really is in a
+        shared-x group -- more than one sibling. Without that condition it
+        fired on figures that share nothing, and read a bottom caption as
+        the x label of every panel, announced on every data point with
+        nothing marking it as a guess and no way to turn it off (#514).
+
+        The condition is the method's own name taken seriously: an axes
+        that shares its x with nobody has no *shared* label to recover, so
+        an unrelated text in the margin is not a candidate for one.
+        ``supxlabel`` needs no such guard, because a figure that calls it
+        has said what the text means.
+        """
         # First, try to get an xlabel from any shared axes.
         siblings = ax.get_shared_x_axes().get_siblings(ax)
         for shared_ax in siblings:
-            xlabel = shared_ax.get_xlabel()
-            if xlabel:  # if non-empty
+            xlabel = shared_ax.get_xlabel().strip()
+            if xlabel:  # if non-blank
                 return xlabel
 
-        for text in ax.figure.texts:
-            if text.get_position()[1] < y_threshold:
-                label = text.get_text().strip()
-                if label:
-                    return label
+        supxlabel = ax.figure.get_supxlabel().strip()
+        if supxlabel:
+            return supxlabel
+
+        if len(siblings) > 1:
+            for text in ax.figure.texts:
+                if text.get_position()[1] < y_threshold:
+                    label = text.get_text().strip()
+                    if label:
+                        return label
 
         return ""
 
@@ -243,8 +285,10 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         When a faceted figure sets the y-label on only one member of a shared
         y-axis group, the sibling axes report an empty ``get_ylabel()``. This
         mirrors :meth:`extract_shared_xlabel`: it first scans shared-y siblings
-        for a non-blank label, then falls back to a figure-level text sitting
-        in the left margin (e.g. ``fig.supylabel``).
+        for a non-blank label, then ``Figure.supylabel``, then a figure-level
+        text sitting in the left margin -- that last only when the axes is
+        genuinely in a shared-y group. See :meth:`extract_shared_xlabel` for
+        why that condition is there.
 
         Parameters
         ----------
@@ -268,13 +312,18 @@ class MaidrPlot(ABC, FormatExtractorMixin):
             if ylabel:  # if non-blank
                 return ylabel
 
-        # Fallback heuristic: assume a figure-level text sitting in the left
-        # margin is a shared y-label (e.g. ``fig.supylabel``/``fig.text``).
-        for text in ax.figure.texts:
-            if text.get_position()[0] < x_threshold:
-                label = text.get_text().strip()
-                if label:
-                    return label
+        supylabel = ax.figure.get_supylabel().strip()
+        if supylabel:
+            return supylabel
+
+        # Only for an axes that really is in a shared-y group -- see
+        # :meth:`extract_shared_xlabel` for what the unguarded scan cost.
+        if len(siblings) > 1:
+            for text in ax.figure.texts:
+                if text.get_position()[0] < x_threshold:
+                    label = text.get_text().strip()
+                    if label:
+                        return label
 
         return ""
 

--- a/tests/core/test_axes_schema.py
+++ b/tests/core/test_axes_schema.py
@@ -342,6 +342,90 @@ class TestSharedAxisLabels:
         finally:
             plt.close(fig)
 
+    def test_a_caption_is_not_read_as_the_x_label_of_unshared_axes(self):
+        """A bottom caption labels the figure, not anyone's x axis (#514).
+
+        The margin scan exists for a faceted figure that labels the group
+        once. Without a sharing condition it also fired here, and the
+        caption was announced on every data point of both panels as if it
+        were the x axis -- with nothing marking it as a guess.
+        """
+        # Deliberately no sharex/sharey: these two panels share nothing.
+        fig, axs = plt.subplots(1, 2)
+        try:
+            axs[0].bar(["a", "b"], [1, 2])
+            axs[1].bar(["a", "b"], [3, 4])
+            fig.text(0.5, 0.02, "Milliseconds of overhead", ha="center")
+
+            m = FigureManager.get_maidr(fig)
+            for index in (0, 1):
+                schema = _stringify_keys(m._plots[index].schema)
+                assert schema["axes"]["x"]["label"] == "X"
+        finally:
+            plt.close(fig)
+
+    def test_a_margin_text_is_not_read_as_the_y_label_of_unshared_axes(self):
+        """The mirror of the case above, on the left margin."""
+        fig, axs = plt.subplots(1, 2)
+        try:
+            axs[0].bar(["a", "b"], [1, 2])
+            axs[1].bar(["a", "b"], [3, 4])
+            fig.text(0.02, 0.5, "a note in the margin", rotation="vertical")
+
+            m = FigureManager.get_maidr(fig)
+            for index in (0, 1):
+                schema = _stringify_keys(m._plots[index].schema)
+                assert schema["axes"]["y"]["label"] == "Y"
+        finally:
+            plt.close(fig)
+
+    def test_supxlabel_labels_an_axes_that_shares_with_nobody(self):
+        """``supxlabel`` says what it means, so it needs no sharing.
+
+        The distinction the sharing condition draws is between a text whose
+        purpose is declared and one whose purpose is inferred from where it
+        sits -- not between shared and unshared figures.
+        """
+        fig, ax = plt.subplots()
+        try:
+            ax.bar(["a", "b"], [1, 2])
+            fig.supxlabel("Categories")
+            fig.supylabel("Values")
+
+            schema = _first_schema(fig)
+
+            assert schema["axes"]["x"]["label"] == "Categories"
+            assert schema["axes"]["y"]["label"] == "Values"
+        finally:
+            plt.close(fig)
+
+    def test_a_faceted_figure_still_recovers_both_margin_labels(self):
+        """The shape the margin scan was written for keeps working.
+
+        ``example/facet-subplots/matplotlib/example_mpl_facet_bar_plot.py``
+        is exactly this: a shared 2x2 whose axis labels are written once
+        with ``fig.text`` in each margin.
+        """
+        fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
+        try:
+            for ax in axs.flat:
+                ax.bar(["a", "b"], [1, 2])
+            fig.text(0.5, 0.04, "Categories", ha="center", va="center")
+            fig.text(0.04, 0.5, "Values", va="center", rotation="vertical")
+
+            m = FigureManager.get_maidr(fig)
+            labels = [
+                (
+                    _stringify_keys(plot.schema)["axes"]["x"]["label"],
+                    _stringify_keys(plot.schema)["axes"]["y"]["label"],
+                )
+                for plot in m._plots
+            ]
+
+            assert labels == [("Categories", "Values")] * 4
+        finally:
+            plt.close(fig)
+
     def test_scatterplot_recovers_shared_ylabel(self):
         # Exercise ScatterPlot._extract_axes_data directly.
         from maidr.core.plot.scatterplot import ScatterPlot

--- a/tests/core/test_segmented_bar_merge.py
+++ b/tests/core/test_segmented_bar_merge.py
@@ -60,9 +60,9 @@ def _close_figures():
 def _emitted(fig) -> list[list[list[str]]]:
     """The layer types of every subplot cell, as a row-major grid.
 
-    A cell with nothing registered in it is ``{}`` rather than a cell with an
-    empty ``layers``, so the key is read defensively -- an empty panel is one
-    of the states under test here.
+    ``.get`` rather than ``[]`` because an empty panel is one of the states
+    under test, and a missing key would report as this helper's ``KeyError``
+    rather than as the assertion that wanted to see it.
     """
     grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
     return [


### PR DESCRIPTION
Closes #514, closes #515.

## What breaks

A figure with a bottom caption and an unlabelled x axis announces the caption as the axis label, on **every data point of every panel**:

> **Milliseconds of overhead for full accessibility** is Matplotlib, Overhead (milliseconds) is 1.48

That string is `fig.text(0.5, 0.02, ...)`. The x axis is categorical and unlabelled, so it should read `X`. Nothing marks it as a guess and the reader cannot turn it off. Found while re-testing #238 — whose reported symptom (an unreachable second subplot) no longer reproduces; details in [that thread](https://github.com/xability/py-maidr/issues/238#issuecomment-5332849219).

| figure | `ax.get_xlabel()` | before | after |
|---|---|---|---|
| no `fig.text`, no xlabel | `''` | `'X'` | `'X'` |
| `fig.text` at y=0.02, no sharing | `''` | `'FIGURE LEVEL CAPTION'` ❌ | `'X'` ✅ |
| `fig.text` at y=0.04, `sharex=True` | `''` | `'Categories'` | `'Categories'` |
| explicit xlabel | `'REAL X LABEL'` | `'REAL X LABEL'` | `'REAL X LABEL'` |

The y side had the mirror bug on the left margin.

## Why it could not just be deleted

`extract_shared_xlabel` took any figure-level text below `y=0.2` as the x label. That scan is load-bearing: it arrived with facet support (#148), the shipped facet example writes its shared labels exactly that way (`example/facet-subplots/matplotlib/example_mpl_facet_bar_plot.py:50`), and `test_shared_ylabel_recovered_from_figure_text` asserts it. Position genuinely cannot separate a shared label from a caption — both sit centred in the margin, and neither length nor centring distinguishes `fig.text(0.5, 0.04, "Categories")` from `fig.text(0.5, 0.02, "<a sentence>")`.

## What does separate them

Whether the axes shares its axis at all. Measured:

| figure | x-siblings | y-siblings |
|---|---|---|
| `subplots(1, 2)` | 1 | 1 |
| `subplots(1, 2, sharey=True)` | 1 | 2 |
| `subplots(1, 2, sharex=True)` | 2 | 1 |

So the scan now runs only when the sibling group has more than one member. That is the method's own name taken seriously: an axes that shares its x with nobody has no *shared* label to recover, so an unrelated text in the margin is not a candidate for one.

`supxlabel`/`supylabel` are consulted before the scan and without that condition, because a figure that calls them has said what the text means rather than leaving it to be inferred from position. The distinction drawn is declared purpose versus inferred purpose — not shared figures versus unshared ones.

## Also in this PR

A second commit removes the unreachable merge branch in `_flatten_maidr` (#515), raised in review on #512. `position_groups` is keyed by `(row, col)`, so each position is visited once and the `if subplot_grid[row][col]` could never be true. Confirmed rather than reasoned — replacing the branch body with a raise left the suite green (2389 unit, 13 browser), including every multi-layer case that would exercise it if anything did. It would also have been wrong if reached: `layers` is a list, so `.append(layers)` nests rather than extends.

It also corrects a docstring in the segmented-bar tests that #512 made stale — an unoccupied cell is no longer `{}`.

## Tests

Four added to `TestSharedAxisLabels`, each mutation-checked:

- removing the sharing gate → the two "unshared" tests fail, the others pass
- removing the `supxlabel` lookup → only the `supxlabel` test fails
- the faceted 2×2 case is the control: it passes either way, because it genuinely shares

The existing `test_shared_ylabel_recovered_from_figure_text` keeps passing untouched, since it uses `sharey=True`.

```
2393 passed, 1 skipped        # full suite, excluding browser
All checks passed!            # ruff
```

## The trade

Someone who writes a shared axis label as `fig.text` on a figure with **no** `sharex`/`sharey` loses it and gets `X`. Against that, a caption stops being announced as an axis label on every point of every panel. The second failure is worse and invisible to the reader, and the fix for the first is either adding the sharing that was already implied or calling `supxlabel` — so the trade looks right, but it is a behaviour change on a heuristic the project's own examples use, and worth a maintainer's eye.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_