### PR TITLE
test(altair): hold the warning's script list to what the adapter fetches

### DIFF
--- a/maidr/api.py
+++ b/maidr/api.py
@@ -160,9 +160,23 @@ def _resolve_use_cdn(
     return value
 
 
-#: Named in the warning so a reader can see what would have to travel with
-#: the page, rather than being told only that something will not.
-_ALTAIR_REMOTE_RUNTIME = "vega, vega-lite, vega-embed and maidr's own vegalite.js"
+#: What the Altair path fetches remotely, named in the warning so a reader
+#: can see what would have to travel with the page rather than being told
+#: only that something will not.
+#:
+#: A tuple rather than the prose it becomes, so a test can compare it to
+#: what the adapter really requests. As one string it could not be: `vega`
+#: is a substring of both `vega-lite` and `vega-embed`, so a check for it
+#: passes whether or not plain `vega` is still fetched, and a dependency
+#: quietly dropped would go on being named.
+#: `tests/core/test_altair_use_cdn_is_not_silent.py` holds it to the four.
+_ALTAIR_REMOTE_RUNTIME = ("vega", "vega-lite", "vega-embed", "vegalite.js")
+
+
+def _listed() -> str:
+    """Render :data:`_ALTAIR_REMOTE_RUNTIME` as prose for the warning."""
+    *rest, last = _ALTAIR_REMOTE_RUNTIME
+    return f"{', '.join(rest)} and maidr's own {last}"
 
 
 def _warn_altair_ignores_use_cdn(
@@ -201,8 +215,8 @@ def _warn_altair_ignores_use_cdn(
     warnings.warn(
         "maidr: use_cdn=False cannot be honoured for an Altair chart. That "
         "path renders through the upstream Vega-Lite adapter, which is only "
-        f"published on a CDN, so the page still loads {_ALTAIR_REMOTE_RUNTIME} "
-        "remotely and will not initialise without network access. Render the "
+        f"published on a CDN, so the page still loads {_listed()} remotely "
+        "and will not initialise without network access. Render the "
         "same data through matplotlib or seaborn for an offline chart.",
         stacklevel=stacklevel,
     )

--- a/tests/core/test_altair_use_cdn_is_not_silent.py
+++ b/tests/core/test_altair_use_cdn_is_not_silent.py
@@ -12,6 +12,7 @@ maidr's own ``vegalite.js``. Saying so is not, and is what these pin.
 
 from __future__ import annotations
 
+import re
 import warnings
 
 import matplotlib
@@ -23,6 +24,7 @@ import pandas as pd  # noqa: E402
 import pytest  # noqa: E402
 
 import maidr  # noqa: E402
+from maidr.api import _ALTAIR_REMOTE_RUNTIME  # noqa: E402
 
 alt = pytest.importorskip("altair")
 
@@ -112,3 +114,37 @@ def test_a_matplotlib_chart_is_not_warned_about():
     ax.bar(["p", "q"], [1, 2])
 
     assert not _complaints(lambda: maidr.render(fig, use_cdn=False))
+
+
+def _fetched_remotely(markup: str) -> set[str]:
+    """What the emitted page actually goes to a CDN for.
+
+    A URL names its package before the ``@``, except maidr's own adapter,
+    which is a file inside a versioned package -- so a trailing ``.js``
+    segment is the name there.
+    """
+    names = set()
+    for url in re.findall(r'<script[^>]+src="(https://[^"]+)"', markup):
+        tail = url.rsplit("/", 1)[-1]
+        names.add(tail if tail.endswith(".js") else tail.split("@")[0])
+    return names
+
+
+def test_the_warning_names_exactly_what_is_fetched():
+    """The listed scripts are held to what the adapter really requests.
+
+    Compared as a set rather than by substring, which is why the constant
+    is a tuple: ``vega`` occurs inside both ``vega-lite`` and
+    ``vega-embed``, so a substring check would keep passing if plain
+    ``vega`` were dropped, and the warning would name a script nobody
+    fetches any more.
+    """
+    fetched = _fetched_remotely(str(maidr.render(_chart(), use_cdn=True)))
+
+    assert fetched, "the fixture fetched nothing, so this proves nothing"
+    assert fetched == set(_ALTAIR_REMOTE_RUNTIME), (
+        f"the adapter fetches {sorted(fetched)} but the warning names "
+        f"{sorted(_ALTAIR_REMOTE_RUNTIME)}. Update _ALTAIR_REMOTE_RUNTIME "
+        f"in maidr/api.py so the message keeps naming what a reader would "
+        f"have to carry."
+    )


### PR DESCRIPTION
Follow-up to #523, closing a hazard I flagged there and deliberately left unfixed:

> On the second nit — `_ALTAIR_REMOTE_RUNTIME` drifting if the adapter's peer dependencies change — that is a real hazard and nothing here pins it. … flagging it so it is on the record.

## Why it matters

The warning added in #523 tells an offline reader *which* scripts the page still fetches. Nothing tied that list to reality, so if the Vega-Lite adapter gained or dropped a peer dependency the message would go on naming the old set. A warning that lists a script nobody fetches is worse than one that lists none — it sends the reader looking for something that is not there.

## Why the constant becomes a tuple

Because as prose the check cannot be exact. `vega` is a substring of both `vega-lite` and `vega-embed`, so a substring test passes whether or not plain `vega` is still fetched. Verified rather than assumed:

```python
"vega" in "vega-lite, vega-embed and maidr's own vegalite.js"   # -> True
```

A test built that way would have kept passing while the message named a script the adapter no longer requests — exactly the drift it was meant to catch.

So `_ALTAIR_REMOTE_RUNTIME` is now `("vega", "vega-lite", "vega-embed", "vegalite.js")` and the prose is built from it by `_listed()`. **The warning text is unchanged**, verified by rendering it:

```
… so the page still loads vega, vega-lite, vega-embed and maidr's own
vegalite.js remotely and will not initialise without network access. …
```

## The test

Reads the `<script src>` URLs out of an emitted Altair chart and compares the **set** against the tuple, so drift fails in either direction. Both were run:

| mutation | result |
|---|---|
| drop plain `vega` from the tuple (the substring trap) | 1 failed, 8 passed |
| add a script nothing fetches (`d3`) | 1 failed, 8 passed |

One test each, and it names both sides in the failure message so the fix is obvious from the output alone.

There is also a guard that the fixture fetched *something* — without it the comparison would pass trivially if the adapter ever stopped emitting script tags in a form the regex matches.

```
2421 passed, 1 skipped     # full suite, excluding browser
All checks passed!         # ruff
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_