### PR TITLE
docs: point the websocket-payload note at an issue that is still open

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -326,7 +326,7 @@ Measured through the renderer on a 50-bar chart, longest gap between successive 
 
 Same throughput either way — the work did not get cheaper, it stopped being in everyone else's way.
 
-Two things this does not do. Renders of the **same figure** are serialised, because `savefig` writes `fig.dpi` for its duration and two concurrent writes leave one chart drawn at the other's scale; distinct figures, which is the usual per-session shape, run in parallel. And the chart still travels over the websocket on every flush — roughly 25 KB, or a couple of megabytes with `use_cdn=False`. That part is still open in [#454](https://github.com/xability/py-maidr/issues/454).
+Two things this does not do. Renders of the **same figure** are serialised, because `savefig` writes `fig.dpi` for its duration and two concurrent writes leave one chart drawn at the other's scale; distinct figures, which is the usual per-session shape, run in parallel. That lock is shared with the Streamlit path rather than private to this one, so a figure reached from both is still rendered one at a time. And the chart still travels over the websocket on every flush — roughly 25 KB, or a couple of megabytes with `use_cdn=False`; that part is tracked in [#534](https://github.com/xability/py-maidr/issues/534).
 
 `uv run pytest tests/core/test_render_is_synchronous.py --run-benchmark` re-measures the underlying `maidr.render()`, which is still synchronous and still blocks its caller — that is what makes moving it off the loop necessary rather than optional.
 :::


### PR DESCRIPTION
`docs/index.qmd`'s "Shiny and other async servers" callout ends by telling the reader that the per-flush websocket payload is *"still open in #454"*.

#454 is closed. It shipped: option 1 (render off the loop, per-figure lock) in #504 and #531, option 3 (document the blocking accurately) in #511. **Option 2 — serving the chart out of band via `session.dynamic_route` — was never actioned**, so a reader following that link now lands on a closed issue and reasonably concludes the payload question is settled too.

It is not, and the cost is not small: roughly 25 KB per flush by default, ~1.9 MB per chart with `use_cdn=False`, measured at 3891 KB for two offline charts under the #457 QA. That now has its own issue (#534) and the callout points there.

## The other half

The same paragraph says renders of one figure are serialised. Since #531 that lock is shared with the Streamlit path rather than private to the Shiny one, so a figure reached from both doors is still rendered one at a time — worth a clause, because "the Shiny renderer serialises" and "this figure is serialised wherever it is rendered" are different promises to anyone caching a figure across sessions.

## Scope

One paragraph, prose only. No links elsewhere in `docs/` point at a closed issue — checked by extracting every `py-maidr/issues/N` reference in `docs/*.qmd` and reading each one's state; the only other is #339, which is open.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_