### PR TITLE
fix(core): render one figure at a time for every caller, not just two doors

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -326,7 +326,7 @@ Measured through the renderer on a 50-bar chart, longest gap between successive 
 
 Same throughput either way — the work did not get cheaper, it stopped being in everyone else's way.
 
-Two things this does not do. Renders of the **same figure** are serialised, because `savefig` writes `fig.dpi` for its duration and two concurrent writes leave one chart drawn at the other's scale; distinct figures, which is the usual per-session shape, run in parallel. That lock is shared with the Streamlit path rather than private to this one, so a figure reached from both is still rendered one at a time. And the chart still travels over the websocket on every flush — roughly 25 KB, or a couple of megabytes with `use_cdn=False`; that part is tracked in [#534](https://github.com/xability/py-maidr/issues/534).
+Two things this does not do. Renders of the **same figure** are serialised, because `savefig` writes `fig.dpi` for its duration and two concurrent writes leave one chart drawn at the other's scale; distinct figures, which is the usual per-session shape, run in parallel. That lock is held by the render path itself rather than by this integration, so a figure is rendered one at a time however it is reached — through Shiny, through Streamlit, or from a thread of your own. And the chart still travels over the websocket on every flush — roughly 25 KB, or a couple of megabytes with `use_cdn=False`; that part is tracked in [#534](https://github.com/xability/py-maidr/issues/534).
 
 `uv run pytest tests/core/test_render_is_synchronous.py --run-benchmark` re-measures the underlying `maidr.render()`, which is still synchronous and still blocks its caller — that is what makes moving it off the loop necessary rather than optional.
 :::

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -429,13 +429,6 @@ def _get_plot_or_current(plot: Any | None) -> Any:
     """
     Get the plot object or current matplotlib figure if plot is None.
 
-    Underscored but not private to this module:
-    :func:`maidr.util.figure_lock.resolve_figure` and
-    :func:`maidr.widget.streamlit.maidr_html` both call it, so that the
-    figure a render *locks* is the figure it goes on to write. A change
-    here that made this answer differently would put those locks on a
-    figure the render never touches -- synchronised in appearance only.
-
     Parameters
     ----------
     plot : Any or None

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -432,6 +432,15 @@ class Maidr:
         six threads on one figure: 1 of 5 trials came back with two
         distinct outputs.
 
+        The lock covers the whole render rather than the ``savefig`` call
+        alone. That is wider than the mutation strictly needs, and
+        deliberate: the schema is extracted from the same artists
+        ``savefig`` is writing, so a narrower lock would let one render's
+        payload be built while another render mutates the figure under it.
+        It is also what the two doors held before this, so nothing about
+        contention changes for them. In a single-threaded script the lock
+        is never contended and costs an uncontended acquire per render.
+
         Locking by ``self._fig`` also removes a resolution step that could
         disagree with the render. The integrations had to work out *which*
         figure a value named before they could lock it, and when that
@@ -459,11 +468,13 @@ class Maidr:
         data_in_svg: bool = True,
         use_cdn: bool | Literal["auto"] = "auto",
     ) -> Tag:
-        """Render the chart. Call :meth:`_create_html_tag`, which holds the lock.
+        """Render the chart. Callers want :meth:`_create_html_tag`, which locks.
 
-        Separate only so that the lock wraps the whole of this rather than
+        Split out only so that the lock wraps the whole of this rather than
         this being indented under a ``with``: the body is long, and the
-        rename keeps the two concerns readable apart.
+        split keeps the two concerns readable apart. Nothing but
+        :meth:`_create_html_tag` should call this -- a caller reaching past
+        it renders without the lock.
         """
         # Before the artists are collected, not after: reading `plot.elements`
         # renders the layer, and a superseded `BarPlot` on a stacked axes

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -24,6 +24,7 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.plot import MaidrPlot
 from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
+from maidr.util.figure_lock import figure_lock
 from maidr.util.bundle_capability import (
     schema_trace_types,
     warn_if_bundle_cannot_render,
@@ -407,7 +408,36 @@ class Maidr:
         data_in_svg: bool = True,
         use_cdn: bool | Literal["auto"] = "auto",
     ) -> Tag:
-        """Create the MAIDR HTML using HTML tags.
+        """Create the MAIDR HTML using HTML tags, one render of a figure at a time.
+
+        The lock is here rather than in the integrations because this is
+        where the mutation is: ``savefig`` writes ``self._fig.dpi`` for its
+        duration and restores it, so two renders of one figure at once race
+        on that attribute and the loser draws the whole chart at the other
+        call's dpi -- a complete, well-formed SVG at the wrong scale, with
+        nothing raised (#454).
+
+        Every render of a ``matplotlib`` figure funnels through here:
+        ``render``, ``save_html`` and ``_create_html_doc`` all call it, and
+        none of them re-enters it. Holding it at this one point is what
+        makes a plain ``Lock`` safe -- a second lock at a caller would
+        deadlock against this one rather than nest.
+
+        The Shiny and Streamlit integrations held this lock themselves
+        until #532. That covered the two doors this package ships and
+        nothing else: a Flask app -- Werkzeug serves threaded, and
+        ``Environment.is_flask`` makes it a supported embedding -- or any
+        caller rendering from a thread pool met the same race with no lock
+        at all. Measured through ``maidr.render`` with no widget involved,
+        six threads on one figure: 1 of 5 trials came back with two
+        distinct outputs.
+
+        Locking by ``self._fig`` also removes a resolution step that could
+        disagree with the render. The integrations had to work out *which*
+        figure a value named before they could lock it, and when that
+        answer was wrong -- as it was for a ``Figure``, and for the current
+        figure -- the lock was taken on nothing while the render went ahead
+        (#531).
 
         Parameters
         ----------
@@ -419,6 +449,21 @@ class Maidr:
         use_cdn : bool or {"auto"}, default="auto"
             Controls how ``maidr.js`` is referenced.  See :meth:`render`
             for the three possible modes.
+        """
+        with figure_lock(self._fig):
+            return self._build_html_tag(use_iframe, data_in_svg, use_cdn=use_cdn)
+
+    def _build_html_tag(
+        self,
+        use_iframe: bool = True,
+        data_in_svg: bool = True,
+        use_cdn: bool | Literal["auto"] = "auto",
+    ) -> Tag:
+        """Render the chart. Call :meth:`_create_html_tag`, which holds the lock.
+
+        Separate only so that the lock wraps the whole of this rather than
+        this being indented under a ``with``: the body is long, and the
+        rename keeps the two concerns readable apart.
         """
         # Before the artists are collected, not after: reading `plot.elements`
         # renders the layer, and a superseded `BarPlot` on a stacked axes

--- a/maidr/util/figure_lock.py
+++ b/maidr/util/figure_lock.py
@@ -24,23 +24,25 @@ format's own canvas, which for SVG is pure Python and has no thread
 affinity. maidr's own backend delegates to ``FigureCanvasAgg`` besides,
 and is what ``import maidr`` activates.
 
-The registry lives here rather than in one integration because more than
-one door renders on threads. Shiny renders off the event loop through
-``asyncio.to_thread``; Streamlit runs every session's script in its own
-ScriptRunner thread. Two doors with two registries would let a Shiny
-render and a Streamlit render of the *same* figure overlap, which is the
-case the lock exists to prevent -- so there is one registry, keyed by
-figure, for the process.
+The registry lives here, and :meth:`maidr.core.maidr.Maidr._create_html_tag`
+is the only thing that takes a lock from it. That is deliberate: every
+render of a matplotlib figure funnels through that one method, so a lock
+held there covers every caller -- the Shiny and Streamlit integrations,
+a threaded Flask app, a notebook doing its own threading, anything.
+
+The integrations each held their own lock until #532, which covered the
+two doors this package ships and nothing else. It also meant each door
+had to work out *which* figure a value named before it could lock it, and
+a resolver that disagreed with the renderer locked a figure the render
+never touched (#531). Locking where the figure is already known removes
+that class of bug rather than fixing instances of it.
 """
 
 from __future__ import annotations
 
-import logging
 import threading
 import weakref
 from typing import Any
-
-_logger = logging.getLogger(__name__)
 
 #: The locks themselves, keyed weakly so a closed figure's lock goes with
 #: it. The lock does not reference the figure, so this adds no retention
@@ -95,67 +97,4 @@ def figure_lock(figure: Any) -> threading.Lock:
         return lock
 
 
-def resolve_figure(value: Any) -> Any:
-    """Return the ``matplotlib`` figure ``value`` belongs to, or ``None``.
-
-    Resolves the way :func:`maidr.render` does, deliberately: ``None``
-    means the current figure there, and a value naming several axes is
-    rendered as the last one's figure. A resolver that disagreed with the
-    renderer would take a lock on a figure the render never touches, which
-    looks synchronised and is not.
-
-    Parameters
-    ----------
-    value : Any
-        Whatever the caller is about to render. ``None`` is the current
-        matplotlib figure, as it is for :func:`maidr.render`.
-
-    Returns
-    -------
-    Any
-        The figure to lock, or ``None`` when there is none to lock --
-        which :func:`figure_lock` answers with an unshared lock.
-    """
-    from maidr.api import _get_plot_or_current
-    from maidr.core.figure_manager import FigureManager
-
-    try:
-        axes = FigureManager.get_axes(_get_plot_or_current(value))
-    except (AttributeError, StopIteration):
-        # Narrow, and not the case one might expect. A foreign figure --
-        # plotly, altair -- does not raise: `get_axes` matches no branch
-        # and returns `None`, which the `getattr` below turns into `None`
-        # without ever reaching here. Measured: plotly-shaped, `None`,
-        # `int` and `str` all return `None`; only an empty list or dict
-        # raises, as `StopIteration`.
-        #
-        # So this catches malformed input that the caller's own validation
-        # should already have rejected. Logged rather than swallowed: a
-        # bare `except Exception` here would quietly downgrade a real bug
-        # in `get_axes` to "lock scope lost", immediately before an
-        # unsynchronised render.
-        _logger.debug(
-            "could not resolve a figure to lock for %r; rendering "
-            "without a shared lock",
-            type(value).__name__,
-            exc_info=True,
-        )
-        return None
-
-    if isinstance(axes, list):
-        # Only a ``Figure`` lands here: ``get_axes`` returns its ``.axes``
-        # property, while a list of artists takes a different branch and
-        # comes back as a single ``Axes``. That is a coupling to
-        # ``FigureManager.get_axes``'s branch order rather than to
-        # matplotlib -- a ``Figure``-specific branch added ahead of the
-        # ``Artist`` one would change which shape arrives here. A figure's axes all share that
-        # figure, so which one is picked does not matter -- the last,
-        # matching ``render``'s own loop over the list.
-        axes = axes[-1] if axes else None
-
-    # ``axes`` is an ``Axes`` or ``None`` by here: ``get_axes`` returns one
-    # of those or a list, and the list is unwrapped above.
-    return getattr(axes, "figure", None)
-
-
-__all__ = ["figure_lock", "resolve_figure"]
+__all__ = ["figure_lock"]

--- a/maidr/widget/shiny.py
+++ b/maidr/widget/shiny.py
@@ -337,15 +337,17 @@ class render_maidr(Renderer[Any]):
         is what this is for.
 
         Lock contention eats into that same pool rather than sitting
-        outside it: a render waiting on
-        :func:`maidr.util.figure_lock.figure_lock` is blocked
-        *inside* its executor thread, still holding the slot. Enough
-        sessions rendering one shared module-level figure could therefore
-        make unrelated figures queue for a thread -- the stall this moves
-        off the loop, reappearing one level down. Typical Shiny usage is a
-        figure per session, where this does not arise.
+        outside it. This function no longer takes a lock itself -- since
+        #532 it is :meth:`maidr.core.maidr.Maidr._create_html_tag`, one
+        call down through :func:`maidr.render`, that serialises renders of
+        one figure -- but it waits on that lock *inside* its executor
+        thread, still holding the slot. Enough sessions rendering one
+        shared module-level figure could therefore make unrelated figures
+        queue for a thread -- the stall this moves off the loop,
+        reappearing one level down. Typical Shiny usage is a figure per
+        session, where this does not arise.
 
-        The lock is what makes the move safe rather than merely faster --
+        That lock is what makes the move safe rather than merely faster --
         see :mod:`maidr.util.figure_lock`.
 
         Parameters

--- a/maidr/widget/shiny.py
+++ b/maidr/widget/shiny.py
@@ -27,7 +27,6 @@ except ImportError as error:
 
 import maidr
 from maidr.core.figure_manager import FigureManager
-from maidr.util.figure_lock import figure_lock, resolve_figure
 from maidr.widget._focus import FOCUS_RESTORE_JS
 
 
@@ -359,8 +358,7 @@ class render_maidr(Renderer[Any]):
         Any
             The rendered chart, as :func:`maidr.render` returns it.
         """
-        with figure_lock(resolve_figure(value)):
-            return maidr.render(value, use_cdn=self.use_cdn)
+        return maidr.render(value, use_cdn=self.use_cdn)
 
     async def render(self) -> Optional[Jsonifiable]:
         """

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -40,9 +40,7 @@ from typing import Any, Literal, Optional, Union
 from htmltools import tags
 
 import maidr
-from maidr.api import _get_plot_or_current
 from maidr.util.dependencies import inline_bundle_tags, read_bundled_js
-from maidr.util.figure_lock import figure_lock, resolve_figure
 
 #: Accepted by ``use_cdn``; ``None`` defers to :func:`maidr.get_use_cdn`.
 UseCdn = Optional[Union[bool, Literal["auto"]]]
@@ -114,32 +112,7 @@ def maidr_html(
     # in which this function decides whether to inline against one answer
     # while the chart was built from another.
     resolved = maidr.get_use_cdn() if use_cdn is None else use_cdn
-    # ``plt.gcf()`` is process-global, so resolving the current figure
-    # twice -- once to decide which lock to take, once again inside
-    # ``render`` -- leaves a window in which another thread's
-    # ``plt.figure()`` moves it between the two, and the lock ends up
-    # guarding a figure the render never touches. Resolve once, here, and
-    # hand ``render`` the figure rather than ``None``: it calls this same
-    # helper, which is the identity for anything that is not ``None``, so
-    # nothing about the output changes. Raised in review of #531.
-    #
-    # Deliberately not ``resolve_figure(None)``, which answers *which
-    # figure to lock* and is ``None`` both for no current figure and for a
-    # current figure with no axes yet. Substituting only when that is
-    # non-``None`` would leave the second ``gcf()`` in place for the
-    # axes-less case -- the window narrowed rather than closed.
-    plot = _get_plot_or_current(plot)
-
-    # One render of a given figure at a time, for the reason in
-    # :mod:`maidr.util.figure_lock`.  Streamlit runs every session's script
-    # in its own ScriptRunner thread, so two sessions sharing one figure --
-    # a module-level one, or anything behind ``@st.cache_resource`` -- can
-    # be inside ``savefig`` together.  Measured on the shipped path: one
-    # render in 30 came back a well-formed SVG of the same chart at the
-    # wrong scale, ``L 640 -134.4`` where every other render had
-    # ``L 460.8 0``.
-    with figure_lock(resolve_figure(plot)):
-        rendered = maidr.render(plot, use_cdn=resolved)
+    rendered = maidr.render(plot, use_cdn=resolved)
     html = str(rendered.get_html_string())
 
     if resolved is False:

--- a/tests/core/test_render_serialises.py
+++ b/tests/core/test_render_serialises.py
@@ -1,0 +1,153 @@
+"""Every caller renders one figure at a time, not only the two doors.
+
+``savefig`` writes ``fig.dpi`` for its duration and restores it, so two
+renders of one figure at once race on that attribute and the loser draws
+its whole chart at the other call's dpi -- a complete, well-formed SVG at
+the wrong scale, raising nothing (#454).
+
+The Shiny and Streamlit integrations each held a lock against that until
+#532. This covers the callers that never went near a widget: a threaded
+Flask app -- ``Environment.is_flask`` makes it a supported embedding, and
+Werkzeug serves threaded -- or anything rendering from a thread pool.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+import maidr  # noqa: E402
+
+#: Attributes that differ between two renders of the same chart by design --
+#: fresh uuids per layer, and the timestamp matplotlib stamps into the SVG.
+_VOLATILE_IN_SVG = re.compile(
+    r'(\bid="[^"]*"|url\(#[^)]*\)|<dc:date>[^<]*</dc:date>'
+    r'|xlink:href="#[^"]*"|maidr="[^"]*")'
+)
+
+
+def _render_from_threads(name, workers=6):
+    """Render ``name`` from ``workers`` threads at once, normalised."""
+    outputs: list[str] = []
+    failures: list[Exception] = []
+    # One constant for the barrier and the thread count, because they must
+    # agree: a barrier expecting more arrivals than there are threads waits
+    # forever (#506).
+    start = threading.Barrier(workers)
+
+    def render_once() -> None:
+        try:
+            start.wait(timeout=30)
+            outputs.append(
+                _VOLATILE_IN_SVG.sub("", str(maidr.render(name, use_cdn=True)))
+            )
+        except Exception as error:  # noqa: BLE001 - reported after the join
+            failures.append(error)
+
+    threads = [threading.Thread(target=render_once, daemon=True) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        # Longer than the barrier's own deadline, so a thread still
+        # legitimately waiting there is not reported as a deadlocked render.
+        thread.join(timeout=60)
+        assert not thread.is_alive(), "a render deadlocked on the lock"
+
+    assert not failures, failures
+    assert len(outputs) == workers
+    return outputs
+
+
+@pytest.mark.parametrize("names", ["axes", "figure"], ids=["axes", "figure"])
+def test_concurrent_renders_through_the_api_agree(names):
+    """``maidr.render`` serialises by itself, with no integration involved.
+
+    Measured before the lock moved here, six threads on one figure through
+    ``maidr.render`` directly: 1 of 5 trials came back with two distinct
+    outputs. Nothing raised in any of them.
+
+    Parametrised over what names the chart because the two used to take
+    different paths to the lock -- a ``Figure`` resolved to a list of axes
+    and, before #531, to no lock at all. Locking by the figure the ``Maidr``
+    instance already holds removes the resolution step rather than fixing
+    it, so both names now reach one lock by construction; this pins that
+    they still do.
+
+    The barrier synchronises the *start*, not the duration. On a runner
+    slow enough that each render finishes before the next thread is
+    scheduled this would pass with no lock at all -- a false negative
+    rather than CI noise. Measured 10 of 10 detections with the lock
+    removed.
+    """
+    fig, ax = plt.subplots()
+    ax.bar([str(i) for i in range(30)], list(range(30)))
+    try:
+        outputs = _render_from_threads(ax if names == "axes" else fig)
+    finally:
+        plt.close(fig)
+
+    assert len(set(outputs)) == 1, (
+        "concurrent renders of one figure disagreed; one drew the chart at "
+        "another render's dpi, which produces a valid SVG at the wrong "
+        "scale rather than an error"
+    )
+
+
+def test_two_figures_still_render_in_parallel():
+    """The lock is per figure, so unrelated renders are not serialised.
+
+    A process-wide lock would pass the test above and quietly throw away
+    the parallelism that rendering on a thread exists for. Asserted by
+    overlap rather than by timing: each render reports when it is inside
+    the lock, and two figures must be inside at once.
+    """
+    first, first_ax = plt.subplots()
+    first_ax.bar(["a"], [1])
+    second, second_ax = plt.subplots()
+    second_ax.bar(["b"], [2])
+
+    from maidr.core.figure_manager import FigureManager
+
+    inside = threading.Barrier(2)
+    overlapped = threading.Event()
+    original = type(FigureManager.get_maidr(first))._build_html_tag
+
+    def reporting_build(self, *args, **kwargs):
+        try:
+            # Both renders must be inside the lock at once, or this times
+            # out -- which is the failure this test is looking for.
+            inside.wait(timeout=5)
+            overlapped.set()
+        except threading.BrokenBarrierError:
+            pass
+        return original(self, *args, **kwargs)
+
+    type(FigureManager.get_maidr(first))._build_html_tag = reporting_build
+    try:
+        threads = [
+            threading.Thread(
+                target=lambda axes=axes: maidr.render(axes, use_cdn=True), daemon=True
+            )
+            for axes in (first_ax, second_ax)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=60)
+            assert not thread.is_alive(), "a render deadlocked"
+    finally:
+        type(FigureManager.get_maidr(first))._build_html_tag = original
+        plt.close(first)
+        plt.close(second)
+
+    assert overlapped.is_set(), (
+        "two distinct figures did not render at the same time; the lock is "
+        "serialising more than one figure's worth of work"
+    )

--- a/tests/core/test_render_serialises.py
+++ b/tests/core/test_render_serialises.py
@@ -100,7 +100,7 @@ def test_concurrent_renders_through_the_api_agree(names):
     )
 
 
-def test_two_figures_still_render_in_parallel():
+def test_two_figures_still_render_in_parallel(monkeypatch):
     """The lock is per figure, so unrelated renders are not serialised.
 
     A process-wide lock would pass the test above and quietly throw away
@@ -113,11 +113,11 @@ def test_two_figures_still_render_in_parallel():
     second, second_ax = plt.subplots()
     second_ax.bar(["b"], [2])
 
-    from maidr.core.figure_manager import FigureManager
+    from maidr.core.maidr import Maidr
 
     inside = threading.Barrier(2)
     overlapped = threading.Event()
-    original = type(FigureManager.get_maidr(first))._build_html_tag
+    original = Maidr._build_html_tag
 
     def reporting_build(self, *args, **kwargs):
         try:
@@ -129,7 +129,7 @@ def test_two_figures_still_render_in_parallel():
             pass
         return original(self, *args, **kwargs)
 
-    type(FigureManager.get_maidr(first))._build_html_tag = reporting_build
+    monkeypatch.setattr(Maidr, "_build_html_tag", reporting_build)
     try:
         threads = [
             threading.Thread(
@@ -143,7 +143,6 @@ def test_two_figures_still_render_in_parallel():
             thread.join(timeout=60)
             assert not thread.is_alive(), "a render deadlocked"
     finally:
-        type(FigureManager.get_maidr(first))._build_html_tag = original
         plt.close(first)
         plt.close(second)
 

--- a/tests/util/test_figure_lock.py
+++ b/tests/util/test_figure_lock.py
@@ -1,9 +1,12 @@
-"""The per-figure render lock, and the resolution that decides its scope.
+"""The per-figure render lock.
 
 The lock's behaviour was covered from ``tests/widget/test_shiny.py`` while
-it lived inside the Shiny integration. It now serves every threaded door,
-so the unit tests move here with it; the Shiny-specific ones (that a
-render actually takes it, that two renders do not overlap) stay there.
+it lived inside the Shiny integration, and moved here when it became
+shared (#531). Since #532 the only thing that takes it is
+``Maidr._create_html_tag``, so that it covers every caller rather than the
+two doors this package ships; ``tests/core/test_render_serialises.py``
+covers that, and the per-door concurrency tests still assert the
+consequence through each integration.
 """
 
 from __future__ import annotations
@@ -12,14 +15,13 @@ import gc
 import weakref
 
 import matplotlib
-import pytest
 
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.figure import Figure  # noqa: E402
 
-from maidr.util.figure_lock import figure_lock, resolve_figure  # noqa: E402
+from maidr.util.figure_lock import figure_lock  # noqa: E402
 
 
 def test_each_figure_gets_its_own_lock_and_keeps_it():
@@ -67,72 +69,3 @@ def test_the_lock_does_not_keep_a_closed_figure_alive():
     gc.collect()
 
     assert ref() is None, "the lock map is keeping the figure alive"
-
-
-@pytest.mark.parametrize(
-    "shape",
-    ["axes", "figure", "list of artists", "no argument"],
-    ids=["axes", "figure", "list", "current"],
-)
-def test_every_way_of_naming_one_chart_takes_the_same_lock(shape):
-    """The lock is only exclusion if two names for one figure agree on it.
-
-    ``maidr.render`` accepts an ``Axes``, a ``Figure``, a list of artists
-    and ``None`` for the current figure, and renders the same chart from
-    every one of them. Resolution that answered ``None`` for some of those
-    would hand back a *fresh* lock -- so two renders of one figure, named
-    differently, would not exclude each other and would race on
-    ``fig.dpi`` exactly as if there were no lock.
-
-    ``Figure`` and ``None`` are not hypothetical: both resolved to no
-    figure before the resolution moved here, so a Shiny render function
-    returning ``fig`` rather than ``ax`` was unsynchronised.
-    """
-    figure, axes = plt.subplots()
-    axes.bar(["a", "b"], [1, 2])
-    named = {
-        "axes": axes,
-        "figure": figure,
-        "list of artists": [axes],
-        "no argument": None,
-    }[shape]
-    try:
-        assert resolve_figure(named) is figure, "must name the same figure"
-        assert figure_lock(resolve_figure(named)) is figure_lock(figure), (
-            "must take the same lock as the figure itself"
-        )
-    finally:
-        plt.close(figure)
-
-
-def test_a_value_naming_no_figure_resolves_to_none():
-    """The fallback branch, from both directions.
-
-    A value ``get_axes`` does not understand returns ``None``; an empty
-    container makes it raise. Both mean "nothing to lock", and the
-    distinction matters only in that the second reaches the ``except``.
-    """
-    assert resolve_figure("not a plot") is None
-    assert resolve_figure([]) is None
-
-
-def test_an_unexpected_resolver_failure_is_logged_not_swallowed(monkeypatch, caplog):
-    """A bug in ``get_axes`` must not vanish into "lock scope lost".
-
-    The catch sits immediately before an unsynchronised render, so a real
-    failure there is worth a record. It was a bare ``except Exception``
-    with no logging until review of #504.
-    """
-    import logging
-
-    from maidr.core.figure_manager import FigureManager
-
-    monkeypatch.setattr(
-        FigureManager,
-        "get_axes",
-        staticmethod(lambda value: (_ for _ in ()).throw(AttributeError("boom"))),
-    )
-    with caplog.at_level(logging.DEBUG, logger="maidr.util.figure_lock"):
-        assert resolve_figure(object()) is None
-
-    assert any("without a shared lock" in record.message for record in caplog.records)

--- a/tests/widget/test_every_door_agrees.py
+++ b/tests/widget/test_every_door_agrees.py
@@ -181,10 +181,14 @@ def test_the_two_doors_exclude_each_other_on_one_figure(monkeypatch):
     chart differently, so their markup is not comparable, and what matters
     here is that the two renders do not overlap in time.
 
-    ``maidr.render`` is stubbed to a sleeping recorder, so this measures
-    the lock rather than a real render -- the consequence of *not*
+    ``Maidr._build_html_tag`` is stubbed to a sleeping recorder, so this
+    measures the lock rather than a real render -- the consequence of *not*
     excluding is covered per door by the two
     ``test_concurrent_renders_of_one_figure_agree`` tests.
+
+    Stubbed at the body rather than at ``maidr.render`` because since #532
+    the lock is taken in ``_create_html_tag``, one level above it. A stub
+    at ``render`` would replace the lock along with the work.
     """
     import threading
     import time
@@ -206,7 +210,7 @@ def test_the_two_doors_exclude_each_other_on_one_figure(monkeypatch):
         def __str__(self) -> str:
             return self.get_html_string()
 
-    def sleeping_render(plot, **kwargs):
+    def sleeping_build(self, *args, **kwargs):
         nonlocal in_flight, overlapped
         with guard:
             in_flight += 1
@@ -234,7 +238,9 @@ def test_the_two_doors_exclude_each_other_on_one_figure(monkeypatch):
         except Exception as error:  # noqa: BLE001 - re-raised after the join
             failures.append(error)
 
-    monkeypatch.setattr(maidr, "render", sleeping_render)
+    from maidr.core.maidr import Maidr
+
+    monkeypatch.setattr(Maidr, "_build_html_tag", sleeping_build)
     try:
         threads = [
             threading.Thread(target=through_shiny, daemon=True),

--- a/tests/widget/test_shiny.py
+++ b/tests/widget/test_shiny.py
@@ -542,10 +542,14 @@ def test_two_renders_of_one_figure_do_not_overlap(monkeypatch):
     """The scenario this whole change exists to make safe.
 
     ``tests/util/test_figure_lock.py`` checks that ``figure_lock`` hands
-    back matching
-    objects; none of them shows that two renders actually serialise. That
-    is the one thing a race here would break, so it is worth exercising
-    end to end.
+    back matching objects; none of them shows that two renders actually
+    serialise through this door. That is the one thing a race here would
+    break, so it is worth exercising end to end.
+
+    The stub is ``Maidr._build_html_tag`` rather than ``maidr.render``
+    because since #532 the lock is taken in ``_create_html_tag``, one
+    level above the body: stubbing ``render`` would replace the lock
+    along with the work and leave this asserting nothing.
 
     Detects **overlap** rather than measuring duration, so it cannot flake
     into a false pass on a loaded machine: if the lock works, the second
@@ -557,13 +561,13 @@ def test_two_renders_of_one_figure_do_not_overlap(monkeypatch):
     emits a valid SVG of the whole chart at the wrong scale -- measured at
     460.8x345.6 for a 640x480 figure, on 1 of 6 concurrent attempts.
     """
-    import maidr.widget.shiny as shiny_module
+    from maidr.core.maidr import Maidr
 
     inside = 0
     overlapped = False
     bookkeeping = threading.Lock()
 
-    def slow_render(value, **kwargs):
+    def slow_build(self, *args, **kwargs):
         nonlocal inside, overlapped
         with bookkeeping:
             inside += 1
@@ -574,7 +578,7 @@ def test_two_renders_of_one_figure_do_not_overlap(monkeypatch):
             inside -= 1
         return "rendered"
 
-    monkeypatch.setattr(shiny_module.maidr, "render", slow_render)
+    monkeypatch.setattr(Maidr, "_build_html_tag", slow_build)
 
     fig, ax = plt.subplots()
     ax.bar(["a", "b"], [1, 2])
@@ -605,17 +609,16 @@ def test_two_renders_of_one_figure_do_not_overlap(monkeypatch):
 
 
 def test_a_value_that_resolves_to_no_figure_still_renders(fake_session, monkeypatch):
-    """The fallback branch, driven through the real path rather than alone.
+    """A value that names no matplotlib figure still renders.
 
-    ``tests/util/test_figure_lock.py`` calls ``figure_lock(None)``
-    directly, which shows the helper's behaviour and not that anything
-    reaches it. This goes through ``render()``.
-
-    Both shapes are covered because they are not the same shape, which an
-    earlier comment in ``_render_off_loop`` got wrong: a foreign figure
-    **returns** ``None`` from ``get_axes`` and never raises, while an empty
-    container raises ``StopIteration``. Only the second reaches the
-    ``except``; the first is handled by the ``getattr`` default.
+    Both shapes are covered because they are not the same shape: a foreign
+    figure -- plotly, altair -- **returns** ``None`` from ``get_axes`` and
+    never raises, while an empty container raises ``StopIteration``. The
+    Shiny door used to resolve the figure itself, to decide which lock to
+    take, and had to survive both; since #532 the lock is taken in the core
+    render path by the figure it already holds, and neither shape reaches
+    a matplotlib render at all. This pins that they still come back with a
+    chart rather than an exception.
     """
     import maidr.widget.shiny as shiny_module
 
@@ -639,48 +642,6 @@ def test_a_value_that_resolves_to_no_figure_still_renders(fake_session, monkeypa
             assert _render(chart) is not None, label
     finally:
         plt.close(fig)
-
-
-def test_an_unexpected_resolver_failure_is_logged_not_swallowed(
-    fake_session, monkeypatch, caplog
-):
-    """A bug in ``get_axes`` must not vanish into "lock scope lost".
-
-    The catch sits immediately before an unsynchronised render, so a real
-    failure there is worth a record. It was a bare ``except Exception``
-    with no logging until review of #504.
-
-    ``tests/util/test_figure_lock.py`` makes the same assertion against
-    :func:`resolve_figure` directly. This one is what says the Shiny
-    render path still reaches it -- a renderer that resolved its own
-    figure again would pass that test and fail this one.
-    """
-    import logging
-
-    import maidr.widget.shiny as shiny_module
-
-    fig, ax = plt.subplots()
-    ax.bar(["a", "b"], [1, 2])
-    monkeypatch.setattr(shiny_module.maidr, "render", lambda value, **kw: "rendered")
-    monkeypatch.setattr(shiny_module, "_check_supported", lambda value, name: None)
-    monkeypatch.setattr(
-        shiny_module.FigureManager,
-        "get_axes",
-        staticmethod(lambda value: (_ for _ in ()).throw(AttributeError("boom"))),
-    )
-    try:
-        # The resolver, and so the record, now belongs to the shared module.
-        with caplog.at_level(logging.DEBUG, logger="maidr.util.figure_lock"):
-
-            @render_maidr
-            def chart():
-                return ax
-
-            _render(chart)
-    finally:
-        plt.close(fig)
-
-    assert any("without a shared lock" in record.message for record in caplog.records)
 
 
 def test_two_different_figures_rendering_at_once_keep_their_selectors():

--- a/tests/widget/test_streamlit.py
+++ b/tests/widget/test_streamlit.py
@@ -655,60 +655,21 @@ def test_concurrent_renders_of_one_figure_agree():
     )
 
 
-def test_the_current_figure_is_resolved_once_and_rendered(monkeypatch):
-    """``maidr_html()`` locks the figure it renders, not whichever is current
-    a moment later.
-
-    ``plt.gcf()`` is process-global. Resolving it separately for the lock
-    and for the render leaves a window in which another thread's
-    ``plt.figure()`` moves the current figure between the two, so the lock
-    guards one figure while the render writes another -- synchronised in
-    appearance only. Raised in review of #531.
-
-    Driven by moving the current figure *between* the two resolutions,
-    which is the interleaving a second thread would produce.
-    """
-    import maidr.widget.streamlit as streamlit_module
-
-    mine, ax = plt.subplots()
-    ax.bar(["a", "b"], [1, 2])
-    locked: list[object] = []
-    real_lock = streamlit_module.figure_lock
-
-    def lock_and_move(figure):
-        locked.append(figure)
-        # What another thread plotting concurrently would do.
-        plt.figure()
-        return real_lock(figure)
-
-    monkeypatch.setattr(streamlit_module, "figure_lock", lock_and_move)
-    try:
-        html = maidr_html(use_cdn=True)
-    finally:
-        plt.close("all")
-
-    assert locked == [mine], "locked a different figure than the current one"
-    # The chart rendered is the one that was locked: two bars, not an empty
-    # figure. `_flatten_maidr` puts the data in the root `maidr` attribute.
-    assert '&quot;y&quot;: 2' in html or '"y": 2' in html, html[:200]
-
-
 def test_an_axes_less_current_figure_is_still_resolved_only_once(monkeypatch):
-    """The narrow case the resolve-once fix must not leave behind.
+    """``maidr_html()`` resolves the current figure once, whatever it holds.
 
-    ``resolve_figure(None)`` answers *which figure to lock*, and it is
-    ``None`` both when there is no current figure and when the current
-    figure has no axes yet. Substituting only when it is non-``None``
-    would leave ``render`` calling ``plt.gcf()`` a second time for the
-    axes-less case -- the window narrowed rather than closed. Raised in
-    review of #531.
+    ``plt.gcf()`` is process-global, so a call that resolved it twice
+    could render a different figure than the one it started with, if
+    another thread's ``plt.figure()`` landed between the two. This door
+    resolved separately for its own lock until #532 and had to be fixed
+    for exactly that; the lock is now taken in the core render path, so
+    ``render`` is the only thing that resolves.
 
-    Asserted by counting the resolutions rather than by racing them: one
-    ``plt.gcf()`` for the whole call, however few axes the figure has.
+    Kept as a counter rather than a race: one ``plt.gcf()`` for the whole
+    call, however few axes the figure has. A door that started resolving
+    on its own account again would show up here.
     """
     import matplotlib.pyplot as pyplot
-
-    import maidr.api as api_module
 
     plt.figure()  # current, and deliberately empty
     calls: list[int] = []
@@ -719,7 +680,6 @@ def test_an_axes_less_current_figure_is_still_resolved_only_once(monkeypatch):
         return real_gcf()
 
     monkeypatch.setattr(pyplot, "gcf", counting_gcf)
-    assert api_module._get_plot_or_current is not None
     try:
         with pytest.raises(Exception):  # noqa: B017 - what it raises is not the point
             maidr_html(use_cdn=True)


### PR DESCRIPTION
Closes #532.

#504 and #531 put a per-figure lock on the Shiny and Streamlit doors. **The race is a level below them**, so those two are the only callers it protects.

## Measured, with no widget involved

Six threads, barrier-synchronised, through `maidr.render` on one figure; outputs compared with per-render uuids and the SVG timestamp normalised away:

```
trial 0: 2 distinct outputs from 6 renders
trial 1: 1 distinct outputs from 6 renders
...
trials with disagreeing renders: 1/5
```

Same root cause as #454 — `savefig` writes `fig.dpi` for its duration and restores it, so the loser of the race draws its whole chart at the other call's dpi. A complete, well-formed SVG at 72% scale, raising nothing.

Who was exposed: a threaded **Flask** app (`Environment.is_flask` makes it a supported embedding, and Werkzeug serves threaded by default), anything calling `render` or `save_html` from a thread pool, a notebook doing its own threading. None of them go through `maidr/widget/`.

## The fix is smaller than what it replaces

`Maidr._create_html_tag` takes the lock. Every render of a matplotlib figure funnels through it — `render`, `save_html` and `_create_html_doc` all call it and none re-enters it — so **one lock site covers every caller**, and a plain `Lock` stays safe. The doors drop theirs, because a second lock above this one would deadlock against it rather than nest, exactly as the module docstring warned.

The body moves to `_build_html_tag` so the lock wraps it without re-indenting sixty lines.

## It also deletes the bug class the last two reviews kept circling

The doors had to work out *which* figure a value named before they could lock it. When that answer was wrong — as it was for a `Figure`, and for the current figure — the lock was taken on nothing while the render went ahead (#531). Two reviewers then flagged the resolver's reliance on `api._get_plot_or_current` and on `get_axes`'s branch order.

Locking by `self._fig`, which the `Maidr` instance already holds, **cannot disagree with the render**. So `resolve_figure` goes, its coupling goes, and the `maidr_html` resolve-once dance goes with them.

| | before | after |
|---|---|---|
| lock sites | 2 (per door) | 1 (core) |
| callers covered | Shiny, Streamlit | every caller |
| figure resolved for locking | yes, twice, by two modules | never — the figure is already known |
| lines | — | **−192** |

## Verification

`pytest 0 / ruff 0 / uv lock --check 0` — **2,442 passed, 14 skipped**. (`ruff check` reports the 6 pre-existing re-export findings in `maidr/core/**/__init__.py`; every file this touches is clean.)

| mutation | result |
|---|---|
| the core lock removed | **5 of 6** concurrency guards fail, 3 runs of 3 |
| …the sixth being `test_two_figures_still_render_in_parallel`, which correctly does not care | passes |
| the lock made process-wide instead of per-figure | **that sixth guard fails**, 3 of 3 |

The second row is the point of the sixth test: a process-wide lock passes every "do they agree?" test while throwing away the parallelism that rendering on a thread exists for.

## Tests

- `tests/core/test_render_serialises.py` — new. Concurrent renders through `maidr.render` agree (parametrised over naming the chart by `ax` and by `fig`), and two *distinct* figures still overlap.
- `tests/widget/test_shiny.py`, `tests/widget/test_every_door_agrees.py` — the two overlap tests now stub `Maidr._build_html_tag` rather than `maidr.render`. Stubbing `render` would replace the lock along with the work and leave them asserting nothing; this is the shape of false pass worth naming.
- `tests/util/test_figure_lock.py` — the resolver's tests go with the resolver. What they protected (every way of naming one chart reaches one lock) is now structural, and is asserted at the render level instead.
- The per-door `test_concurrent_renders_of_one_figure_agree` tests are untouched and still pass, now through the core lock — which is the point: the doors' *behaviour* is unchanged.

## Scope

Still does not close #530 — a figure mutated *while* a render is in flight is not a concurrent render, and no lock keyed on renders can cover it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_