### PR TITLE
fix(core): stop a colorbar from moving its panel out of its grid position

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -41,6 +41,7 @@ from maidr.util.cdn import (
     bundled_cdn_url,
     maidr_js_cdn_url,
 )
+from maidr.util.grid_position import topmost_subplotspec
 from maidr.util.environment import Environment
 from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_matplotlib
 
@@ -766,8 +767,8 @@ class Maidr:
         spans = [
             ss
             for ss in (
-                *(ax.get_subplotspec() for ax in self._fig.axes),
-                *(plot.ax.get_subplotspec() for plot in self._plots),
+                *(topmost_subplotspec(ax) for ax in self._fig.axes),
+                *(topmost_subplotspec(plot.ax) for plot in self._plots),
             )
             if ss is not None
         ]

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from matplotlib.axes import Axes
 
 from maidr.core.enum import MaidrKey, PlotType
+from maidr.util.grid_position import topmost_subplotspec
 from maidr.util.mixin import FormatExtractorMixin
 
 # uuid is used to generate unique identifiers for each plot layer in the MAIDR schema.
@@ -45,7 +46,7 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         self.ax = ax
         self._support_highlighting = True
         self._elements = []
-        ss = self.ax.get_subplotspec()
+        ss = topmost_subplotspec(self.ax)
         # Handle cases where subplotspec is None (dynamically created axes)
         if ss is not None:
             self.row_index = ss.rowspan.start

--- a/maidr/util/grid_position.py
+++ b/maidr/util/grid_position.py
@@ -1,0 +1,41 @@
+"""Where a panel sits in the grid a reader navigates.
+
+A panel is keyed by where its gridspec span starts, so anything that
+changes which gridspec an axes belongs to changes its coordinates. Adding
+a colorbar does exactly that, which is why this is worth one function
+rather than a call inlined in two places that could drift apart.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from matplotlib.axes import Axes
+
+
+def topmost_subplotspec(ax: Axes) -> Any:
+    """Return the outermost subplotspec of an axes, or None if it has none.
+
+    Attaching a colorbar re-parents its panel into a fresh sub-gridspec
+    where the panel sits at the origin. Two ``sns.heatmap`` calls into a
+    ``subplots(1, 2)`` therefore both report ``(0, 0)`` for their own spec,
+    and were emitted as a single position holding two ``heat`` layers
+    rather than as two panels (#518).
+
+    ``get_topmost_subplotspec`` walks up through the nesting to the
+    gridspec the figure was laid out with, where the two are still the
+    ``(0, 0)`` and ``(0, 1)`` their author wrote.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes whose position is being resolved.
+
+    Returns
+    -------
+    SubplotSpec or None
+        The outermost spec, or None for an axes with no subplotspec at all
+        (one added by ``fig.add_axes``, say).
+    """
+    ss = ax.get_subplotspec()
+    return None if ss is None else ss.get_topmost_subplotspec()

--- a/tests/core/test_colorbar_reparents_its_panel.py
+++ b/tests/core/test_colorbar_reparents_its_panel.py
@@ -1,0 +1,83 @@
+"""A colorbar must not move its panel out of the grid position it was drawn in.
+
+Attaching a colorbar re-parents its panel into a fresh sub-gridspec where
+the panel sits at the origin. A panel is keyed by where its span starts, so
+two ``sns.heatmap`` calls into a ``subplots(1, 2)`` both reported ``(0, 0)``
+and were emitted as one position holding two ``heat`` layers -- a reader
+handed a single panel to page two layers of, with one set of titles and
+axis labels, instead of two charts to move between (#518).
+
+Only figures with more than one colorbar-bearing panel were affected: a
+heatmap beside a bar chart was fine, because only the heatmap got
+re-parented.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _occupied(fig) -> list[list[list[str]]]:
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return [
+        [[layer["type"].value for layer in cell["layers"]] for cell in row]
+        for row in grid
+    ]
+
+
+def _data() -> np.ndarray:
+    return np.arange(16).reshape(4, 4)
+
+
+def test_two_heatmaps_side_by_side_are_two_panels() -> None:
+    """The reported reproduction."""
+    fig, axs = plt.subplots(1, 2)
+    sns.heatmap(_data(), ax=axs[0])
+    sns.heatmap(_data(), ax=axs[1])
+
+    assert _occupied(fig) == [[["heat"], ["heat"]]]
+
+
+def test_a_grid_of_heatmaps_keeps_every_one_in_its_own_position() -> None:
+    """Four, so a fix that merely separates two is not enough to pass."""
+    fig, axs = plt.subplots(2, 2)
+    for ax in axs.flat:
+        sns.heatmap(_data(), ax=ax)
+
+    assert _occupied(fig) == [
+        [["heat"], ["heat"]],
+        [["heat"], ["heat"]],
+    ]
+
+
+def test_a_lone_heatmap_is_still_one_panel() -> None:
+    """Resolving through the nesting must not invent a position either."""
+    fig, ax = plt.subplots()
+    sns.heatmap(_data(), ax=ax)
+
+    assert _occupied(fig) == [[["heat"]]]
+
+
+def test_a_heatmap_beside_a_bar_chart_keeps_working() -> None:
+    """The case that was already correct, because only one panel re-parents."""
+    fig, axs = plt.subplots(1, 2)
+    sns.heatmap(_data(), ax=axs[0])
+    axs[1].bar(["p", "q"], [1, 2])
+
+    assert _occupied(fig) == [[["heat"], ["bar"]]]


### PR DESCRIPTION
Closes #518. Found while stress-testing #517 and deliberately left out of that PR.

## What breaks

Two `sns.heatmap` calls into a `subplots(1, 2)` were emitted as **one** grid position holding two `heat` layers:

```
1 x 1
    [['heat', 'heat']]
```

So a reader was handed a single panel to page two layers of — one set of titles, one set of axis labels, one position announcement — instead of two charts to move between.

## Root cause

Attaching a colorbar re-parents its panel into a fresh sub-gridspec where the panel sits at the origin, and a panel is keyed by where its span starts:

```
fig axes starts: [(0, 0), (0, 0), (1, 1), (1, 1)]
                  heat_l  heat_r  cbar_l  cbar_r
```

Both heatmaps report `(0, 0)` for their own spec — each is at the origin of *its own* 3×2 sub-gridspec rather than at its position in the authored 1×2 — so `_flatten_maidr` grouped them into the same cell.

Only figures with more than one colorbar-bearing panel were affected. A heatmap beside a bar chart was already correct, because only the heatmap gets re-parented.

## The fix

`SubplotSpec.get_topmost_subplotspec()` walks up through the nesting to the gridspec the figure was laid out with, where the two heatmaps are still the `(0, 0)` and `(0, 1)` their author wrote:

```
own=(0,0) geom=(3, 2)   topmost=(0,0) geom=(1, 2)
own=(0,0) geom=(3, 2)   topmost=(0,1) geom=(1, 2)
```

One helper in `maidr/util/grid_position.py` rather than the call inlined at both sites (`MaidrPlot.__init__` and `Maidr._grid_coordinates`), since the two would otherwise have to be kept in step by hand — the same drift the reviewer flagged on xability/maidr#1077.

jointplot is unaffected: its panels are not nested, so `topmost` returns the same spec and #517's ranking behaves identically.

## Results

| figure | before | after |
|---|---|---|
| two heatmaps in `subplots(1, 2)` | 1×1, both layers in one cell | **1×2, one each** |
| four heatmaps in `subplots(2, 2)` | 1×1, all four in one cell | **2×2, one each** |
| lone heatmap + colorbar | 1×1 | 1×1 |
| heatmap + bar chart | 1×2 | 1×2 |
| everything in #517's table | unchanged | unchanged |

## Tests

Four in a new file. The two heatmap cases fail against a build with the topmost resolution removed; the lone heatmap and the heatmap-beside-a-bar-chart pass either way, which is what makes them controls — resolving through the nesting must not invent a position, and must not disturb the case that was already right.

The 2×2 case is there so that a fix which merely separates *two* panels is not enough to pass.

```
2403 passed, 1 skipped        # full suite, excluding browser
All checks passed!            # ruff
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_