### PR TITLE
fix(streamlit): render one figure at a time, as the Shiny door already does

### DIFF
--- a/maidr/api.py
+++ b/maidr/api.py
@@ -429,6 +429,13 @@ def _get_plot_or_current(plot: Any | None) -> Any:
     """
     Get the plot object or current matplotlib figure if plot is None.
 
+    Underscored but not private to this module:
+    :func:`maidr.util.figure_lock.resolve_figure` and
+    :func:`maidr.widget.streamlit.maidr_html` both call it, so that the
+    figure a render *locks* is the figure it goes on to write. A change
+    here that made this answer differently would put those locks on a
+    figure the render never touches -- synchronised in appearance only.
+
     Parameters
     ----------
     plot : Any or None

--- a/maidr/util/figure_lock.py
+++ b/maidr/util/figure_lock.py
@@ -153,6 +153,8 @@ def resolve_figure(value: Any) -> Any:
         # matching ``render``'s own loop over the list.
         axes = axes[-1] if axes else None
 
+    # ``axes`` is an ``Axes`` or ``None`` by here: ``get_axes`` returns one
+    # of those or a list, and the list is unwrapped above.
     return getattr(axes, "figure", None)
 
 

--- a/maidr/util/figure_lock.py
+++ b/maidr/util/figure_lock.py
@@ -143,10 +143,11 @@ def resolve_figure(value: Any) -> Any:
         return None
 
     if isinstance(axes, list):
-        # A ``Figure`` resolves to its list of axes, and so does a list of
-        # artists. They share one figure in every ordinary case; where they
-        # do not, ``render`` writes the last one's, so that is the one to
-        # hold.
+        # Only a ``Figure`` lands here: ``get_axes`` returns its ``.axes``
+        # property, while a list of artists takes a different branch and
+        # comes back as a single ``Axes``. A figure's axes all share that
+        # figure, so which one is picked does not matter -- the last,
+        # matching ``render``'s own loop over the list.
         axes = axes[-1] if axes else None
 
     return getattr(axes, "figure", None)

--- a/maidr/util/figure_lock.py
+++ b/maidr/util/figure_lock.py
@@ -1,0 +1,155 @@
+"""One lock per matplotlib ``Figure``, shared by every threaded entry point.
+
+Not process-wide: ``savefig`` on distinct figures is safe in parallel, and
+a single lock would serialise unrelated sessions and throw away most of
+what threading buys.
+
+Why a lock is needed at all: ``savefig`` mutates the figure it is writing,
+for the duration of the write. Two things, both measured by watching the
+attribute from another thread while renders ran:
+
+* ``fig.dpi`` goes 100 -> 72 -> 100, so two concurrent writes race on that
+  one attribute and the loser renders its whole chart at the other's dpi.
+  A 640x480 chart came out 460.8x345.6 -- exactly the 100/72 ratio -- as a
+  valid SVG, raising nothing, on 1 of 6 concurrent renders (#454).
+* ``fig.canvas`` is swapped to a canvas that supports the output format and
+  swapped back (``FigureCanvasAgg`` -> ``FigureCanvasSVG`` ->
+  ``FigureCanvasAgg``), by
+  ``FigureCanvasBase._switch_canvas_and_return_print_method``.
+
+That second one also answers a question this raises: a render may run on a
+worker thread, and GUI backends generally want canvas work on the main
+thread. It does not reach the GUI canvas -- the write goes through the
+format's own canvas, which for SVG is pure Python and has no thread
+affinity. maidr's own backend delegates to ``FigureCanvasAgg`` besides,
+and is what ``import maidr`` activates.
+
+The registry lives here rather than in one integration because more than
+one door renders on threads. Shiny renders off the event loop through
+``asyncio.to_thread``; Streamlit runs every session's script in its own
+ScriptRunner thread. Two doors with two registries would let a Shiny
+render and a Streamlit render of the *same* figure overlap, which is the
+case the lock exists to prevent -- so there is one registry, keyed by
+figure, for the process.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import weakref
+from typing import Any
+
+_logger = logging.getLogger(__name__)
+
+#: The locks themselves, keyed weakly so a closed figure's lock goes with
+#: it. The lock does not reference the figure, so this adds no retention
+#: (#498).
+#:
+#: ``threading.Lock``, not ``RLock``: nothing re-enters a render of the
+#: same figure on the same thread today, and if something ever does, a
+#: deadlock is a better outcome than two interleaved writes to one figure,
+#: because it is the one that shows up.
+_FIGURE_LOCKS: weakref.WeakKeyDictionary[Any, threading.Lock] = (
+    weakref.WeakKeyDictionary()
+)
+
+#: Guards creation of the per-figure locks above, which is itself a
+#: check-then-act on a shared mapping.
+_FIGURE_LOCKS_GUARD = threading.Lock()
+
+
+def figure_lock(figure: Any) -> threading.Lock:
+    """Return the lock for ``figure``, creating it on first use.
+
+    Parameters
+    ----------
+    figure : Any
+        The ``matplotlib`` figure about to be rendered, or ``None`` when it
+        could not be resolved.
+
+    Returns
+    -------
+    threading.Lock
+        A lock unique to that figure. An unresolvable figure gets a fresh
+        lock rather than a shared one -- serialising things we cannot tell
+        apart would be a guess in the direction of a deadlock, and the
+        render is safe on its own.
+
+        Note what that means: an unresolvable value gets **no**
+        synchronisation at all. Correct today because the values that land
+        here -- plotly, altair -- are rendered without touching a
+        ``matplotlib`` figure's ``dpi`` or ``canvas``, so there is no
+        shared state to race on. A future plot type that resolves to
+        ``None`` here *and* mutates shared figure state would be
+        unprotected silently, which is the reason to say so rather than
+        leave it to be inferred.
+    """
+    if figure is None:
+        return threading.Lock()
+    with _FIGURE_LOCKS_GUARD:
+        lock = _FIGURE_LOCKS.get(figure)
+        if lock is None:
+            lock = threading.Lock()
+            _FIGURE_LOCKS[figure] = lock
+        return lock
+
+
+def resolve_figure(value: Any) -> Any:
+    """Return the ``matplotlib`` figure ``value`` belongs to, or ``None``.
+
+    Resolves the way :func:`maidr.render` does, deliberately: ``None``
+    means the current figure there, and a value naming several axes is
+    rendered as the last one's figure. A resolver that disagreed with the
+    renderer would take a lock on a figure the render never touches, which
+    looks synchronised and is not.
+
+    Parameters
+    ----------
+    value : Any
+        Whatever the caller is about to render. ``None`` is the current
+        matplotlib figure, as it is for :func:`maidr.render`.
+
+    Returns
+    -------
+    Any
+        The figure to lock, or ``None`` when there is none to lock --
+        which :func:`figure_lock` answers with an unshared lock.
+    """
+    from maidr.api import _get_plot_or_current
+    from maidr.core.figure_manager import FigureManager
+
+    try:
+        axes = FigureManager.get_axes(_get_plot_or_current(value))
+    except (AttributeError, StopIteration):
+        # Narrow, and not the case one might expect. A foreign figure --
+        # plotly, altair -- does not raise: `get_axes` matches no branch
+        # and returns `None`, which the `getattr` below turns into `None`
+        # without ever reaching here. Measured: plotly-shaped, `None`,
+        # `int` and `str` all return `None`; only an empty list or dict
+        # raises, as `StopIteration`.
+        #
+        # So this catches malformed input that the caller's own validation
+        # should already have rejected. Logged rather than swallowed: a
+        # bare `except Exception` here would quietly downgrade a real bug
+        # in `get_axes` to "lock scope lost", immediately before an
+        # unsynchronised render.
+        _logger.debug(
+            "could not resolve a figure to lock for %r; rendering "
+            "without a shared lock",
+            type(value).__name__,
+            exc_info=True,
+        )
+        return None
+
+    if isinstance(axes, list):
+        # A ``Figure`` resolves to its list of axes, and so does a list of
+        # artists. They share one figure in every ordinary case; where they
+        # do not, ``render`` writes the last one's, so that is the one to
+        # hold.
+        axes = axes[-1] if axes else None
+
+    return getattr(axes, "figure", None)
+
+
+__all__ = ["figure_lock", "resolve_figure"]

--- a/maidr/util/figure_lock.py
+++ b/maidr/util/figure_lock.py
@@ -145,7 +145,10 @@ def resolve_figure(value: Any) -> Any:
     if isinstance(axes, list):
         # Only a ``Figure`` lands here: ``get_axes`` returns its ``.axes``
         # property, while a list of artists takes a different branch and
-        # comes back as a single ``Axes``. A figure's axes all share that
+        # comes back as a single ``Axes``. That is a coupling to
+        # ``FigureManager.get_axes``'s branch order rather than to
+        # matplotlib -- a ``Figure``-specific branch added ahead of the
+        # ``Artist`` one would change which shape arrives here. A figure's axes all share that
         # figure, so which one is picked does not matter -- the last,
         # matching ``render``'s own loop over the list.
         axes = axes[-1] if axes else None

--- a/maidr/widget/shiny.py
+++ b/maidr/widget/shiny.py
@@ -12,10 +12,7 @@ Requires the optional ``shiny`` extra::
 from __future__ import annotations
 
 import asyncio
-import logging
-import threading
 import warnings
-import weakref
 from typing import Any, Literal, Optional, Union
 
 try:
@@ -30,87 +27,8 @@ except ImportError as error:
 
 import maidr
 from maidr.core.figure_manager import FigureManager
+from maidr.util.figure_lock import figure_lock, resolve_figure
 from maidr.widget._focus import FOCUS_RESTORE_JS
-
-_logger = logging.getLogger(__name__)
-
-#: One lock per ``Figure``, so two renders of the *same* figure cannot run
-#: at once. Not process-wide: ``savefig`` on distinct figures is safe in
-#: parallel, and a single lock would serialise unrelated sessions and throw
-#: away most of what moving off the event loop buys.
-#:
-#: Why a lock is needed at all: ``savefig`` mutates the figure it is
-#: writing, for the duration of the write. Two things, both measured by
-#: watching the attribute from another thread while renders ran:
-#:
-#: * ``fig.dpi`` goes 100 -> 72 -> 100, so two concurrent writes race on
-#:   that one attribute and the loser renders its whole chart at the
-#:   other's dpi. A 640x480 chart came out 460.8x345.6 -- exactly the
-#:   100/72 ratio -- as a valid SVG, raising nothing, on 1 of 6 concurrent
-#:   renders. For a tool whose highlight overlay is positioned against
-#:   that geometry, silently wrong dimensions are the bad kind of wrong.
-#: * ``fig.canvas`` is swapped to a canvas that supports the output format
-#:   and swapped back (``FigureCanvasAgg`` -> ``FigureCanvasSVG`` ->
-#:   ``FigureCanvasAgg``), by
-#:   ``FigureCanvasBase._switch_canvas_and_return_print_method``.
-#:
-#: That second one also answers a question this raises: ``savefig`` now
-#: runs on a worker thread, and GUI backends generally want canvas work on
-#: the main thread. It does not reach the GUI canvas -- the write goes
-#: through the format's own canvas, which for SVG is pure Python and has
-#: no thread affinity. maidr's own backend delegates to ``FigureCanvasAgg``
-#: besides, and is what ``import maidr`` activates.
-#:
-#: ``threading.Lock``, not ``RLock``: nothing re-enters a render of the
-#: same figure on the same thread today, and if something ever does, a
-#: deadlock is a better outcome than two interleaved writes to one figure,
-#: because it is the one that shows up.
-#:
-#: A ``WeakKeyDictionary`` so a closed figure's lock goes with it. The lock
-#: does not reference the figure, so this adds no retention (#498).
-_FIGURE_LOCKS: weakref.WeakKeyDictionary[Any, threading.Lock] = (
-    weakref.WeakKeyDictionary()
-)
-
-#: Guards creation of the per-figure locks above, which is itself a
-#: check-then-act on a shared mapping.
-_FIGURE_LOCKS_GUARD = threading.Lock()
-
-
-def _figure_lock(figure: Any) -> threading.Lock:
-    """Return the lock for ``figure``, creating it on first use.
-
-    Parameters
-    ----------
-    figure : Any
-        The ``matplotlib`` figure about to be rendered, or ``None`` when it
-        could not be resolved.
-
-    Returns
-    -------
-    threading.Lock
-        A lock unique to that figure. An unresolvable figure gets a fresh
-        lock rather than a shared one -- serialising things we cannot tell
-        apart would be a guess in the direction of a deadlock, and the
-        render is safe on its own.
-
-        Note what that means: an unresolvable value gets **no**
-        synchronisation at all. Correct today because the values that land
-        here -- plotly, altair -- are rendered without touching a
-        ``matplotlib`` figure's ``dpi`` or ``canvas``, so there is no
-        shared state to race on. A future plot type that resolves to
-        ``None`` here *and* mutates shared figure state would be
-        unprotected silently, which is the reason to say so rather than
-        leave it to be inferred.
-    """
-    if figure is None:
-        return threading.Lock()
-    with _FIGURE_LOCKS_GUARD:
-        lock = _FIGURE_LOCKS.get(figure)
-        if lock is None:
-            lock = threading.Lock()
-            _FIGURE_LOCKS[figure] = lock
-        return lock
 
 
 #: Accepted by ``use_cdn`` on :class:`render_maidr`; ``None`` defers to the
@@ -420,7 +338,8 @@ class render_maidr(Renderer[Any]):
         is what this is for.
 
         Lock contention eats into that same pool rather than sitting
-        outside it: a render waiting on :func:`_figure_lock` is blocked
+        outside it: a render waiting on
+        :func:`maidr.util.figure_lock.figure_lock` is blocked
         *inside* its executor thread, still holding the slot. Enough
         sessions rendering one shared module-level figure could therefore
         make unrelated figures queue for a thread -- the stall this moves
@@ -428,7 +347,7 @@ class render_maidr(Renderer[Any]):
         figure per session, where this does not arise.
 
         The lock is what makes the move safe rather than merely faster --
-        see :data:`_FIGURE_LOCKS`.
+        see :mod:`maidr.util.figure_lock`.
 
         Parameters
         ----------
@@ -440,32 +359,7 @@ class render_maidr(Renderer[Any]):
         Any
             The rendered chart, as :func:`maidr.render` returns it.
         """
-        figure = None
-        try:
-            axes = FigureManager.get_axes(value)
-            figure = getattr(axes, "figure", None)
-        except (AttributeError, StopIteration):
-            # Narrow, and not the case an earlier comment here claimed. A
-            # foreign figure -- plotly, altair -- does not raise: `get_axes`
-            # matches no branch and returns `None`, which `getattr` above
-            # turns into `figure = None` without ever reaching here.
-            # Measured: plotly-shaped, `None`, `int` and `str` all return
-            # `None`; only an empty list or dict raises, as `StopIteration`.
-            #
-            # So this catches malformed input that `_check_supported`
-            # should already have rejected. Logged rather than swallowed:
-            # a bare `except Exception` here would quietly downgrade a real
-            # bug in `get_axes` to "lock scope lost", immediately before an
-            # unsynchronised render.
-            _logger.debug(
-                "could not resolve a figure to lock for %r; rendering "
-                "without a shared lock",
-                type(value).__name__,
-                exc_info=True,
-            )
-            figure = None
-
-        with _figure_lock(figure):
+        with figure_lock(resolve_figure(value)):
             return maidr.render(value, use_cdn=self.use_cdn)
 
     async def render(self) -> Optional[Jsonifiable]:

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -41,6 +41,7 @@ from htmltools import tags
 
 import maidr
 from maidr.util.dependencies import inline_bundle_tags, read_bundled_js
+from maidr.util.figure_lock import figure_lock, resolve_figure
 
 #: Accepted by ``use_cdn``; ``None`` defers to :func:`maidr.get_use_cdn`.
 UseCdn = Optional[Union[bool, Literal["auto"]]]
@@ -112,7 +113,16 @@ def maidr_html(
     # in which this function decides whether to inline against one answer
     # while the chart was built from another.
     resolved = maidr.get_use_cdn() if use_cdn is None else use_cdn
-    rendered = maidr.render(plot, use_cdn=resolved)
+    # One render of a given figure at a time, for the reason in
+    # :mod:`maidr.util.figure_lock`.  Streamlit runs every session's script
+    # in its own ScriptRunner thread, so two sessions sharing one figure --
+    # a module-level one, or anything behind ``@st.cache_resource`` -- can
+    # be inside ``savefig`` together.  Measured on the shipped path: one
+    # render in 30 came back a well-formed SVG of the same chart at the
+    # wrong scale, ``L 640 -134.4`` where every other render had
+    # ``L 460.8 0``.
+    with figure_lock(resolve_figure(plot)):
+        rendered = maidr.render(plot, use_cdn=resolved)
     html = str(rendered.get_html_string())
 
     if resolved is False:

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -113,6 +113,18 @@ def maidr_html(
     # in which this function decides whether to inline against one answer
     # while the chart was built from another.
     resolved = maidr.get_use_cdn() if use_cdn is None else use_cdn
+    if plot is None:
+        # ``plt.gcf()`` is process-global, so resolving the current figure
+        # twice -- once to decide which lock to take, once again inside
+        # ``render`` -- leaves a window in which another thread's
+        # ``plt.figure()`` moves it between the two, and the lock ends up
+        # guarding a figure the render never touches. Resolve once and
+        # render *that* figure; ``render`` resolves it to the same one, so
+        # nothing about the output changes. Raised in review of #531.
+        current = resolve_figure(None)
+        if current is not None:
+            plot = current
+
     # One render of a given figure at a time, for the reason in
     # :mod:`maidr.util.figure_lock`.  Streamlit runs every session's script
     # in its own ScriptRunner thread, so two sessions sharing one figure --

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -40,6 +40,7 @@ from typing import Any, Literal, Optional, Union
 from htmltools import tags
 
 import maidr
+from maidr.api import _get_plot_or_current
 from maidr.util.dependencies import inline_bundle_tags, read_bundled_js
 from maidr.util.figure_lock import figure_lock, resolve_figure
 
@@ -113,17 +114,21 @@ def maidr_html(
     # in which this function decides whether to inline against one answer
     # while the chart was built from another.
     resolved = maidr.get_use_cdn() if use_cdn is None else use_cdn
-    if plot is None:
-        # ``plt.gcf()`` is process-global, so resolving the current figure
-        # twice -- once to decide which lock to take, once again inside
-        # ``render`` -- leaves a window in which another thread's
-        # ``plt.figure()`` moves it between the two, and the lock ends up
-        # guarding a figure the render never touches. Resolve once and
-        # render *that* figure; ``render`` resolves it to the same one, so
-        # nothing about the output changes. Raised in review of #531.
-        current = resolve_figure(None)
-        if current is not None:
-            plot = current
+    # ``plt.gcf()`` is process-global, so resolving the current figure
+    # twice -- once to decide which lock to take, once again inside
+    # ``render`` -- leaves a window in which another thread's
+    # ``plt.figure()`` moves it between the two, and the lock ends up
+    # guarding a figure the render never touches. Resolve once, here, and
+    # hand ``render`` the figure rather than ``None``: it calls this same
+    # helper, which is the identity for anything that is not ``None``, so
+    # nothing about the output changes. Raised in review of #531.
+    #
+    # Deliberately not ``resolve_figure(None)``, which answers *which
+    # figure to lock* and is ``None`` both for no current figure and for a
+    # current figure with no axes yet. Substituting only when that is
+    # non-``None`` would leave the second ``gcf()`` in place for the
+    # axes-less case -- the window narrowed rather than closed.
+    plot = _get_plot_or_current(plot)
 
     # One render of a given figure at a time, for the reason in
     # :mod:`maidr.util.figure_lock`.  Streamlit runs every session's script

--- a/tests/util/test_figure_lock.py
+++ b/tests/util/test_figure_lock.py
@@ -1,0 +1,138 @@
+"""The per-figure render lock, and the resolution that decides its scope.
+
+The lock's behaviour was covered from ``tests/widget/test_shiny.py`` while
+it lived inside the Shiny integration. It now serves every threaded door,
+so the unit tests move here with it; the Shiny-specific ones (that a
+render actually takes it, that two renders do not overlap) stay there.
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+
+from maidr.util.figure_lock import figure_lock, resolve_figure  # noqa: E402
+
+
+def test_each_figure_gets_its_own_lock_and_keeps_it():
+    """Per figure, not process-wide, and stable across calls.
+
+    A single shared lock would serialise unrelated sessions and give back
+    most of what rendering on a thread buys, since ``savefig`` on
+    *distinct* figures is safe in parallel. A lock that differed per call
+    would guard nothing at all.
+    """
+    first, _ = plt.subplots()
+    second, _ = plt.subplots()
+    try:
+        assert figure_lock(first) is figure_lock(first), "must be stable"
+        assert figure_lock(first) is not figure_lock(second), "must be per figure"
+    finally:
+        plt.close(first)
+        plt.close(second)
+
+
+def test_an_unresolvable_figure_gets_a_fresh_lock_rather_than_a_shared_one():
+    """Sharing one lock among things we cannot tell apart invites a deadlock.
+
+    The render is safe on its own -- only the lock's scope is lost -- so
+    the fallback hands back an unshared lock rather than a sentinel-keyed
+    one.
+    """
+    assert figure_lock(None) is not figure_lock(None)
+
+
+def test_the_lock_does_not_keep_a_closed_figure_alive():
+    """The map is weak-keyed, so it adds no retention of its own (#498).
+
+    Worth pinning because a strong map keyed by figure is exactly the
+    shape that kept every registered figure alive for the life of the
+    process (#456), and this one is keyed the same way.
+    """
+    # A bare `Figure`, deliberately not `plt.subplots()`, so that nothing
+    # but the lock map can be the reason this passes or fails.
+    figure = Figure()
+    figure_lock(figure)
+    ref = weakref.ref(figure)
+
+    del figure
+    gc.collect()
+
+    assert ref() is None, "the lock map is keeping the figure alive"
+
+
+@pytest.mark.parametrize(
+    "shape",
+    ["axes", "figure", "list of artists", "no argument"],
+    ids=["axes", "figure", "list", "current"],
+)
+def test_every_way_of_naming_one_chart_takes_the_same_lock(shape):
+    """The lock is only exclusion if two names for one figure agree on it.
+
+    ``maidr.render`` accepts an ``Axes``, a ``Figure``, a list of artists
+    and ``None`` for the current figure, and renders the same chart from
+    every one of them. Resolution that answered ``None`` for some of those
+    would hand back a *fresh* lock -- so two renders of one figure, named
+    differently, would not exclude each other and would race on
+    ``fig.dpi`` exactly as if there were no lock.
+
+    ``Figure`` and ``None`` are not hypothetical: both resolved to no
+    figure before the resolution moved here, so a Shiny render function
+    returning ``fig`` rather than ``ax`` was unsynchronised.
+    """
+    figure, axes = plt.subplots()
+    axes.bar(["a", "b"], [1, 2])
+    named = {
+        "axes": axes,
+        "figure": figure,
+        "list of artists": [axes],
+        "no argument": None,
+    }[shape]
+    try:
+        assert resolve_figure(named) is figure, "must name the same figure"
+        assert figure_lock(resolve_figure(named)) is figure_lock(figure), (
+            "must take the same lock as the figure itself"
+        )
+    finally:
+        plt.close(figure)
+
+
+def test_a_value_naming_no_figure_resolves_to_none():
+    """The fallback branch, from both directions.
+
+    A value ``get_axes`` does not understand returns ``None``; an empty
+    container makes it raise. Both mean "nothing to lock", and the
+    distinction matters only in that the second reaches the ``except``.
+    """
+    assert resolve_figure("not a plot") is None
+    assert resolve_figure([]) is None
+
+
+def test_an_unexpected_resolver_failure_is_logged_not_swallowed(monkeypatch, caplog):
+    """A bug in ``get_axes`` must not vanish into "lock scope lost".
+
+    The catch sits immediately before an unsynchronised render, so a real
+    failure there is worth a record. It was a bare ``except Exception``
+    with no logging until review of #504.
+    """
+    import logging
+
+    from maidr.core.figure_manager import FigureManager
+
+    monkeypatch.setattr(
+        FigureManager,
+        "get_axes",
+        staticmethod(lambda value: (_ for _ in ()).throw(AttributeError("boom"))),
+    )
+    with caplog.at_level(logging.DEBUG, logger="maidr.util.figure_lock"):
+        assert resolve_figure(object()) is None
+
+    assert any("without a shared lock" in record.message for record in caplog.records)

--- a/tests/widget/test_every_door_agrees.py
+++ b/tests/widget/test_every_door_agrees.py
@@ -164,7 +164,7 @@ def test_no_door_post_processes_the_schema(build, expected, fake_session):
     )
 
 
-def test_the_two_doors_exclude_each_other_on_one_figure():
+def test_the_two_doors_exclude_each_other_on_one_figure(monkeypatch):
     """One lock registry, not one per integration -- asserted, not inferred.
 
     The Shiny renderer and ``maidr_html`` both take the per-figure lock in
@@ -234,8 +234,7 @@ def test_the_two_doors_exclude_each_other_on_one_figure():
         except Exception as error:  # noqa: BLE001 - re-raised after the join
             failures.append(error)
 
-    original = maidr.render
-    maidr.render = sleeping_render
+    monkeypatch.setattr(maidr, "render", sleeping_render)
     try:
         threads = [
             threading.Thread(target=through_shiny, daemon=True),
@@ -247,7 +246,6 @@ def test_the_two_doors_exclude_each_other_on_one_figure():
             thread.join(timeout=60)
             assert not thread.is_alive(), "a render deadlocked on the lock"
     finally:
-        maidr.render = original
         plt.close(fig)
 
     assert not failures, failures

--- a/tests/widget/test_every_door_agrees.py
+++ b/tests/widget/test_every_door_agrees.py
@@ -162,3 +162,96 @@ def test_no_door_post_processes_the_schema(build, expected, fake_session):
         f"a door altered the grid on its way out: {doors}. A reader is not "
         f"told which entry point their host used."
     )
+
+
+def test_the_two_doors_exclude_each_other_on_one_figure():
+    """One lock registry, not one per integration -- asserted, not inferred.
+
+    The Shiny renderer and ``maidr_html`` both take the per-figure lock in
+    ``maidr.util.figure_lock``. That they take the *same* lock follows from
+    both importing one module-level registry, which is a guarantee from
+    Python's import semantics rather than from any test -- so a later
+    change that gave either door a registry of its own would keep every
+    per-door test green while reopening exactly the case the shared
+    registry exists to prevent: a Shiny session and a Streamlit session
+    rendering one shared figure at the same moment, racing on ``fig.dpi``
+    (#454, #531).
+
+    Asserts exclusion rather than output equality: the two doors wrap the
+    chart differently, so their markup is not comparable, and what matters
+    here is that the two renders do not overlap in time.
+
+    ``maidr.render`` is stubbed to a sleeping recorder, so this measures
+    the lock rather than a real render -- the consequence of *not*
+    excluding is covered per door by the two
+    ``test_concurrent_renders_of_one_figure_agree`` tests.
+    """
+    import threading
+    import time
+
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+
+    in_flight = 0
+    overlapped = False
+    guard = threading.Lock()
+
+    class _Rendered:
+        """The little of a rendered chart that ``maidr_html`` goes on to use."""
+
+        @staticmethod
+        def get_html_string() -> str:
+            return '<script src="https://cdn.jsdelivr.net/npm/maidr@4/dist/maidr.js"></script>'
+
+        def __str__(self) -> str:
+            return self.get_html_string()
+
+    def sleeping_render(plot, **kwargs):
+        nonlocal in_flight, overlapped
+        with guard:
+            in_flight += 1
+            if in_flight > 1:
+                overlapped = True
+        time.sleep(0.2)
+        with guard:
+            in_flight -= 1
+        return _Rendered()
+
+    start = threading.Barrier(2)
+    failures: list[Exception] = []
+
+    def through_shiny():
+        try:
+            start.wait(timeout=30)
+            render_maidr(lambda: ax, use_cdn=True)._render_off_loop(ax)
+        except Exception as error:  # noqa: BLE001 - re-raised after the join
+            failures.append(error)
+
+    def through_streamlit():
+        try:
+            start.wait(timeout=30)
+            maidr_html(ax, use_cdn=True)
+        except Exception as error:  # noqa: BLE001 - re-raised after the join
+            failures.append(error)
+
+    original = maidr.render
+    maidr.render = sleeping_render
+    try:
+        threads = [
+            threading.Thread(target=through_shiny, daemon=True),
+            threading.Thread(target=through_streamlit, daemon=True),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=60)
+            assert not thread.is_alive(), "a render deadlocked on the lock"
+    finally:
+        maidr.render = original
+        plt.close(fig)
+
+    assert not failures, failures
+    assert not overlapped, (
+        "a Shiny render and a Streamlit render of one figure ran at once; "
+        "the two doors are not sharing a lock registry"
+    )

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -7,13 +7,11 @@ inside a session context -- without starting a server.
 from __future__ import annotations
 
 import asyncio
-import gc
 import re
 import sys
 import threading
 import time
 import warnings
-import weakref
 from html import unescape
 
 import matplotlib
@@ -483,62 +481,6 @@ def test_import_error_advice_matches_the_failure(monkeypatch, error, expected):
 # ---------------------------------------------------------------------------
 
 
-def test_each_figure_gets_its_own_lock_and_keeps_it():
-    """Per figure, not process-wide, and stable across calls.
-
-    A single shared lock would serialise unrelated sessions and give back
-    most of what moving off the loop buys, since ``savefig`` on *distinct*
-    figures is safe in parallel. A lock that differed per call would guard
-    nothing at all.
-    """
-    from maidr.widget.shiny import _figure_lock
-
-    first, _ = plt.subplots()
-    second, _ = plt.subplots()
-    try:
-        assert _figure_lock(first) is _figure_lock(first), "must be stable"
-        assert _figure_lock(first) is not _figure_lock(second), "must be per figure"
-    finally:
-        plt.close(first)
-        plt.close(second)
-
-
-def test_an_unresolvable_figure_gets_a_fresh_lock_rather_than_a_shared_one():
-    """Sharing one lock among things we cannot tell apart invites a deadlock.
-
-    The render is safe on its own -- only the lock's scope is lost -- so the
-    fallback hands back an unshared lock rather than a sentinel-keyed one.
-    """
-    from maidr.widget.shiny import _figure_lock
-
-    assert _figure_lock(None) is not _figure_lock(None)
-
-
-def test_the_lock_does_not_keep_a_closed_figure_alive():
-    """The map is weak-keyed, so it adds no retention of its own (#498).
-
-    Worth pinning because a strong map keyed by figure is exactly the shape
-    that kept every registered figure alive for the life of the process
-    (#456), and this one is keyed the same way.
-    """
-    from matplotlib.figure import Figure
-    from maidr.widget.shiny import _figure_lock
-
-    # A bare `Figure`, deliberately not `plt.subplots()`, so that nothing
-    # but the lock map can be the reason this passes or fails. When this was
-    # written `FigureManager` retained every figure and a pyplot figure
-    # failed here for that reason rather than the lock map's; that is fixed
-    # now, and the isolation is still worth keeping.
-    figure = Figure()
-    _figure_lock(figure)
-    ref = weakref.ref(figure)
-
-    del figure
-    gc.collect()
-
-    assert ref() is None, "the lock map is keeping the figure alive"
-
-
 def test_the_render_runs_off_the_event_loop(fake_session, monkeypatch):
     """The whole point of #454: ``maidr.render`` must not run on the loop.
 
@@ -587,7 +529,8 @@ def test_the_render_runs_off_the_event_loop(fake_session, monkeypatch):
 def test_two_renders_of_one_figure_do_not_overlap(monkeypatch):
     """The scenario this whole change exists to make safe.
 
-    The unit tests above check that ``_figure_lock`` hands back matching
+    ``tests/util/test_figure_lock.py`` checks that ``figure_lock`` hands
+    back matching
     objects; none of them shows that two renders actually serialise. That
     is the one thing a race here would break, so it is worth exercising
     end to end.
@@ -652,9 +595,9 @@ def test_two_renders_of_one_figure_do_not_overlap(monkeypatch):
 def test_a_value_that_resolves_to_no_figure_still_renders(fake_session, monkeypatch):
     """The fallback branch, driven through the real path rather than alone.
 
-    ``test_an_unresolvable_figure_gets_a_fresh_lock_...`` calls
-    ``_figure_lock(None)`` directly, which shows the helper's behaviour and
-    not that anything reaches it. This goes through ``render()``.
+    ``tests/util/test_figure_lock.py`` calls ``figure_lock(None)``
+    directly, which shows the helper's behaviour and not that anything
+    reaches it. This goes through ``render()``.
 
     Both shapes are covered because they are not the same shape, which an
     earlier comment in ``_render_off_loop`` got wrong: a foreign figure
@@ -694,6 +637,11 @@ def test_an_unexpected_resolver_failure_is_logged_not_swallowed(
     The catch sits immediately before an unsynchronised render, so a real
     failure there is worth a record. It was a bare ``except Exception``
     with no logging until review of #504.
+
+    ``tests/util/test_figure_lock.py`` makes the same assertion against
+    :func:`resolve_figure` directly. This one is what says the Shiny
+    render path still reaches it -- a renderer that resolved its own
+    figure again would pass that test and fail this one.
     """
     import logging
 
@@ -709,7 +657,8 @@ def test_an_unexpected_resolver_failure_is_logged_not_swallowed(
         staticmethod(lambda value: (_ for _ in ()).throw(AttributeError("boom"))),
     )
     try:
-        with caplog.at_level(logging.DEBUG, logger=shiny_module.__name__):
+        # The resolver, and so the record, now belongs to the shared module.
+        with caplog.at_level(logging.DEBUG, logger="maidr.util.figure_lock"):
 
             @render_maidr
             def chart():
@@ -791,7 +740,8 @@ _VOLATILE_IN_SVG = re.compile(
 )
 
 
-def test_concurrent_renders_of_one_figure_agree():
+@pytest.mark.parametrize("hand_back", ["axes", "figure"])
+def test_concurrent_renders_of_one_figure_agree(hand_back):
     """Concurrent renders of one figure must produce the same chart.
 
     Narrower than it first looks, and worth stating plainly:
@@ -844,10 +794,18 @@ def test_concurrent_renders_of_one_figure_agree():
     address that (detection was 8 of 8 at 30, 100 and 200 bars alike, so
     the margin was never the variable); starting them together does,
     because it does not depend on the scheduler being busy.
+
+    Parametrised over what the render function returns because the two
+    used to be different: a ``Figure`` resolves to a *list* of axes, and
+    the old resolver read ``.figure`` off that list, got ``None``, and
+    took a fresh unshared lock -- so an app whose render function returned
+    ``fig`` rather than ``ax`` raced exactly as if there were no lock. Both
+    now resolve to the same figure, and so to the same lock.
     """
     fig, ax = plt.subplots()
     ax.bar([str(i) for i in range(30)], list(range(30)))
-    renderer = render_maidr(lambda: ax)
+    returned = ax if hand_back == "axes" else fig
+    renderer = render_maidr(lambda: returned)
 
     # Appended from several threads without a lock, which is safe because
     # `list.append` is atomic under the GIL, and read only after every
@@ -864,7 +822,7 @@ def test_concurrent_renders_of_one_figure_agree():
     def render_once():
         try:
             start.wait(timeout=10)
-            rendered = str(renderer._render_off_loop(ax))
+            rendered = str(renderer._render_off_loop(returned))
             outputs.append(_VOLATILE_IN_SVG.sub("", rendered))
         except Exception as exc:  # reported below, not swallowed
             # Narrow enough to cover everything expected --

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -307,13 +307,25 @@ def test_each_cdn_mode_ships_the_source_it_promises(
 
 
 def test_none_renders_nothing(fake_session):
-    """Returning ``None`` leaves the output blank, per the Renderer contract."""
+    """Returning ``None`` leaves the output blank, per the Renderer contract.
+
+    Also asserts that nothing is *created* on the way. ``render()`` returns
+    before ``_render_off_loop``, so a ``None`` never reaches the figure
+    resolution -- which since #531 goes through ``_get_plot_or_current``
+    and would answer ``plt.gcf()``, opening a blank figure for an output
+    the app asked to leave empty. That short-circuit is load-bearing for
+    two reasons now, and only one of them was pinned.
+    """
 
     @render_maidr
     def blank():
         return None
 
+    open_before = set(plt.get_fignums())
     assert _render(blank) is None
+    assert set(plt.get_fignums()) == open_before, (
+        "rendering nothing opened a figure"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/widget/test_streamlit.py
+++ b/tests/widget/test_streamlit.py
@@ -574,3 +574,82 @@ def test_import_error_advice_matches_the_failure(
 
     with pytest.raises(ImportError, match=re.escape(expected)):
         render_maidr(bar_axes, use_cdn=True)
+
+
+# ---------------------------------------------------------------------------
+# One render of a figure at a time (#454's lock, on this door)
+# ---------------------------------------------------------------------------
+
+#: Attributes that differ between two renders of the same chart by design --
+#: fresh uuids per layer, and the timestamp matplotlib stamps into the SVG.
+_VOLATILE_IN_SVG = re.compile(
+    r'(\bid="[^"]*"|url\(#[^)]*\)|<dc:date>[^<]*</dc:date>'
+    r'|xlink:href="#[^"]*"|maidr="[^"]*")'
+)
+
+
+def test_concurrent_renders_of_one_figure_agree():
+    """Streamlit runs every session in its own thread; this door had no lock.
+
+    ``savefig`` writes ``fig.dpi`` for its duration and restores it
+    afterwards, so two renders of the **same** figure at once race on one
+    mutable attribute and the loser draws the whole chart at the other
+    call's dpi (#454). The Shiny renderer has held a per-figure lock since
+    #504. Nothing held one here, and Streamlit is if anything more exposed:
+    it runs each session's script on its own ScriptRunner thread, and
+    ``@st.cache_resource`` is its documented way to share one object --
+    a figure included -- across them.
+
+    Measured on the shipped path before the fix: 1 of 30 concurrent renders
+    came back as a complete, well-formed SVG of the same chart at the wrong
+    scale, ``L 640 -134.4`` where every other render had ``L 460.8 0``. Not
+    garbled markup and not an exception -- geometry is what the highlight
+    overlay and the tactile export are positioned against, so a chart at
+    72% scale is wrong in the modality a sighted reviewer checks least.
+
+    Asserted as agreement between renders rather than against a fixed size,
+    since the wrong-dpi output is internally consistent: it is only wrong
+    relative to what every other render produced.
+
+    The barrier synchronises the *start*, not the duration, so on a runner
+    slow enough that each render finishes before the next thread is
+    scheduled this passes with a broken lock -- a false negative rather
+    than CI noise. Measured 10 of 10 runs mismatching with the lock
+    removed and 10 of 10 identical with it.
+    """
+    import threading
+
+    fig, ax = plt.subplots()
+    ax.bar([str(i) for i in range(30)], list(range(30)))
+
+    outputs: list[str] = []
+    failures: list[Exception] = []
+    # One constant for the barrier and the thread count, because they must
+    # agree: a barrier expecting more arrivals than there are threads waits
+    # forever (#506).
+    workers = 6
+    start = threading.Barrier(workers)
+
+    def render() -> None:
+        try:
+            start.wait(timeout=30)
+            outputs.append(_VOLATILE_IN_SVG.sub("", maidr_html(ax, use_cdn=True)))
+        except Exception as error:  # noqa: BLE001 - re-raised after the join
+            failures.append(error)
+
+    threads = [threading.Thread(target=render, daemon=True) for _ in range(workers)]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=60)
+            assert not thread.is_alive(), "a render deadlocked on the lock"
+    finally:
+        plt.close(fig)
+
+    assert not failures, failures
+    assert len(outputs) == workers
+    assert all(output == outputs[0] for output in outputs), (
+        "concurrent renders of one figure disagree; they race on fig.dpi "
+        "and one of them emits the chart at the wrong scale"
+    )

--- a/tests/widget/test_streamlit.py
+++ b/tests/widget/test_streamlit.py
@@ -691,3 +691,40 @@ def test_the_current_figure_is_resolved_once_and_rendered(monkeypatch):
     # The chart rendered is the one that was locked: two bars, not an empty
     # figure. `_flatten_maidr` puts the data in the root `maidr` attribute.
     assert '&quot;y&quot;: 2' in html or '"y": 2' in html, html[:200]
+
+
+def test_an_axes_less_current_figure_is_still_resolved_only_once(monkeypatch):
+    """The narrow case the resolve-once fix must not leave behind.
+
+    ``resolve_figure(None)`` answers *which figure to lock*, and it is
+    ``None`` both when there is no current figure and when the current
+    figure has no axes yet. Substituting only when it is non-``None``
+    would leave ``render`` calling ``plt.gcf()`` a second time for the
+    axes-less case -- the window narrowed rather than closed. Raised in
+    review of #531.
+
+    Asserted by counting the resolutions rather than by racing them: one
+    ``plt.gcf()`` for the whole call, however few axes the figure has.
+    """
+    import matplotlib.pyplot as pyplot
+
+    import maidr.api as api_module
+
+    plt.figure()  # current, and deliberately empty
+    calls: list[int] = []
+    real_gcf = pyplot.gcf
+
+    def counting_gcf():
+        calls.append(1)
+        return real_gcf()
+
+    monkeypatch.setattr(pyplot, "gcf", counting_gcf)
+    assert api_module._get_plot_or_current is not None
+    try:
+        with pytest.raises(Exception):  # noqa: B017 - what it raises is not the point
+            maidr_html(use_cdn=True)
+    finally:
+        monkeypatch.setattr(pyplot, "gcf", real_gcf)
+        plt.close("all")
+
+    assert calls == [1], f"the current figure was resolved {len(calls)} times"

--- a/tests/widget/test_streamlit.py
+++ b/tests/widget/test_streamlit.py
@@ -653,3 +653,41 @@ def test_concurrent_renders_of_one_figure_agree():
         "concurrent renders of one figure disagree; they race on fig.dpi "
         "and one of them emits the chart at the wrong scale"
     )
+
+
+def test_the_current_figure_is_resolved_once_and_rendered(monkeypatch):
+    """``maidr_html()`` locks the figure it renders, not whichever is current
+    a moment later.
+
+    ``plt.gcf()`` is process-global. Resolving it separately for the lock
+    and for the render leaves a window in which another thread's
+    ``plt.figure()`` moves the current figure between the two, so the lock
+    guards one figure while the render writes another -- synchronised in
+    appearance only. Raised in review of #531.
+
+    Driven by moving the current figure *between* the two resolutions,
+    which is the interleaving a second thread would produce.
+    """
+    import maidr.widget.streamlit as streamlit_module
+
+    mine, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    locked: list[object] = []
+    real_lock = streamlit_module.figure_lock
+
+    def lock_and_move(figure):
+        locked.append(figure)
+        # What another thread plotting concurrently would do.
+        plt.figure()
+        return real_lock(figure)
+
+    monkeypatch.setattr(streamlit_module, "figure_lock", lock_and_move)
+    try:
+        html = maidr_html(use_cdn=True)
+    finally:
+        plt.close("all")
+
+    assert locked == [mine], "locked a different figure than the current one"
+    # The chart rendered is the one that was locked: two bars, not an empty
+    # figure. `_flatten_maidr` puts the data in the root `maidr` attribute.
+    assert '&quot;y&quot;: 2' in html or '"y": 2' in html, html[:200]


### PR DESCRIPTION
The per-figure render lock added for Shiny in #504 guards one door. Streamlit renders through the other one, unsynchronised — and Streamlit is if anything the more exposed of the two: it runs **every session's script in its own ScriptRunner thread**, and `@st.cache_resource` is its documented way to share one object across them.

## The failure

`savefig` writes `fig.dpi` for its duration and restores it afterwards, so two renders of the same figure at once race on that one attribute and the loser draws its whole chart at the other call's dpi. Six concurrent `maidr_html()` calls on one figure, five trials, diffed against a serial render with per-render uuids and timestamps normalised away:

```
trial 0: 1/6 differ from a serial render [1]
trial 1: 0/6 ...
total mismatching concurrent renders: 1/30
```

The one that differs is not garbled markup and not an exception. Its background path traces a different rectangle from every other render's:

| | the same element's `d` attribute |
|---|---|
| the other five renders | `M 0 345.6  L 460.8 345.6  L 460.8 0  L 0 0  z` |
| the loser of the race | `M 0 345.6  L 640 345.6  L 640 -134.4  L 0 -134.4  z` |

`640 / (100/72) = 460.8` — a complete, well-formed SVG of the same chart at 72% scale. Geometry is what the highlight overlay and the tactile export are positioned against, so this is wrong in the modality a sighted reviewer checks least — and it only happens under concurrent traffic, so it would not reproduce from a bug report.

## The fix

The lock moves to `maidr/util/figure_lock.py` and both doors take it. **One registry, not one per integration:** two registries would let a Shiny render and a Streamlit render of the same figure overlap, which is precisely the case the lock exists to prevent.

## A second gap, found while moving the resolution

Deciding *which* figure to lock moved too, and two shapes were silently missing:

| value handed to the renderer | old resolution | now |
|---|---|---|
| `ax` | the figure | the figure |
| `fig` | **`None`** | the figure |
| `None` (current figure) | **`None`** | the figure |

A `Figure` resolves to a *list* of axes, and `getattr(list, "figure", None)` is `None` — which `figure_lock` answers with a fresh, unshared lock. So **a Shiny render function returning `fig` rather than `ax` raced exactly as if there were no lock at all**, and `maidr_html()` with no argument would have done the same. Resolution now goes through `maidr.render`'s own `_get_plot_or_current`, because a resolver that disagrees with the renderer takes a lock on a figure the render never touches — synchronised-looking and not synchronised.

Review raised the follow-on: resolving `plt.gcf()` separately for the lock and for the render leaves the same window one level up, since `Gcf` is process-global. `maidr_html` now resolves once and renders *that* figure (`a1c5e9c`).

## Verification

`pytest 0 / ruff 0 / uv lock --check 0` — **2,430 passed, 14 skipped**. (`ruff check` reports 6 pre-existing re-export findings in `maidr/core/**/__init__.py` on a clean tree; every file this touches is clean.)

Every guard falsified by mutation rather than assumed:

| mutation | result |
|---|---|
| the Streamlit lock removed (the reported bug) | new test fails **5 of 5** runs |
| lock restored | passes **10 of 10** runs |
| resolver back to the old logic | Shiny concurrency test fails its new `figure` arm **3 of 3**, `axes` arm passes |
| the resolve-once step dropped | new current-figure test fails **3 of 3** |

The third row is the point of parametrising that test: the two arms were genuinely different before this change, and only one of them was covered.

## Tests

- `tests/util/test_figure_lock.py` — the lock's own unit tests move here with it (per-figure, stable, weak-keyed), plus `test_every_way_of_naming_one_chart_takes_the_same_lock` pinning the table above.
- `tests/widget/test_streamlit.py::test_concurrent_renders_of_one_figure_agree` — mirrors the Shiny sibling, barrier-synchronised so it does not depend on the scheduler being busy.
- `tests/widget/test_streamlit.py::test_the_current_figure_is_resolved_once_and_rendered` — moves the current figure *inside* `figure_lock`, which is the interleaving a second thread would produce.
- `tests/widget/test_shiny.py` — the three moved unit tests are gone from here; the tests that say the *render path* reaches the shared lock and resolver stay, with the log assertion repointed at the shared module's logger.

## Scope

This is the concurrent-**render** case, through the two doors this package ships. Two things it deliberately does not do, both filed with their own measurements:

- the window where an app mutates a figure *while* a render is in flight, which no lock keyed on renders can close — #530
- the same race reached through `maidr.render` directly, which is where Flask and any other threaded caller meet it — #532

Refs #454.