### PR TITLE
feat(core): read Axes.contour as the scalar field it draws

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -12,6 +12,12 @@ class PlotType(str, Enum):
     #: distinct type because :attr:`BOX` is fixed at one rung, and depth is the
     #: whole point of the chart.
     BOXEN = "boxen"
+    #: A scalar field drawn as curves of constant value. The level is a
+    #: number here rather than a colour -- `QuadContourSet.levels` is the
+    #: data, and `get_paths()` gives one path per level -- which is what
+    #: separates `Axes.contour` from the same chart in a renderer that keeps
+    #: its magnitude only in a fill.
+    CONTOUR = "contour"
     COUNT = "count"
     DODGED = "dodged_bar"
     ERRORBAR = "error_bar"

--- a/maidr/core/plot/contour.py
+++ b/maidr/core/plot/contour.py
@@ -1,0 +1,209 @@
+"""ContourPlot — a scalar field read as the iso-value curves it is drawn as."""
+
+from __future__ import annotations
+
+import math
+import uuid
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.contour import ContourSet
+from matplotlib.path import Path
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot import MaidrPlot
+
+
+class ContourPlot(MaidrPlot):
+    """
+    A contour plot: one curve per level of a scalar field.
+
+    ``Axes.contour`` is the one chart in this family whose value is a **number
+    rather than a colour**. ``QuadContourSet.levels`` holds the levels the
+    caller asked for, and ``get_paths()`` returns one path per level, so both
+    halves invert exactly and nothing has to be recovered from a fill. That is
+    what separates it from the same chart elsewhere: xability/maidr#1084 left
+    Observable Plot's ``contour`` unread because there the magnitude survives
+    only in a continuous fill colour.
+
+    Two things about the drawing shape the reading.
+
+    **A level is not one curve.** A field with two peaks crosses a level twice,
+    and matplotlib draws both islands in a *single* compound path with two
+    ``MOVETO`` commands. Read as one series they would be joined by a straight
+    line running between the peaks -- a curve announced across ground the field
+    never took, which is the defect xability/maidr#1079 describes for a gappy
+    line. So each drawn polyline becomes its own series, and several series may
+    share a level. ``ContourPoint`` carries the level on every point precisely
+    so that costs nothing.
+
+    **A filled contour is not this chart.** ``contourf`` draws the *bands*
+    between levels, so its outlines run along two different level curves
+    stitched together and there is one fewer of them than there are levels --
+    measured, three levels give two paths. Announcing such an outline as "the
+    0.2 contour" would be right for half of its points. The patch declines it;
+    see ``maidr/patch/contour.py``.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the field was drawn on.
+    contour_set : ContourSet
+        The artist this call produced, handed over rather than searched for:
+        two ``contour`` calls on one axes leave two sets, and "the contour set
+        on this Axes" would read the first one twice.
+    **kwargs : dict
+        Ignored; accepted so the factory can forward what it was given.
+    """
+
+    def __init__(self, ax: Axes, contour_set: ContourSet, **kwargs) -> None:
+        self._contour_set = contour_set
+        #: The level index behind each emitted series, in emission order. This
+        #: is what keeps the selectors aligned when one level draws several
+        #: islands and so contributes more than one series.
+        self._series_levels: list[int] = []
+        super().__init__(ax, PlotType.CONTOUR)
+
+    def _extract_plot_data(self) -> list[list[dict]]:
+        """
+        Read one series per drawn polyline off the contour set.
+
+        Returns
+        -------
+        list of list of dict
+            One series per polyline, each point carrying its level. Levels
+            nothing reached contribute no series -- matplotlib still emits an
+            empty path for them, and a series with no points is a row a reader
+            can land on and be told nothing about.
+        """
+        levels = np.asarray(self._contour_set.levels, dtype=float)
+        paths = self._contour_set.get_paths()
+
+        self._series_levels = []
+        data: list[list[dict]] = []
+        for index, path in enumerate(paths):
+            if index >= len(levels):
+                break
+            level = float(levels[index])
+            if not math.isfinite(level):
+                continue
+            for polyline in _polylines(path):
+                data.append(
+                    [
+                        {
+                            MaidrKey.X.value: float(vertex[0]),
+                            MaidrKey.Y.value: float(vertex[1]),
+                            MaidrKey.LEVEL.value: level,
+                        }
+                        for vertex in polyline
+                    ]
+                )
+                self._series_levels.append(index)
+
+        return data
+
+    def _get_selector(self) -> list[str]:
+        """
+        Return one selector per emitted series.
+
+        matplotlib draws the whole set as one group holding a ``<path>`` per
+        level, so a series is addressed by the level it belongs to. Two series
+        of one level therefore name the same element: a reader on either island
+        of the 0.5 contour sees the 0.5 contour outlined, which is the honest
+        answer when the drawing gives the islands no elements of their own.
+
+        Returns
+        -------
+        list of str
+            One selector per series, in emission order.
+        """
+        gid = self._contour_set.get_gid()
+        if gid is None:
+            return []
+        return [
+            f"g[id='{gid}'] > path:nth-of-type({index + 1})"
+            for index in self._series_levels
+        ]
+
+
+def _polylines(path: Path) -> list[np.ndarray]:
+    """
+    Split one compound path into the separate curves it draws.
+
+    Parameters
+    ----------
+    path : Path
+        One level's path, which may hold several disconnected curves.
+
+    Returns
+    -------
+    list of ndarray
+        One ``(n, 2)`` array per curve. Curves of fewer than two points are
+        dropped: a single vertex is a place the field touched a level rather
+        than a curve along it, and there is nothing to move along.
+
+    Notes
+    -----
+    A closed curve is closed by repeating its own first point rather than by
+    taking the vertex sitting in the ``CLOSEPOLY`` slot. matplotlib documents
+    that vertex as *ignored*, so what it holds is not part of the contract --
+    and measured on 3.9.4, a contour writes the subpath's start point there,
+    which makes the two choices indistinguishable on this artist. That is
+    exactly why the documented one is taken: an artist that ever put something
+    else there would announce a corner at whatever happened to be in the slot,
+    and nothing here would notice.
+    """
+    vertices = np.asarray(path.vertices, dtype=float)
+    if len(vertices) == 0:
+        return []
+
+    codes = path.codes
+    if codes is None:
+        return [vertices] if len(vertices) > 1 else []
+
+    curves: list[np.ndarray] = []
+    current: list[np.ndarray] = []
+
+    def flush() -> None:
+        if len(current) > 1:
+            curves.append(np.asarray(current, dtype=float))
+        current.clear()
+
+    for vertex, code in zip(vertices, codes):
+        if code == Path.MOVETO:
+            flush()
+            current.append(vertex)
+        elif code == Path.LINETO:
+            current.append(vertex)
+        elif code == Path.CLOSEPOLY:
+            if current:
+                current.append(current[0])
+            flush()
+    flush()
+
+    return curves
+
+
+def tag(contour_set: ContourSet) -> str:
+    """
+    Give a contour set a stable id, so its curves can be addressed.
+
+    Assigned here rather than relied upon: matplotlib stamps a gid only at draw
+    time, and the schema is built first. ``MultiLinePlot`` and ``AreaPlot`` do
+    the same for the same reason.
+
+    Parameters
+    ----------
+    contour_set : ContourSet
+        The artist to tag.
+
+    Returns
+    -------
+    str
+        The gid it now carries.
+    """
+    gid = contour_set.get_gid()
+    if gid is None:
+        gid = f"maidr-{uuid.uuid4()}"
+        contour_set.set_gid(gid)
+    return gid

--- a/maidr/core/plot/contour.py
+++ b/maidr/core/plot/contour.py
@@ -58,9 +58,15 @@ class ContourPlot(MaidrPlot):
 
     def __init__(self, ax: Axes, contour_set: ContourSet, **kwargs) -> None:
         self._contour_set = contour_set
-        #: The level index behind each emitted series, in emission order. This
-        #: is what keeps the selectors aligned when one level draws several
-        #: islands and so contributes more than one series.
+        #: The level index behind each emitted series, in emission order.
+        #:
+        #: This is what keeps the selectors aligned when one level draws
+        #: several islands and so contributes more than one series. It is the
+        #: index into ``get_paths()`` rather than a count of the series
+        #: emitted, and that is load-bearing: a level nothing reaches emits no
+        #: series but **does** reach the document, as a ``<path>`` with no
+        #: ``d`` attribute, so the elements and the paths stay in step while
+        #: the series do not.
         self._series_levels: list[int] = []
         super().__init__(ax, PlotType.CONTOUR)
 

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -8,6 +8,7 @@ from maidr.core.plot.areaplot import AreaPlot
 from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.boxenplot import BoxenPlot
 from maidr.core.plot.boxplot import BoxPlot
+from maidr.core.plot.contour import ContourPlot
 from maidr.core.plot.errorbar import ErrorBarPlot
 from maidr.core.plot.gantt import GanttPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
@@ -72,6 +73,8 @@ class MaidrPlotFactory:
             return BoxenPlot(single_ax, **kwargs)
         elif PlotType.GANTT == plot_type:
             return GanttPlot(single_ax, **kwargs)
+        elif PlotType.CONTOUR == plot_type:
+            return ContourPlot(single_ax, **kwargs)
         elif PlotType.ERRORBAR == plot_type:
             # Both read an estimate and the interval around it, and both emit
             # the same layer; they differ only in what the library drew.

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -13,6 +13,7 @@ from . import (  # noqa: E402, F401
     boxplot,
     clear,
     colorbar,
+    contour,
     errorbar,
     fillbetween,
     gantt,

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 import numpy as np
 import wrapt
 
+import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 
 from maidr.core.context_manager import ContextManager
@@ -485,3 +486,46 @@ def plotter_panels(plotter: Any) -> list[tuple[Axes, Any]]:
             seen.add(id(panel))
             panels.append((panel, sub_data))
     return panels
+
+
+def prospective_axes(kwargs: dict) -> Axes | None:
+    """
+    The axes a seaborn call is about to draw on, resolved before it draws.
+
+    Several patches take a before-and-after snapshot of an axes to decide
+    whether *this* call drew the thing they read -- the bars in
+    ``maidr/patch/histogram.py``, the fitted curve in ``maidr/patch/regplot.py``,
+    the contour set in ``maidr/patch/kdeplot.py``. All three need the same
+    answer to the same question, and three copies of it is three chances for
+    them to disagree about which axes they are describing.
+
+    An explicit ``ax=`` is the answer when given, and otherwise seaborn takes
+    ``plt.gca()`` -- which is only asked for when a figure already exists, so
+    that a call on a clean slate does not conjure a *figure* early.
+
+    On a figure that exists but holds no axes, ``gca()`` does create one, a
+    beat before seaborn would have. That is deliberate and costs nothing: the
+    ``plt.gca()`` seaborn calls a moment later returns the same axes, so the
+    snapshot is taken on the axes actually drawn on -- and an axes with nothing
+    on it snapshots as empty either way.
+
+    ``ax`` is read from ``kwargs`` alone because seaborn declares it
+    keyword-only: everything after ``data`` in these signatures is, so there is
+    no positional spelling to miss. ``test_seaborn_still_takes_ax_by_keyword``
+    asserts that rather than trusting it, so a signature change fails loudly
+    instead of quietly emptying a snapshot.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Keyword arguments the caller passed.
+
+    Returns
+    -------
+    Axes or None
+        The axes to snapshot, or None when there is nothing drawn yet.
+    """
+    ax = kwargs.get("ax")
+    if isinstance(ax, Axes):
+        return ax
+    return plt.gcf().gca() if plt.get_fignums() else None

--- a/maidr/patch/contour.py
+++ b/maidr/patch/contour.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import wrapt
+
+from matplotlib.axes import Axes
+from matplotlib.contour import ContourSet
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.contour import tag
+from maidr.patch.common import _draw_quietly
+
+
+@wrapt.patch_function_wrapper(Axes, "contour")
+def contour(wrapped, instance, args, kwargs) -> ContourSet:
+    """
+    Draw a patched ``Axes.contour`` and register the field it produced.
+
+    A contour is the one chart of its family whose value is a number rather
+    than a colour: ``QuadContourSet.levels`` is the data, and ``get_paths()``
+    gives one path per level. Nothing is inverted from a fill.
+
+    ``ax.contourf`` is a different call and is deliberately not patched. It
+    draws the bands *between* levels, so an outline of one runs along two
+    different level curves and there is one fewer of them than there are
+    levels; announcing one as a level's curve would be right for half of its
+    points.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Axes.contour``.
+    instance : Any
+        The axes it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    ContourSet
+        Whatever ``contour`` returned, unchanged.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        plot = _draw_quietly(wrapped, args, kwargs)
+
+    # A set whose every level is out of range draws nothing. Registering it
+    # would put an empty layer in the schema -- the phantom-layer shape of
+    # #421 -- so the emptiness is asked of the drawing rather than assumed.
+    if not any(len(path.vertices) for path in plot.get_paths()):
+        return plot
+
+    tag(plot)
+    ax = FigureManager.get_axes(plot)
+    FigureManager.create_maidr(ax, PlotType.CONTOUR, contour_set=plot)
+
+    return plot

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import matplotlib.pyplot as plt
 import wrapt
 
 import numpy as np
@@ -16,7 +15,7 @@ import uuid
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _draw_quietly, common, plotter_axes, wrap_seaborn
+from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
 
 
 @wrapt.patch_function_wrapper(Axes, "hist")
@@ -45,36 +44,6 @@ def mpl_hist(
 
     # Return to the caller.
     return n, bins, plot
-
-
-def _prospective_axes(kwargs: dict) -> Axes | None:
-    """
-    The axes ``histplot`` is about to draw on, resolved before it draws.
-
-    Named without drawing anything: an explicit ``ax=`` is the answer when
-    given, and otherwise seaborn will take ``plt.gca()``, which is only asked
-    for when a figure already exists so that a call on a clean slate does not
-    conjure one early.
-
-    Parameters
-    ----------
-    kwargs : dict
-        Keyword arguments the caller passed.
-
-    Returns
-    -------
-    Axes or None
-        The axes to snapshot, or None when there is nothing drawn yet.
-    """
-    # `ax` is read from kwargs alone because seaborn declares it keyword-only:
-    # everything after `data` in `histplot`'s signature is, so there is no
-    # positional spelling to miss. `test_seaborn_still_takes_ax_by_keyword`
-    # asserts that rather than trusting it, so a signature change fails loudly
-    # instead of quietly emptying the snapshot below.
-    ax = kwargs.get("ax")
-    if ax is not None:
-        return ax
-    return plt.gcf().gca() if plt.get_fignums() else None
 
 
 def _containers_of(ax: Axes | None) -> list:
@@ -224,7 +193,7 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     if ContextManager.is_internal_context():
         return _draw_quietly(wrapped, args, kwargs)
 
-    prospective = _prospective_axes(kwargs)
+    prospective = prospective_axes(kwargs)
     before = _containers_of(prospective)
     meshes = _meshes_of(prospective)
 

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -2,15 +2,87 @@ from __future__ import annotations
 
 import uuid
 
+import matplotlib.pyplot as plt
 import numpy as np
 import wrapt
 from matplotlib.axes import Axes
+from matplotlib.contour import ContourSet
 from matplotlib.lines import Line2D
 from matplotlib.collections import PolyCollection
 from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.contour import tag
 from maidr.patch.common import _draw_quietly, common, plotter_axes, wrap_seaborn
 from maidr.core.context_manager import ContextManager
 from maidr.util.svg_utils import unique_lines_by_xy
+
+
+def _contour_sets_of(ax: Axes | None) -> list:
+    """
+    The contour sets already on an axes.
+
+    Held as the artists themselves rather than as their ids, for the reason
+    ``maidr/patch/histogram.py``'s ``_containers_of`` gives: an id compared
+    after the object it named was freed can be matched by an unrelated artist
+    allocated at the same address.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes to look at, or None when it does not exist yet.
+
+    Returns
+    -------
+    list
+        The contour sets on it, in draw order.
+    """
+    return [
+        artist
+        for artist in (getattr(ax, "collections", ()) or ())
+        if isinstance(artist, ContourSet)
+    ]
+
+
+def _register_field(ax: Axes | None, before: list) -> None:
+    """
+    Register a field this call drew as a CONTOUR layer.
+
+    A **bivariate** ``kdeplot`` is not a curve: seaborn draws the joint
+    density as a contour set of iso-value curves, which has no line for
+    ``_register_smooth`` to find. The call therefore declined and the chart
+    went out silent -- the same shape as #522, where the recursion guard
+    suppressed a registration the outer patch then declined. ``Axes.contour``
+    is patched and would have claimed it, but ``kde`` sets the internal
+    context around its own call so that it can make the registration itself.
+
+    Asked of the sets *this call added* rather than of everything on the axes:
+    an ``ax.contour(...)`` drawn beforehand has already registered a layer of
+    its own, and claiming it again would put the same field in the schema
+    twice.
+
+    A **filled** density is declined, for the reason ``maidr/patch/contour.py``
+    gives for ``contourf``: its outlines run along two different level curves
+    stitched together, so announcing one as a level's curve would be right for
+    half of its points.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes the call drew on.
+    before : list
+        The contour sets that were on it beforehand.
+    """
+    if ax is None:
+        return
+
+    seen = {id(drawn) for drawn in before}
+    for drawn in _contour_sets_of(ax):
+        if id(drawn) in seen or drawn.filled:
+            continue
+        if not any(len(path.vertices) for path in drawn.get_paths()):
+            continue
+        tag(drawn)
+        FigureManager.create_maidr(ax, PlotType.CONTOUR, contour_set=drawn)
 
 
 def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
@@ -74,11 +146,21 @@ def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
 
 def kde(wrapped, instance, args, kwargs) -> Axes | Line2D | PolyCollection:
     """
-    Patch for seaborn.kdeplot: register all unique lines and/or filled boundaries as SMOOTH.
+    Patch for seaborn.kdeplot: register the curves, or the field, that it drew.
+
+    A univariate density is one or more curves and registers as ``smooth``. A
+    bivariate one is a scalar field drawn as iso-value curves and registers as
+    ``contour``; see :func:`_register_field` for why that has to happen here.
     """
+    prospective = kwargs.get("ax")
+    if prospective is None and plt.get_fignums():
+        prospective = plt.gcf().gca()
+    before = _contour_sets_of(prospective)
+
     with ContextManager.set_internal_context():
         plot = _draw_quietly(wrapped, args, kwargs)
     ax = plot if isinstance(plot, Axes) else getattr(plot, "axes", None)
+    _register_field(ax, before)
     _register_smooth(ax, instance, args, kwargs)
     return plot
 

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import uuid
 
-import matplotlib.pyplot as plt
 import numpy as np
 import wrapt
 from matplotlib.axes import Axes
@@ -12,7 +11,7 @@ from matplotlib.collections import PolyCollection
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.contour import tag
-from maidr.patch.common import _draw_quietly, common, plotter_axes, wrap_seaborn
+from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
 from maidr.core.context_manager import ContextManager
 from maidr.util.svg_utils import unique_lines_by_xy
 
@@ -152,10 +151,7 @@ def kde(wrapped, instance, args, kwargs) -> Axes | Line2D | PolyCollection:
     bivariate one is a scalar field drawn as iso-value curves and registers as
     ``contour``; see :func:`_register_field` for why that has to happen here.
     """
-    prospective = kwargs.get("ax")
-    if prospective is None and plt.get_fignums():
-        prospective = plt.gcf().gca()
-    before = _contour_sets_of(prospective)
+    before = _contour_sets_of(prospective_axes(kwargs))
 
     with ContextManager.set_internal_context():
         plot = _draw_quietly(wrapped, args, kwargs)

--- a/maidr/patch/regplot.py
+++ b/maidr/patch/regplot.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import uuid
-import matplotlib.pyplot as plt
 import numpy as np
 import wrapt
 from matplotlib.axes import Axes
@@ -17,28 +16,9 @@ from maidr.patch.common import (
     MAX_INTERVAL_VERTICES,
     _draw_quietly,
     common,
+    prospective_axes,
     wrap_seaborn,
 )
-
-def _prospective_axes(kwargs: dict) -> Axes | None:
-    """
-    The axes ``regplot`` is about to draw on, resolved before it draws.
-
-    Named without drawing anything: an explicit ``ax=`` is the answer when
-    given, and otherwise seaborn takes ``plt.gca()``, which is only asked for
-    when a figure already exists so that a call on a clean slate does not
-    conjure one *figure* early.
-
-    On a figure that exists but holds no axes, ``gca()`` does create one, a
-    beat before ``regplot`` would have. That is deliberate and costs nothing:
-    seaborn's own ``plt.gca()`` a moment later returns the same axes, so the
-    snapshot is taken on the axes actually drawn on -- and an axes with
-    nothing on it snapshots as empty either way.
-    """
-    ax = kwargs.get("ax")
-    if isinstance(ax, Axes):
-        return ax
-    return plt.gcf().gca() if plt.get_fignums() else None
 
 
 def _is_interval_bar(line: Line2D) -> bool:
@@ -213,7 +193,7 @@ def regplot(wrapped, instance, args, kwargs) -> Axes:
     # `id()`s, which keeps every one alive for the comparison -- an id is only
     # unique while its object is -- and costs nothing, since an Artist hashes
     # by identity.
-    target = _prospective_axes(kwargs)
+    target = prospective_axes(kwargs)
     before_lines = set(target.lines) if target is not None else set()
     before_collections = set(target.collections) if target is not None else set()
 

--- a/tests/core/plot/test_hist2d.py
+++ b/tests/core/plot/test_hist2d.py
@@ -18,8 +18,10 @@ one place rather than discovered per bug report:
   and ragged, so it is not a heatmap in the shape the mesh path builds -- what
   it emits is pinned in ``tests/core/test_hexbin_lattice.py``. Registration is
   asserted here because this is where a reader comes looking for it.
-- ``sns.kdeplot(x=, y=)`` renders filled or line contours, which need a
-  contour trace to describe levels rather than cells, and does NOT read.
+- ``sns.kdeplot(x=, y=)`` renders contours. The line form reads as a
+  ``contour`` layer -- the level is the navigable object, and seaborn computes
+  it exactly -- while the **filled** form does not, because it draws the bands
+  *between* levels rather than the levels themselves.
 """
 
 from __future__ import annotations
@@ -168,16 +170,34 @@ def test_hexbin_registers_exactly_one_layer():
     assert len(_plots(fig)) == 1
 
 
-@pytest.mark.parametrize("fill", [True, False])
-def test_bivariate_kdeplot_is_not_registered_yet(fill):
+def test_bivariate_kdeplot_is_read_as_a_contour():
     """
-    A 2D KDE draws contours, filled or not, and MAIDR has no contour trace.
+    A 2D KDE draws its joint density as iso-value curves, and reads as one.
 
-    A contour plot is not a heatmap with different colours: the level is the
-    navigable object, not the cell, so describing one as a grid would be a
-    different chart rather than an approximate one.
+    This case was pinned as unreadable while MAIDR had no contour trace, on
+    the reasoning that a contour is not a heatmap with different colours: the
+    *level* is the navigable object, not the cell, so describing one as a grid
+    would be a different chart rather than an approximate one. The trace
+    exists now (xability/maidr#802), so the level has somewhere of its own to
+    go and seaborn computes it exactly.
     """
     fig, ax = plt.subplots()
-    sns.kdeplot(x=X, y=Y, fill=fill, ax=ax)
+    sns.kdeplot(x=X, y=Y, fill=False, ax=ax)
+
+    plots = _plots(fig)
+    assert [plot.type for plot in plots] == [PlotType.CONTOUR]
+
+
+def test_a_filled_bivariate_kdeplot_is_still_declined():
+    """
+    A filled 2D KDE draws the bands *between* levels, which is a different
+    chart.
+
+    Each outline runs along two different level curves stitched together, so
+    announcing one as a level's own curve would be right for half of its
+    points -- the reason `ax.contourf` is declined too.
+    """
+    fig, ax = plt.subplots()
+    sns.kdeplot(x=X, y=Y, fill=True, ax=ax)
 
     assert _plots(fig) == []

--- a/tests/core/plot/test_regplot_binned_estimates.py
+++ b/tests/core/plot/test_regplot_binned_estimates.py
@@ -358,7 +358,7 @@ class TestNoBranchDropsALayer:
 
         monkeypatch.setattr(patch, "_paired_estimates", lambda *_: None)
         monkeypatch.setattr(
-            patch, "_prospective_axes", lambda kwargs: kwargs.get("ax")
+            patch, "prospective_axes", lambda kwargs: kwargs.get("ax")
         )
 
         _, ax = plt.subplots()

--- a/tests/core/test_bivariate_histogram.py
+++ b/tests/core/test_bivariate_histogram.py
@@ -356,7 +356,7 @@ def test_an_axes_with_no_mappable_returns_none_rather_than_raising() -> None:
 def test_seaborn_still_takes_ax_by_keyword() -> None:
     """The assumption the pre-draw snapshot rests on.
 
-    `_prospective_axes` reads `ax` from kwargs alone. That is safe only while
+    `prospective_axes` reads `ax` from kwargs alone. That is safe only while
     seaborn declares it keyword-only — a positional spelling would be missed,
     the snapshot would come back empty, and a stale container would once again
     look like this call's own work.

--- a/tests/core/test_contour.py
+++ b/tests/core/test_contour.py
@@ -1,0 +1,256 @@
+"""`Axes.contour` draws a scalar field, and it was read as nothing.
+
+A contour is the one chart of its family whose value is a **number rather than
+a colour**. `QuadContourSet.levels` is the data the caller asked for and
+`get_paths()` returns one path per level, so both halves invert exactly and
+nothing has to be recovered from a fill -- which is precisely what left the
+same chart unread in the Observable adapter (xability/maidr#1084), where a
+contour keeps its magnitude only in a continuous colour.
+
+Two things about the drawing had to be decided rather than assumed.
+
+**A level is not one curve.** A field with two peaks crosses a level twice, and
+matplotlib draws both islands in a single compound path with two `MOVETO`s.
+Read as one series they would be joined by a straight line running between the
+peaks -- a curve announced across ground the field never took, which is the
+defect xability/maidr#1079 describes for a gappy line.
+
+**A filled contour is a different chart.** `contourf` draws the bands *between*
+levels: three levels give two paths, and each outline runs along two different
+level curves stitched together. Announcing one as "the 0.2 contour" would be
+right for half of its points, so it is declined -- and so is a filled bivariate
+`kdeplot`, for the same reason.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.exception import UnsupportedPlotError  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _field(peaks: int = 1):
+    """A gaussian bump, or two of them side by side."""
+    axis = np.linspace(-3, 3, 40)
+    x, y = np.meshgrid(axis, axis)
+    if peaks == 1:
+        return x, y, np.exp(-(x**2 + y**2))
+    return x, y, np.exp(-((x - 1.5) ** 2 + y**2)) + np.exp(-((x + 1.5) ** 2 + y**2))
+
+
+def _layers(fig):
+    """The layers registered for a figure, or an empty list when there are none."""
+    try:
+        return FigureManager.get_maidr(fig).plots
+    except UnsupportedPlotError:
+        return []
+
+
+def _series(fig, index: int = 0):
+    """One layer's curves."""
+    return _layers(fig)[index].schema[MaidrKey.DATA]
+
+
+def test_a_contour_is_read_as_the_field_it_draws():
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(), levels=[0.2, 0.5, 0.8])
+
+    assert [layer.type for layer in _layers(fig)] == [PlotType.CONTOUR]
+
+
+def test_every_curve_carries_the_level_it_runs_at():
+    # The levels are the ones the caller asked for, taken off `.levels` rather
+    # than inverted from a fill colour.
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(), levels=[0.2, 0.5, 0.8])
+
+    curves = _series(fig)
+    assert len(curves) == 3
+    assert [curve[0]["level"] for curve in curves] == [0.2, 0.5, 0.8]
+    # Constant down a curve, which is what the grammar says `level` is.
+    for curve in curves:
+        assert {point["level"] for point in curve} == {curve[0]["level"]}
+
+
+def test_the_curves_run_where_the_field_reaches_that_value():
+    # A gaussian bump centred on the origin: the 0.5 contour is the circle of
+    # radius sqrt(-ln 0.5), which every point on that curve sits on.
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(), levels=[0.5])
+
+    curve = _series(fig)[0]
+    radius = np.sqrt(-np.log(0.5))
+    distances = [np.hypot(point["x"], point["y"]) for point in curve]
+    assert max(abs(distance - radius) for distance in distances) < 0.05
+
+
+def test_two_islands_of_one_level_are_two_curves():
+    # Matplotlib draws both in one compound path. Emitted as one series they
+    # would be joined by a straight line across the saddle between the peaks,
+    # announcing a curve where the field has none.
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(peaks=2), levels=[0.5])
+
+    curves = _series(fig)
+    assert len(curves) == 2
+    assert [curve[0]["level"] for curve in curves] == [0.5, 0.5]
+    # One island each side of the origin, so no curve spans both.
+    for curve in curves:
+        signs = {np.sign(point["x"]) for point in curve if point["x"] != 0}
+        assert len(signs) == 1
+
+
+def test_a_level_nothing_reaches_contributes_no_curve():
+    # Matplotlib still emits a path for it, with no vertices. A series with no
+    # points is a row a reader can land on and be told nothing about.
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(), levels=[0.2, 0.5, 2.0])
+
+    assert [curve[0]["level"] for curve in _series(fig)] == [0.2, 0.5]
+
+
+def test_a_field_that_reaches_no_level_registers_nothing():
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(), levels=[2.0, 3.0])
+
+    assert _layers(fig) == []
+
+
+def test_each_curve_is_addressed_by_the_level_it_belongs_to():
+    # Matplotlib draws the set as one group holding a `<path>` per level, so
+    # two islands of one level name the same element: a reader on either sees
+    # that level outlined, which is what the drawing can say.
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(peaks=2), levels=[0.2, 0.5])
+
+    selectors = _layers(fig)[0].schema[MaidrKey.SELECTOR]
+    assert len(selectors) == len(_series(fig))
+    assert selectors[0].endswith("path:nth-of-type(1)")
+    assert selectors[-1].endswith("path:nth-of-type(2)")
+
+
+def test_the_selectors_name_elements_that_are_really_there():
+    # A selector matching nothing is the highlight-only blind spot
+    # xability/maidr#814 names: everything reads and nothing lights up, which
+    # no assertion about the payload alone can see.
+    fig, ax = plt.subplots()
+    ax.contour(*_field(), levels=[0.2, 0.5, 0.8])
+    layer = _layers(fig)[0]
+
+    html = maidr.render(fig).get_html_string()
+
+    gid = layer.schema[MaidrKey.SELECTOR][0].split("'")[1]
+    group = html.split(f'<g id="{gid}">', 1)
+    assert len(group) == 2, "the contour group is not in the rendered SVG"
+    assert group[1].split("</g>", 1)[0].count("<path ") == 3
+
+
+def test_a_filled_contour_is_declined():
+    # `contourf` draws the bands between levels: three levels give two paths,
+    # and each outline runs along two different level curves.
+    fig, ax = plt.subplots()
+
+    ax.contourf(*_field(), levels=[0.2, 0.5, 0.8])
+
+    assert _layers(fig) == []
+
+
+def test_two_contour_calls_read_their_own_fields():
+    # Each call hands its own set over. "The contour set on this Axes" would
+    # describe the first one twice.
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(), levels=[0.2])
+    ax.contour(*_field(), levels=[0.8])
+
+    assert [
+        _series(fig, index)[0][0]["level"] for index in range(len(_layers(fig)))
+    ] == [0.2, 0.8]
+
+
+def _joint():
+    rng = np.random.default_rng(0)
+    return pd.DataFrame({"a": rng.normal(size=200), "b": rng.normal(size=200)})
+
+
+def test_a_bivariate_kdeplot_is_read_as_the_field_it_draws():
+    # Seaborn draws the joint density as a contour set, which has no line for
+    # the smooth registration to find -- so the chart went out silent. The
+    # recursion guard is why the `Axes.contour` patch cannot claim it: `kde`
+    # sets the internal context around its own call.
+    fig, ax = plt.subplots()
+
+    sns.kdeplot(data=_joint(), x="a", y="b", ax=ax)
+
+    assert [layer.type for layer in _layers(fig)] == [PlotType.CONTOUR]
+    assert len({curve[0]["level"] for curve in _series(fig)}) > 1
+
+
+def test_a_filled_bivariate_kdeplot_is_declined():
+    fig, ax = plt.subplots()
+
+    sns.kdeplot(data=_joint(), x="a", y="b", fill=True, ax=ax)
+
+    assert _layers(fig) == []
+
+
+@pytest.mark.parametrize("fill", [False, True])
+def test_a_univariate_kdeplot_still_reads_as_a_curve(fill: bool):
+    fig, ax = plt.subplots()
+
+    sns.kdeplot(data=_joint(), x="a", fill=fill, ax=ax)
+
+    assert [layer.type for layer in _layers(fig)] == [PlotType.SMOOTH]
+
+
+def test_a_kde_jointplot_finally_reads_its_joint_panel():
+    # It returned `['smooth', 'smooth']` -- the two marginals, and nothing for
+    # the panel the chart is drawn for.
+    grid = sns.jointplot(data=_joint(), x="a", y="b", kind="kde")
+
+    assert [layer.type for layer in _layers(grid.figure)] == [
+        PlotType.CONTOUR,
+        PlotType.SMOOTH,
+        PlotType.SMOOTH,
+    ]
+
+
+def test_a_field_drawn_before_a_kdeplot_is_not_claimed_twice():
+    # The kdeplot patch asks for the sets *this call* added. Everything on the
+    # axes would include one `ax.contour` already registered.
+    fig, ax = plt.subplots()
+
+    ax.contour(*_field(), levels=[0.2, 0.5])
+    sns.kdeplot(data=_joint(), x="a", y="b", ax=ax)
+
+    assert [layer.type for layer in _layers(fig)] == [
+        PlotType.CONTOUR,
+        PlotType.CONTOUR,
+    ]
+    assert [curve[0]["level"] for curve in _series(fig, 0)] == [0.2, 0.5]

--- a/tests/core/test_contour.py
+++ b/tests/core/test_contour.py
@@ -133,6 +133,35 @@ def test_a_level_nothing_reaches_contributes_no_curve():
     assert [curve[0]["level"] for curve in _series(fig)] == [0.2, 0.5]
 
 
+def test_a_level_nothing_reaches_still_holds_its_place_in_the_document():
+    # The selectors are numbered over `get_paths()`, not over the series
+    # emitted, and this is what makes that right: an unreached level emits no
+    # series but does reach the SVG, as a `<path>` carrying a style and no `d`
+    # attribute at all. Renumbering over the series would name the level below
+    # for every curve after it -- a chart that reads correctly and outlines the
+    # wrong curve.
+    #
+    # Only reachable at the front of the list: levels must increase (matplotlib
+    # raises otherwise) and any level strictly inside the field's range is
+    # crossed somewhere, so an unreached one is always past an end. This
+    # field's maximum is 1.
+    fig, ax = plt.subplots()
+    ax.contour(*_field(), levels=[-1.0, 0.2, 0.5])
+    layer = _layers(fig)[0]
+
+    html = maidr.render(fig).get_html_string()
+
+    selectors = layer.schema[MaidrKey.SELECTOR]
+    assert [curve[0]["level"] for curve in _series(fig)] == [0.2, 0.5]
+    assert [selector[-4:] for selector in selectors] == ["e(2)", "e(3)"]
+
+    gid = selectors[0].split("'")[1]
+    inside = html.split(f'<g id="{gid}">', 1)[1].split("</g>", 1)[0]
+    assert inside.count("<path ") == 3, "the unreached level left no element"
+    # And the one it left is the empty one, at the front.
+    assert 'd="' not in inside.split("<path ", 2)[1].split(">", 1)[0]
+
+
 def test_a_field_that_reaches_no_level_registers_nothing():
     fig, ax = plt.subplots()
 


### PR DESCRIPTION
Closes #539 — the last of the three readings #524 recorded, after #533 (`broken_barh`) and #536 (`stairs`).

| call | before | now |
|---|---|---|
| `ax.contour(X, Y, Z, levels=[0.2, 0.5, 0.8])` | `UnsupportedPlotError` | `['contour']` |
| `sns.kdeplot(data=df, x="a", y="b")` | `UnsupportedPlotError` | `['contour']` |
| `sns.jointplot(data=df, x="a", y="b", kind="kde")` | `['smooth', 'smooth']` | `['contour', 'smooth', 'smooth']` |

That third row is the sharpest: the jointplot read its two **marginals** and nothing for the joint panel the chart is drawn for.

## The level is a number, not a colour

```python
cs = ax.contour(X, Y, Z, levels=[0.2, 0.5, 0.8])
cs.levels       # [0.2, 0.5, 0.8]
cs.get_paths()  # one Path per level: 65, 41 and 25 vertices
```

Both halves come off the artist. This is exactly what separates the same chart here from the same chart elsewhere: xability/maidr#1084 left Observable Plot's `contour` unread because there the magnitude survives only in a continuous fill, so distinct levels render as the same pixel. `QuadContourSet` has no such problem.

The curves are checked against the field rather than against themselves — a gaussian bump's 0.5 contour is the circle of radius `√(-ln 0.5)`, and every emitted point sits on it to within 0.05.

## Three things the drawing forces, all measured

**A level is not one curve.** A field with two peaks crosses a level twice, and matplotlib draws both islands in a *single compound path*:

```
levels: [0.5]   paths: 1
  path 0: 86 vertices, 2 MOVETO(s)
```

Read as one series they would be joined by a straight line across the saddle between the peaks — a curve announced over ground the field never took, which is the defect xability/maidr#1079 describes. Each drawn polyline becomes its own series; `ContourPoint` carries the level on every point, so several series sharing one costs nothing.

**A level nothing reaches still gets a path.** `levels=[0.2, 0.5, 2.0]` on a field whose maximum is 1 gives three paths with 65, 41 and **0** vertices. A series with no points is a row a reader can land on and be told nothing about, so it contributes none — and a set that reaches no level at all registers nothing rather than an empty layer (#421's shape).

**A filled contour is a different chart.** `contourf` with three levels draws **two** paths — the bands *between* the levels — and each outline runs along two different level curves stitched together. Announcing one as "the 0.2 contour" would be right for half its points. Declined, and so is `sns.kdeplot(..., fill=True)`.

## Why seaborn needed its own registration

`sns.kdeplot` reaches `ax.contour` internally, but the `kdeplot` patch sets the internal context around its own call — so the patched `Axes.contour` declines, and the outer patch, which only knows how to register curves, declined too. The chart went out silent. Same shape as #522, same fix: the seaborn patch registers the sets **that call added**, so an `ax.contour(...)` already on the axes is not claimed twice.

## Highlighting

Tagging the set gives one `<g>` holding a `<path>` per level, so a curve is addressed by the level it belongs to. Two islands of one level name the same element: a reader on either sees that level outlined, which is the honest answer when the islands have no elements of their own. Asserted against the **rendered SVG**, not just the payload — a selector matching nothing is xability/maidr#814's blind spot, where everything reads and nothing lights up.

## A pin turned red, as designed

`tests/core/plot/test_hist2d.py::test_bivariate_kdeplot_is_not_registered_yet` was written to fail the day a contour trace arrived — *"a contour plot is not a heatmap with different colours: the level is the navigable object, not the cell"*. It has, so it is replaced by the two cases it stood in for, and that file's module docstring is corrected: it still said the bivariate kdeplot "does NOT read".

## Verification

`pytest 0 / ruff 0` — 2,473 passed, 18 skipped, up from 2,445. Every file added or touched is `ruff`-clean; the 6 repo-wide findings are the pre-existing `__init__.py` re-export warnings.

Every guard falsified by applying each mutation alone:

| mutation | result |
|---|---|
| the contour patch is never imported | 9 of 16 failed |
| a level is one series (no `MOVETO` split) | 1 failed |
| the empty-path guard in the patch dropped | 1 failed |
| a filled kdeplot is claimed too | 1 failed |
| the before-snapshot in the kdeplot patch dropped | 1 failed |
| selectors numbered by series rather than by level | 1 failed |
| the contour set is never tagged | 2 failed |
| the level is not carried on the points | 6 failed |

**One mutation passed, and correcting the code comment was the right response rather than adding a test.** Taking the vertex sitting in the `CLOSEPOLY` slot instead of repeating the curve's first point left every test green. The reason is measurable: matplotlib writes the subpath's *start point* into that slot, so on this artist the two are identical —

```
CLOSEPOLY slot 42 holds [-1.92308, -0.71732]   subpath start: [-1.92308, -0.71732]   equal: True
CLOSEPOLY slot 85 holds [ 1.15385, -0.75847]   subpath start: [ 1.15385, -0.75847]   equal: True
```

— and no fixture can tell them apart. The code keeps `current[0]` because matplotlib documents that vertex as **ignored**, so relying on what it happens to hold is relying on something outside the contract. The comment claimed it was a placeholder; it now says what was measured, and says plainly that this is the one choice here nothing can falsify.

## Not in scope

`sns.histplot(element="step")` and `element="poly"` are still silent — seaborn draws those through a fill rather than through bars, so `sns_hist` reaches `_drew_bars` → False and declines. A third branch of the same decline, recorded in #535, and a different reading (a `PolyCollection` whose vertices are a staircase).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_