### PR TITLE
feat(core): read the histogram seaborn draws as an outline

### DIFF
--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
+from matplotlib.collections import PolyCollection
 from matplotlib.patches import StepPatch
 from maidr.core.enum import PlotType
 from maidr.core.plot.areaplot import AreaPlot
@@ -22,6 +23,7 @@ from maidr.core.plot.pointplot import PointPlot
 from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.regplot import SmoothPlot
 from maidr.core.plot.stairs import StairsPlot
+from maidr.core.plot.stepped_histogram import SteppedHistPlot
 from maidr.core.plot.stepplot import StepPlot
 from maidr.core.plot.violin_kde_plot import ViolinKdePlot
 from maidr.core.plot.violin_box_plot import ViolinBoxPlot
@@ -97,6 +99,11 @@ class MaidrPlotFactory:
             # find and no per-bin artist to look for.
             if isinstance(kwargs.get("step_patch"), StepPatch):
                 return StairsPlot(single_ax, **kwargs)
+            # `sns.histplot(element="step"/"poly")` draws the same
+            # distribution as one closed outline, so there is no container to
+            # find and the call hands its `PolyCollection` over instead.
+            if isinstance(kwargs.get("collection"), PolyCollection):
+                return SteppedHistPlot(single_ax, **kwargs)
             return HistPlot(single_ax)
         elif PlotType.LINE == plot_type:
             if PlotDetectionUtils.is_mplfinance_line_plot(single_ax, **kwargs):

--- a/maidr/core/plot/stepped_histogram.py
+++ b/maidr/core/plot/stepped_histogram.py
@@ -1,0 +1,344 @@
+"""SteppedHistPlot — the histogram seaborn draws as an outline instead of bars."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import PolyCollection
+
+from maidr.core.plot.histogram import HistPlot
+
+#: How far two bin widths may differ and still count as the same width.
+#:
+#: Relative, because the widths are data coordinates and a histogram of
+#: nanoseconds and one of light-years both have to pass. The tolerance exists
+#: at all because the widths come back through a float division of the axis
+#: range, so evenly spaced bins are equal to within rounding rather than
+#: exactly.
+_WIDTH_TOLERANCE = 1e-9
+
+
+class SteppedHistPlot(HistPlot):
+    """
+    A histogram drawn as one closed outline rather than as a row of bars.
+
+    ``sns.histplot(element="step")`` and ``element="poly"`` draw the same
+    distribution ``element="bars"`` does, as a single ``PolyCollection``
+    instead of a ``BarContainer``. That is the whole of why they were silent:
+    ``HistPlot`` looks a container up, seaborn's own patch asks whether the
+    call drew bars, and neither finds anything -- the third branch of the
+    decline #522 fixed for the bivariate mesh.
+
+    The two spellings differ in what the outline traces, and so in how much of
+    the reading is exact.
+
+    ``step`` traces the **bin edges**. Its ring walks the baseline left to
+    right, up the right-hand edge, and back along the tops, so every edge is
+    visited on the way out and every count is held on the way back. Both
+    halves are read off the drawing and nothing is reconstructed -- an empty
+    bin included: its edges are on both legs, and its count is sampled inside
+    it rather than taken from the flat run the return leg makes across it.
+
+    ``poly`` traces the **bin centres**, joining them with straight lines, and
+    the edges are not in the drawing at all. They are recovered from the
+    spacing, which is exact when the bins are even and impossible when they
+    are not: ``bins=[0, 1, 5, 10]`` gives centres 0.5, 3.0 and 7.5, and three
+    numbers whose gaps are 2.5 and 4.5 do not say where the boundaries were.
+    Such a chart is declined rather than announced with invented edges.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the distribution was drawn on.
+    collection : PolyCollection
+        The outline this call produced, handed over rather than searched for:
+        a ``hue`` draws one per series, and "the collection on this Axes"
+        would read the first series once per layer.
+    **kwargs : dict
+        Ignored; accepted so the factory can forward what it was given.
+    """
+
+    def __init__(self, ax: Axes, collection: PolyCollection, **kwargs) -> None:
+        self._collection = collection
+        super().__init__(ax)
+        # One `<path>` for the whole outline, as `Axes.stairs` has: there is no
+        # per-bin element for a selector to name, and one naming the outline
+        # would light the whole distribution up at every bin.
+        self._support_highlighting = False
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        Read one point per bin off the outline.
+
+        Returns
+        -------
+        list of dict
+            One point per bin, in ascending bin order. Empty when the outline
+            is not one this can read -- an uneven ``poly``, or a ring whose
+            vertex count does not match either shape.
+        """
+        horizontal = _runs_up_the_y_axis(self._collection)
+        if horizontal is None:
+            return []
+        self._orientation = "horz" if horizontal else "vert"
+
+        bins = _read_outline(self._collection, horizontal)
+        if bins is None:
+            return []
+
+        return [
+            self._bin_point(self._orientation, low, high - low, count)
+            for low, high, count in bins
+        ]
+
+
+def _runs_up_the_y_axis(collection: PolyCollection) -> bool | None:
+    """
+    Which way round the outline is, read off the drawing.
+
+    Asked of the geometry rather than of the caller's keywords, because
+    ``sns.histplot(y=...)``, ``sns.histplot(data=df, y="v")`` and a
+    ``displot`` panel are three spellings of one chart and only the drawing is
+    the same in all three.
+
+    The ring opens on the first bin's edge and steps straight to the baseline,
+    then walks along it -- so the second and third vertices share the baseline
+    coordinate and differ in the other. That is the coordinate the bins run
+    along.
+
+    Parameters
+    ----------
+    collection : PolyCollection
+        The outline seaborn drew.
+
+    Returns
+    -------
+    bool or None
+        True when the bins run up y, False when they run along x, and None
+        when the ring is too short or too degenerate to say.
+    """
+    paths = collection.get_paths()
+    if len(paths) != 1:
+        return None
+    vertices = np.asarray(paths[0].vertices, dtype=float)
+    if len(vertices) < 3 or not np.all(np.isfinite(vertices[:3])):
+        return None
+
+    first, second = vertices[1], vertices[2]
+    if first[1] == second[1] and first[0] != second[0]:
+        return False
+    if first[0] == second[0] and first[1] != second[1]:
+        return True
+    return None
+
+
+def _read_outline(
+    collection: PolyCollection, horizontal: bool
+) -> list[tuple[float, float, float]] | None:
+    """
+    Recover ``(low edge, high edge, count)`` for every bin of one outline.
+
+    Parameters
+    ----------
+    collection : PolyCollection
+        The outline seaborn drew.
+    horizontal : bool
+        Whether the bins run up the y axis.
+
+    Returns
+    -------
+    list of tuple, or None
+        The bins in ascending order, or None when the outline cannot be read.
+
+    Notes
+    -----
+    The vertex count narrows the shape but does not settle it: measured across
+    one to eight bins a ``step`` ring holds ``4k + 5`` vertices and a ``poly``
+    ring ``2k + 3``, and those collide at nine -- one bin stepped, three
+    binned as a polygon. Read as the wrong one, an uneven three-bin ``poly``
+    came back as a single bin spanning the first two, with the third gone.
+
+    What separates them is how many distinct positions the ring visits along
+    the binned axis: a step ring walks every **edge**, so ``k + 1`` of them,
+    while a poly ring visits every **centre**, so ``k``. The two counts agree
+    only at five vertices, which is below the step shape's own minimum -- so
+    asking both and taking the one that matches is decisive rather than a
+    tie-break.
+    """
+    paths = collection.get_paths()
+    if len(paths) != 1:
+        return None
+
+    vertices = np.asarray(paths[0].vertices, dtype=float)
+    if not np.all(np.isfinite(vertices)):
+        return None
+
+    # The bins run along one axis and the counts along the other; a horizontal
+    # histogram is the same ring with the two swapped.
+    along = vertices[:, 1] if horizontal else vertices[:, 0]
+    across = vertices[:, 0] if horizontal else vertices[:, 1]
+
+    total = len(vertices)
+    positions = len({float(value) for value in along})
+
+    if total >= 9 and (total - 5) % 4 == 0:
+        bins = (total - 5) // 4
+        if positions == bins + 1:
+            return _read_step(along, across, bins)
+    if total >= 5 and (total - 3) % 2 == 0:
+        bins = (total - 3) // 2
+        if positions == bins:
+            return _read_poly(along, across, bins)
+    return None
+
+
+def _read_step(along: np.ndarray, across: np.ndarray, bins: int) -> list | None:
+    """
+    Read a ``step`` outline, whose ring walks every bin edge.
+
+    Parameters
+    ----------
+    along : ndarray
+        The coordinate the bins run along, per vertex.
+    across : ndarray
+        The coordinate the counts run along, per vertex.
+    bins : int
+        How many bins the vertex count says there are.
+
+    Returns
+    -------
+    list of tuple, or None
+        The bins, or None when the outward leg does not give ``bins + 1``
+        distinct edges.
+    """
+    # The outward leg is the baseline walk, taken here because that is what it
+    # is: the list of edges, in order, before any count is involved.
+    #
+    # Not because the return leg would lose one. It would not -- the ring is
+    # closed, so both legs cross the full width and both visit every edge,
+    # including the edges of a bin nothing landed in. Reading the edges off
+    # the return leg instead gives the same answer on every chart here, which
+    # is worth saying rather than leaving as an implied reason: what the
+    # return leg cannot do is tell a run of empty bins apart by *height*,
+    # since it runs flat across them, and that is why the counts below are
+    # sampled per bin rather than read off its corners.
+    edges = _distinct(along[1 : 2 * bins + 1])
+    if len(edges) != bins + 1:
+        return None
+
+    # Read back left to right, the return leg is the staircase itself: a step
+    # function whose value over a bin is that bin's count. Sampling it at the
+    # midpoint asks the one question that has a single answer, whatever the
+    # ring repeats at the corners.
+    walk = list(zip(along[2 * bins + 2 :][::-1], across[2 * bins + 2 :][::-1]))
+    if not walk:
+        return None
+
+    out = []
+    for index in range(bins):
+        low, high = edges[index], edges[index + 1]
+        middle = (low + high) / 2
+        held = [value for position, value in walk if position <= middle]
+        if not held:
+            return None
+        out.append((low, high, float(held[-1])))
+    return out
+
+
+def _read_poly(along: np.ndarray, across: np.ndarray, bins: int) -> list | None:
+    """
+    Read a ``poly`` outline, whose ring joins the bin centres.
+
+    Parameters
+    ----------
+    along : ndarray
+        The coordinate the bins run along, per vertex.
+    across : ndarray
+        The coordinate the counts run along, per vertex.
+    bins : int
+        How many bins the vertex count says there are.
+
+    Returns
+    -------
+    list of tuple, or None
+        The bins, or None when the edges cannot be recovered -- a single bin,
+        which has no spacing, or uneven bins, whose boundaries the centres do
+        not determine.
+    """
+    if bins < 2:
+        return None
+
+    # The tops are the last leg of the ring, right to left, before the vertex
+    # that closes it.
+    centres = along[bins + 2 : 2 * bins + 2][::-1]
+    counts = across[bins + 2 : 2 * bins + 2][::-1]
+    if len(centres) != bins:
+        return None
+
+    widths = np.diff(centres)
+    if len(widths) == 0 or not np.all(np.isfinite(widths)):
+        return None
+    width = float(widths[0])
+    if width <= 0:
+        return None
+    if any(abs(other - width) > _WIDTH_TOLERANCE * max(abs(width), 1.0)
+           for other in widths):
+        return None
+
+    half = width / 2
+    return [
+        (float(centre) - half, float(centre) + half, float(count))
+        for centre, count in zip(centres, counts)
+    ]
+
+
+def _distinct(values: np.ndarray) -> list[float]:
+    """
+    Consecutive duplicates removed, order kept.
+
+    Parameters
+    ----------
+    values : ndarray
+        The coordinates of one leg of the ring.
+
+    Returns
+    -------
+    list of float
+        The distinct values, in the order walked.
+    """
+    out: list[float] = []
+    for value in values:
+        number = float(value)
+        if not math.isfinite(number):
+            continue
+        if not out or out[-1] != number:
+            out.append(number)
+    return out
+
+
+def reads(collection: PolyCollection) -> bool:
+    """
+    Whether an outline is one this can read, asked before a layer exists.
+
+    An outline it cannot read -- an uneven ``poly``, whose centres do not say
+    where the boundaries were -- must not become a layer at all. Registered
+    anyway it is an empty row the core has to navigate into and cannot
+    announce, which is the phantom-layer shape of #421, and the reading's own
+    refusal would arrive too late to prevent it.
+
+    Parameters
+    ----------
+    collection : PolyCollection
+        The outline seaborn drew.
+
+    Returns
+    -------
+    bool
+        True when the bins and their counts come back off the drawing.
+    """
+    horizontal = _runs_up_the_y_axis(collection)
+    if horizontal is None:
+        return False
+    return bool(_read_outline(collection, horizontal))

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -159,6 +159,30 @@ def _meshes_of(ax: Axes | None) -> list:
     ]
 
 
+#: The exact types a stepped or filled histogram outline arrives as.
+#:
+#: seaborn draws ``element="step"`` and ``element="poly"`` through
+#: ``Axes.fill_between``, and matplotlib 3.10 gave that method a
+#: ``PolyCollection`` subclass of its own. So the same chart is a plain
+#: ``PolyCollection`` on 3.9 and a ``FillBetweenPolyCollection`` on 3.10 and
+#: later -- measured, identically shaped either way: five bins give 25
+#: vertices as a step and 13 as a polygon on both.
+#:
+#: Named as exact types rather than matched with ``isinstance(artist,
+#: PolyCollection)``, because the *other* subclasses are other charts:
+#: ``PolyQuadMesh`` is a heatmap and has its own reading, and ``Quiver`` and
+#: ``Barbs`` are vector fields that a histogram reader would announce as a
+#: distribution over nothing.
+_OUTLINE_TYPES: tuple[type, ...] = (PolyCollection,)
+
+try:  # pragma: no cover - depends on the installed matplotlib
+    from matplotlib.collections import FillBetweenPolyCollection
+
+    _OUTLINE_TYPES += (FillBetweenPolyCollection,)
+except ImportError:
+    pass
+
+
 def _outlines_of(ax: Axes | None) -> list:
     """
     The closed outlines already on an axes.
@@ -184,7 +208,7 @@ def _outlines_of(ax: Axes | None) -> list:
     return [
         artist
         for artist in (getattr(ax, "collections", ()) or ())
-        if type(artist) is PolyCollection
+        if type(artist) in _OUTLINE_TYPES
     ]
 
 

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -6,7 +6,7 @@ import wrapt
 
 import numpy as np
 from matplotlib.axes import Axes
-from matplotlib.collections import PolyQuadMesh, QuadMesh
+from matplotlib.collections import PolyCollection, PolyQuadMesh, QuadMesh
 from matplotlib.container import BarContainer
 from matplotlib.patches import Polygon
 from matplotlib.lines import Line2D
@@ -15,6 +15,7 @@ import uuid
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.stepped_histogram import reads as _reads_outline
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
 
 
@@ -158,6 +159,75 @@ def _meshes_of(ax: Axes | None) -> list:
     ]
 
 
+def _outlines_of(ax: Axes | None) -> list:
+    """
+    The closed outlines already on an axes.
+
+    ``PolyCollection`` is what ``element="step"`` and ``element="poly"`` draw
+    a histogram as, and what a violin, a `fill_between` band and a hexbin
+    lattice are drawn as too -- which is exactly why the comparison below is
+    against what *this call* added rather than against everything present.
+
+    Held as the artists themselves rather than as their ids, for the reason
+    ``_containers_of`` gives.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes to look at, or None when it does not exist yet.
+
+    Returns
+    -------
+    list
+        The outlines on it, in draw order.
+    """
+    return [
+        artist
+        for artist in (getattr(ax, "collections", ()) or ())
+        if type(artist) is PolyCollection
+    ]
+
+
+def _drew_outlines(ax: Axes | None, before: list) -> list:
+    """
+    The outlines *this call* added, if any.
+
+    ``sns.histplot(element="step")`` and ``element="poly"`` draw the same
+    distribution ``element="bars"`` does, as one closed outline per series
+    rather than as a row of bars. Neither ``_drew_bars`` nor ``_drew_mesh``
+    sees one, so the call declined and the chart went out silent -- the third
+    branch of the decline #522 fixed for the bivariate mesh, and measured::
+
+        element=bars   containers=[BarContainer]     -> ['hist']
+        element=step   collections=[PolyCollection]  -> nothing
+        element=poly   collections=[PolyCollection]  -> nothing
+
+    One outline per series, so a ``hue`` gives one layer per level: each is an
+    independent histogram over the same bins, which is what `hist` describes.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes the call drew on.
+    before : list
+        The outlines that were on it beforehand.
+
+    Returns
+    -------
+    list
+        The outlines this call added *and* can read, in draw order. An uneven
+        ``poly`` is left out here rather than registered and then refused: a
+        layer whose data comes back empty is a row the core has to navigate
+        into and cannot announce (#421).
+    """
+    seen = {id(outline) for outline in before}
+    return [
+        outline
+        for outline in _outlines_of(ax)
+        if id(outline) not in seen and _reads_outline(outline)
+    ]
+
+
 def _drew_mesh(ax: Axes | None, before: list) -> bool:
     """
     Whether *this call* drew a mesh of joint counts.
@@ -196,6 +266,7 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     prospective = prospective_axes(kwargs)
     before = _containers_of(prospective)
     meshes = _meshes_of(prospective)
+    outlines = _outlines_of(prospective)
 
     with ContextManager.set_internal_context():
         drawn = _draw_quietly(wrapped, args, kwargs)
@@ -214,6 +285,13 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
         # context -- which is what made the same figure readable through one
         # spelling and silent through the other (#522).
         axes = FigureManager.get_axes(drawn)
+        drew = _drew_outlines(axes, outlines)
+        if drew:
+            # `element="step"` / `"poly"`: the same distribution drawn as one
+            # closed outline per series instead of a row of bars.
+            for outline in drew:
+                FigureManager.create_maidr(axes, PlotType.HIST, collection=outline)
+            return drawn
         if _drew_mesh(axes, meshes):
             # Named from `stat` rather than hardcoded, because it is what the
             # cells actually hold: the default is a count, but

--- a/tests/core/test_stepped_histogram.py
+++ b/tests/core/test_stepped_histogram.py
@@ -1,0 +1,217 @@
+"""`sns.histplot(element="step")` draws a histogram, and it was read as nothing.
+
+`element="bars"` leaves a `BarContainer` and reads as `hist`. `element="step"`
+and `element="poly"` draw the *same distribution* as a single closed
+`PolyCollection` outline, so `HistPlot`'s container lookup finds nothing and
+`_drew_bars` answers no -- the third branch of the decline #522 fixed for the
+bivariate mesh, measured::
+
+    element=bars   containers=[BarContainer]     -> ['hist']
+    element=step   collections=[PolyCollection]  -> nothing
+    element=poly   collections=[PolyCollection]  -> nothing
+
+The two spellings differ in how much of the reading is exact.
+
+**`step` traces the bin edges.** Its ring walks the baseline left to right, up
+the right-hand edge and back along the tops, so every edge is visited going out
+and every count is held coming back. An empty bin survives that: the outward
+leg still walks through it, where the return leg runs flat across a whole run
+of them and could not tell one wide gap from two narrow ones.
+
+**`poly` traces the bin centres**, and the edges are not in the drawing at all.
+They come back from the spacing, which is exact when the bins are even and
+impossible when they are not -- `bins=[0, 1, 5, 10]` gives centres 0.5, 3.0 and
+7.5, and gaps of 2.5 and 4.5 do not say where the boundaries were.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.exception import UnsupportedPlotError  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+#: A sample with no ties, so the counts are lopsided and a transposed or
+#: mis-paired reading cannot pass by symmetry.
+SAMPLE = np.random.default_rng(0).normal(size=200)
+
+#: Ten at one end and twenty at the other, so the two middle bins are empty.
+GAPPED = np.concatenate([np.full(10, 0.1), np.full(20, 3.9)])
+
+#: Author-set thresholds, so the bins are not evenly spaced.
+UNEVEN = np.concatenate([np.full(5, 0.5), np.full(9, 2.5), np.full(3, 7.0)])
+
+
+def _layers(fig):
+    """The layers registered for a figure, or an empty list when there are none."""
+    try:
+        return FigureManager.get_maidr(fig).plots
+    except UnsupportedPlotError:
+        return []
+
+
+def _flat(bins):
+    """The bins as one flat list, which is what ``approx`` compares cleanly."""
+    return [value for triple in bins for value in triple]
+
+
+def _vertical_bins(fig, index: int = 0):
+    return [
+        (point["xMin"], point["xMax"], point["y"])
+        for point in _layers(fig)[index].schema[MaidrKey.DATA]
+    ]
+
+
+def _horizontal_bins(fig, index: int = 0):
+    return [
+        (point["yMin"], point["yMax"], point["x"])
+        for point in _layers(fig)[index].schema[MaidrKey.DATA]
+    ]
+
+
+def _drawn(sample, element: str, **kwargs):
+    fig, ax = plt.subplots()
+    sns.histplot(x=sample, element=element, ax=ax, **kwargs)
+    return fig
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+def test_an_outlined_histogram_is_read_at_all(element: str):
+    fig = _drawn(SAMPLE, element, bins=4)
+
+    assert [layer.type for layer in _layers(fig)] == [PlotType.HIST]
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+def test_an_outline_and_the_bars_describe_the_same_distribution(element: str):
+    # The point of the change: the same data drawn three ways has to come back
+    # as one reading, not three that resemble each other.
+    outlined = _drawn(SAMPLE, element, bins=4)
+    barred = _drawn(SAMPLE, "bars", bins=4)
+
+    assert _vertical_bins(outlined) == _vertical_bins(barred)
+
+
+def test_a_step_outline_keeps_the_bins_nothing_landed_in():
+    # The return leg runs flat across the two empty bins and could not tell
+    # one wide gap from two narrow ones. The outward leg walks every edge, so
+    # the bins survive -- and a reader sweeping the distribution hears the two
+    # zeroes rather than a hole.
+    fig = _drawn(GAPPED, "step", bins=4)
+
+    # `approx`, because the edges are the drawing's own floats: seaborn
+    # divides the range and matplotlib writes what that division gave, so 0.1
+    # arrives as 0.10000000000000003. Rounding them here would assert a
+    # tidiness the chart does not have.
+    assert _flat(_vertical_bins(fig)) == pytest.approx(
+        [0.1, 1.05, 10.0, 1.05, 2.0, 0.0, 2.0, 2.95, 0.0, 2.95, 3.9, 20.0]
+    )
+
+
+def test_a_step_outline_reads_author_set_thresholds():
+    # The edges are walked rather than reconstructed, so bins that are not
+    # evenly spaced come back exactly.
+    fig = _drawn(UNEVEN, "step", bins=[0, 1, 5, 10])
+
+    assert _flat(_vertical_bins(fig)) == pytest.approx(
+        [0.0, 1.0, 5.0, 1.0, 5.0, 9.0, 5.0, 10.0, 3.0]
+    )
+
+
+def test_a_poly_outline_with_uneven_bins_is_declined():
+    # Its centres are 0.5, 3.0 and 7.5, and gaps of 2.5 and 4.5 do not say
+    # where the boundaries were. Declined *before* a layer exists, so the
+    # chart falls back rather than carrying an empty row (#421).
+    fig = _drawn(UNEVEN, "poly", bins=[0, 1, 5, 10])
+
+    assert _layers(fig) == []
+
+
+def test_a_horizontal_outline_runs_its_bins_up_the_y_axis():
+    fig, ax = plt.subplots()
+    sns.histplot(y=SAMPLE, element="step", ax=ax, bins=3)
+
+    schema = _layers(fig)[0].schema
+    assert schema[MaidrKey.ORIENTATION] == "horz"
+    # And it is the same distribution the bars give the other way round.
+    barred = plt.subplots()
+    sns.histplot(y=SAMPLE, element="bars", ax=barred[1], bins=3)
+    assert _horizontal_bins(fig) == _horizontal_bins(barred[0])
+
+
+def test_each_hue_level_is_its_own_histogram():
+    # One outline per series, each an independent count over the same bins,
+    # which is what `hist` describes. "The collection on this Axes" would read
+    # the first series once per layer.
+    rng = np.random.default_rng(1)
+    groups = np.where(rng.random(len(SAMPLE)) < 0.5, "a", "b")
+    fig, ax = plt.subplots()
+    sns.histplot(x=SAMPLE, hue=groups, element="step", ax=ax, bins=3)
+
+    layers = _layers(fig)
+    assert [layer.type for layer in layers] == [PlotType.HIST, PlotType.HIST]
+    counts = [[low_high_count[2] for low_high_count in _vertical_bins(fig, i)]
+              for i in range(2)]
+    assert counts[0] != counts[1]
+    # Together they account for every observation.
+    assert sum(counts[0]) + sum(counts[1]) == len(SAMPLE)
+
+
+def test_a_one_bin_step_is_not_mistaken_for_a_three_bin_polygon():
+    # Their rings are the same length -- 4k+5 and 2k+3 collide at nine -- so
+    # the vertex count alone is not decisive. What separates them is how many
+    # distinct positions the ring visits along the binned axis: a step walks
+    # every edge, a poly visits every centre.
+    fig = _drawn(SAMPLE, "step", bins=1)
+
+    bins = _vertical_bins(fig)
+
+    assert len(bins) == 1
+    # One bin holds everything, and it spans the whole sample.
+    low, high, count = bins[0]
+    assert count == float(len(SAMPLE))
+    assert low == pytest.approx(SAMPLE.min())
+    assert high == pytest.approx(SAMPLE.max())
+
+
+def test_a_three_bin_polygon_is_not_mistaken_for_a_one_bin_step():
+    fig = _drawn(SAMPLE, "poly", bins=3)
+
+    assert len(_vertical_bins(fig)) == 3
+    assert sum(count for _, _, count in _vertical_bins(fig)) == float(len(SAMPLE))
+
+
+def test_an_outlined_histogram_announces_its_bins_but_highlights_none():
+    # One `<path>` for the whole outline, as `Axes.stairs` has. A selector
+    # matching it would light the entire distribution up at every bin, which
+    # tells a low-vision reader nothing about where they are.
+    fig = _drawn(SAMPLE, "step", bins=4)
+
+    schema = _layers(fig)[0].schema
+    assert len(schema[MaidrKey.DATA]) == 4
+    assert MaidrKey.SELECTOR not in schema
+
+
+def test_bars_still_read_through_the_container_they_always_did():
+    fig = _drawn(SAMPLE, "bars", bins=4)
+
+    assert [layer.type for layer in _layers(fig)] == [PlotType.HIST]
+    assert len(_vertical_bins(fig)) == 4

--- a/tests/core/test_stepped_histogram.py
+++ b/tests/core/test_stepped_histogram.py
@@ -40,6 +40,7 @@ from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 from maidr.exception import UnsupportedPlotError  # noqa: E402
+from maidr.patch import histogram as patch_histogram  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -94,6 +95,7 @@ def _drawn(sample, element: str, **kwargs):
 
 
 @pytest.mark.parametrize("element", ["step", "poly"])
+
 def test_an_outlined_histogram_is_read_at_all(element: str):
     fig = _drawn(SAMPLE, element, bins=4)
 
@@ -215,3 +217,32 @@ def test_bars_still_read_through_the_container_they_always_did():
 
     assert [layer.type for layer in _layers(fig)] == [PlotType.HIST]
     assert len(_vertical_bins(fig)) == 4
+
+
+def test_the_artist_fill_between_returns_is_one_this_reads():
+    """
+    Whatever ``fill_between`` draws on *this* matplotlib is an outline here.
+
+    This is the guard that was missing, and the one that would have caught
+    #543 before it shipped rather than in CI. seaborn draws
+    ``element="step"`` and ``element="poly"`` through ``Axes.fill_between``,
+    and matplotlib 3.10 gave that method a ``PolyCollection`` subclass of its
+    own -- so the reader's exact-type check saw a plain ``PolyCollection`` on
+    3.9 and nothing at all on 3.10 and later. Every test in this file passed
+    on the development interpreter and eleven of them failed on the other
+    three.
+
+    Asked of the artist matplotlib actually returns rather than of a version
+    number, so it keeps holding when the next release renames the class
+    again. Nothing here goes through seaborn: the point is what the *drawing
+    primitive* returns, and a seaborn-shaped test would fail for a dozen
+    other reasons first.
+    """
+    fig, ax = plt.subplots()
+    band = ax.fill_between([0.0, 1.0, 2.0], [0.0, 0.0, 0.0], [1.0, 2.0, 1.0])
+    plt.close(fig)
+
+    assert type(band) in patch_histogram._OUTLINE_TYPES, (
+        f"fill_between returns {type(band).__name__}, which the outline "
+        "reader does not recognise, so a stepped histogram reads as nothing"
+    )


### PR DESCRIPTION
Closes #542 — the gap #535 and #540 both recorded as found-alongside.

| call | before | now |
|---|---|---|
| `sns.histplot(x=v, element="bars")` | `['hist']` | `['hist']` |
| `sns.histplot(x=v, element="step")` | `UnsupportedPlotError` | `['hist']` |
| `sns.histplot(x=v, element="poly")` | `UnsupportedPlotError` | `['hist']` |

Three spellings of one distribution. seaborn draws the outlined two as a single closed `PolyCollection` instead of a `BarContainer`, so `HistPlot` looks a container up and finds nothing and `sns_hist`'s `_drew_bars` answers no — the third branch of the decline #522 fixed for the bivariate mesh, after #540's contour set.

## The reading, and how exact each spelling is

**`step` traces the bin edges.** Its ring walks the baseline left to right, up the right-hand edge and back along the tops, so every edge is visited and every count is held. Against `element="bars"` on the same sample the payloads are **identical**, and author-set thresholds come back exactly because the edges are walked rather than reconstructed:

```
bins=[0, 1, 5, 10]  →  (0.0, 1.0, 5.0)  (1.0, 5.0, 9.0)  (5.0, 10.0, 3.0)
```

**`poly` traces the bin centres**, and the edges are not in the drawing at all. They come back from the spacing when the bins are even — and cannot when they are not: `bins=[0, 1, 5, 10]` gives centres 0.5, 3.0 and 7.5, and gaps of 2.5 and 4.5 do not say where the boundaries were. Such a chart is declined **before a layer exists**, so it falls back rather than carrying a row that announces nothing (#421's shape).

## Three things the drawing forced

**An empty bin.** Ten observations at one end, twenty at the other, four bins: the return leg runs flat across the two empty ones. Counts are therefore sampled *inside* each bin rather than read off where the staircase turns, and all four bins survive — a reader sweeping the distribution hears the two zeroes rather than a hole.

**Orientation, read off the drawing.** `sns.histplot(y=...)` draws the same ring transposed, and the second and third vertices share the baseline coordinate whichever way round it is. Asked of the geometry rather than the keywords, because `y=`, `data=df, y="v"` and a `displot` panel are three spellings and only the drawing is the same in all three.

**The vertex count narrows the shape but does not settle it.** Measured across one to eight bins, a `step` ring holds `4k + 5` vertices and a `poly` ring `2k + 3` — and those collide at nine, one bin stepped against three binned as a polygon. My first version used the count alone, and the uneven three-bin `poly` above came back as **a single bin spanning the first two, with the third gone**. What separates them is how many distinct positions the ring visits along the binned axis: a step walks every **edge** (`k + 1`), a poly visits every **centre** (`k`). The two counts agree only at five vertices, which is below the step shape's own minimum, so asking both and taking the match is decisive rather than a tie-break.

## `hue` and highlighting

One outline per series, so a hue'd chart is several independent histograms over the same bins — one `hist` layer each, and together they account for every observation. The layer emits **no selectors**: one `<path>` covers the whole outline, as `Axes.stairs` has (#536), so a selector matching it would light the entire distribution up at every bin.

## Verification

`pytest 0 / ruff 0` — 2,482 passed, 18 skipped, up from 2,473. Every file added or touched is `ruff`-clean; the 6 repo-wide findings are the pre-existing `__init__.py` re-export warnings.

Every guard falsified by applying each mutation alone:

| mutation | result |
|---|---|
| the patch never registers an outline | 11 of 13 failed |
| the shape settled by the vertex count alone | 2 failed |
| the even-spacing guard on `poly` dropped | 1 failed |
| orientation always vertical | 1 failed |
| `_support_highlighting` left on | 1 failed |
| only the first outline of a `hue` registers | 1 failed |

**One mutation passed, and it corrected a claim rather than adding a test.** Reading the edges off the *return* leg instead of the outward one left every test green — including the empty-bin case, which I had written the comment as being the reason for the choice. It is not: the ring is closed, so both legs cross the full width and both visit every edge, empty bins included. What the return leg genuinely cannot do is tell a run of empty bins apart by *height*, which is why the counts are sampled per bin. The comment now says that instead of implying a difference no fixture can show.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_