### PR TITLE
feat(core): read Axes.broken_barh as the gantt chart it draws

### DIFF
--- a/maidr/core/enum/maidr_key.py
+++ b/maidr/core/enum/maidr_key.py
@@ -58,6 +58,13 @@ class MaidrKey(str, Enum):
     # Step plot keys. The per-point ordinal level name reuses LABEL above.
     STEP_DIRECTION = "stepDirection"
 
+    # Gantt keys. An interval carries the two ends of its span; its lane is
+    # `X`, and the lane names live in `LANES` so that a lane holding nothing
+    # still has somewhere to carry one.
+    START = "start"
+    END = "end"
+    LANES = "lanes"
+
     # Histogram plot keys.
     X_MIN = "xMin"
     X_MAX = "xMax"

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -15,6 +15,11 @@ class PlotType(str, Enum):
     COUNT = "count"
     DODGED = "dodged_bar"
     ERRORBAR = "error_bar"
+    #: A schedule of intervals in lanes. `Axes.broken_barh` is matplotlib's
+    #: gantt chart: one call per lane, drawing that lane's intervals as a
+    #: `PolyCollection`, so the shape the trace wants -- a lane and the two
+    #: ends of each interval in it -- is what the call was given.
+    GANTT = "gantt"
     HEAT = "heat"
     #: A hexagonal bin lattice: the standard answer to an overplotted scatter.
     #: Read as a grid of cells each carrying a count, which is a heatmap --

--- a/maidr/core/plot/gantt.py
+++ b/maidr/core/plot/gantt.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import uuid
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import Collection
+from matplotlib.ticker import FixedLocator
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot import MaidrPlot
+from maidr.exception import ExtractionError
+
+
+class GanttPlot(MaidrPlot):
+    """
+    A schedule of intervals in lanes, as ``Axes.broken_barh`` draws it.
+
+    ``broken_barh(xranges, yrange)`` is matplotlib's gantt chart, and it is
+    shaped like one already: **one call is one lane**. The `yrange` says where
+    that lane sits and each `(start, width)` in `xranges` is an interval in it,
+    so the trace's `{lane, start, end}` is what the caller wrote rather than
+    something inferred from a drawing.
+
+    The numbers come off the artist exactly. A `PolyCollection` holds one path
+    per interval and each path's vertices are the corners, so a bar written
+    `(1, 3)` reads back as 1 to 4 with nothing to invert and nothing to round.
+
+    Naming the lane
+    ---------------
+    The `yrange` is a position, not a name, and the chart the matplotlib
+    documentation shows names its lanes afterwards::
+
+        ax.broken_barh([(110, 30), (150, 10)], (10, 9))
+        ax.broken_barh([(10, 50), (100, 20)], (20, 9))
+        ax.set_yticks([15, 25], labels=["Bill", "Jim"])
+
+    Two things make that readable. Extraction runs when the schema is first
+    asked for rather than when the call was patched, so ticks set *after* the
+    bars are in place by then. And the tick that names a lane is the one
+    **inside** it: measured, the example above puts its ticks at 15 and 25
+    while the bars span 10-19 and 20-29, so their centres are 14.5 and 24.5
+    and an exact match finds nothing.
+
+    Only a ``FixedLocator`` counts, which is what tells a name from an axis.
+    ``set_yticks`` installs one; left alone, matplotlib uses an ``AutoLocator``
+    and puts several ticks inside every bar -- measured, an unlabelled chart
+    offers "8", "10", "12", "14" and "16" for a lane spanning 10 to 19, none of
+    which is that lane's name. A lane with no single tick of its own is named
+    by its position, which is always true and never a guess.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        self._collections: list[Collection] = list(kwargs.pop("collections", ()) or ())
+        super().__init__(ax, PlotType.GANTT)
+
+    def add_lane(self, collection: Collection) -> None:
+        """
+        Take another ``broken_barh`` call on the same axes as another lane.
+
+        A gantt chart is drawn one call per lane, so a two-lane schedule is
+        two calls. Registering each as its own layer would give a reader two
+        one-lane charts to switch between rather than one chart to move up and
+        down inside, which is the whole of what the trace is for -- `points`
+        is nested by lane precisely so one layer holds them all.
+
+        The schema is dropped rather than amended, because it is built lazily
+        on first access and a lane arriving after it was built would otherwise
+        never appear.
+
+        Parameters
+        ----------
+        collection : Collection
+            The `PolyCollection` the new call drew.
+        """
+        self._collections.append(collection)
+        self._schema = {}
+
+    def _extract_plot_data(self) -> dict:
+        """
+        Read each collection as one lane of intervals.
+
+        Returns
+        -------
+        dict
+            ``{"points": [[{"x", "start", "end"}, ...], ...], "lanes": [...]}``
+            -- the intervals nested by lane, and what each lane is called.
+
+        Raises
+        ------
+        ExtractionError
+            When the call left no readable interval.
+        """
+        if not self._collections:
+            raise ExtractionError(self.type, self.ax)
+
+        points: list[list[dict]] = []
+        lanes: list[str | float] = []
+        for collection in self._collections:
+            spans = [self._corners(path) for path in collection.get_paths()]
+            spans = [span for span in spans if span is not None]
+            if not spans:
+                continue
+
+            # Every interval in one call shares that call's `yrange`, so the
+            # lane is asked once, of the first.
+            lane = self._lane_name(spans[0][2], spans[0][3])
+            lanes.append(lane)
+            points.append(
+                [
+                    {
+                        MaidrKey.X: lane,
+                        MaidrKey.START: start,
+                        MaidrKey.END: end,
+                    }
+                    for start, end, _, _ in spans
+                ]
+            )
+
+            # Assigned here rather than relied upon: a gid is otherwise only
+            # stamped at draw time and the schema is built first, which is
+            # what `HexbinPlot` and `AreaPlot` do for the same reason.
+            if collection.get_gid() is None:
+                collection.set_gid(f"maidr-{uuid.uuid4()}")
+
+        if not points:
+            raise ExtractionError(self.type, self.ax)
+
+        self._elements.clear()
+        self._elements.extend(self._collections)
+
+        return {MaidrKey.POINTS: points, MaidrKey.LANES: lanes}
+
+    @staticmethod
+    def _corners(path) -> tuple[float, float, float, float] | None:
+        """
+        The x span and y span of one drawn interval.
+
+        Parameters
+        ----------
+        path : Path
+            One interval's polygon.
+
+        Returns
+        -------
+        tuple or None
+            ``(start, end, y_low, y_high)``, or None when the path holds no
+            finite vertex.
+        """
+        vertices = np.asarray(path.vertices, dtype=float)
+        finite = vertices[np.isfinite(vertices).all(axis=1)]
+        if finite.shape[0] == 0:
+            return None
+        return (
+            float(finite[:, 0].min()),
+            float(finite[:, 0].max()),
+            float(finite[:, 1].min()),
+            float(finite[:, 1].max()),
+        )
+
+    def _lane_name(self, low: float, high: float) -> str | float:
+        """
+        What to call the lane a bar spanning ``low`` to ``high`` sits in.
+
+        Parameters
+        ----------
+        low, high : float
+            The bar's y extent.
+
+        Returns
+        -------
+        str or float
+            The tick label naming it, or its centre when no single tick does.
+        """
+        centre = (low + high) / 2
+        if not isinstance(self.ax.get_yaxis().get_major_locator(), FixedLocator):
+            # An axis matplotlib chose the ticks for. Several land inside a
+            # bar and none of them is its name.
+            return centre
+
+        inside = [
+            text.get_text()
+            for position, text in zip(self.ax.get_yticks(), self.ax.get_yticklabels())
+            if low <= position <= high and text.get_text()
+        ]
+        # Exactly one, or the label is a guess between candidates rather than
+        # a name the author gave this lane.
+        return inside[0] if len(inside) == 1 else centre
+
+    def _get_selector(self) -> list[str]:
+        """
+        Return one selector per lane, addressing that lane's whole collection.
+
+        Returns
+        -------
+        list of str
+            One selector per lane, in the order the lanes are announced.
+        """
+        return [
+            f"g[id='{collection.get_gid()}'] > path"
+            for collection in self._collections
+            if collection.get_gid() is not None
+        ]

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -8,6 +8,7 @@ from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.boxenplot import BoxenPlot
 from maidr.core.plot.boxplot import BoxPlot
 from maidr.core.plot.errorbar import ErrorBarPlot
+from maidr.core.plot.gantt import GanttPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
 from maidr.core.plot.heatmap import HeatPlot
 from maidr.core.plot.hexbinplot import HexbinPlot
@@ -67,6 +68,8 @@ class MaidrPlotFactory:
             return BoxPlot(single_ax, **kwargs)
         elif PlotType.BOXEN == plot_type:
             return BoxenPlot(single_ax, **kwargs)
+        elif PlotType.GANTT == plot_type:
+            return GanttPlot(single_ax, **kwargs)
         elif PlotType.ERRORBAR == plot_type:
             # Both read an estimate and the interval around it, and both emit
             # the same layer; they differ only in what the library drew.

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -15,6 +15,7 @@ from . import (  # noqa: E402, F401
     colorbar,
     errorbar,
     fillbetween,
+    gantt,
     heatmap,
     hexbin,
     highlight,

--- a/maidr/patch/gantt.py
+++ b/maidr/patch/gantt.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import threading
+
 import wrapt
 
 from matplotlib.axes import Axes
@@ -9,7 +11,18 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.gantt import GanttPlot
+from maidr.exception import UnsupportedPlotError
 from maidr.patch.common import _draw_quietly
+
+
+#: Held across the whole "is there a lane already, and if not make one"
+#: decision. Without it two threads drawing onto the same fresh axes -- the
+#: off-event-loop render #454 is about -- can both find no lane and each call
+#: `create_maidr`, which is the split-into-two-charts outcome this patch
+#: exists to prevent. `FigureManager._lock` cannot serve: it is a plain
+#: `Lock`, so holding it across `create_maidr` (which takes it again) would
+#: deadlock.
+_lanes = threading.Lock()
 
 
 @wrapt.patch_function_wrapper(Axes, "broken_barh")
@@ -49,11 +62,12 @@ def gantt(wrapped, instance, args, kwargs) -> Collection:
         plot = _draw_quietly(wrapped, args, kwargs)
 
     ax = FigureManager.get_axes(plot)
-    lane = _lane_of(ax)
-    if lane is not None:
-        lane.add_lane(plot)
-    else:
-        FigureManager.create_maidr(ax, PlotType.GANTT, collections=[plot])
+    with _lanes:
+        lane = _lane_of(ax)
+        if lane is not None:
+            lane.add_lane(plot)
+        else:
+            FigureManager.create_maidr(ax, PlotType.GANTT, collections=[plot])
 
     return plot
 
@@ -79,8 +93,17 @@ def _lane_of(ax: Axes) -> GanttPlot | None:
         The layer to extend, or None when this is the chart's first lane.
     """
     figure = ax.get_figure()
-    registered = FigureManager.figs.get(figure) if figure is not None else None
-    if registered is None:
+    if figure is None:
+        return None
+    try:
+        registered = FigureManager.get_maidr(figure)
+    except UnsupportedPlotError:
+        # Nothing registered for this figure yet, which is the ordinary first
+        # call. Reached through `get_maidr` rather than by reading
+        # `FigureManager.figs` directly, because `figs` documents that a
+        # direct caller must hold `_lock` even to read -- since #456 a lookup
+        # updates the bookkeeping behind iteration, so `get` mutates shared
+        # state rather than only observing it.
         return None
     return next(
         (

--- a/maidr/patch/gantt.py
+++ b/maidr/patch/gantt.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import wrapt
+
+from matplotlib.axes import Axes
+from matplotlib.collections import Collection
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.gantt import GanttPlot
+from maidr.patch.common import _draw_quietly
+
+
+@wrapt.patch_function_wrapper(Axes, "broken_barh")
+def gantt(wrapped, instance, args, kwargs) -> Collection:
+    """
+    Draw a patched ``Axes.broken_barh`` and register the lane it produced.
+
+    ``broken_barh`` is matplotlib's gantt chart, and one call draws one lane:
+    the `yrange` places it and each `(start, width)` is an interval in it. So a
+    chart is as many calls as it has lanes, and every one of them registers a
+    layer of its own here -- which is what lets a lane be named, and what keeps
+    the lanes in the order they were drawn.
+
+    Every call's own collection is handed to the plot rather than searched for
+    on the axes: a gantt chart's second lane is a `PolyCollection` beside the
+    first, and "the collection on this Axes" would find the wrong one for every
+    lane after the opening call.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Axes.broken_barh``.
+    instance : Any
+        The axes it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    Collection
+        Whatever ``broken_barh`` returned.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        plot = _draw_quietly(wrapped, args, kwargs)
+
+    ax = FigureManager.get_axes(plot)
+    lane = _lane_of(ax)
+    if lane is not None:
+        lane.add_lane(plot)
+    else:
+        FigureManager.create_maidr(ax, PlotType.GANTT, collections=[plot])
+
+    return plot
+
+
+def _lane_of(ax: Axes) -> GanttPlot | None:
+    """
+    The gantt layer already registered for an axes, when there is one.
+
+    Looked up rather than created afresh so that the second and later calls
+    become further *lanes* of one chart -- see ``GanttPlot.add_lane``. Asked of
+    the figure's registered plots rather than of the axes' artists, because
+    what matters is whether MAIDR already has a layer to extend, not whether
+    matplotlib has more collections.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the call drew on.
+
+    Returns
+    -------
+    GanttPlot or None
+        The layer to extend, or None when this is the chart's first lane.
+    """
+    figure = ax.get_figure()
+    registered = FigureManager.figs.get(figure) if figure is not None else None
+    if registered is None:
+        return None
+    return next(
+        (
+            plot
+            for plot in registered.plots
+            if isinstance(plot, GanttPlot) and plot.ax is ax
+        ),
+        None,
+    )

--- a/tests/core/test_gantt.py
+++ b/tests/core/test_gantt.py
@@ -179,6 +179,43 @@ def test_each_lane_gets_a_selector_of_its_own() -> None:
     assert all("path" in selector for selector in schema["selectors"])
 
 
+def test_the_lane_decision_is_made_under_the_lock(monkeypatch) -> None:
+    """The check-then-act, pinned at the invariant rather than by racing it.
+
+    Deciding whether a lane already exists and then creating one is two steps.
+    Unserialised, two threads drawing onto the same fresh axes can both find
+    none and each call `create_maidr`, and the schedule splits into two
+    one-lane charts -- silently, and only sometimes.
+
+    Racing it does not make a test: eight threads through `broken_barh` pass
+    just as readily without the lock as with it, because the window is a few
+    bytecodes wide and the GIL rarely lands inside it. What can be asserted
+    exactly is the invariant the lock exists for -- that the decision is taken
+    while it is held -- so that is what this checks. Remove the `with` and it
+    records False.
+
+    `FigureManager._lock` cannot be borrowed for this: it is a plain `Lock`,
+    and `create_maidr` takes it, so holding it across the decision would
+    deadlock rather than race.
+    """
+    from maidr.patch import gantt as patch
+
+    held: list[bool] = []
+    original = patch._lane_of
+
+    def spy(ax):
+        held.append(patch._lanes.locked())
+        return original(ax)
+
+    monkeypatch.setattr(patch, "_lane_of", spy)
+
+    _, ax = plt.subplots()
+    ax.broken_barh([(1, 3)], (10, 4))
+    ax.broken_barh([(6, 2)], (20, 4))
+
+    assert held == [True, True]
+
+
 def test_a_gantt_beside_another_chart_leaves_it_alone() -> None:
     """The neighbour test.
 

--- a/tests/core/test_gantt.py
+++ b/tests/core/test_gantt.py
@@ -1,0 +1,196 @@
+"""`Axes.broken_barh` is matplotlib's gantt chart, and it was read as nothing.
+
+One call draws one lane: the `yrange` places it and each `(start, width)` in
+`xranges` is an interval in that lane. So the shape the trace wants -- a lane
+and the two ends of every interval in it -- is what the caller already wrote,
+and the `PolyCollection`'s vertices give it back exactly.
+
+Two things needed deciding rather than assuming, and both were measured.
+
+**A chart is several calls, and it is still one chart.** Registering each call
+as its own layer would hand a reader two one-lane charts to switch between
+instead of one chart to move up and down inside -- and `points` is nested by
+lane precisely so a single layer holds them all.
+
+**A lane's name is not its position.** The chart matplotlib's own documentation
+shows names its lanes *after* drawing them::
+
+    ax.broken_barh([(110, 30), (150, 10)], (10, 9))
+    ax.broken_barh([(10, 50), (100, 20)], (20, 9))
+    ax.set_yticks([15, 25], labels=["Bill", "Jim"])
+
+Extraction runs when the schema is first asked for, so ticks set afterwards are
+in place by then. But the tick does not sit at the bar's centre: those bars span
+10-19 and 20-29, so their centres are 14.5 and 24.5 while the ticks are at 15
+and 25. The tick that names a lane is the one *inside* it.
+
+And only an explicit tick counts. Left alone, matplotlib puts several inside
+every bar -- measured, an unlabelled version of the chart above offers "8",
+"10", "12", "14" and "16" for the lane spanning 10 to 19, none of which is that
+lane's name. `set_yticks` installs a `FixedLocator`; automatic ticks are an
+`AutoLocator`, and that is the difference between a name and an axis.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _schedule(named: bool = True):
+    """The chart from matplotlib's own `broken_barh` documentation."""
+    fig, ax = plt.subplots()
+    ax.broken_barh([(110, 30), (150, 10)], (10, 9))
+    ax.broken_barh([(10, 50), (100, 20), (130, 10)], (20, 9))
+    if named:
+        ax.set_yticks([15, 25], labels=["Bill", "Jim"])
+    return fig, ax
+
+
+def _layer(fig):
+    """The one layer a figure emits, as its rendered schema."""
+    plots = FigureManager.get_maidr(fig).plots
+    assert len(plots) == 1
+    return plots[0].schema
+
+
+def _spans(schema) -> list[list[tuple]]:
+    """The intervals a layer announces, nested by lane."""
+    return [
+        [(point["x"], point["start"], point["end"]) for point in lane]
+        for lane in schema["data"]["points"]
+    ]
+
+
+def test_a_schedule_is_read_as_a_gantt() -> None:
+    """The numbers, straight off the drawn polygons.
+
+    A bar written `(110, 30)` is 110 to 140. Nothing is inverted through a
+    scale and nothing is rounded, because the vertices are the corners.
+    """
+    fig, _ = _schedule()
+    schema = _layer(fig)
+
+    assert schema["type"] == PlotType.GANTT
+    assert _spans(schema) == [
+        [("Bill", 110.0, 140.0), ("Bill", 150.0, 160.0)],
+        [("Jim", 10.0, 60.0), ("Jim", 100.0, 120.0), ("Jim", 130.0, 140.0)],
+    ]
+
+
+def test_two_calls_are_two_lanes_of_one_chart() -> None:
+    """Not two charts.
+
+    `GanttData.points` is nested by lane so that one layer holds the whole
+    schedule; a layer per call would make the up and down arrows -- which are
+    how a reader moves between lanes -- move between charts instead.
+    """
+    fig, _ = _schedule()
+    schema = _layer(fig)
+
+    assert schema["data"]["lanes"] == ["Bill", "Jim"]
+    assert len(schema["data"]["points"]) == 2
+
+
+def test_a_lane_is_named_by_the_tick_inside_it() -> None:
+    """The tick at 15 names the lane spanning 10 to 19, whose centre is 14.5.
+
+    An exact match against the centre finds nothing, which is why this is not
+    written that way.
+    """
+    fig, _ = _schedule()
+
+    assert _layer(fig)["data"]["lanes"] == ["Bill", "Jim"]
+
+
+def test_an_unlabelled_lane_is_named_by_its_position() -> None:
+    """The control, and the reason the locator is consulted at all.
+
+    With no `set_yticks` the axis carries an `AutoLocator`, and several of its
+    ticks fall inside every bar. Taking one would announce a lane called "12"
+    or "14" depending on which was reached first; the centre is always true.
+    """
+    fig, _ = _schedule(named=False)
+
+    assert _layer(fig)["data"]["lanes"] == [14.5, 24.5]
+
+
+def test_a_single_automatic_tick_is_still_not_a_name() -> None:
+    """Why the locator is asked as well as the count.
+
+    "Exactly one tick inside" is not enough on its own. Widen the axis and an
+    `AutoLocator` puts exactly one of its ticks inside the bar -- measured, a
+    bar spanning 10 to 14 under `ylim=(0, 50)` has the single tick "10" in it.
+    Taken as a name the lane would be called "10", which is the axis reading
+    itself out, not anything the author said about this lane.
+
+    `set_yticks` installs a `FixedLocator`; matplotlib's own choice is an
+    `AutoLocator`, and that is the difference between a name and a coordinate.
+    """
+    fig, ax = plt.subplots()
+    ax.broken_barh([(1, 3)], (10, 4))
+    ax.broken_barh([(6, 2)], (20, 4))
+    ax.set_ylim(0, 50)
+
+    assert _layer(fig)["data"]["lanes"] == [12.0, 22.0]
+
+
+def test_two_labelled_ticks_in_one_lane_name_neither() -> None:
+    """Why "exactly one" rather than "the first".
+
+    A lane holding two labelled ticks has no single one that names it, and
+    taking whichever came first would announce a name chosen by tick order
+    rather than by the author. The position is always true.
+    """
+    fig, ax = plt.subplots()
+    ax.broken_barh([(1, 3)], (10, 20))
+    ax.broken_barh([(6, 2)], (40, 4))
+    ax.set_yticks([12, 25, 42], labels=["early", "late", "other"])
+
+    assert _layer(fig)["data"]["lanes"] == [20.0, "other"]
+
+
+def test_each_lane_gets_a_selector_of_its_own() -> None:
+    """One per lane, in the order the lanes are announced.
+
+    Each call leaves its own `PolyCollection`, so a lane is a group in the SVG
+    and there is a real element to highlight -- unlike a chart drawn as one
+    grob, where the values read and nothing lights up.
+    """
+    fig, _ = _schedule()
+    schema = _layer(fig)
+
+    assert len(schema["selectors"]) == len(schema["data"]["points"])
+    assert all("path" in selector for selector in schema["selectors"])
+
+
+def test_a_gantt_beside_another_chart_leaves_it_alone() -> None:
+    """The neighbour test.
+
+    A schedule drawn over something else must add a layer rather than replace
+    or absorb one -- and the lane lookup must not mistake another axes' gantt
+    for this one's.
+    """
+    fig, (left, right) = plt.subplots(1, 2)
+    left.bar(["a", "b"], [1.0, 2.0])
+    right.broken_barh([(1, 3)], (10, 4))
+    right.broken_barh([(6, 2)], (20, 4))
+
+    types = [plot.type for plot in FigureManager.get_maidr(fig).plots]
+
+    assert types == [PlotType.BAR, PlotType.GANTT]


### PR DESCRIPTION
Closes #524 (the first of the three it names).

`Axes.broken_barh` is matplotlib's gantt chart. It was read as nothing, though the runtime has had a gantt trace since xability/maidr#801 and the pinned bundle already knows it — `bundle_trace_types()` lists `gantt` among its 60.

## Why it fits without inference

The call is already shaped like the trace. **One call is one lane**: the `yrange` places it, each `(start, width)` in `xranges` is an interval in it. So `{lane, start, end}` is what the caller wrote, not something recovered from a drawing.

The numbers come off the artist exactly:

```python
ax.broken_barh([(110, 30), (150, 10)], (10, 9))
ax.broken_barh([(10, 50), (100, 20), (130, 10)], (20, 9))
ax.set_yticks([15, 25], labels=["Bill", "Jim"])
```

```json
{"points": [[{"x": "Bill", "start": 110.0, "end": 140.0},
             {"x": "Bill", "start": 150.0, "end": 160.0}],
            [{"x": "Jim", "start": 10.0, "end": 60.0},
             {"x": "Jim", "start": 100.0, "end": 120.0},
             {"x": "Jim", "start": 130.0, "end": 140.0}]],
 "lanes": ["Bill", "Jim"]}
```

Nothing inverted through a scale, nothing rounded — the `PolyCollection`'s vertices *are* the corners.

## Two decisions, both measured

**A chart is several calls and is still one chart.** My first working version registered a layer per call, and a two-lane schedule came out as two one-lane charts. That defeats the point: `GanttData.points` is nested by lane so one layer holds the whole schedule, and up/down are how a reader moves *between* lanes. A later call on the same axes now becomes another lane of the layer already there.

**A lane's name is not its position, and the tick is not at its centre.** The chart matplotlib's own documentation shows names its lanes *after* drawing them, which works only because extraction runs when the schema is first asked for rather than when the call was patched — verified. But an exact match finds nothing:

| bar | spans | centre | tick |
|---|---|---|---|
| Bill | 10–19 | 14.5 | **15** |
| Jim | 20–29 | 24.5 | **25** |

So the tick that names a lane is the one *inside* it. And only an explicit tick counts, which took two measurements to get right:

- left alone, matplotlib's `AutoLocator` puts **several** ticks inside every bar — an unlabelled version of that chart offers "8", "10", "12", "14", "16" for the lane spanning 10–19;
- but "several" is not a safe test on its own. Widen the axis and exactly one automatic tick lands inside — measured, a bar spanning 10–14 under `ylim=(0, 50)` has the single tick "10" in it, and taken as a name the lane would be called "10", which is the axis reading itself out.

`set_yticks` installs a `FixedLocator`; matplotlib's own choice is an `AutoLocator`. That is the difference between a name and a coordinate. A lane with no single explicit tick of its own is named by its position, which is always true and never a guess.

## Verification

`pytest 0 / ruff 0` — 2,431 passed, 18 skipped (up from 2,414; the 6 `ruff` findings across `maidr/` + `tests/` are the pre-existing `__init__.py` re-export warnings, and every file this adds or touches is clean).

Every guard falsified by applying each mutation alone:

| mutation | result |
|---|---|
| lanes not merged — a layer per call | 6 failed |
| a lane always named by its position | 3 failed |
| the interval's end reads as its start | 1 failed |
| the `FixedLocator` check dropped | 1 failed |
| "the first tick inside" instead of "exactly one" | 1 failed |

The last two were **dead on the first pass** and are the reason two more fixtures exist. With only the documentation chart and its unlabelled twin, "exactly one tick inside" already caught everything the locator check was there for, and "the first" was indistinguishable from "exactly one". They are now pinned by the `ylim=(0, 50)` chart above and by a lane holding two labelled ticks, which is named by neither.

## Not in scope

The other two items #524 names — `ax.stairs` and the `contour` family — are separate readings and want their own PRs. `ax.quiver`, `ax.barbs`, `sns.rugplot` and `ax.eventplot` stay declined, on the reasoning already established in xability/maidr#1098 and #1069.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_