### PR TITLE
fix(altair): say that use_cdn=False cannot be honoured, instead of ignoring it

### DIFF
--- a/maidr/api.py
+++ b/maidr/api.py
@@ -189,9 +189,11 @@ def _warn_altair_ignores_use_cdn(
         caller because ``None`` defers to the process default, which may
         itself be ``False``.
     stacklevel : int
-        Passed through to :func:`warnings.warn`. Keyword-only for the same
-        reason :func:`maidr.util.fallback.warn_unsupported` does it: the
-        frame count differs per entry point.
+        Passed through to :func:`warnings.warn`. Keyword-only because it is
+        a frame count rather than a value about the chart, and the three
+        entry points that pass it sit at the same depth today -- so a
+        positional argument would read as one more thing about `use_cdn`
+        and silently become wrong the moment one of them grew a wrapper.
     """
     if _resolve_use_cdn(use_cdn) is not False:
         return

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import warnings
 from typing import Any, Literal
 
 from htmltools import Tag
@@ -157,6 +158,54 @@ def _resolve_use_cdn(
     if value is None:
         return get_use_cdn()
     return value
+
+
+#: Named in the warning so a reader can see what would have to travel with
+#: the page, rather than being told only that something will not.
+_ALTAIR_REMOTE_RUNTIME = (
+    "vega, vega-lite, vega-embed and maidr's own vegalite.js"
+)
+
+
+def _warn_altair_ignores_use_cdn(
+    use_cdn: bool | Literal["auto"] | None, *, stacklevel: int
+) -> None:
+    """Say that ``use_cdn=False`` cannot be honoured for an Altair chart.
+
+    The Altair path delegates to the upstream Vega-Lite adapter, which is
+    loaded from a CDN and has no bundled counterpart -- so the flag was
+    accepted and discarded, and the reader who most needs to know is the
+    one it fails for: ``use_cdn=False`` means they cannot reach a CDN, and
+    without this they get a chart that never initialises and no reason why
+    (#521).
+
+    Only an explicit ``False`` warns. ``"auto"`` is the CDN with a fallback
+    that this path does not have either, but a reader on ``"auto"`` has not
+    said they are offline, and warning them on every render would be noise
+    on the common case.
+
+    Parameters
+    ----------
+    use_cdn : bool, {"auto"}, or None
+        The caller's value, unresolved. Resolved here rather than by the
+        caller because ``None`` defers to the process default, which may
+        itself be ``False``.
+    stacklevel : int
+        Passed through to :func:`warnings.warn`. Keyword-only for the same
+        reason :func:`maidr.util.fallback.warn_unsupported` does it: the
+        frame count differs per entry point.
+    """
+    if _resolve_use_cdn(use_cdn) is not False:
+        return
+
+    warnings.warn(
+        "maidr: use_cdn=False cannot be honoured for an Altair chart. That "
+        "path renders through the upstream Vega-Lite adapter, which is only "
+        f"published on a CDN, so the page still loads {_ALTAIR_REMOTE_RUNTIME} "
+        "remotely and will not initialise without network access. Render the "
+        "same data through matplotlib or seaborn for an offline chart.",
+        stacklevel=stacklevel,
+    )
 
 
 def init_notebook(
@@ -421,6 +470,8 @@ def render(
     if _is_altair_chart(plot):
         from maidr.altair import AltairMaidr
 
+        _warn_altair_ignores_use_cdn(use_cdn, stacklevel=3)
+
         return AltairMaidr(plot).render()
 
     use_cdn = _resolve_use_cdn(use_cdn)
@@ -479,6 +530,8 @@ def show(
     """
     if _is_altair_chart(plot):
         from maidr.altair import AltairMaidr
+
+        _warn_altair_ignores_use_cdn(use_cdn, stacklevel=3)
 
         return AltairMaidr(plot).show(renderer)
 
@@ -555,6 +608,8 @@ def save_html(
     """
     if _is_altair_chart(plot):
         from maidr.altair import AltairMaidr
+
+        _warn_altair_ignores_use_cdn(use_cdn, stacklevel=3)
 
         return AltairMaidr(plot).save_html(
             file,

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -162,9 +162,7 @@ def _resolve_use_cdn(
 
 #: Named in the warning so a reader can see what would have to travel with
 #: the page, rather than being told only that something will not.
-_ALTAIR_REMOTE_RUNTIME = (
-    "vega, vega-lite, vega-embed and maidr's own vegalite.js"
-)
+_ALTAIR_REMOTE_RUNTIME = "vega, vega-lite, vega-embed and maidr's own vegalite.js"
 
 
 def _warn_altair_ignores_use_cdn(
@@ -461,6 +459,10 @@ def render(
         * ``None`` (default): use the process-wide default set via
           :func:`set_use_cdn` or the ``MAIDR_USE_CDN`` env var (both
           default to ``"auto"``).
+
+        Altair charts always use the CDN — this argument is not
+        plumbed through that adapter, so ``False`` warns rather than
+        taking effect (#521).
 
     Returns
     -------

--- a/tests/core/test_altair_use_cdn_is_not_silent.py
+++ b/tests/core/test_altair_use_cdn_is_not_silent.py
@@ -62,7 +62,9 @@ def test_save_html_says_it_too(tmp_path):
     """The entry point an offline reader is most likely to use."""
     target = tmp_path / "chart.html"
 
-    assert _complaints(lambda: maidr.save_html(_chart(), file=str(target), use_cdn=False))
+    said = _complaints(lambda: maidr.save_html(_chart(), file=str(target), use_cdn=False))
+
+    assert len(said) == 1
 
 
 @pytest.mark.parametrize("mode", [True, "auto", None], ids=["cdn", "auto", "default"])

--- a/tests/core/test_altair_use_cdn_is_not_silent.py
+++ b/tests/core/test_altair_use_cdn_is_not_silent.py
@@ -1,0 +1,94 @@
+"""``use_cdn=False`` on an Altair chart says it cannot be honoured.
+
+The Altair path renders through the upstream Vega-Lite adapter, which is
+published only on a CDN, so there is nothing to inline and the flag cannot
+be obeyed. It was accepted and discarded in silence, which fails the one
+reader it matters to: ``use_cdn=False`` means they cannot reach a CDN, so
+they got a chart that never initialises and no reason why (#521).
+
+Whether the flag should one day be honoured is a packaging question about
+maidr's own ``vegalite.js``. Saying so is not, and is what these pin.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: E402
+
+alt = pytest.importorskip("altair")
+
+_COMPLAINT = "cannot be honoured"
+
+
+@pytest.fixture(autouse=True)
+def _restore_default():
+    before = maidr.get_use_cdn()
+    yield
+    maidr.set_use_cdn(before)
+    plt.close("all")
+
+
+def _chart():
+    frame = pd.DataFrame({"cat": list("abc"), "val": [1, 2, 3]})
+    return alt.Chart(frame).mark_bar().encode(x="cat", y="val")
+
+
+def _complaints(call) -> list[str]:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        call()
+    return [str(w.message) for w in caught if _COMPLAINT in str(w.message)]
+
+
+def test_an_offline_altair_render_is_told_it_cannot_be_offline():
+    said = _complaints(lambda: maidr.render(_chart(), use_cdn=False))
+
+    assert len(said) == 1
+    # Naming the pieces matters more than the wording: without them the
+    # reader cannot tell what would have to travel with the page.
+    assert "vega" in said[0] and "vegalite.js" in said[0]
+
+
+def test_save_html_says_it_too(tmp_path):
+    """The entry point an offline reader is most likely to use."""
+    target = tmp_path / "chart.html"
+
+    assert _complaints(lambda: maidr.save_html(_chart(), file=str(target), use_cdn=False))
+
+
+@pytest.mark.parametrize("mode", [True, "auto", None], ids=["cdn", "auto", "default"])
+def test_every_other_mode_stays_quiet(mode):
+    """Only an explicit offline request is worth interrupting for.
+
+    ``"auto"`` has no fallback on this path either, but a reader on it has
+    not said they are offline, and warning on the common case is noise.
+    """
+    assert not _complaints(lambda: maidr.render(_chart(), use_cdn=mode))
+
+
+def test_a_process_wide_default_of_false_also_warns():
+    """`use_cdn=None` defers to the default, so the check must resolve it.
+
+    Reading the caller's argument alone would let `set_use_cdn(False)`
+    through -- the same silent discard, reached by the other door.
+    """
+    maidr.set_use_cdn(False)
+
+    assert _complaints(lambda: maidr.render(_chart()))
+
+
+def test_a_matplotlib_chart_is_not_warned_about():
+    """It honours the flag by inlining the bundle, so it has nothing to say."""
+    fig, ax = plt.subplots()
+    ax.bar(["p", "q"], [1, 2])
+
+    assert not _complaints(lambda: maidr.render(fig, use_cdn=False))

--- a/tests/core/test_altair_use_cdn_is_not_silent.py
+++ b/tests/core/test_altair_use_cdn_is_not_silent.py
@@ -62,7 +62,25 @@ def test_save_html_says_it_too(tmp_path):
     """The entry point an offline reader is most likely to use."""
     target = tmp_path / "chart.html"
 
-    said = _complaints(lambda: maidr.save_html(_chart(), file=str(target), use_cdn=False))
+    said = _complaints(
+        lambda: maidr.save_html(_chart(), file=str(target), use_cdn=False)
+    )
+
+    assert len(said) == 1
+
+
+def test_show_says_it_too(monkeypatch):
+    """The third entry point, which nothing else here reaches.
+
+    `show` warns before it hands off to a renderer, so the renderer is
+    stubbed rather than exercised -- opening a browser is not what this
+    is about, and letting it try would make the test depend on a display.
+    """
+    monkeypatch.setattr(
+        "maidr.altair.altair_maidr.AltairMaidr.show", lambda self, renderer: None
+    )
+
+    said = _complaints(lambda: maidr.show(_chart(), use_cdn=False))
 
     assert len(said) == 1
 


### PR DESCRIPTION
Closes #521.

## What breaks

`maidr.render(chart, use_cdn=False)` accepts the flag on an Altair chart and discards it. The emitted HTML is **identical** with the flag on and off, once the generated UUIDs are normalised:

```
render(): identical once UUIDs are normalised: True
```

No warning is raised — measured with `warnings.catch_warnings(record=True)`, zero. So the page still needs four remote scripts:

```
https://cdn.jsdelivr.net/npm/vega@5
https://cdn.jsdelivr.net/npm/vega-lite@5
https://cdn.jsdelivr.net/npm/vega-embed@6
https://cdn.jsdelivr.net/npm/maidr@4.4.0/dist/vegalite.js
```

The reader this fails is precisely the one who set the flag: `use_cdn=False` means they cannot reach a CDN, so they get a chart that never initialises and no reason why. Same class as #358 and #455.

## Root cause

`api.py` returns for Altair **before** `use_cdn` is even resolved:

```python
if _is_altair_chart(plot):
    from maidr.altair import AltairMaidr
    return AltairMaidr(plot).render()      # use_cdn never passed

use_cdn = _resolve_use_cdn(use_cdn)        # only reached by other plot types
```

Repeated at `show` and `save_html`. And `maidr/altair/altair_maidr.py` has nothing to pass it to — that file contains no reference to `use_cdn`, `bundled_js_path`, or any inline handling at all. The path renders through the upstream Vega-Lite adapter, published only on a CDN, so there is genuinely nothing to inline.

| path | `use_cdn=False` honoured? | remote refs left |
|---|---|---|
| matplotlib | fully — bundle inlined | 0 |
| plotly | partly | 1 (`cdn.plot.ly`, plotly's own library) |
| **altair** | **not at all** | **4** |

## What this changes

Nothing about behaviour — it says so instead of staying quiet. Whether the flag could one day be honoured is a packaging question about maidr's own `vegalite.js`, separate from the third-party vega bundle, and is left open on #521 as options 2 and 3.

Two deliberate narrowings:

- **Only an explicit `False` warns.** `"auto"` has no fallback on this path either, but a reader on `"auto"` has not said they are offline, and warning on the common case would be noise.
- **The check resolves through `_resolve_use_cdn`.** Reading the caller's argument alone would let `set_use_cdn(False)` through silently — the same discard, reached by the other door.

## Tests

Seven, in a new file. Three mutations, each biting only its own tests:

| mutation | fails |
|---|---|
| warning removed entirely | the 3 that expect it |
| raw argument read instead of the resolved mode | only the process-default test |
| warn on every mode | only the 3 "stays quiet" cases |

The matplotlib control is there because it honours the flag by inlining, so it must stay silent — that is what keeps the warning from being wired to the wrong condition.

```
2419 passed, 1 skipped     # full suite, excluding browser
All checks passed!         # ruff
```

## Found how

Extending the #457 browser QA to the Plotly and Altair paths. That extension could not be completed — Chromium in my sandbox cannot reach the CDNs those paths need — and this is why there was no offline mode to fall back to. Recorded on [#457](https://github.com/xability/py-maidr/issues/457#issuecomment-5360409488).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_