### PR TITLE
fix(core): stop emitting a layout gridspec's padding as empty panels

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -760,9 +760,15 @@ class Maidr:
         rank rather than a row to arrow through. Ranking preserves order, so
         one falling between two panels separates them exactly as before.
         """
+        # Every panel's own spec as well as the figure's axes, so a panel
+        # whose axes has been detached from the figure still gets a rank
+        # rather than falling to the front of the grid.
         spans = [
             ss
-            for ss in (ax.get_subplotspec() for ax in self._fig.axes)
+            for ss in (
+                *(ax.get_subplotspec() for ax in self._fig.axes),
+                *(plot.ax.get_subplotspec() for plot in self._plots),
+            )
             if ss is not None
         ]
         rows = {ss.rowspan.start for ss in spans}

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -9,7 +9,7 @@ import uuid
 import webbrowser
 import subprocess
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Callable, Literal, cast
 from collections import defaultdict
 
 import matplotlib.pyplot as plt
@@ -724,6 +724,56 @@ class Maidr:
 
         return metadata
 
+    def _grid_coordinates(self) -> tuple[Callable[[int], int], Callable[[int], int]]:
+        """Return functions mapping a gridspec span start to a grid index.
+
+        A panel is keyed by where its span starts, and the emitted grid is
+        sized from the largest start seen. That reads a gridspec as a grid of
+        positions, which it is only when every axes occupies one cell.
+
+        A library that uses a gridspec for *proportions* breaks the reading.
+        ``seaborn.jointplot`` lays three panels out on a 6x6 grid to get the
+        marginal-to-joint size ratio, and they start at rows 0 and 1 and
+        columns 0 and 5 -- so the largest start forced six columns for two
+        occupied ones, and the reader met nine panels holding nothing on the
+        way between the three real ones (#513).
+
+        Ranking the starts collapses the rows and columns no axes begins in,
+        which are the ones that exist for proportion rather than position.
+
+        Returns
+        -------
+        tuple of callable
+            ``(row_of, col_of)``, each mapping a span start to a grid index.
+
+        Notes
+        -----
+        Ranked over every axes on the figure rather than only the ones
+        carrying a layer, which is what keeps a position the author left
+        empty: the middle panel of a ``subplots(1, 3)`` drawn on twice is an
+        axes with frame and ticks, on the screen, and a reader should meet
+        it. Its own start is what reserves it a column.
+
+        An axes ranked but never occupied costs nothing, because the grid is
+        still sized from the largest rank a *panel* reaches -- so a
+        heatmap's colorbar, which carries a subplotspec of its own, adds a
+        rank rather than a row to arrow through. Ranking preserves order, so
+        one falling between two panels separates them exactly as before.
+        """
+        spans = [
+            ss
+            for ss in (ax.get_subplotspec() for ax in self._fig.axes)
+            if ss is not None
+        ]
+        rows = {ss.rowspan.start for ss in spans}
+        cols = {ss.colspan.start for ss in spans}
+        row_rank = {start: rank for rank, start in enumerate(sorted(rows))}
+        col_rank = {start: rank for rank, start in enumerate(sorted(cols))}
+        return (
+            lambda index: row_rank.get(index, 0),
+            lambda index: col_rank.get(index, 0),
+        )
+
     def _flatten_maidr(self) -> dict:
         """Return the top-level MAIDR schema for this figure."""
         # A layer that already describes what another drew is a duplicate of
@@ -757,6 +807,11 @@ class Maidr:
                     "col": getattr(plot, "col_index", 0),
                 }
             )
+
+        row_of, col_of = self._grid_coordinates()
+        for plot in plot_schemas:
+            plot["row"] = row_of(plot.get("row", 0))
+            plot["col"] = col_of(plot.get("col", 0))
 
         max_row = max([plot.get("row", 0) for plot in plot_schemas], default=0)
         max_col = max([plot.get("col", 0) for plot in plot_schemas], default=0)

--- a/tests/core/test_layout_gridspec_padding.py
+++ b/tests/core/test_layout_gridspec_padding.py
@@ -1,0 +1,123 @@
+"""A gridspec used for proportions is not a grid of navigable positions.
+
+A panel is keyed by where its span starts and the emitted grid is sized
+from the largest start seen. That reads a gridspec as a grid of positions,
+which it is only when every panel occupies exactly one cell.
+
+``seaborn.jointplot`` does not. ``JointGrid`` lays three panels out on a
+6x6 gridspec to get the marginal-to-joint size ratio, so the largest start
+forced six columns for two occupied ones and the reader met nine panels
+holding nothing on the way between the three real ones (#513).
+
+The counterpart matters as much: a figure whose gridspec really is its
+grid must keep the indices it authored, including a position it left
+empty on purpose between two panels.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _shape(fig) -> tuple[int, int]:
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return len(grid), len(grid[0])
+
+
+def _occupied(fig) -> list[list[list[str]]]:
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return [
+        [[layer["type"].value for layer in cell["layers"]] for cell in row]
+        for row in grid
+    ]
+
+
+def _joint(**kwargs):
+    df = pd.DataFrame({"x": np.arange(30) % 7, "y": (np.arange(30) * 3) % 11})
+    return sns.jointplot(data=df, x="x", y="y", **kwargs).figure
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"marginal_ticks": True}], ids=["plain", "ticks"])
+def test_a_jointplot_is_the_three_panels_it_draws(kwargs) -> None:
+    """Not those three plus nine of layout padding."""
+    fig = _joint(**kwargs)
+
+    assert _shape(fig) == (2, 2)
+    assert _occupied(fig) == [
+        [["hist"], []],
+        [["point"], ["hist"]],
+    ]
+
+
+def test_a_grid_that_is_a_grid_keeps_the_positions_it_authored() -> None:
+    """An empty panel between two drawn ones is on the screen, so keep it.
+
+    Every panel here occupies one cell, which is what makes the gridspec's
+    indices positions rather than proportions.
+    """
+    fig, axs = plt.subplots(1, 3)
+    axs[0].bar(["p", "q"], [1, 2])
+    axs[2].bar(["p", "q"], [3, 4])
+
+    assert _shape(fig) == (1, 3)
+    assert _occupied(fig) == [[["bar"], [], ["bar"]]]
+
+
+def test_a_spanning_panel_still_leaves_its_neighbour_empty() -> None:
+    """Ranking must not collapse a hole a spanning panel really leaves."""
+    fig = plt.figure()
+    top = plt.subplot2grid((2, 2), (0, 0), colspan=2, fig=fig)
+    left = plt.subplot2grid((2, 2), (1, 0), fig=fig)
+    right = plt.subplot2grid((2, 2), (1, 1), fig=fig)
+    for ax in (top, left, right):
+        ax.bar(["p", "q"], [1, 2])
+
+    assert _shape(fig) == (2, 2)
+    assert _occupied(fig) == [[["bar"], []], [["bar"], ["bar"]]]
+
+
+def test_a_colorbar_does_not_become_a_row_and_column_of_its_own() -> None:
+    """A ranked axes that holds no panel must not enlarge the grid.
+
+    A heatmap's colorbar carries a subplotspec of its own -- row 1,
+    column 1 of a 3x2 -- so it takes a rank. The grid is sized from the
+    largest rank a *panel* reaches rather than the largest rank issued,
+    which is what keeps that from handing the reader a second row and
+    column to arrow through: the phantom panel #369 removed at the layer
+    level, back at grid level.
+    """
+    fig, ax = plt.subplots()
+    sns.heatmap(np.arange(16).reshape(4, 4), ax=ax)
+
+    assert _shape(fig) == (1, 1)
+    assert _occupied(fig) == [[["heat"]]]
+
+
+def test_a_pairplot_keeps_every_one_of_its_cells() -> None:
+    """Its panels are one cell each, so nothing is ranked away."""
+    df = pd.DataFrame(
+        {
+            "a": np.arange(20) % 5,
+            "b": (np.arange(20) * 2) % 7,
+            "c": (np.arange(20) * 3) % 4,
+        }
+    )
+
+    assert _shape(sns.pairplot(df).figure) == (3, 3)

--- a/tests/core/test_layout_gridspec_padding.py
+++ b/tests/core/test_layout_gridspec_padding.py
@@ -54,7 +54,9 @@ def _joint(**kwargs):
     return sns.jointplot(data=df, x="x", y="y", **kwargs).figure
 
 
-@pytest.mark.parametrize("kwargs", [{}, {"marginal_ticks": True}], ids=["plain", "ticks"])
+@pytest.mark.parametrize(
+    "kwargs", [{}, {"marginal_ticks": True}], ids=["plain", "ticks"]
+)
 def test_a_jointplot_is_the_three_panels_it_draws(kwargs) -> None:
     """Not those three plus nine of layout padding."""
     fig = _joint(**kwargs)


### PR DESCRIPTION
Closes #513.

## What breaks

`seaborn.jointplot` draws three panels and emitted **twelve** grid positions, nine of them holding nothing:

```
grid 2 x 6   cells=12   empty=9
  [[hist],  [], [], [], [], []    ]
  [[point], [], [], [], [], [hist]]
```

`JointGrid` lays its panels out on a 6×6 gridspec to get the marginal-to-joint size ratio, and they start at rows 0 and 1 and columns 0 and 5:

```
scatter: rowspan=range(1, 6) colspan=range(0, 5)
hist:    rowspan=range(0, 1) colspan=range(0, 5)
hist:    rowspan=range(1, 6) colspan=range(5, 6)
```

Sizing the grid from the largest start forces six columns for two occupied ones, so a reader arrowing between the three real panels met nine that exist only for proportion.

## The change

Key each panel by the **rank** of its span start among the starts some axes actually uses. That collapses the rows and columns no axes begins in — exactly the ones a gridspec grows for proportion rather than position. jointplot becomes the 2×2 it looks like:

```
[[hist],  []    ]
[[point], [hist]]
```

marginal above, marginal right, joint below-left, and one genuinely empty corner.

**Ranked over every axes on the figure**, not only the ones carrying a layer. That is what keeps a position the author left empty: the middle panel of a `subplots(1, 3)` drawn on twice is an axes with frame and ticks, on the screen, and a reader should meet it — its own start is what reserves it a column.

**An axes ranked but never occupied costs nothing**, because the grid is still sized from the largest rank a *panel* reaches. So a heatmap's colorbar, which carries a subplotspec of its own (row 1, column 1 of a 3×2), adds a rank rather than a row to arrow through. Ranking preserves order, so one falling between two panels separates them exactly as before.

## What is unchanged

| figure | before | after |
|---|---|---|
| `jointplot` | 2×6, 9 empty | **2×2, 1 empty** |
| `jointplot(marginal_ticks=True)` | 2×6, 9 empty | **2×2, 1 empty** |
| `subplots(1, 3)`, middle undrawn | 1×3, gap kept | 1×3, gap kept |
| `subplot2grid((2,2))` spanning top row | 2×2, 1 empty | 2×2, 1 empty |
| `subplot_mosaic` with a spanning panel | 2×2, 1 empty | 2×2, 1 empty |
| heatmap + colorbar | 1×1 | 1×1 |
| `pairplot` 3×3 | 3×3 | 3×3 |
| plain `subplots(2, 2)` | 2×2 | 2×2 |

Only the two jointplot rows move.

## Tests

Six in a new `tests/core/test_layout_gridspec_padding.py`. Each of the three design choices is covered by a test that fails without it:

| mutation | fails |
|---|---|
| ranking removed entirely | both jointplot cases |
| ranked over panels alone, not every axes | the `subplots(1, 3)` gap |
| sized from every rank rather than every panel | the colorbar case |

```
2399 passed, 1 skipped        # full suite, excluding browser
All checks passed!            # ruff
```

## Note for the record

While stress-testing this I found a **pre-existing** bug that is not touched here and reproduces identically on `main`: two `sns.heatmap` calls in a `subplots(1, 2)` collapse into a single position holding two `heat` layers, because each colorbar re-parents its heatmap into a fresh subgridspec and both then report start `(0, 0)`. Filing separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_