### PR TITLE
fix(core): read a bivariate histogram as the heatmap it draws

### DIFF
--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -244,9 +244,17 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
         # reason than that it is unpatched, so the inner call runs outside the
         # context -- which is what made the same figure readable through one
         # spelling and silent through the other (#522).
-        axes = drawn if isinstance(drawn, Axes) else FigureManager.get_axes(drawn)
+        axes = FigureManager.get_axes(drawn)
         if _drew_mesh(axes, meshes):
-            FigureManager.create_maidr(axes, PlotType.HEAT)
+            # Named from `stat` rather than hardcoded, because it is what the
+            # cells actually hold: the default is a count, but
+            # `stat="density"` or `"probability"` makes them something else,
+            # and a reader hearing "count" for a density has been told the
+            # wrong thing about every cell. `HexbinPlot` labels its own `z`
+            # the same way and for the same reason.
+            FigureManager.create_maidr(
+                axes, PlotType.HEAT, z_label=str(kwargs.get("stat", "count"))
+            )
         return drawn
 
     # Register the histogram as HIST as before

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -7,7 +7,7 @@ import wrapt
 
 import numpy as np
 from matplotlib.axes import Axes
-from matplotlib.collections import QuadMesh
+from matplotlib.collections import PolyQuadMesh, QuadMesh
 from matplotlib.container import BarContainer
 from matplotlib.patches import Polygon
 from matplotlib.lines import Line2D
@@ -156,7 +156,16 @@ def _drew_bars(plot: Any, before: list) -> bool:
 
 def _meshes_of(ax: Axes | None) -> list:
     """
-    The ``QuadMesh`` artists already on an axes.
+    The mesh artists already on an axes.
+
+    Both mesh classes, not only the one seaborn currently draws through.
+    Measured on seaborn 0.13.2, a bivariate ``histplot`` reaches
+    ``Axes.pcolormesh`` and so produces a ``QuadMesh`` -- but naming only that
+    would tie this to a seaborn internal, and the failure if it ever moved to
+    ``Axes.pcolor`` would be the silent one this whole change exists to
+    remove: the mesh would go unrecognised, the call would decline as before,
+    and the chart would be quiet again. ``PolyQuadMesh`` costs nothing to
+    accept and is a heatmap by the same argument.
 
     Held as a list of the artists themselves rather than of their ids, for the
     reason ``_containers_of`` gives: an id compared after the object it named
@@ -176,7 +185,7 @@ def _meshes_of(ax: Axes | None) -> list:
     return [
         artist
         for artist in (getattr(ax, "collections", ()) or ())
-        if isinstance(artist, QuadMesh)
+        if isinstance(artist, (QuadMesh, PolyQuadMesh))
     ]
 
 

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -7,6 +7,7 @@ import wrapt
 
 import numpy as np
 from matplotlib.axes import Axes
+from matplotlib.collections import QuadMesh
 from matplotlib.container import BarContainer
 from matplotlib.patches import Polygon
 from matplotlib.lines import Line2D
@@ -153,6 +154,57 @@ def _drew_bars(plot: Any, before: list) -> bool:
     )
 
 
+def _meshes_of(ax: Axes | None) -> list:
+    """
+    The ``QuadMesh`` artists already on an axes.
+
+    Held as a list of the artists themselves rather than of their ids, for the
+    reason ``_containers_of`` gives: an id compared after the object it named
+    was freed can be matched by an unrelated artist allocated at the same
+    address.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes to look at, or None when it does not exist yet.
+
+    Returns
+    -------
+    list
+        The meshes on it, in draw order.
+    """
+    return [
+        artist
+        for artist in (getattr(ax, "collections", ()) or ())
+        if isinstance(artist, QuadMesh)
+    ]
+
+
+def _drew_mesh(ax: Axes | None, before: list) -> bool:
+    """
+    Whether *this call* drew a mesh of joint counts.
+
+    Asked the same way ``_drew_bars`` asks its question, and for the same
+    reason: an axes that already held a heatmap -- ``sns.heatmap(ax=ax)``
+    first, then a bivariate ``histplot(ax=ax)`` -- would otherwise have
+    someone else's mesh claimed as this call's.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes the call drew on.
+    before : list
+        The meshes that were on it beforehand.
+
+    Returns
+    -------
+    bool
+        True when a mesh appeared that was not there before.
+    """
+    seen = {id(mesh) for mesh in before}
+    return any(id(mesh) not in seen for mesh in _meshes_of(ax))
+
+
 def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     """
     Patch seaborn.histplot to register HIST and (if kde=True) SMOOTH layers for MAIDR.
@@ -163,12 +215,29 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     if ContextManager.is_internal_context():
         return _draw_quietly(wrapped, args, kwargs)
 
-    before = _containers_of(_prospective_axes(kwargs))
+    prospective = _prospective_axes(kwargs)
+    before = _containers_of(prospective)
+    meshes = _meshes_of(prospective)
 
     with ContextManager.set_internal_context():
         drawn = _draw_quietly(wrapped, args, kwargs)
 
     if not _drew_bars(drawn, before):
+        # A bivariate histogram, which draws a `QuadMesh` of joint counts.
+        # Declining `hist` for it is right -- see `_drew_bars` -- but declining
+        # it is not the same as leaving the chart silent. Seaborn reaches the
+        # mesh through `Axes.pcolormesh`, which is patched and would register
+        # `heat` on its own; the internal context set above suppressed that
+        # registration so this function could make its own, and then this
+        # function declined. So make the one the chart is owed here.
+        #
+        # `sns.displot(x=..., y=...)` reads as `heat` today for no better
+        # reason than that it is unpatched, so the inner call runs outside the
+        # context -- which is what made the same figure readable through one
+        # spelling and silent through the other (#522).
+        axes = drawn if isinstance(drawn, Axes) else FigureManager.get_axes(drawn)
+        if _drew_mesh(axes, meshes):
+            FigureManager.create_maidr(axes, PlotType.HEAT)
         return drawn
 
     # Register the histogram as HIST as before

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
+from matplotlib.collections import PolyQuadMesh, QuadMesh
+from matplotlib.image import AxesImage
 from matplotlib.lines import Line2D
 
 from maidr.core.enum import MaidrKey
@@ -275,10 +277,51 @@ class CollectionExtractorMixin:
 class ScalarMappableExtractorMixin:
     @staticmethod
     def extract_scalar_mappable(ax: Axes) -> Optional[ScalarMappable]:
-        """Retrieve the first collection ScalarMappable from an Axes object."""
+        """
+        Retrieve the artist a heatmap keeps its grid of values in.
+
+        A heatmap's values live in a mesh or an image. Preferring one matters
+        because ``ScalarMappable`` is a much wider net than it looks: a
+        scatter's ``PathCollection`` is one too -- that is how a colour-mapped
+        scatter works -- so "the first ``ScalarMappable`` on the axes" finds
+        the *scatter* whenever one was drawn first, and the heatmap beside it
+        is then read from an artist that has no grid at all::
+
+            sns.scatterplot(...); ax.pcolormesh(...)
+            ExtractionError: ... from <class 'matplotlib.collections.PathCollection'>
+
+        Falls back to the first mappable of any kind, so a mesh subclass this
+        does not name is still found rather than newly refused.
+
+        Returns ``None`` on an axes holding none, which is the ``Optional``
+        this has always been annotated with and what ``HeatPlot`` is written
+        for -- it opens with ``if data is None``. Reaching that answer through
+        a bare ``next()`` raised ``StopIteration`` instead, fatal to the whole
+        figure and naming nothing, which is the shape of failure #388 removed
+        from ``extract_container`` for the same reason.
+
+        Parameters
+        ----------
+        ax : Axes
+            The axes to search.
+
+        Returns
+        -------
+        ScalarMappable or None
+            The mesh or image if there is one, else the first mappable of any
+            kind, else None.
+        """
         if ax is None or ax.get_children() is None:
             return None
 
-        # We assume only one ScalarMappable is present to avoid plot clutter,
-        # even though multiples are technically possible.
-        return next(sm for sm in ax.get_children() if isinstance(sm, ScalarMappable))
+        mappables = [
+            child for child in ax.get_children() if isinstance(child, ScalarMappable)
+        ]
+        grids = [
+            mappable
+            for mappable in mappables
+            if isinstance(mappable, (QuadMesh, PolyQuadMesh, AxesImage))
+        ]
+        if grids:
+            return grids[0]
+        return mappables[0] if mappables else None

--- a/tests/core/test_bivariate_histogram.py
+++ b/tests/core/test_bivariate_histogram.py
@@ -43,7 +43,10 @@ from matplotlib.container import BarContainer  # noqa: E402
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
-from maidr.util.mixin import ContainerExtractorMixin  # noqa: E402
+from maidr.util.mixin import (  # noqa: E402
+    ContainerExtractorMixin,
+    ScalarMappableExtractorMixin,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -81,19 +84,29 @@ def test_a_scatter_under_a_2d_histogram_still_renders() -> None:
     sns.scatterplot(data=frame, x="v", y="w", ax=ax)
     sns.histplot(data=frame, x="v", y="w", ax=ax)
 
-    assert _layers(fig) == [PlotType.SCATTER]
+    # The mesh is read as the heatmap it is (#522). It used to be nothing at
+    # all: `hist` was declined, correctly, and the `heat` the inner
+    # `pcolormesh` would have registered had been suppressed by the recursion
+    # guard the decline made pointless.
+    assert _layers(fig) == [PlotType.SCATTER, PlotType.HEAT]
     assert maidr.render(fig) is not None
 
 
 def test_a_jointplot_of_histograms_renders() -> None:
     """A documented `jointplot` kind that produced nothing at all.
 
-    Its central panel is the bivariate histogram; its marginals are ordinary
-    1D ones, and those are what should be announced.
+    Its central panel is the bivariate histogram and its marginals are
+    ordinary 1D ones. All three are announced now: the joint panel as `heat`
+    and the margins as `hist`.
+
+    Before #522 this returned the two margins alone — which is the worse
+    symptom of the two, because nothing raised. A reader was handed a
+    complete-sounding chart with the joint distribution, the thing a joint
+    plot is drawn for, silently missing.
     """
     grid = sns.jointplot(data=_frame(), x="v", y="w", kind="hist")
 
-    assert _layers(grid.figure) == [PlotType.HIST, PlotType.HIST]
+    assert _layers(grid.figure) == [PlotType.HEAT, PlotType.HIST, PlotType.HIST]
     assert maidr.render(grid.figure) is not None
 
 
@@ -180,7 +193,10 @@ def test_bars_already_on_the_axes_do_not_make_it_a_histogram() -> None:
     sns.barplot(data=frame, x="g", y="v", ax=ax)
     sns.histplot(data=frame, x="v", y="w", ax=ax)
 
-    assert _layers(fig) == [PlotType.BAR]
+    # No `hist`, which is the point of this case. The `heat` beside it is the
+    # mesh that call did draw, and is asked the same question about ownership
+    # that the bars are — see the mesh test below (#522).
+    assert _layers(fig) == [PlotType.BAR, PlotType.HEAT]
 
 
 def test_a_second_histogram_on_the_same_axes_still_registers() -> None:
@@ -209,6 +225,88 @@ def test_a_histogram_drawn_without_an_explicit_axes_registers() -> None:
     sns.histplot(data=_frame(), x="v")
 
     assert _layers(plt.gcf()) == [PlotType.HIST]
+
+
+def test_the_two_spellings_of_one_bivariate_histogram_agree() -> None:
+    """The row the fix is for.
+
+    `sns.displot(x=, y=)` read as `heat` and `sns.histplot(x=, y=)` was
+    silent, and the only difference between them was that `histplot` is
+    patched: `common()` sets the internal context so a patched seaborn call
+    does not register twice, the inner `Axes.pcolormesh` therefore declines,
+    and then `_drew_bars` declines as well. `displot` escaped by not being
+    patched at all.
+
+    Asserted as an equality rather than as two literals, because what was
+    wrong was the disagreement (#522).
+    """
+    frame = _frame()
+
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="v", y="w", ax=ax)
+    through_histplot = _layers(fig)
+
+    grid = sns.displot(data=frame, x="v", y="w")
+    through_displot = _layers(grid.figure)
+
+    assert through_histplot == through_displot == [PlotType.HEAT]
+
+
+def test_a_mesh_already_on_the_axes_is_not_claimed_by_a_later_call() -> None:
+    """The ownership question, asked of meshes as it is of bars.
+
+    `_drew_mesh` asks what *this call* added, not what the axes holds. Asked
+    the second way, the `heatmap` drawn first is claimed all over again by the
+    `histplot` beside it, and the reader navigates two identical heatmaps --
+    the double-registration the recursion guard exists to prevent, arriving by
+    another route.
+
+    Drawn with nothing in it, which is what makes the case reachable: a
+    histplot that draws bars registers its `hist` and never reaches the mesh
+    branch, and a bivariate one always adds a mesh of its own, so neither can
+    tell the two readings apart. An empty one takes the decline path and adds
+    nothing, so the only mesh on the axes is somebody else's.
+    """
+    fig, ax = plt.subplots()
+
+    sns.heatmap(np.arange(6).reshape(2, 3), ax=ax)
+    sns.histplot(x=[], ax=ax)
+
+    assert _layers(fig) == [PlotType.HEAT]
+
+
+def test_a_heatmap_is_read_from_the_mesh_and_not_from_a_scatter() -> None:
+    """`ScalarMappable` is a wider net than the extractor assumed.
+
+    A scatter's `PathCollection` is a `ScalarMappable` -- that is what makes a
+    colour-mapped scatter possible -- so "the first mappable on the axes"
+    picked the scatter and `HeatPlot` was handed an artist with no grid. This
+    fails on `pcolormesh` alone, with nothing from #522 involved, which is why
+    it is asserted on that rather than through `histplot`.
+    """
+    rng = np.random.default_rng(20260820)
+    fig, ax = plt.subplots()
+
+    sns.scatterplot(x=rng.normal(size=30), y=rng.normal(size=30), ax=ax)
+    ax.pcolormesh(np.arange(12).reshape(3, 4))
+
+    assert _layers(fig) == [PlotType.SCATTER, PlotType.HEAT]
+    assert maidr.render(fig) is not None
+
+
+def test_an_axes_with_no_mappable_returns_none_rather_than_raising() -> None:
+    """The contract the annotation always claimed.
+
+    `extract_scalar_mappable` is typed `Optional[ScalarMappable]` and
+    `HeatPlot._extract_plot_data` opens with `if data is None`, but a bare
+    `next()` meant that branch could never run -- an axes holding no mappable
+    raised `StopIteration`, which names nothing and takes the figure with it.
+    The same shape #388 removed from `extract_container`.
+    """
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [3, 2, 1])  # a line is not a ScalarMappable
+
+    assert ScalarMappableExtractorMixin.extract_scalar_mappable(ax) is None
 
 
 def test_seaborn_still_takes_ax_by_keyword() -> None:

--- a/tests/core/test_bivariate_histogram.py
+++ b/tests/core/test_bivariate_histogram.py
@@ -297,6 +297,28 @@ def test_a_second_bivariate_histogram_on_the_same_axes_registers_too() -> None:
     assert _layers(fig) == [PlotType.HEAT, PlotType.HEAT]
 
 
+def test_the_joint_panel_says_what_its_cells_hold() -> None:
+    """The `z` label, which `HeatPlot` otherwise defaults to a bare "Z".
+
+    A bivariate histogram's cells hold whatever `stat` asked for, so the label
+    is read from it rather than assumed: the default is a count, and
+    `stat="density"` makes every cell a density. Announced as a "count" a
+    density would be the wrong word for every number in the grid.
+    """
+    frame = _frame()
+
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="v", y="w", ax=ax)
+    counted = FigureManager.get_maidr(fig).plots[0].schema["axes"]["z"]
+
+    other, second = plt.subplots()
+    sns.histplot(data=frame, x="v", y="w", ax=second, stat="density")
+    dense = FigureManager.get_maidr(other).plots[0].schema["axes"]["z"]
+
+    assert counted == {"label": "count"}
+    assert dense == {"label": "density"}
+
+
 def test_a_heatmap_is_read_from_the_mesh_and_not_from_a_scatter() -> None:
     """`ScalarMappable` is a wider net than the extractor assumed.
 

--- a/tests/core/test_bivariate_histogram.py
+++ b/tests/core/test_bivariate_histogram.py
@@ -275,6 +275,28 @@ def test_a_mesh_already_on_the_axes_is_not_claimed_by_a_later_call() -> None:
     assert _layers(fig) == [PlotType.HEAT]
 
 
+def test_a_second_bivariate_histogram_on_the_same_axes_registers_too() -> None:
+    """The mesh analogue of the bar case above: new mesh, new layer.
+
+    Two overlaid joint distributions are two charts, and each call adds its
+    own `QuadMesh`, so the ownership check must let the second through rather
+    than treat the first one's mesh as already accounting for it.
+
+    Only the layer count is asserted. Both layers currently read their values
+    from the *first* mesh, because `HeatPlot` resolves its artist from the
+    axes at extraction time rather than being bound to the one it was
+    registered for -- a separate defect (#527) which reproduces on two plain
+    `ax.pcolormesh` calls and which this change neither causes nor fixes.
+    """
+    frame = _frame()
+    fig, ax = plt.subplots()
+
+    sns.histplot(data=frame, x="v", y="w", ax=ax)
+    sns.histplot(data=frame, x="w", y="v", ax=ax)
+
+    assert _layers(fig) == [PlotType.HEAT, PlotType.HEAT]
+
+
 def test_a_heatmap_is_read_from_the_mesh_and_not_from_a_scatter() -> None:
     """`ScalarMappable` is a wider net than the extractor assumed.
 

--- a/tests/core/test_displot_distribution.py
+++ b/tests/core/test_displot_distribution.py
@@ -183,15 +183,19 @@ class TestWhatMustNotChange:
 
         assert layers(ax.get_figure()) == ["hist", "smooth"]
 
-    def test_a_bivariate_histogram_still_declines(self):
+    def test_a_bivariate_histogram_still_declines_to_be_a_histogram(self):
         # `sns.histplot(x=..., y=...)` is a 2D histogram drawn as a QuadMesh,
         # not as bars. `hist` promises one bin per bar with a count, which
         # such a layer has neither of, so registering it would promise a
-        # reading nothing can produce (#388).
+        # reading nothing can produce (#388). That decline stands.
+        #
+        # What it no longer costs is the chart: a mesh of joint counts is a
+        # heatmap, and is now read as one rather than being lost with the
+        # `hist` it is not (#522).
         _, ax = plt.subplots()
         sns.histplot(frame(), x="v", y="w", ax=ax)
 
-        assert layers(ax.get_figure()) == []
+        assert layers(ax.get_figure()) == ["heat"]
 
     def test_a_histogram_does_not_claim_someone_elses_bars(self):
         # The per-axes snapshot. An axes that already holds bars must not have
@@ -201,7 +205,9 @@ class TestWhatMustNotChange:
         sns.barplot(frame(), x="g", y="v", ax=ax)
         sns.histplot(frame(), x="v", y="w", ax=ax)
 
-        assert layers(ax.get_figure()) == ["bar"]
+        # No `hist`, which is what this case is about. The `heat` beside it is
+        # the mesh that call drew, asked the same ownership question (#522).
+        assert layers(ax.get_figure()) == ["bar", "heat"]
 
     def test_a_jointplot_is_unchanged(self):
         # It reaches the defining-module binding rather than the plotter


### PR DESCRIPTION
Closes #522.

`sns.histplot(df, x=..., y=...)` draws a `QuadMesh` of joint counts, exactly as `ax.hist2d` and `ax.pcolormesh` do. Those read as `heat`. This raised `UnsupportedPlotError` and the figure was unreadable — while the *same chart* through `sns.displot(df, x=..., y=...)` read as `heat` all along.

## Why the two spellings disagreed

Three correct decisions composed into a wrong one.

1. `common()` sets the internal context before the draw, so a patched seaborn call that reaches a patched matplotlib one does not register twice.
2. Inside the draw seaborn calls `ax.pcolormesh` — confirmed by spying on `Axes.pcolormesh`, which records exactly one call. The `heat()` patch sees the context and draws quietly, registering nothing.
3. `_drew_bars` then answers *no*, and the histogram patch declines. That decline is right, and #388's tests pin it: `hist` promises one bin per bar with a count, which a mesh has neither of.

The guard in step 2 assumes the outer patch will make a registration of its own. In step 3 the outer patch declined, and the one the chart could have had went with it.

`displot` escaped only by accident: it drives `_DistributionPlotter.plot_bivariate_histogram`, which nothing patches, so the inner `pcolormesh` runs outside the context and registers on its own account.

## The fix

Having declined `hist`, the seaborn histogram patch now registers `heat` when the call added a mesh. `_drew_mesh` asks what *this call* drew, the way `_drew_bars` does, so a heatmap already on the axes is not claimed a second time.

## A second defect it had to land on

The first version of this passed my own probe and then failed an existing test — `test_a_scatter_under_a_2d_histogram_still_renders` — with `ExtractionError … from <class 'matplotlib.collections.PathCollection'>`.

`extract_scalar_mappable` took the first `ScalarMappable` on the axes, and **a scatter's `PathCollection` is a `ScalarMappable` too** — that is how a colour-mapped scatter works. So a heatmap drawn beside a scatter was read from an artist with no grid.

This is not new and not mine: on unmodified `main`,

```python
sns.scatterplot(...); ax.pcolormesh(...)
```

already fails exactly this way. It now prefers a `QuadMesh`, `PolyQuadMesh` or `AxesImage` and falls back to the first mappable of any kind, so nothing that resolved before resolves differently. It also returns `None` on an axes holding none rather than raising `StopIteration` through a bare `next()` — which is the `Optional` it has always been annotated with, what `HeatPlot` is written for (`if data is None`), and the same shape of failure #388 removed from `extract_container`.

## Four existing expectations move

Every one of them is the point of the fix, and none is a weakened assertion:

| test | was | now |
|---|---|---|
| `test_a_scatter_under_a_2d_histogram_still_renders` | `[SCATTER]` | `[SCATTER, HEAT]` |
| `test_a_jointplot_of_histograms_renders` | `[HIST, HIST]` | `[HEAT, HIST, HIST]` |
| `test_bars_already_on_the_axes_do_not_make_it_a_histogram` | `[BAR]` | `[BAR, HEAT]` |
| `test_a_bivariate_histogram_still_declines` | `[]` | `[HEAT]` |

The jointplot row is the one worth pausing on. It returned both marginal histograms and nothing for the joint panel — so nothing raised, and a reader was handed a complete-sounding chart with the thing a joint plot is drawn for silently missing. Each test keeps its original point: none of them now asserts a `hist` for a mesh.

## Verification

`pytest 0 / ruff 0 / uv lock --check 0` — 2,412 passed, 18 skipped. (`ruff check` reports 51 pre-existing findings across the example notebooks on a clean tree; the four files this touches are clean.)

Every guard falsified by applying each mutation alone:

| mutation | result |
|---|---|
| the mesh registration removed (the reported bug) | 6 failed |
| ownership dropped — register whenever *any* mesh is present | 1 failed |
| the pre-draw snapshot emptied, so everything looks new | 1 failed |
| extractor back to the first mappable of any kind | 2 failed |
| extractor indexes an empty list instead of returning `None` | 1 failed |

The ownership case took two attempts to make honest. My first test drew `sns.heatmap` then a bivariate `histplot`, which passed the mutation as well as the real code — a bivariate call always adds a mesh of its own, so nothing distinguishes "this call's" from "any". The reachable case is a call that declines bars *and* adds no mesh: `sns.histplot(x=[])`. That one reddens both mutations.

## Not in scope, found while measuring

Two things this touches but does not fix, both pre-existing and both reproducible without any of the above:

- **A numeric-axis heatmap's row and column labels are the axis ticks, not the bins.** `ax.hist2d(a, b, bins=(3, 2))` emits a 2×3 grid with **nine** x labels and seven y labels; `pcolormesh` and `imshow` do the same. Only `sns.heatmap` lines up, because its axis is categorical. A reader navigating column 2 of 3 is told a label from a list of 9.
- **Two meshes on one axes are both read from the first.** Two `pcolormesh` calls emit two `heat` layers with identical data. `extract_scalar_mappable`'s own comment has always admitted the assumption — *"We assume only one ScalarMappable is present to avoid plot clutter"* — and resolving a layer's artist per layer rather than per axes is a larger change than this one.

I'll file both rather than widen this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_