### PR TITLE
feat(core): read Axes.stairs as the pre-binned histogram it draws

### DIFF
--- a/maidr/core/plot/histogram.py
+++ b/maidr/core/plot/histogram.py
@@ -53,6 +53,61 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
 
         return data
 
+    @staticmethod
+    def _bin_point(
+        orientation: str, bin_start: float, bin_size: float, count: float | None
+    ) -> dict:
+        """
+        Build one bin's point, whichever way the histogram was drawn.
+
+        Shared with :class:`~maidr.core.plot.stairs.StairsPlot`, so the two
+        spellings of a histogram -- a row of bars from ``Axes.hist``, a
+        staircase from ``Axes.stairs`` -- emit the same payload for the same
+        chart rather than two that merely resemble one another.
+
+        Parameters
+        ----------
+        orientation : str
+            ``"horz"`` when the bins run up the y axis, ``"vert"`` otherwise.
+        bin_start : float
+            The bin's lower edge, along the axis the bins run on.
+        bin_size : float
+            The width of the bin, on that same axis.
+        count : float or None
+            What the bin holds, or ``None`` when it holds nothing measurable.
+
+        Returns
+        -------
+        dict
+            The point, with the bin edges on the axis the bins run on.
+
+        Notes
+        -----
+        The bounds across the bins -- ``yMin``/``yMax`` on a vertical
+        histogram, ``xMin``/``xMax`` on a horizontal one -- are emitted for
+        the shape's sake and are not read: the core's ``Histogram`` trace
+        takes its bin range from the pair on the *binned* axis and never
+        looks at the other.
+        """
+        if orientation == "horz":
+            return {
+                MaidrKey.X.value: count,
+                MaidrKey.Y.value: bin_start + bin_size / 2,
+                MaidrKey.Y_MIN.value: bin_start,
+                MaidrKey.Y_MAX.value: bin_start + bin_size,
+                MaidrKey.X_MIN.value: 0,
+                MaidrKey.X_MAX.value: count,
+            }
+
+        return {
+            MaidrKey.Y.value: count,
+            MaidrKey.X.value: bin_start + bin_size / 2,
+            MaidrKey.X_MIN.value: bin_start,
+            MaidrKey.X_MAX.value: bin_start + bin_size,
+            MaidrKey.Y_MIN.value: 0,
+            MaidrKey.Y_MAX.value: count,
+        }
+
     def _extract_bar_container_data(
         self, plot: BarContainer | None
     ) -> list[dict] | None:
@@ -66,35 +121,23 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
             # height and the count off its width. The vertical case is the
             # mirror of that.
             if self._orientation == "horz":
-                count = float(patch.get_width())
-                bin_start = float(patch.get_y())
-                bin_size = float(patch.get_height())
-
                 data.append(
-                    {
-                        MaidrKey.X.value: count,
-                        MaidrKey.Y.value: bin_start + bin_size / 2,
-                        MaidrKey.Y_MIN.value: bin_start,
-                        MaidrKey.Y_MAX.value: bin_start + bin_size,
-                        MaidrKey.X_MIN.value: 0,
-                        MaidrKey.X_MAX.value: count,
-                    }
+                    self._bin_point(
+                        "horz",
+                        float(patch.get_y()),
+                        float(patch.get_height()),
+                        float(patch.get_width()),
+                    )
                 )
                 continue
 
-            count = float(patch.get_height())
-            bin_start = float(patch.get_x())
-            bin_size = float(patch.get_width())
-
             data.append(
-                {
-                    MaidrKey.Y.value: count,
-                    MaidrKey.X.value: bin_start + bin_size / 2,
-                    MaidrKey.X_MIN.value: bin_start,
-                    MaidrKey.X_MAX.value: bin_start + bin_size,
-                    MaidrKey.Y_MIN.value: 0,
-                    MaidrKey.Y_MAX.value: count,
-                }
+                self._bin_point(
+                    "vert",
+                    float(patch.get_x()),
+                    float(patch.get_width()),
+                    float(patch.get_height()),
+                )
             )
 
         # Tag the elements for highlighting

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
+from matplotlib.patches import StepPatch
 from maidr.core.enum import PlotType
 from maidr.core.plot.areaplot import AreaPlot
 from maidr.core.plot.barplot import BarPlot
@@ -19,6 +20,7 @@ from maidr.core.plot.pieplot import PiePlot
 from maidr.core.plot.pointplot import PointPlot
 from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.regplot import SmoothPlot
+from maidr.core.plot.stairs import StairsPlot
 from maidr.core.plot.stepplot import StepPlot
 from maidr.core.plot.violin_kde_plot import ViolinKdePlot
 from maidr.core.plot.violin_box_plot import ViolinBoxPlot
@@ -86,6 +88,12 @@ class MaidrPlotFactory:
         elif PlotType.HEXBIN == plot_type:
             return HexbinPlot(single_ax, **kwargs)
         elif PlotType.HIST == plot_type:
+            # Two spellings of one chart. `Axes.hist` leaves a `BarContainer`
+            # for `HistPlot` to find; `Axes.stairs` leaves a single
+            # `StepPatch` and hands it over, because there is no container to
+            # find and no per-bin artist to look for.
+            if isinstance(kwargs.get("step_patch"), StepPatch):
+                return StairsPlot(single_ax, **kwargs)
             return HistPlot(single_ax)
         elif PlotType.LINE == plot_type:
             if PlotDetectionUtils.is_mplfinance_line_plot(single_ax, **kwargs):

--- a/maidr/core/plot/stairs.py
+++ b/maidr/core/plot/stairs.py
@@ -1,0 +1,115 @@
+"""StairsPlot — the pre-binned histogram ``Axes.stairs`` draws as a staircase."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from matplotlib.axes import Axes
+from matplotlib.patches import StepPatch
+
+from maidr.core.plot.histogram import HistPlot
+
+
+class StairsPlot(HistPlot):
+    """
+    A histogram whose bars were drawn as one continuous outline.
+
+    ``Axes.stairs`` is how modern matplotlib draws a histogram that was binned
+    somewhere else -- ``np.histogram`` first, ``ax.stairs(counts, edges)``
+    after -- and the artist keeps both halves of it exactly::
+
+        ax.stairs([1, 3, 2], [0, 1, 2, 3]).get_data()
+        # StairData(values=array([1, 3, 2]), edges=array([0, 1, 2, 3]), ...)
+
+    Counts and bin edges, unrounded, straight off the artist. So this reads
+    the same layer :class:`HistPlot` does, from a different place: there is no
+    ``BarContainer`` on the axes to find, because a staircase is a single
+    :class:`~matplotlib.patches.StepPatch` rather than one patch per bin.
+
+    That single patch is also what it costs. It renders as **one** ``<path>``
+    covering every bin, where ``ax.hist`` renders one per bar, so there is no
+    per-bin element for a selector to name and the chart announces every bin
+    while highlighting none of them. A selector matching the one path would be
+    worse than none: it would outline the whole staircase identically at every
+    bin, telling a low-vision reader nothing about which bin they are on. The
+    reading ships anyway because it is a strict gain -- the chart was silent
+    before, so no highlight is being taken away -- and ``ax.hist`` draws the
+    same histogram with a patch per bin for anyone who needs both.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the staircase was drawn on.
+    step_patch : StepPatch
+        The artist this call produced. Handed over rather than searched for:
+        two ``stairs`` calls on one axes leave two patches, and "the patch on
+        this axes" would read the first one twice.
+    **kwargs : dict
+        Ignored; accepted so the factory can forward what it was given.
+    """
+
+    def __init__(self, ax: Axes, step_patch: StepPatch, **kwargs) -> None:
+        self._step_patch = step_patch
+        super().__init__(ax)
+        self._support_highlighting = False
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        Read one point per bin off the artist.
+
+        Returns
+        -------
+        list of dict
+            One point per bin, in the order the bins were given.
+        """
+        values, edges, _ = self._step_patch.get_data()
+        self._orientation = (
+            "horz" if self._step_patch.orientation == "horizontal" else "vert"
+        )
+
+        data = []
+        for index, value in enumerate(values):
+            low = float(edges[index])
+            high = float(edges[index + 1])
+            # A bin with no position is nowhere to navigate to, and a bare
+            # `NaN` or `Infinity` in the payload is not JSON -- `JSON.parse`
+            # rejects the whole schema and the chart never initialises (#427).
+            if not (math.isfinite(low) and math.isfinite(high)):
+                continue
+            data.append(
+                self._bin_point(self._orientation, low, high - low, _reading(value))
+            )
+
+        return data
+
+
+def _reading(value: Any) -> float | None:
+    """
+    One bin's count, or ``None`` when it has none.
+
+    ``NaN`` is how a ``stairs`` chart leaves a bin blank -- matplotlib draws a
+    gap there -- and unlike the edges that is a bin with a position and no
+    value, which the payload can say. ``None`` serialises to ``null``, which
+    the core's bar family reads as a gap: kept out of the range, sounded as
+    the empty tone, announced as missing. A zero would claim the bin was
+    measured and found empty, which is a different statement.
+
+    Parameters
+    ----------
+    value : Any
+        The count matplotlib recorded, in whatever numpy type it arrived as.
+
+    Returns
+    -------
+    float or None
+        The count as a plain ``float``, or ``None`` when it is not finite.
+
+    Notes
+    -----
+    The ``float()`` is not decoration: ``json.dumps`` cannot serialise a
+    ``numpy.int64``, and ``ax.stairs([1, 3, 2], ...)`` hands back exactly
+    that.
+    """
+    raw = float(value)
+    return raw if math.isfinite(raw) else None

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -24,6 +24,7 @@ from . import (  # noqa: E402, F401
     pieplot,
     pointplot,
     scatterplot,
+    stairs,
     regplot,
     kdeplot,
     candlestick,

--- a/maidr/patch/stairs.py
+++ b/maidr/patch/stairs.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import wrapt
+
+from matplotlib.axes import Axes
+from matplotlib.patches import StepPatch
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import _draw_quietly
+
+
+@wrapt.patch_function_wrapper(Axes, "stairs")
+def stairs(wrapped, instance, args, kwargs) -> StepPatch:
+    """
+    Draw a patched ``Axes.stairs`` and register the histogram it produced.
+
+    ``ax.step`` already reads as ``step`` and ``ax.hist`` as ``hist``, so a
+    staircase drawn by the third spelling was the only one of the three that
+    left the chart silent -- and it is the spelling matplotlib's own
+    documentation reaches for once the binning has already happened.
+
+    The patch's own artist is handed to the layer rather than looked up on the
+    axes, for the reason ``maidr/patch/gantt.py`` gives: a second ``stairs``
+    call leaves a second ``StepPatch`` beside the first, and "the patch on
+    this axes" would describe the opening call twice.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Axes.stairs``.
+    instance : Any
+        The axes it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    StepPatch
+        Whatever ``stairs`` returned, unchanged.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        plot = _draw_quietly(wrapped, args, kwargs)
+
+    # `ax.stairs([], [0])` is legal and draws nothing. Registering it would
+    # put an empty layer in the schema, which the core has to navigate into
+    # and cannot read -- the phantom-layer shape of #421.
+    if len(plot.get_data().values) == 0:
+        return plot
+
+    ax = FigureManager.get_axes(plot)
+    FigureManager.create_maidr(ax, PlotType.HIST, step_patch=plot)
+
+    return plot

--- a/tests/core/test_stairs.py
+++ b/tests/core/test_stairs.py
@@ -156,6 +156,23 @@ def test_each_call_reads_its_own_staircase():
     ]
 
 
+def test_the_baseline_is_a_drawing_choice_and_not_a_reading():
+    # `baseline` takes None, a scalar or a per-bin array, and `get_data()`
+    # returns `values` unchanged in every case -- it decides where the outline
+    # is closed, not what the bins hold. Encoded here rather than argued,
+    # because a later change could start folding it into the counts and
+    # nothing else would notice.
+    default_figure, default_ax = plt.subplots()
+    default_ax.stairs([1, 3, 2], [0, 1, 2, 3])
+    expected = _data(default_figure)
+
+    for baseline in (None, 2, [0, 1, 0]):
+        fig, ax = plt.subplots()
+        ax.stairs([1, 3, 2], [0, 1, 2, 3], baseline=baseline)
+
+        assert _data(fig) == expected, f"baseline={baseline!r} changed the reading"
+
+
 def test_a_blank_bin_keeps_its_place_and_reports_no_count():
     # `NaN` is how a staircase leaves a bin blank -- matplotlib draws a gap.
     # The bin has a position the reader can still land on, so it is kept and

--- a/tests/core/test_stairs.py
+++ b/tests/core/test_stairs.py
@@ -1,0 +1,247 @@
+"""`Axes.stairs` is matplotlib's pre-binned histogram, and it was read as nothing.
+
+`ax.step` already read as `step` and `ax.hist` as `hist`, so of the three ways
+matplotlib draws a staircase this was the one that left the chart silent -- and
+it is the one its own documentation reaches for once the binning has already
+happened::
+
+    counts, edges = np.histogram(values, bins=8)
+    ax.stairs(counts, edges)
+
+Nothing has to be inferred. `StepPatch.get_data()` returns the counts and the
+bin edges unrounded, which is exactly the pair `hist` recovers from its bars --
+so the two spellings of one chart are held to emitting the *same* payload here
+rather than two that merely resemble each other.
+
+What a staircase cannot do is highlight. It renders as one `<path>` covering
+every bin where `ax.hist` renders one per bar, so there is no per-bin element
+for a selector to name. That limit is asserted below rather than described,
+so it turns red the day a renderer starts emitting per-bin elements.
+"""
+
+from __future__ import annotations
+
+import json
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.exception import UnsupportedPlotError  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _layers(fig):
+    """The layers registered for a figure, or an empty list when there are none."""
+    try:
+        return FigureManager.get_maidr(fig).plots
+    except UnsupportedPlotError:
+        return []
+
+
+def _data(fig, index: int = 0):
+    """One layer's point payload."""
+    return _layers(fig)[index].schema[MaidrKey.DATA]
+
+
+def _parse_as_a_browser_would(schema) -> None:
+    """
+    Serialise a layer and parse it back the way the core does.
+
+    Python's ``json.loads`` accepts the bare ``NaN``, ``Infinity`` and
+    ``-Infinity`` tokens ``json.dumps`` writes, so a round trip through it
+    proves nothing about the payload the browser has to read: ``JSON.parse``
+    rejects all three, and one of them stops the chart initialising at all
+    (#427). ``parse_constant`` is the hook that makes the two agree.
+    """
+
+    def reject(token: str):
+        raise AssertionError(f"{token} is not JSON; JSON.parse would reject it")
+
+    json.loads(json.dumps(schema), parse_constant=reject)
+
+
+def test_a_staircase_is_read_as_a_histogram():
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, 3, 2], [0, 1, 2, 3])
+
+    assert [layer.type for layer in _layers(fig)] == [PlotType.HIST]
+
+
+def test_counts_and_bin_edges_come_off_the_artist_exactly():
+    # `StepPatch` keeps both halves, so nothing here is measured from pixels
+    # or reconstructed from bar spacing.
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, 3, 2], [0, 1, 2, 3])
+
+    assert _data(fig) == [
+        {"y": 1.0, "x": 0.5, "xMin": 0.0, "xMax": 1.0, "yMin": 0, "yMax": 1.0},
+        {"y": 3.0, "x": 1.5, "xMin": 1.0, "xMax": 2.0, "yMin": 0, "yMax": 3.0},
+        {"y": 2.0, "x": 2.5, "xMin": 2.0, "xMax": 3.0, "yMin": 0, "yMax": 2.0},
+    ]
+
+
+def test_the_two_spellings_of_one_histogram_emit_the_same_payload():
+    # Six observations binned into [0, 1, 2, 3] give counts 1, 3, 2 -- the same
+    # chart the `stairs` call above draws from the counts directly. Parity is
+    # the point of the change, so it is asserted rather than assumed.
+    stairs_figure, stairs_ax = plt.subplots()
+    stairs_ax.stairs([1, 3, 2], [0, 1, 2, 3])
+
+    hist_figure, hist_ax = plt.subplots()
+    hist_ax.hist([0.5, 1.5, 1.5, 1.5, 2.5, 2.5], bins=[0, 1, 2, 3])
+
+    assert _data(stairs_figure) == _data(hist_figure)
+
+
+def test_a_horizontal_staircase_runs_its_bins_up_the_y_axis():
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, 3, 2], [0, 1, 2, 3], orientation="horizontal")
+
+    schema = _layers(fig)[0].schema
+    assert schema[MaidrKey.ORIENTATION] == "horz"
+    # The bin edges move to y and the count to x, which is what the core's
+    # histogram trace reads on a horizontal chart.
+    assert _data(fig)[1] == {
+        "x": 3.0,
+        "y": 1.5,
+        "yMin": 1.0,
+        "yMax": 2.0,
+        "xMin": 0,
+        "xMax": 3.0,
+    }
+
+
+def test_a_horizontal_staircase_matches_a_horizontal_hist():
+    stairs_figure, stairs_ax = plt.subplots()
+    stairs_ax.stairs([1, 3, 2], [0, 1, 2, 3], orientation="horizontal")
+
+    hist_figure, hist_ax = plt.subplots()
+    hist_ax.hist(
+        [0.5, 1.5, 1.5, 1.5, 2.5, 2.5], bins=[0, 1, 2, 3], orientation="horizontal"
+    )
+
+    assert _data(stairs_figure) == _data(hist_figure)
+
+
+def test_each_call_reads_its_own_staircase():
+    # Two `stairs` calls leave two patches on one axes. Looking the artist up
+    # on the axes rather than taking the call's own would describe the first
+    # staircase twice and lose the second entirely.
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, 3, 2], [0, 1, 2, 3])
+    ax.stairs([9, 8, 7], [0, 1, 2, 3])
+
+    assert [[point["y"] for point in _data(fig, i)] for i in range(2)] == [
+        [1.0, 3.0, 2.0],
+        [9.0, 8.0, 7.0],
+    ]
+
+
+def test_a_blank_bin_keeps_its_place_and_reports_no_count():
+    # `NaN` is how a staircase leaves a bin blank -- matplotlib draws a gap.
+    # The bin has a position the reader can still land on, so it is kept and
+    # its count emitted as null rather than dropped, which would silently
+    # shorten the chart by a bin.
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, np.nan, 2], [0, 1, 2, 3])
+
+    points = _data(fig)
+    assert len(points) == 3
+    assert points[1]["y"] is None
+    assert (points[1]["xMin"], points[1]["xMax"]) == (1.0, 2.0)
+
+
+def test_a_blank_bin_leaves_the_payload_parseable():
+    # `json.dumps` writes a bare `NaN`, which is legal JavaScript and not
+    # JSON: `JSON.parse` rejects the whole schema and the chart never
+    # initialises at all (#427). Asserted through a real parse rather than by
+    # looking for the token.
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, np.nan, 2], [0, 1, 2, 3])
+
+    _parse_as_a_browser_would(_layers(fig)[0].schema)
+
+
+def test_a_bin_with_no_finite_edge_is_dropped():
+    # An infinite edge is a real idiom rather than a contrivance: seaborn's
+    # `ecdfplot` opens its staircase at -inf so the first step has somewhere
+    # to come from, and matplotlib accepts one here (it rejects only NaN).
+    # Such a bin has no position to navigate to, and `Infinity` in the payload
+    # is not JSON -- `JSON.parse` would reject the whole schema (#427).
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, 2, 3], [-np.inf, 1, 2, 3])
+
+    assert [(p["xMin"], p["xMax"]) for p in _data(fig)] == [(1.0, 2.0), (2.0, 3.0)]
+    _parse_as_a_browser_would(_layers(fig)[0].schema)
+
+
+def test_an_empty_staircase_registers_nothing():
+    # `ax.stairs([], [0])` is legal and draws nothing. A layer for it would be
+    # one the core has to navigate into and cannot read.
+    fig, ax = plt.subplots()
+
+    ax.stairs([], [0])
+
+    assert _layers(fig) == []
+
+
+def test_uneven_bins_keep_the_edges_they_were_given():
+    # Nothing is reconstructed from bar spacing here, so author-set thresholds
+    # survive exactly rather than being regularised.
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, 3, 2], [0, 1, 5, 6])
+
+    assert [(p["xMin"], p["xMax"]) for p in _data(fig)] == [
+        (0.0, 1.0),
+        (1.0, 5.0),
+        (5.0, 6.0),
+    ]
+
+
+def test_a_staircase_announces_its_bins_but_has_nothing_to_highlight():
+    # One `<path>` covers every bin, so there is no per-bin element to name.
+    # The layer must exist first: a chart that registered nothing would also
+    # have no selectors, and would pass this test for the wrong reason.
+    fig, ax = plt.subplots()
+
+    ax.stairs([1, 3, 2], [0, 1, 2, 3])
+
+    schema = _layers(fig)[0].schema
+    assert len(schema[MaidrKey.DATA]) == 3
+    assert MaidrKey.SELECTOR not in schema
+
+
+def test_the_np_histogram_idiom_reads_end_to_end():
+    # The call matplotlib's documentation shows, through the public API.
+    rng = np.random.default_rng(0)
+    counts, edges = np.histogram(rng.normal(size=200), bins=5)
+    fig, ax = plt.subplots()
+    ax.stairs(counts, edges)
+
+    html = maidr.render(fig).get_html_string()
+
+    assert "&quot;type&quot;:&quot;hist&quot;" in html.replace(" ", "")
+    assert [point["y"] for point in _data(fig)] == [float(c) for c in counts]


### PR DESCRIPTION
Closes #535 — the second of the three readings #524 recorded, after #533.

Three ways to draw a staircase, one of them silent:

| call | before |
|---|---|
| `ax.step([0, 1, 2, 3], [1, 3, 2, 2], where="post")` | `['step']` |
| `ax.hist([0.5, 1.5, 1.5, 2.5], bins=[0, 1, 2, 3])` | `['hist']` |
| `ax.stairs([1, 3, 2], [0, 1, 2, 3])` | **`UnsupportedPlotError`** |

`ax.stairs` is the spelling matplotlib's documentation reaches for once `np.histogram` has already done the binning, and that chart was a static picture.

## Nothing inferred

`StepPatch.get_data()` returns `StairData(values=[1, 3, 2], edges=[0, 1, 2, 3], baseline=0)` — counts and bin edges, unrounded, straight off the artist. Nothing inverted from a pixel, nothing reconstructed from bar spacing, so author-set uneven thresholds survive exactly.

`baseline` does not complicate it. It takes `None`, a scalar or a per-bin array, and `get_data()` returns `values` unchanged in all four cases I measured — it is a drawing choice. Nor does it reach anything announced: the core's `Histogram` trace takes its bin range from `xMin`/`xMax` on a vertical chart and `yMin`/`yMax` on a horizontal one, and **never reads the pair on the other axis** (`src/model/histogram.ts:22,38,56`). That is what settles the question rather than a convention.

## The parity is structural, not coincidental

`ax.stairs` leaves no `BarContainer` — it adds a single `StepPatch` — so `HistPlot`'s container lookup cannot find it and `StairsPlot` reads the artist the patch hands over. But the point *builder* is now shared (`HistPlot._bin_point`), so the two spellings emit the same payload for the same chart:

```
stairs [{"y": 1.0, "x": 0.5, "xMin": 0.0, "xMax": 1.0, "yMin": 0, "yMax": 1.0}, …]
hist   [{"y": 1.0, "x": 0.5, "xMin": 0.0, "xMax": 1.0, "yMin": 0, "yMax": 1.0}, …]
                                                                       equal ✓
```

That extraction is what a second caller earns, and the mutation table below shows it guards both.

The patch's own artist is handed over rather than looked up, for the reason `maidr/patch/gantt.py` gives: a second `stairs` call leaves a second `StepPatch` beside the first, and "the patch on this axes" would describe the opening call twice.

## The limit, stated rather than buried

A staircase is **one** `<path>` for the whole chart. Measured on the same three-bin chart:

| call | `<path>` elements for the data |
|---|---|
| `ax.hist` | 3 — one per bar |
| `ax.stairs` | 1 — the whole outline; `fill=True` and `baseline=None` alike |

So the layer emits **no selectors**: the chart announces every bin and highlights none. A selector matching that one path would be worse than none — it would outline the entire staircase identically at every bin, telling a low-vision reader nothing about where they are. This is the blind spot xability/maidr#814 names, and the same trade made in xability/r-maidr#193: a blind reader gains every number, nobody loses a highlight they had, and `ax.hist` draws the same histogram with a patch per bin for anyone who needs both.

It is asserted rather than described — `test_a_staircase_announces_its_bins_but_has_nothing_to_highlight` — so it reddens the day per-bin elements appear. The layer is checked to *exist* first, because a chart that registered nothing would also have no selectors and would pass for the wrong reason (the defect I had to fix in xability/r-maidr#193's equivalent test).

## Two non-finite cases, measured rather than assumed

matplotlib accepts an infinite bin edge and rejects a NaN one (`ValueError: Nan values in "edges" are disallowed`), and accepts a NaN count. They are not the same case:

- a **count** of NaN is how a staircase leaves a bin blank — the bin still has a position, so it is kept and its count emitted as `null`, the gap the core's bar family already reads;
- an **edge** that is infinite leaves the bin nowhere to be, so it is dropped. Not a contrivance: `sns.ecdfplot` opens its staircase at `-inf` for exactly this reason, which is what #427 was about.

Both keep the payload loadable. `json.dumps` writes bare `NaN`/`Infinity`, which `JSON.parse` rejects — and the chart then never initialises at all.

## Verification

`pytest 0 / ruff 0` — 2,445 passed, 18 skipped, up from 2,432. Every file this adds or touches is `ruff`-clean; the 6 repo-wide findings are the pre-existing `__init__.py` re-export warnings.

Every guard falsified by applying each mutation alone:

| mutation | result |
|---|---|
| the patch is never imported | 12 of 13 failed |
| the factory ignores `step_patch` and always builds a `HistPlot` | 11 failed |
| read the axes' first patch instead of the call's own | 1 failed |
| a NaN count is emitted raw instead of as `null` | 2 failed |
| a NaN count drops the bin instead of nulling it | 1 failed |
| the non-finite **edge** guard dropped | 1 failed |
| the empty-staircase guard dropped | 1 failed |
| `_support_highlighting` left on | 1 failed |
| orientation always vertical | 2 failed |
| the shared `_bin_point` mutated | 4 stairs tests **and** `test_bar_orientation.py::test_vertical_histogram_bins_run_along_x` |

The last row is the one worth reading: mutating the shared builder reddens the existing `hist` suite as well, which is what makes the parity structural rather than a coincidence two tests happen to agree on.

**One mutation passed and led to a real fix.** Emitting the NaN raw left `test_a_blank_bin_leaves_the_payload_parseable` green, because Python's `json.loads` *accepts* the bare `NaN` token that `JSON.parse` rejects — so the round trip proved nothing about the payload the browser has to read. The test now parses with a `parse_constant` hook that refuses all three tokens, which is what makes the two agree, and it reddens.

## Found alongside, not in this PR

**`sns.histplot(element="step")` and `element="poly"` are silent too**, and not through `ax.stairs`:

```
element=bars   containers=[BarContainer]     → ['hist']
element=step   collections=[PolyCollection]  → nothing
element=poly   collections=[PolyCollection]  → nothing
```

Seaborn draws those through a fill rather than through bars, so `sns_hist` reaches `_drew_bars` → False and declines — the third branch of the same decline #522 fixed for the bivariate mesh. It needs its own reading and its own issue; recorded in #535.

`ax.contour` / `ax.contourf` / bivariate `sns.kdeplot` → `CONTOUR` is what remains of #524, and is the largest of the three since it introduces a plot type py-maidr has never emitted.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_