### PR TITLE
feat(core): say when a figure was drawn into while it was being rendered

### DIFF
--- a/maidr/__init__.py
+++ b/maidr/__init__.py
@@ -211,6 +211,7 @@ from .patch import (  # noqa: E402, F401
     violinplot,
 )
 from .util.bundle_capability import MaidrBundleTraceWarning  # noqa: E402
+from .util.render_census import MaidrRenderRaceWarning  # noqa: E402
 from .util.bundle_freshness import (  # noqa: E402
     STALE_MINOR_GAP,
     BundleStatus,
@@ -267,6 +268,7 @@ __all__ = [
     "LATEST_TAG",
     "MaidrBundleStaleWarning",
     "MaidrBundleTraceWarning",
+    "MaidrRenderRaceWarning",
     "STALE_MINOR_GAP",
     "bundle_status",
     "resolver_outcome",

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -532,6 +532,13 @@ class Maidr:
                 "for it may not match. Finish plotting before rendering, "
                 "or render a figure no other thread is using.",
                 UserWarning,
+                # No stacklevel points at the caller here, and it is worth
+                # saying so rather than implying otherwise: the depth from
+                # a user's call varies by entry point -- `render`,
+                # `save_html` and `show` reach this through different
+                # numbers of frames. 2 names maidr's own render machinery,
+                # which is at least a frame the reader recognises. What
+                # went wrong is in the message rather than in the location.
                 stacklevel=2,
             )
 
@@ -941,7 +948,7 @@ class Maidr:
             "subplots": subplot_grid,
         }
 
-    def _artist_census(self) -> tuple:
+    def _artist_census(self) -> tuple[int, tuple[tuple[Any, ...], ...]]:
         """A cheap description of what is currently drawn on the figure.
 
         Compared either side of a render to notice a figure being drawn
@@ -949,11 +956,24 @@ class Maidr:
         artists themselves: it has to be cheap enough to take twice per
         render, and it only has to answer "did this change", not what.
 
+        **What it does not see.** Everything here is O(1) per axes, which
+        buys the cheapness and costs the guarantee: a mutation that changes
+        an *existing* artist in place -- ``patch.set_height``,
+        ``line.set_ydata``, ``collection.set_offsets`` -- moves no count
+        and no label, and passes unnoticed. So this is a detector for
+        artists appearing, disappearing, or being relabelled, not for the
+        data inside them, and silence from it is not a promise that a
+        figure was still. Catching a data change would mean hashing the
+        data on every render, which is the cost this is shaped to avoid.
+        Both mutations measured on #530 -- a title set and a bar added --
+        are the kind it sees.
+
         Measured stable across a render for bar, heatmap, hist, line,
         scatter, boxplot, a mesh with a colorbar -- which re-parents its
         axes -- and a seaborn countplot, so it does not report the render's
-        own work as interference. Tagging for highlight sets attributes on
-        artists that already exist; nothing here adds one.
+        own work as interference. ``tests/core/test_mid_render_mutation.py``
+        holds that to those shapes; tagging for highlight sets attributes
+        on artists that already exist, and adds none.
         """
         return (
             len(self._fig.axes),
@@ -963,7 +983,14 @@ class Maidr:
                     len(ax.patches),
                     len(ax.collections),
                     len(ax.images),
-                    ax.get_title(),
+                    len(ax.texts),
+                    ax.get_legend() is not None,
+                    # Three titles, not one: `get_title()` reads the centre
+                    # one only, so a left- or right-placed title moved
+                    # during a render would otherwise be invisible here.
+                    ax.get_title(loc="center"),
+                    ax.get_title(loc="left"),
+                    ax.get_title(loc="right"),
                     ax.get_xlabel(),
                     ax.get_ylabel(),
                 )

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import warnings
 
 import io
 import os
@@ -26,6 +25,7 @@ from maidr.core.plot import MaidrPlot
 from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
 from maidr.util.figure_lock import figure_lock
+from maidr.util.render_census import artist_census, warn_if_figure_changed
 from maidr.util.bundle_capability import (
     schema_trace_types,
     warn_if_bundle_cannot_render,
@@ -496,7 +496,7 @@ class Maidr:
                 selector_ids.append(self.selector_ids[i])
 
         # Build schema once so id stays consistent across SVG and global var
-        drawn_before = self._artist_census()
+        drawn_before = artist_census(self._fig)
         schema = self._flatten_maidr()
 
         # Ask the bundle whether it can draw what this render is about to
@@ -517,30 +517,8 @@ class Maidr:
 
         # The schema was read from the artists; the SVG was written from
         # them afterwards. Anything that drew into the figure in between
-        # is in one and not the other -- a chart that shows something it
-        # never announces, or announces something it does not show. The
-        # lock stops another *render* from doing that; it cannot stop the
-        # application itself, on a figure it still holds (#530).
-        #
-        # Reported rather than repaired: re-reading the schema would race
-        # the same way, and the caller is the only one who knows whether
-        # the figure was supposed to be still.
-        if self._artist_census() != drawn_before:
-            warnings.warn(
-                "maidr: this figure was drawn into while it was being "
-                "rendered, so the chart's SVG and the data maidr announces "
-                "for it may not match. Finish plotting before rendering, "
-                "or render a figure no other thread is using.",
-                UserWarning,
-                # No stacklevel points at the caller here, and it is worth
-                # saying so rather than implying otherwise: the depth from
-                # a user's call varies by entry point -- `render`,
-                # `save_html` and `show` reach this through different
-                # numbers of frames. 2 names maidr's own render machinery,
-                # which is at least a frame the reader recognises. What
-                # went wrong is in the message rather than in the location.
-                stacklevel=2,
-            )
+        # is in one and not the other -- see :mod:`maidr.util.render_census`.
+        warn_if_figure_changed(drawn_before, self._fig)
 
         # Generate external payload if data is not embedded in SVG
         maidr = None
@@ -947,56 +925,6 @@ class Maidr:
             **self._figure_metadata(),
             "subplots": subplot_grid,
         }
-
-    def _artist_census(self) -> tuple[int, tuple[tuple[Any, ...], ...]]:
-        """A cheap description of what is currently drawn on the figure.
-
-        Compared either side of a render to notice a figure being drawn
-        into while it is read (#530). Counts and labels rather than the
-        artists themselves: it has to be cheap enough to take twice per
-        render, and it only has to answer "did this change", not what.
-
-        **What it does not see.** Everything here is O(1) per axes, which
-        buys the cheapness and costs the guarantee: a mutation that changes
-        an *existing* artist in place -- ``patch.set_height``,
-        ``line.set_ydata``, ``collection.set_offsets`` -- moves no count
-        and no label, and passes unnoticed. So this is a detector for
-        artists appearing, disappearing, or being relabelled, not for the
-        data inside them, and silence from it is not a promise that a
-        figure was still. Catching a data change would mean hashing the
-        data on every render, which is the cost this is shaped to avoid.
-        Both mutations measured on #530 -- a title set and a bar added --
-        are the kind it sees.
-
-        Measured stable across a render for bar, heatmap, hist, line,
-        scatter, boxplot, a mesh with a colorbar -- which re-parents its
-        axes -- and a seaborn countplot, so it does not report the render's
-        own work as interference. ``tests/core/test_mid_render_mutation.py``
-        holds that to those shapes; tagging for highlight sets attributes
-        on artists that already exist, and adds none.
-        """
-        return (
-            len(self._fig.axes),
-            tuple(
-                (
-                    len(ax.lines),
-                    len(ax.patches),
-                    len(ax.collections),
-                    len(ax.images),
-                    len(ax.texts),
-                    ax.get_legend() is not None,
-                    # Three titles, not one: `get_title()` reads the centre
-                    # one only, so a left- or right-placed title moved
-                    # during a render would otherwise be invisible here.
-                    ax.get_title(loc="center"),
-                    ax.get_title(loc="left"),
-                    ax.get_title(loc="right"),
-                    ax.get_xlabel(),
-                    ax.get_ylabel(),
-                )
-                for ax in self._fig.axes
-            ),
-        )
 
     def _get_svg(self, embed_data: bool = True, schema: dict | None = None) -> HTML:
         """Extract the chart SVG from ``matplotlib.figure.Figure``.

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 
 import io
 import os
@@ -495,6 +496,7 @@ class Maidr:
                 selector_ids.append(self.selector_ids[i])
 
         # Build schema once so id stays consistent across SVG and global var
+        drawn_before = self._artist_census()
         schema = self._flatten_maidr()
 
         # Ask the bundle whether it can draw what this render is about to
@@ -512,6 +514,26 @@ class Maidr:
 
         with HighlightContextManager.set_maidr_elements(tagged_elements, selector_ids):
             svg = self._get_svg(embed_data=data_in_svg, schema=schema)
+
+        # The schema was read from the artists; the SVG was written from
+        # them afterwards. Anything that drew into the figure in between
+        # is in one and not the other -- a chart that shows something it
+        # never announces, or announces something it does not show. The
+        # lock stops another *render* from doing that; it cannot stop the
+        # application itself, on a figure it still holds (#530).
+        #
+        # Reported rather than repaired: re-reading the schema would race
+        # the same way, and the caller is the only one who knows whether
+        # the figure was supposed to be still.
+        if self._artist_census() != drawn_before:
+            warnings.warn(
+                "maidr: this figure was drawn into while it was being "
+                "rendered, so the chart's SVG and the data maidr announces "
+                "for it may not match. Finish plotting before rendering, "
+                "or render a figure no other thread is using.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         # Generate external payload if data is not embedded in SVG
         maidr = None
@@ -918,6 +940,36 @@ class Maidr:
             **self._figure_metadata(),
             "subplots": subplot_grid,
         }
+
+    def _artist_census(self) -> tuple:
+        """A cheap description of what is currently drawn on the figure.
+
+        Compared either side of a render to notice a figure being drawn
+        into while it is read (#530). Counts and labels rather than the
+        artists themselves: it has to be cheap enough to take twice per
+        render, and it only has to answer "did this change", not what.
+
+        Measured stable across a render for bar, heatmap, hist, line,
+        scatter, boxplot, a mesh with a colorbar -- which re-parents its
+        axes -- and a seaborn countplot, so it does not report the render's
+        own work as interference. Tagging for highlight sets attributes on
+        artists that already exist; nothing here adds one.
+        """
+        return (
+            len(self._fig.axes),
+            tuple(
+                (
+                    len(ax.lines),
+                    len(ax.patches),
+                    len(ax.collections),
+                    len(ax.images),
+                    ax.get_title(),
+                    ax.get_xlabel(),
+                    ax.get_ylabel(),
+                )
+                for ax in self._fig.axes
+            ),
+        )
 
     def _get_svg(self, embed_data: bool = True, schema: dict | None = None) -> HTML:
         """Extract the chart SVG from ``matplotlib.figure.Figure``.

--- a/maidr/util/render_census.py
+++ b/maidr/util/render_census.py
@@ -82,7 +82,13 @@ def artist_census(figure: Figure) -> tuple[Any, ...]:
     ``collection.set_offsets`` -- moves no count and no label, and passes
     unnoticed. So this is a detector for artists appearing, disappearing,
     or being relabelled, not for the data inside them, and silence from it
-    is not a promise that a figure was still. Catching a data change would
+    is not a promise that a figure was still. Nor is this read itself
+    atomic against the application: it walks ``figure.axes`` while another
+    thread may be part-way through changing it, so the "before" it
+    captures can be a figure mid-mutation rather than a clean one. Both
+    are the same trade -- a detector that locked the application out would
+    be a repair, and repairing this is what the module deliberately does
+    not do. Catching a data change would
     mean hashing the data on every render, which is the cost this is
     shaped to avoid. Both mutations measured on #530 -- a title set and a
     bar added -- are the kind it sees.
@@ -130,7 +136,7 @@ def artist_census(figure: Figure) -> tuple[Any, ...]:
     )
 
 
-def warn_if_figure_changed(before: tuple[Any, ...], figure: Figure) -> bool:
+def warn_if_figure_changed(before: tuple[Any, ...], figure: Figure) -> None:
     """Warn when ``figure`` no longer matches the census taken ``before``.
 
     Parameters
@@ -142,12 +148,13 @@ def warn_if_figure_changed(before: tuple[Any, ...], figure: Figure) -> bool:
 
     Returns
     -------
-    bool
-        Whether a change was found, so a caller can act on it without
-        parsing the warning. Nothing does today.
+    None
+        Nothing: the warning is the whole output. A boolean "did it race"
+        would be an API with no caller, and the one place that asks the
+        question is the one place that raises the warning.
     """
     if artist_census(figure) == before:
-        return False
+        return
 
     # Named rather than described: the default warning rule keys on the
     # message text, so identifying the figure is what stops two different
@@ -197,7 +204,6 @@ def warn_if_figure_changed(before: tuple[Any, ...], figure: Figure) -> bool:
             # message, not the location.
             stacklevel=4,
         )
-    return True
 
 
 __all__ = ["MaidrRenderRaceWarning", "artist_census", "warn_if_figure_changed"]

--- a/maidr/util/render_census.py
+++ b/maidr/util/render_census.py
@@ -10,6 +10,13 @@ it cannot stop the application itself, on a figure it still holds (#530).
 Reported rather than repaired. Re-reading the schema would race the same
 way, and only the caller knows whether the figure was supposed to be
 still -- so the warning names both remedies instead of guessing one.
+
+**Importing this module mutates global interpreter state.** It registers
+an always-filter for its own warning category, permanently, for the life
+of the process -- see the note on that call below for why the alternative
+is worse. Every other filter change in this package is scoped to a
+``catch_warnings`` block; this one cannot be, because it has to be in
+force at a moment none of this code controls.
 """
 
 from __future__ import annotations
@@ -146,24 +153,50 @@ def warn_if_figure_changed(before: tuple[Any, ...], figure: Figure) -> bool:
     # message text, so identifying the figure is what stops two different
     # figures racing in one process from being reported as one. `number`
     # is what a user sees in `plt.figure(3)` and in a traceback; a figure
-    # made without pyplot has none, and its identity is all there is.
+    # made without pyplot has none, and its address is all there is.
+    #
+    # An address can be reused once a figure is collected, so two
+    # unrelated pyplot-less figures could in principle be named the same
+    # across a long process and the second's collision be read as a repeat
+    # of the first's. Left as is: the always-filter below covers the
+    # repeat case, and a counter would name the *report* rather than the
+    # figure, which is not what a reader trying to find the chart needs.
     known_as = getattr(figure, "number", None)
-    named = f"figure {known_as}" if known_as is not None else f"figure at {id(figure):#x}"
-
-    warnings.warn(
-        f"maidr: {named} was drawn into while it was being rendered, so "
-        "the chart's SVG and the data maidr announces for it may not "
-        "match. Finish plotting before rendering, or render a figure no "
-        "other thread is using.",
-        MaidrRenderRaceWarning,
-        # No stacklevel points at the caller here, and it is worth saying
-        # so rather than implying otherwise: the depth from a user's call
-        # varies by entry point -- `render`, `save_html` and `show` reach
-        # this through different numbers of frames. 3 names maidr's own
-        # render machinery, which is at least a frame a reader
-        # recognises. What went wrong is in the message, not the location.
-        stacklevel=3,
+    named = (
+        f"figure {known_as}" if known_as is not None else f"figure at {id(figure):#x}"
     )
+
+    # The same lock `maidr/patch/common.py` takes around its own
+    # `catch_warnings` block. `warnings.filters` is process-global mutable
+    # state, and a patched plot call on another thread saves, replaces and
+    # restores the whole list -- so a warning raised while that is in
+    # flight can be judged against filters that are not this process's,
+    # including the ignore-everything one that call installs. Taking the
+    # same lock is what makes "every collision is reported" true when a
+    # render and a plot call overlap, rather than only when they do not.
+    #
+    # No deadlock against the render lock: a plot call holds this one and
+    # never renders, so it never waits on `figure_lock` while a render
+    # waits on this. Imported here rather than at module scope because
+    # `maidr.patch` imports the renderer.
+    from maidr.patch.common import _FILTER_LOCK
+
+    with _FILTER_LOCK:
+        warnings.warn(
+            f"maidr: {named} was drawn into while it was being rendered, "
+            "so the chart's SVG and the data maidr announces for it may "
+            "not match. Finish plotting before rendering, or render a "
+            "figure no other thread is using.",
+            MaidrRenderRaceWarning,
+            # No stacklevel points at the caller here, and it is worth
+            # saying so rather than implying otherwise: the depth from a
+            # user's call varies by entry point -- `render`, `save_html`
+            # and `show` reach this through different numbers of frames.
+            # 4 names maidr's own render machinery, which is at least a
+            # frame a reader recognises. What went wrong is in the
+            # message, not the location.
+            stacklevel=4,
+        )
     return True
 
 

--- a/maidr/util/render_census.py
+++ b/maidr/util/render_census.py
@@ -185,7 +185,15 @@ def warn_if_figure_changed(before: tuple[Any, ...], figure: Figure) -> None:
     # No deadlock against the render lock: a plot call holds this one and
     # never renders, so it never waits on `figure_lock` while a render
     # waits on this. Imported here rather than at module scope because
-    # `maidr.patch` imports the renderer.
+    # `maidr.patch` imports the renderer -- a module-level import would
+    # reach `patch.common` while it is still executing its own imports,
+    # before `_FILTER_LOCK` is assigned.
+    #
+    # `warnings.warn` calls `showwarning` synchronously, and that can be a
+    # user's hook -- `logging.captureWarnings` installs one. So this holds
+    # the filter lock for however long that hook takes. Accepted: the
+    # alternative is releasing before the warning is delivered, which is
+    # the window this lock exists to close.
     from maidr.patch.common import _FILTER_LOCK
 
     with _FILTER_LOCK:

--- a/maidr/util/render_census.py
+++ b/maidr/util/render_census.py
@@ -1,0 +1,170 @@
+"""Noticing that a figure was drawn into while it was being rendered.
+
+A render reads the schema from the artists and writes the SVG from them
+afterwards. Anything that draws into the figure between those two points
+lands in one and not the other: a chart that shows something it never
+announces, or announces something it does not show. The per-figure lock
+in :mod:`maidr.util.figure_lock` stops another *render* from doing that;
+it cannot stop the application itself, on a figure it still holds (#530).
+
+Reported rather than repaired. Re-reading the schema would race the same
+way, and only the caller knows whether the figure was supposed to be
+still -- so the warning names both remedies instead of guessing one.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+from matplotlib.figure import Figure
+
+
+class MaidrRenderRaceWarning(UserWarning):
+    """Raised when a figure changed while maidr was rendering it.
+
+    Its own category rather than a bare ``UserWarning`` for the usual
+    reason -- a consumer running under ``-W error`` can silence this
+    advisory alone::
+
+        warnings.filterwarnings("ignore", category=maidr.MaidrRenderRaceWarning)
+
+    -- and for one specific to it, below.
+    """
+
+
+# Every occurrence is a *different* wrong chart, so every occurrence is
+# worth saying. Python's default rule is once per (message, category,
+# module, line), and this warning is raised from one fixed line, so the
+# default would report the first collision in a process's lifetime and
+# silently drop every later one -- in a long-running server, for every
+# other session and every other figure, for the life of the process.
+# That is the failure this module exists to prevent, arriving one
+# occurrence later.
+#
+# Measured before this line existed: three collisions in one process
+# produced two warnings, the missing one swallowed by that rule. (Two
+# rather than one only because maidr's own plot patches mutate the filter
+# state as a side effect, which invalidates the registry sometimes -- an
+# accident, and not something to rely on.)
+#
+# Inserted at the front of the filter list, so a user's own
+# ``filterwarnings`` call -- which also inserts at the front, later --
+# still wins.
+#
+# Not sufficient on its own, which is why the message below also names
+# the figure: anything that *rebuilds* the filter list drops this
+# registration, and pytest does exactly that between tests. A process
+# that has had its filters reset falls back to the default rule, and the
+# per-figure detail is what keeps distinct figures from collapsing into
+# one report there.
+warnings.simplefilter("always", MaidrRenderRaceWarning)
+
+
+def artist_census(figure: Figure) -> tuple[Any, ...]:
+    """A cheap description of what is currently drawn on ``figure``.
+
+    Compared either side of a render to notice a figure being drawn into
+    while it is read. Counts and labels rather than the artists
+    themselves: it has to be cheap enough to take twice per render, and it
+    only has to answer "did this change", not what.
+
+    **What it does not see.** Everything here is O(1) per axes, which buys
+    the cheapness and costs the guarantee: a mutation that changes an
+    *existing* artist in place -- ``patch.set_height``, ``line.set_ydata``,
+    ``collection.set_offsets`` -- moves no count and no label, and passes
+    unnoticed. So this is a detector for artists appearing, disappearing,
+    or being relabelled, not for the data inside them, and silence from it
+    is not a promise that a figure was still. Catching a data change would
+    mean hashing the data on every render, which is the cost this is
+    shaped to avoid. Both mutations measured on #530 -- a title set and a
+    bar added -- are the kind it sees.
+
+    What it reads is what the schema reads, which is the point: the
+    figure-level ``suptitle``/``supxlabel``/``supylabel`` feed the emitted
+    ``title`` and ``axes`` just as the per-axes ones do, so leaving them
+    out left a suptitle changed mid-render silently unreported -- the
+    exact failure, one level up (review of #541).
+
+    Parameters
+    ----------
+    figure : matplotlib.figure.Figure
+        The figure about to be, or just, rendered.
+
+    Returns
+    -------
+    tuple
+        Opaque. Only ever compared with another census of the same figure.
+    """
+    return (
+        len(figure.axes),
+        figure.get_suptitle(),
+        figure.get_supxlabel(),
+        figure.get_supylabel(),
+        tuple(
+            (
+                len(ax.lines),
+                len(ax.patches),
+                len(ax.collections),
+                len(ax.images),
+                len(ax.texts),
+                ax.get_legend() is not None,
+                # Three titles, not one: `get_title()` reads the centre one
+                # only, so a left- or right-placed title moved during a
+                # render would otherwise be invisible here.
+                ax.get_title(loc="center"),
+                ax.get_title(loc="left"),
+                ax.get_title(loc="right"),
+                ax.get_xlabel(),
+                ax.get_ylabel(),
+            )
+            for ax in figure.axes
+        ),
+    )
+
+
+def warn_if_figure_changed(before: tuple[Any, ...], figure: Figure) -> bool:
+    """Warn when ``figure`` no longer matches the census taken ``before``.
+
+    Parameters
+    ----------
+    before : tuple
+        The census taken before the schema was read.
+    figure : matplotlib.figure.Figure
+        The figure whose SVG has just been written.
+
+    Returns
+    -------
+    bool
+        Whether a change was found, so a caller can act on it without
+        parsing the warning. Nothing does today.
+    """
+    if artist_census(figure) == before:
+        return False
+
+    # Named rather than described: the default warning rule keys on the
+    # message text, so identifying the figure is what stops two different
+    # figures racing in one process from being reported as one. `number`
+    # is what a user sees in `plt.figure(3)` and in a traceback; a figure
+    # made without pyplot has none, and its identity is all there is.
+    known_as = getattr(figure, "number", None)
+    named = f"figure {known_as}" if known_as is not None else f"figure at {id(figure):#x}"
+
+    warnings.warn(
+        f"maidr: {named} was drawn into while it was being rendered, so "
+        "the chart's SVG and the data maidr announces for it may not "
+        "match. Finish plotting before rendering, or render a figure no "
+        "other thread is using.",
+        MaidrRenderRaceWarning,
+        # No stacklevel points at the caller here, and it is worth saying
+        # so rather than implying otherwise: the depth from a user's call
+        # varies by entry point -- `render`, `save_html` and `show` reach
+        # this through different numbers of frames. 3 names maidr's own
+        # render machinery, which is at least a frame a reader
+        # recognises. What went wrong is in the message, not the location.
+        stacklevel=3,
+    )
+    return True
+
+
+__all__ = ["MaidrRenderRaceWarning", "artist_census", "warn_if_figure_changed"]

--- a/tests/core/test_mid_render_mutation.py
+++ b/tests/core/test_mid_render_mutation.py
@@ -318,11 +318,10 @@ print(len([m for m in shown if "was drawn into while it was being rendered" in m
 """
 
 
-#: The same, with a thread hammering patched plot calls throughout. Each
-#: one enters `catch_warnings()` and installs an ignore-everything filter
-#: for its duration, so a warning raised in that window is judged against
-#: filters that are not this process's.
-_COLLISIONS_UNDER_PLOT_TRAFFIC = """
+#: One collision raised while another thread is inside the
+#: ignore-everything window a patched plot call opens -- held open
+#: deliberately rather than raced for.
+_COLLISION_INSIDE_THE_PLOT_WINDOW = """
 import threading
 import warnings
 import matplotlib
@@ -330,22 +329,27 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import maidr
 from maidr.core.maidr import Maidr
+from maidr.patch.common import _FILTER_LOCK
 
 shown = []
 original = Maidr._get_svg
-stop = threading.Event()
+inside = threading.Event()
+
+
+def hold_the_filters_open():
+    # What `_draw_quietly` does for the duration of a patched plot call.
+    with _FILTER_LOCK, warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        inside.set()
+        threading.Event().wait(1.0)
 
 
 def mutate_then_render(self, *args, **kwargs):
-    self._fig.axes[0].set_title("moved-%d" % len(shown))
+    self._fig.axes[0].set_title("moved")
+    holder = threading.Thread(target=hold_the_filters_open, daemon=True)
+    holder.start()
+    inside.wait(timeout=30)
     return original(self, *args, **kwargs)
-
-
-def keep_plotting():
-    while not stop.is_set():
-        other, other_ax = plt.subplots()
-        other_ax.bar(["x"], [1])
-        plt.close(other)
 
 
 Maidr._get_svg = mutate_then_render
@@ -353,14 +357,7 @@ warnings.showwarning = lambda message, *a, **k: shown.append(str(message))
 
 fig, ax = plt.subplots()
 ax.bar(["a", "b"], [1, 2])
-traffic = threading.Thread(target=keep_plotting, daemon=True)
-traffic.start()
-try:
-    for _ in range(8):
-        maidr.render(ax, use_cdn=True)
-finally:
-    stop.set()
-    traffic.join(timeout=30)
+maidr.render(ax, use_cdn=True)
 
 print(len([m for m in shown if "was drawn into while it was being rendered" in m]))
 """
@@ -421,26 +418,23 @@ def test_collisions_are_reported_while_another_thread_is_plotting():
     rebuilds the filter list between tests, so in-process this would
     measure pytest rather than the lock.
 
-    The plotting thread drives pyplot's global figure registry from a
-    second thread, which pyplot does not document as safe. That is
-    deliberate -- it is what a patched plot call on another thread looks
-    like, which is the situation being tested -- but it is worth knowing
-    if this ever turns flaky rather than failing honestly. A healthy run
-    is ~35s.
+    A healthy run is ~2s, and it holds the window for one second, so a
+    much longer run means the warn is blocked on the lock rather than
+    passing through it -- which is the behaviour, not a hang.
     """
     import subprocess
     import sys
 
     completed = subprocess.run(
-        [sys.executable, "-c", _COLLISIONS_UNDER_PLOT_TRAFFIC],
+        [sys.executable, "-c", _COLLISION_INSIDE_THE_PLOT_WINDOW],
         capture_output=True,
         text=True,
         timeout=180,
     )
 
     assert completed.returncode == 0, completed.stderr[-2000:]
-    assert completed.stdout.strip().splitlines()[-1] == "8", (
-        "collisions were lost while another thread held the warning "
+    assert completed.stdout.strip().splitlines()[-1] == "1", (
+        "the collision was lost while another thread held the warning "
         f"filters: {completed.stdout.strip()!r}"
     )
 

--- a/tests/core/test_mid_render_mutation.py
+++ b/tests/core/test_mid_render_mutation.py
@@ -391,7 +391,7 @@ def test_repeat_collisions_on_one_figure_are_all_reported():
         [sys.executable, "-c", _REPEAT_COLLISIONS],
         capture_output=True,
         text=True,
-        timeout=300,
+        timeout=120,
     )
 
     assert completed.returncode == 0, completed.stderr[-2000:]
@@ -420,6 +420,13 @@ def test_collisions_are_reported_while_another_thread_is_plotting():
     In a subprocess for the same reason as its sibling above: pytest
     rebuilds the filter list between tests, so in-process this would
     measure pytest rather than the lock.
+
+    The plotting thread drives pyplot's global figure registry from a
+    second thread, which pyplot does not document as safe. That is
+    deliberate -- it is what a patched plot call on another thread looks
+    like, which is the situation being tested -- but it is worth knowing
+    if this ever turns flaky rather than failing honestly. A healthy run
+    is ~35s.
     """
     import subprocess
     import sys
@@ -428,7 +435,7 @@ def test_collisions_are_reported_while_another_thread_is_plotting():
         [sys.executable, "-c", _COLLISIONS_UNDER_PLOT_TRAFFIC],
         capture_output=True,
         text=True,
-        timeout=600,
+        timeout=180,
     )
 
     assert completed.returncode == 0, completed.stderr[-2000:]

--- a/tests/core/test_mid_render_mutation.py
+++ b/tests/core/test_mid_render_mutation.py
@@ -245,7 +245,7 @@ def test_a_value_changed_in_place_is_not_detected(monkeypatch):
 
     assert not _render_catching_warnings(ax), (
         "the census now sees in-place data changes; update the limitation "
-        "documented on Maidr._artist_census"
+        "documented on maidr.util.render_census.artist_census"
     )
 
 
@@ -318,6 +318,54 @@ print(len([m for m in shown if "was drawn into while it was being rendered" in m
 """
 
 
+#: The same, with a thread hammering patched plot calls throughout. Each
+#: one enters `catch_warnings()` and installs an ignore-everything filter
+#: for its duration, so a warning raised in that window is judged against
+#: filters that are not this process's.
+_COLLISIONS_UNDER_PLOT_TRAFFIC = """
+import threading
+import warnings
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import maidr
+from maidr.core.maidr import Maidr
+
+shown = []
+original = Maidr._get_svg
+stop = threading.Event()
+
+
+def mutate_then_render(self, *args, **kwargs):
+    self._fig.axes[0].set_title("moved-%d" % len(shown))
+    return original(self, *args, **kwargs)
+
+
+def keep_plotting():
+    while not stop.is_set():
+        other, other_ax = plt.subplots()
+        other_ax.bar(["x"], [1])
+        plt.close(other)
+
+
+Maidr._get_svg = mutate_then_render
+warnings.showwarning = lambda message, *a, **k: shown.append(str(message))
+
+fig, ax = plt.subplots()
+ax.bar(["a", "b"], [1, 2])
+traffic = threading.Thread(target=keep_plotting, daemon=True)
+traffic.start()
+try:
+    for _ in range(8):
+        maidr.render(ax, use_cdn=True)
+finally:
+    stop.set()
+    traffic.join(timeout=30)
+
+print(len([m for m in shown if "was drawn into while it was being rendered" in m]))
+"""
+
+
 def test_repeat_collisions_on_one_figure_are_all_reported():
     """The case the naming cannot cover, measured where it is true.
 
@@ -350,6 +398,43 @@ def test_repeat_collisions_on_one_figure_are_all_reported():
     assert completed.stdout.strip().splitlines()[-1] == "3", (
         "collisions were swallowed by the once-per-location rule: "
         f"{completed.stdout.strip()!r}"
+    )
+
+
+def test_collisions_are_reported_while_another_thread_is_plotting():
+    """The guarantee under the concurrency this whole feature is about.
+
+    ``maidr/patch/common.py`` wraps every patched plot call in
+    ``catch_warnings()`` with an ignore-everything filter, and
+    ``warnings.filters`` is process-global. So a collision reported while
+    another thread is inside that window can be judged against filters
+    that are not this process's, and dropped -- which would make "every
+    collision is reported" true only for renders that happen not to
+    overlap a plot call. That is the scenario this PR exists for, so the
+    claim has to hold there or not be made (review of #541).
+
+    ``warn_if_figure_changed`` therefore takes the same ``_FILTER_LOCK``
+    that module takes. Eight collisions against a thread plotting
+    continuously; falsified by removing the lock, 3 runs of 3.
+
+    In a subprocess for the same reason as its sibling above: pytest
+    rebuilds the filter list between tests, so in-process this would
+    measure pytest rather than the lock.
+    """
+    import subprocess
+    import sys
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _COLLISIONS_UNDER_PLOT_TRAFFIC],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+    assert completed.returncode == 0, completed.stderr[-2000:]
+    assert completed.stdout.strip().splitlines()[-1] == "8", (
+        "collisions were lost while another thread held the warning "
+        f"filters: {completed.stdout.strip()!r}"
     )
 
 

--- a/tests/core/test_mid_render_mutation.py
+++ b/tests/core/test_mid_render_mutation.py
@@ -18,14 +18,15 @@ import warnings
 
 import matplotlib
 import numpy as np
+import pandas as pd
 import pytest
+import seaborn as sns
 
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
 
 import maidr  # noqa: E402
-from maidr.core.figure_manager import FigureManager  # noqa: E402
 
 _MESSAGE = "drawn into while it was being rendered"
 
@@ -68,7 +69,7 @@ def test_a_figure_drawn_into_mid_render_warns(monkeypatch):
     assert _render_catching_warnings(ax), "a mid-render mutation went unreported"
 
 
-def test_the_warning_says_what_to_do_about_it():
+def test_the_warning_says_what_to_do_about_it(monkeypatch):
     """A warning a reader cannot act on is noise.
 
     Pinned because the two remedies are not obvious from the symptom: the
@@ -80,18 +81,14 @@ def test_the_warning_says_what_to_do_about_it():
     ax.bar(["a"], [1])
     original = Maidr._get_svg
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        Maidr._get_svg = lambda self, *a, **k: (  # noqa: E731
-            self._fig.axes[0].set_title("moved"),
-            original(self, *a, **k),
-        )[1]
-        try:
-            maidr.render(ax, use_cdn=True)
-        finally:
-            Maidr._get_svg = original
+    def retitle_then_render(self, *args, **kwargs):
+        self._fig.axes[0].set_title("moved")
+        return original(self, *args, **kwargs)
 
-    message = str(next(w.message for w in caught if _MESSAGE in str(w.message)))
+    monkeypatch.setattr(Maidr, "_get_svg", retitle_then_render)
+    caught = _render_catching_warnings(ax)
+
+    message = str(caught[0].message)
     assert "Finish plotting before rendering" in message
     assert "no other thread is using" in message
 
@@ -106,6 +103,18 @@ def test_the_warning_says_what_to_do_about_it():
         pytest.param(lambda ax: ax.boxplot([[1, 2, 3], [2, 3, 4]]), id="boxplot"),
         pytest.param(
             lambda ax: ax.pcolormesh(np.arange(6).reshape(2, 3)), id="heatmap"
+        ),
+        pytest.param(
+            lambda ax: sns.countplot(pd.DataFrame({"g": list("aabbb")}), x="g", ax=ax),
+            id="seaborn-countplot",
+        ),
+        pytest.param(
+            lambda ax: (ax.plot([1, 2], [2, 1], label="one"), ax.legend()),
+            id="line-with-legend",
+        ),
+        pytest.param(
+            lambda ax: (ax.bar(["a"], [1]), ax.set_title("left", loc="left")),
+            id="left-placed-title",
         ),
     ],
 )
@@ -151,7 +160,75 @@ def test_the_census_is_not_confused_by_a_second_render_of_the_same_figure():
     """
     fig, ax = plt.subplots()
     ax.bar(["a", "b"], [1, 2])
-    FigureManager.get_maidr(fig)
 
     assert not _render_catching_warnings(ax)
     assert not _render_catching_warnings(ax), "the second render warned"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "what"),
+    [
+        pytest.param(lambda ax: ax.bar(["c"], [3]), "an artist added", id="added-bar"),
+        pytest.param(
+            lambda ax: ax.set_title("moved", loc="left"),
+            "a left-placed title",
+            id="left-title",
+        ),
+        pytest.param(
+            lambda ax: ax.text(0, 0, "note"), "an annotation", id="annotation"
+        ),
+        # Just the legend: the labelled line is drawn before the render,
+        # so `len(ax.lines)` does not move and only the legend dimension
+        # can catch this. An earlier version of this case plotted the line
+        # here too, and passed with that dimension deleted.
+        pytest.param(lambda ax: ax.legend(), "a legend", id="legend"),
+    ],
+)
+def test_each_census_dimension_is_load_bearing(monkeypatch, mutate, what):
+    """One case per thing the census looks at, so none of them is decoration.
+
+    A dimension nothing exercises is a dimension that can be dropped in a
+    refactor without a test noticing -- which is how ``get_title()``
+    reading only the centre title stayed invisible until review of #541.
+    """
+    from maidr.core.maidr import Maidr
+
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2], label="bars")
+    original = Maidr._get_svg
+
+    def mutate_then_render(self, *args, **kwargs):
+        mutate(self._fig.axes[0])
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Maidr, "_get_svg", mutate_then_render)
+
+    assert _render_catching_warnings(ax), f"{what} mid-render went unreported"
+
+
+def test_a_value_changed_in_place_is_not_detected(monkeypatch):
+    """The documented limit, executable rather than only in prose.
+
+    Everything the census reads is O(1) per axes, which is what makes it
+    cheap enough to take twice per render and what stops it seeing a bar
+    whose height changed: no count moves, no label moves. This test exists
+    so that the docstring's admission cannot quietly become false -- if
+    someone strengthens the census, this fails and tells them to update
+    the claim rather than leaving the docs describing an older detector.
+    """
+    from maidr.core.maidr import Maidr
+
+    fig, ax = plt.subplots()
+    bars = ax.bar(["a", "b"], [1, 2])
+    original = Maidr._get_svg
+
+    def restyle_then_render(self, *args, **kwargs):
+        bars.patches[0].set_height(99)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Maidr, "_get_svg", restyle_then_render)
+
+    assert not _render_catching_warnings(ax), (
+        "the census now sees in-place data changes; update the limitation "
+        "documented on Maidr._artist_census"
+    )

--- a/tests/core/test_mid_render_mutation.py
+++ b/tests/core/test_mid_render_mutation.py
@@ -28,7 +28,7 @@ import matplotlib.pyplot as plt  # noqa: E402
 
 import maidr  # noqa: E402
 
-_MESSAGE = "drawn into while it was being rendered"
+_MESSAGE = "was drawn into while it was being rendered"
 
 
 @pytest.fixture(autouse=True)
@@ -182,6 +182,21 @@ def test_the_census_is_not_confused_by_a_second_render_of_the_same_figure():
         # can catch this. An earlier version of this case plotted the line
         # here too, and passed with that dimension deleted.
         pytest.param(lambda ax: ax.legend(), "a legend", id="legend"),
+        pytest.param(
+            lambda ax: ax.get_figure().suptitle("moved"),
+            "a figure-level suptitle",
+            id="suptitle",
+        ),
+        pytest.param(
+            lambda ax: ax.get_figure().supxlabel("moved"),
+            "a figure-level x label",
+            id="supxlabel",
+        ),
+        pytest.param(
+            lambda ax: ax.get_figure().supylabel("moved"),
+            "a figure-level y label",
+            id="supylabel",
+        ),
     ],
 )
 def test_each_census_dimension_is_load_bearing(monkeypatch, mutate, what):
@@ -232,3 +247,122 @@ def test_a_value_changed_in_place_is_not_detected(monkeypatch):
         "the census now sees in-place data changes; update the limitation "
         "documented on Maidr._artist_census"
     )
+
+
+def test_the_warning_names_the_figure_it_is_about(monkeypatch):
+    """Two figures racing in one process must not read as one report.
+
+    Python's default warning rule keys on the message *text*, among other
+    things, so a message that described the problem without identifying
+    the figure would let the second figure's collision be swallowed as a
+    repeat of the first's. Naming the figure is what keeps them apart --
+    and it is what a reader needs anyway to know which chart to distrust.
+
+    This replaced a test that counted reports across three renders and
+    passed with the naming removed: creating each figure runs maidr's own
+    plot patches, which mutate the warning filters as a side effect and
+    invalidate the once-per-location registry, so the count was measuring
+    that accident rather than this. Asserting on the messages cannot
+    drift that way.
+    """
+    from maidr.core.maidr import Maidr
+
+    original = Maidr._get_svg
+
+    def retitle_then_render(self, *args, **kwargs):
+        self._fig.axes[0].set_title("moved")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Maidr, "_get_svg", retitle_then_render)
+
+    messages = []
+    for _ in range(2):
+        fig, ax = plt.subplots()
+        ax.bar(["a", "b"], [1, 2])
+        messages.append(str(_render_catching_warnings(ax)[0].message))
+
+    assert len(set(messages)) == 2, (
+        "both figures produced the same warning text, so the default "
+        f"once-per-location rule would report only one of them: {messages[0]!r}"
+    )
+
+
+#: Three mid-render collisions on **one** figure, counted in a process
+#: whose warning filters are whatever importing maidr leaves them.
+_REPEAT_COLLISIONS = """
+import warnings
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import maidr
+from maidr.core.maidr import Maidr
+
+shown = []
+original = Maidr._get_svg
+
+
+def mutate_then_render(self, *args, **kwargs):
+    self._fig.axes[0].set_title("moved-%d" % len(shown))
+    return original(self, *args, **kwargs)
+
+
+Maidr._get_svg = mutate_then_render
+warnings.showwarning = lambda message, *a, **k: shown.append(str(message))
+
+fig, ax = plt.subplots()
+ax.bar(["a", "b"], [1, 2])
+for _ in range(3):
+    maidr.render(ax, use_cdn=True)
+
+print(len([m for m in shown if "was drawn into while it was being rendered" in m]))
+"""
+
+
+def test_repeat_collisions_on_one_figure_are_all_reported():
+    """The case the naming cannot cover, measured where it is true.
+
+    One figure racing twice produces the same message text, so the
+    per-figure naming cannot keep those apart -- only the always-filter
+    registered at import can. Python's default rule would report the first
+    collision in a process's lifetime and drop the rest, which in a
+    long-running server means every later session, silently.
+
+    Run in a subprocess because that is the only place the guarantee
+    exists: pytest rebuilds the filter list between tests and drops the
+    registration, so measuring this in-process would measure pytest.
+
+    Falsified by removing the registration: 2 of 3 rather than 3 of 3,
+    three runs of three. (Two rather than one only because maidr's own
+    plot patches mutate filter state as a side effect, which invalidates
+    the registry sometimes -- an accident, not something to rely on.)
+    """
+    import subprocess
+    import sys
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _REPEAT_COLLISIONS],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+    assert completed.returncode == 0, completed.stderr[-2000:]
+    assert completed.stdout.strip().splitlines()[-1] == "3", (
+        "collisions were swallowed by the once-per-location rule: "
+        f"{completed.stdout.strip()!r}"
+    )
+
+
+def test_the_warning_has_its_own_category_so_it_can_be_silenced_alone():
+    """A consumer under ``-W error`` must be able to exempt this one.
+
+    The same reason the bundle warnings carry their own categories. Pinned
+    because the category is also what the always-filter is registered
+    against, so replacing it with a bare ``UserWarning`` would quietly
+    take the previous test's guarantee with it.
+    """
+    import maidr as maidr_package
+    from maidr.util.render_census import MaidrRenderRaceWarning
+
+    assert issubclass(MaidrRenderRaceWarning, UserWarning)
+    assert maidr_package.MaidrRenderRaceWarning is MaidrRenderRaceWarning

--- a/tests/core/test_mid_render_mutation.py
+++ b/tests/core/test_mid_render_mutation.py
@@ -1,0 +1,157 @@
+"""A figure drawn into *while* it is rendered says so, instead of lying.
+
+The schema is read from the artists and the SVG is written from them
+afterwards, so anything that draws into the figure between those two
+points lands in one and not the other: a chart that shows something it
+never announces, or announces something it does not show. The per-figure
+lock stops another *render* from doing that; it cannot stop the
+application itself, on a figure it still holds (#530).
+
+The failure is the kind this project treats as worst -- a sighted user
+sees the change, a screen-reader user is never told it exists, and every
+check that reads the payload passes.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+
+import maidr  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+_MESSAGE = "drawn into while it was being rendered"
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _render_catching_warnings(axes):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        maidr.render(axes, use_cdn=True)
+    return [w for w in caught if _MESSAGE in str(w.message)]
+
+
+def test_a_figure_drawn_into_mid_render_warns(monkeypatch):
+    """Driven deterministically, not by racing two threads.
+
+    A thread race would make this a test of the scheduler: it would pass
+    on a machine where the mutation happened to land inside the window and
+    silently stop testing anything on one where it did not. Mutating from
+    inside ``_get_svg`` puts the change exactly where a concurrent
+    application would have to put it to go unnoticed -- after the schema
+    is read, before the SVG is written -- every time.
+    """
+    from maidr.core.maidr import Maidr
+
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    original = Maidr._get_svg
+
+    def draw_into_the_figure_first(self, *args, **kwargs):
+        self._fig.axes[0].bar(["c"], [3])
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Maidr, "_get_svg", draw_into_the_figure_first)
+
+    assert _render_catching_warnings(ax), "a mid-render mutation went unreported"
+
+
+def test_the_warning_says_what_to_do_about_it():
+    """A warning a reader cannot act on is noise.
+
+    Pinned because the two remedies are not obvious from the symptom: the
+    chart looks fine, and nothing raised.
+    """
+    from maidr.core.maidr import Maidr
+
+    fig, ax = plt.subplots()
+    ax.bar(["a"], [1])
+    original = Maidr._get_svg
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Maidr._get_svg = lambda self, *a, **k: (  # noqa: E731
+            self._fig.axes[0].set_title("moved"),
+            original(self, *a, **k),
+        )[1]
+        try:
+            maidr.render(ax, use_cdn=True)
+        finally:
+            Maidr._get_svg = original
+
+    message = str(next(w.message for w in caught if _MESSAGE in str(w.message)))
+    assert "Finish plotting before rendering" in message
+    assert "no other thread is using" in message
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        pytest.param(lambda ax: ax.bar(["a", "b"], [1, 2]), id="bar"),
+        pytest.param(lambda ax: ax.plot([1, 2, 3], [3, 2, 1]), id="line"),
+        pytest.param(lambda ax: ax.scatter([1, 2], [2, 1]), id="scatter"),
+        pytest.param(lambda ax: ax.hist([1, 2, 2, 3]), id="hist"),
+        pytest.param(lambda ax: ax.boxplot([[1, 2, 3], [2, 3, 4]]), id="boxplot"),
+        pytest.param(
+            lambda ax: ax.pcolormesh(np.arange(6).reshape(2, 3)), id="heatmap"
+        ),
+    ],
+)
+def test_an_undisturbed_render_is_silent(build):
+    """The direction that decides whether this can ship at all.
+
+    A detector that reports the render's own work would fire on every
+    chart, and a warning that always fires is one nobody reads. The census
+    counts artists and labels, and the render adds neither -- tagging for
+    highlight sets attributes on artists that already exist.
+
+    Parametrised across the shapes whose renders do the most to the
+    figure. Verified over the whole suite as well: 2,456 tests, zero
+    occurrences of this warning.
+    """
+    fig, ax = plt.subplots()
+    build(ax)
+
+    assert not _render_catching_warnings(ax), "an ordinary render warned"
+
+
+def test_a_colorbar_does_not_look_like_interference():
+    """The one shape that re-parents axes during its own construction.
+
+    ``fig.colorbar`` adds an axes, which is exactly what the census
+    counts. It happens before the render rather than during it, and this
+    pins that distinction -- the census is taken inside the render, so a
+    figure that was *built* with a colorbar is not interference (#519).
+    """
+    fig, ax = plt.subplots()
+    mesh = ax.pcolormesh(np.arange(6).reshape(2, 3))
+    fig.colorbar(mesh, ax=ax)
+
+    assert not _render_catching_warnings(ax), "a colorbar was read as interference"
+
+
+def test_the_census_is_not_confused_by_a_second_render_of_the_same_figure():
+    """Rendering twice must not report the first render as interference.
+
+    The census is taken fresh inside each render rather than stored on the
+    instance, so nothing carries over. Worth pinning because storing it
+    would be the obvious optimisation and would break exactly this.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    FigureManager.get_maidr(fig)
+
+    assert not _render_catching_warnings(ax)
+    assert not _render_catching_warnings(ax), "the second render warned"


### PR DESCRIPTION
Takes option 4 from #530. The issue stays open — this does not stop the wrong chart, it stops it being **silent**, which is the part that matters most here.

## The window

The schema is read from the artists; the SVG is written from them afterwards. Anything that draws into the figure between those two points lands in one and not the other — a chart that shows something it never announces, or announces something it does not show.

The per-figure lock (#504, #531, #532) stops another *render* from doing that. It cannot stop the application itself, on a figure it still holds. Measured through the shipped Shiny renderer, with one session's render in flight and another session's render function drawing into a shared module-level figure:

```
B's SVG carries A's label = True      B's payload has it = False
```

3 of 3 runs, nothing raised. A sighted user sees the change; a screen-reader user is never told it exists; **every check that reads the payload passes**. That is the shape of bug this project exists to prevent, arriving through the door meant to prevent it.

## Reported, not repaired — deliberately

Re-reading the schema after the SVG would race the same way, and only the caller knows whether the figure was supposed to be still. So the warning names both remedies rather than guessing one:

> maidr: this figure was drawn into while it was being rendered, so the chart's SVG and the data maidr announces for it may not match. Finish plotting before rendering, or render a figure no other thread is using.

## The detector

A census of artist counts and axis labels per axes, taken either side of the render. It has to be cheap enough to take twice per render and only has to answer *did this change* — not what.

## Verification

`pytest 0 / ruff 0 / uv lock --check 0` — **2,466 passed, 14 skipped**.

Falsified in both directions:

| mutation | result |
|---|---|
| the check removed | 2 of the new tests fail, **3 runs of 3** |
| the census reduced to counts without labels | 1 fails, **3 of 3** |
| **false positives** | **0** occurrences across the whole suite |

The false-positive direction is what decides whether this can ship at all — a detector that reported the render's own work would fire on every chart, and a warning that always fires is one nobody reads. Beyond the zero-across-the-suite count there is an explicit silent-render test over six chart shapes, plus a colorbar: the one construction that adds an axes of its own, which is exactly what the census counts.

## A note on how it is tested

The mid-render case is driven from **inside `_get_svg`**, not by racing two threads. A race would make it a test of the scheduler — passing where the timing happened to land inside the window, and silently testing nothing where it did not. Mutating from inside the render puts the change exactly where a concurrent application would have to put it to go unnoticed, every time.

I also had to correct my own probe while measuring this: the first version set the same title on every trial, so after the first there was nothing to detect, and it reported 1 of 5 where the truth is 5 of 5. Distinct mutations per trial is the fix, and the test comment says so.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAVKCcEEugLbot6CcYU2f8)_