### PR TITLE
fix(core): name a heatmap's cells from the grid, not from its axis ticks

### DIFF
--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import numpy as np
 import numpy.ma as ma
 from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
 from matplotlib.collections import PolyQuadMesh, QuadMesh
+from matplotlib.image import AxesImage
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
@@ -51,11 +53,141 @@ class HeatPlot(
         if data is None:
             raise ExtractionError(self.type, plot)
 
+        rows = len(data)
+        cols = len(data[0]) if rows else 0
+
         return {
             MaidrKey.POINTS: data,
-            MaidrKey.X: self.extract_level(self.ax, MaidrKey.X),
-            MaidrKey.Y: self.extract_level(self.ax, MaidrKey.Y),
+            MaidrKey.X: self._cell_names(plot, MaidrKey.X, cols),
+            MaidrKey.Y: self._cell_names(plot, MaidrKey.Y, rows),
         }
+
+    def _cell_names(
+        self, sm: ScalarMappable | None, key: MaidrKey, count: int
+    ) -> list[str] | None:
+        """
+        What each column or row of the grid is called.
+
+        The axis ticks are the answer when they *are* the cells, which is the
+        case a categorical heatmap draws: ``sns.heatmap`` puts one fixed tick
+        at the centre of every cell and labels it, so the axis already names
+        the grid.
+
+        On a numeric axis they are not. A tick locator chooses positions that
+        look tidy on an axis, with no relation to where the cells fall, and
+        there are usually more of them: measured on matplotlib 3.9.4, a 2 x 3
+        ``ax.hist2d(a, b, bins=(3, 2))`` produced nine x labels and seven y
+        labels. Nothing raises and the values are right, so a reader moving
+        to the second of three columns hears a number off the locator and has
+        no way to tell it is somebody else's coordinate (#526).
+
+        So the ticks are checked against the cells rather than assumed to be
+        them, and the artist is asked when they disagree. Every one of these
+        artists knows its own boundaries -- a mesh carries them as its
+        coordinates, an image as its extent.
+
+        A cell is named by its **centre**, not by the range it covers. That
+        follows ``HexbinPoint``, which carries a bin's centre for the same
+        reason: the grammar has one label per column, the label is announced
+        on every move of the cursor, and a range doubles the length of an
+        announcement to say something consecutive centres already give -- the
+        spacing between them *is* the cell width.
+
+        Parameters
+        ----------
+        sm : ScalarMappable or None
+            The artist that drew the grid.
+        key : MaidrKey
+            Which axis, ``X`` or ``Y``.
+        count : int
+            How many cells the grid has along that axis.
+
+        Returns
+        -------
+        list of str or None
+            One name per cell, or whatever the axis gave when the cells
+            cannot be located.
+        """
+        ticks = self.extract_level(self.ax, key)
+        centres = self._cell_centres(sm, key, count)
+        if centres is None:
+            return ticks
+
+        at = self.extract_level_positions(self.ax, key)
+        if (
+            ticks is not None
+            and at is not None
+            and len(ticks) == len(centres)
+            and all(
+                np.isclose(position, centre)
+                for position, centre in zip(at, centres)
+            )
+        ):
+            return ticks
+
+        # Six significant figures, and deliberately not `self._fmt`: that is
+        # the caller's format for the cell *values* -- what `sns.heatmap`
+        # annotates a cell with -- and a coordinate is not one of those. Six
+        # separates adjacent cells in any grid a reader can navigate and is
+        # short enough to be said on every move.
+        return [f"{centre:.6g}" for centre in centres]
+
+    @staticmethod
+    def _cell_centres(
+        sm: ScalarMappable | None, key: MaidrKey, count: int
+    ) -> list[float] | None:
+        """
+        Where the grid's cells sit along one axis, in the order they are read.
+
+        Read from the artist rather than the axis, and in the order the
+        emitted rows are already in, so the names pair with the values
+        without reordering either. Which end row 0 is at is the artist's
+        answer too: an image's ``origin`` decides it, and ``get_extent()``
+        reports the two ends in a fixed order rather than in that one.
+
+        Parameters
+        ----------
+        sm : ScalarMappable or None
+            The artist that drew the grid.
+        key : MaidrKey
+            Which axis, ``X`` or ``Y``.
+        count : int
+            How many cells the grid has along that axis.
+
+        Returns
+        -------
+        list of float or None
+            One centre per cell, or ``None`` when the artist does not say.
+        """
+        if count <= 0:
+            return None
+
+        if isinstance(sm, (QuadMesh, PolyQuadMesh)):
+            coordinates = np.asarray(ma.getdata(sm.get_coordinates()))
+            if coordinates.ndim != 3:
+                return None
+            edges = (
+                coordinates[0, :, 0] if key == MaidrKey.X else coordinates[:, 0, 1]
+            )
+        elif isinstance(sm, AxesImage):
+            left, right, bottom, top = (float(edge) for edge in sm.get_extent())
+            if key == MaidrKey.X:
+                edges = np.linspace(left, right, count + 1)
+            else:
+                # `get_extent()` names its ends bottom-then-top whichever way
+                # up the image is drawn, so which of them row 0 sits against
+                # comes from `origin` and not from their order. Measured on a
+                # 2 x 3: `origin="upper"` gives (-0.5, 2.5, 1.5, -0.5) and
+                # `origin="lower"` gives (-0.5, 2.5, -0.5, 1.5), and row 0 is
+                # at -0.5 in both.
+                first, last = (bottom, top) if sm.origin == "lower" else (top, bottom)
+                edges = np.linspace(first, last, count + 1)
+        else:
+            return None
+
+        if len(edges) != count + 1:
+            return None
+        return [float((edges[i] + edges[i + 1]) / 2) for i in range(count)]
 
     def _extract_scalar_mappable_data(
         self, sm: ScalarMappable | None

--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -229,6 +229,15 @@ class HeatPlot(
         else:
             return None
 
+        # One coordinate per cell rather than one per boundary is what
+        # `shading="gouraud"` gives: the values sit *at* the coordinates
+        # instead of filling the quads between them, so each coordinate is
+        # already a cell's position and there is no midpoint to take.
+        # Measured on a 2 x 3:
+        # `pcolormesh(z, shading="gouraud")` returns coordinates of shape
+        # (2, 3, 2) against the flat-shaded (3, 4, 2).
+        if len(edges) == count:
+            return [float(edge) for edge in edges]
         if len(edges) != count + 1:
             return None
         return [float((edges[i] + edges[i + 1]) / 2) for i in range(count)]

--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -114,10 +114,14 @@ class HeatPlot(
             return ticks
 
         at = self.extract_level_positions(self.ax, key)
+        # Both lengths, not just the labels': `zip` stops at the shorter of
+        # its arguments, so a positions list shorter than the cells would
+        # leave the tail of the comparison unmade and pass on a prefix.
         if (
             ticks is not None
             and at is not None
             and len(ticks) == len(centres)
+            and len(at) == len(centres)
             and all(
                 np.isclose(position, centre)
                 for position, centre in zip(at, centres)
@@ -125,12 +129,41 @@ class HeatPlot(
         ):
             return ticks
 
-        # Six significant figures, and deliberately not `self._fmt`: that is
-        # the caller's format for the cell *values* -- what `sns.heatmap`
-        # annotates a cell with -- and a coordinate is not one of those. Six
-        # separates adjacent cells in any grid a reader can navigate and is
-        # short enough to be said on every move.
-        return [f"{centre:.6g}" for centre in centres]
+        return self._as_names(centres)
+
+    @staticmethod
+    def _as_names(centres: list[float]) -> list[str]:
+        """
+        Write the centres out at the shortest precision that keeps them apart.
+
+        Six significant figures to begin with, and deliberately not
+        ``self._fmt``: that is the caller's format for the cell *values* --
+        what ``sns.heatmap`` annotates a cell with -- and a coordinate is not
+        one of those. Six is short enough to be said on every move of the
+        cursor and separates the cells of any ordinary grid.
+
+        Not of every grid, though. Cells a millionth of their own magnitude
+        apart -- centres around 1e9 spaced by 1 -- all round to the same six
+        figures, and two cells with one name are worse than a long one: a
+        reader moving between them is told they have not moved. So the
+        precision is raised until the names differ, rather than assumed to be
+        enough.
+
+        Parameters
+        ----------
+        centres : list of float
+            One centre per cell.
+
+        Returns
+        -------
+        list of str
+            One name per cell, distinct wherever the centres are.
+        """
+        for precision in (6, 12, 17):
+            names = [f"{centre:.{precision}g}" for centre in centres]
+            if len(set(names)) == len(set(centres)):
+                return names
+        return names
 
     @staticmethod
     def _cell_centres(
@@ -166,9 +199,20 @@ class HeatPlot(
             coordinates = np.asarray(ma.getdata(sm.get_coordinates()))
             if coordinates.ndim != 3:
                 return None
-            edges = (
-                coordinates[0, :, 0] if key == MaidrKey.X else coordinates[:, 0, 1]
-            )
+            # Row 0's x and column 0's y stand for the whole grid only when
+            # the mesh is axis-aligned. `pcolormesh(X, Y, Z)` accepts a
+            # curvilinear one, and a sheared 2 x 3 measured as x edges of
+            # [0, 1, 2, 3] on row 0 and [0.3, 1.3, 2.3, 3.3] on row 1 -- a
+            # grid whose columns do not share an x, and so has no one name
+            # per column. Say so by declining rather than by naming every
+            # column after the row that happens to be first.
+            xs, ys = coordinates[:, :, 0], coordinates[:, :, 1]
+            if not (
+                np.allclose(xs, xs[0, :], equal_nan=True)
+                and np.allclose(ys, ys[:, :1], equal_nan=True)
+            ):
+                return None
+            edges = xs[0, :] if key == MaidrKey.X else ys[:, 0]
         elif isinstance(sm, AxesImage):
             left, right, bottom, top = (float(edge) for edge in sm.get_extent())
             if key == MaidrKey.X:

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -61,9 +61,17 @@ class LevelExtractorMixin:
 
         A caller that has its own idea of what the axis positions mean -- a
         heatmap, which knows where its own cells sit -- can only check the
-        ticks against it by knowing where they are. Kept beside
-        ``extract_level`` and filtered by the same rule, so the two answers
-        stay index-aligned however that rule changes (#526).
+        ticks against it by knowing where they are. Filtered
+        through the same code ``extract_level`` filters through --
+        ``_ticks_in_view`` -- so the two answers are index-aligned by
+        construction rather than by both being edited together (#526).
+
+        One divergence is deliberate and is not mirrored here:
+        ``extract_level`` falls back to a *sibling* axes' labels when its own
+        filter comes back empty, and a sibling's positions would be numbers
+        off a different axes to pair against this one's cells. A caller that
+        needs the two to line up therefore checks the lengths, which is what
+        ``HeatPlot._cell_names`` does.
 
         Parameters
         ----------
@@ -80,18 +88,56 @@ class LevelExtractorMixin:
         if ax is None or key not in (MaidrKey.X, MaidrKey.Y):
             return None
 
+        return [
+            float(position) for position, _ in LevelExtractorMixin._ticks_in_view(ax, key)
+        ]
+
+    @staticmethod
+    def _ticks_in_view(ax: Axes, key: MaidrKey) -> List[tuple]:
+        """
+        The ticks of one axis that fall inside the data, with their labels.
+
+        The one place the filter lives, so ``extract_level`` and
+        ``extract_level_positions`` cannot disagree about which ticks they
+        describe. They used to hold a copy each, and the claim that they
+        stay index-aligned "however that rule changes" was true only for as
+        long as both copies were edited together -- a claim about the habits
+        of a future editor rather than about the code.
+
+        Padded view limits are deliberately not used: a tick drawn outside
+        the data is furniture, not a position anything was plotted at.
+
+        Parameters
+        ----------
+        ax : Axes
+            The axes to read.
+        key : MaidrKey
+            Which axis, ``X`` or ``Y``.
+
+        Returns
+        -------
+        list of tuple
+            ``(position, label)`` per kept tick, in axis order.
+        """
         if MaidrKey.X == key:
             ticks = ax.get_xticks()
+            labels = [label.get_text() for label in ax.get_xticklabels()]
             span = ax.dataLim.width if hasattr(ax, "dataLim") else 0
-            low = ax.dataLim.x0 if span else None
+            low = ax.dataLim.x0 if span else 0
         else:
             ticks = ax.get_yticks()
+            labels = [label.get_text() for label in ax.get_yticklabels()]
             span = ax.dataLim.height if hasattr(ax, "dataLim") else 0
-            low = ax.dataLim.y0 if span else None
+            low = ax.dataLim.y0 if span else 0
 
-        if low is None or span == 0:
-            return [float(tick) for tick in ticks]
-        return [float(tick) for tick in ticks if low <= tick <= low + span]
+        kept = [
+            index
+            for index, position in enumerate(ticks)
+            if span == 0 or low <= position <= low + span
+        ]
+        return [
+            (ticks[index], labels[index]) for index in kept if index < len(labels)
+        ]
 
     @staticmethod
     def extract_level(ax: Axes, key: MaidrKey = MaidrKey.X) -> Optional[List[str]]:
@@ -100,37 +146,11 @@ class LevelExtractorMixin:
             return None
 
         level = None
-        if MaidrKey.X == key:
-            ticks = ax.get_xticks()
-            labels = [label.get_text() for label in ax.get_xticklabels()]
-
-            if hasattr(ax, "dataLim") and ax.dataLim.width != 0:
-                # Use the actual data limits rather than padded view limits
-                data_x_min, data_x_max = ax.dataLim.x0, ax.dataLim.x0 + ax.dataLim.width
-                # Filter tick labels to only those within the actual data range
-                valid_indices = [
-                    i for i, pos in enumerate(ticks) if data_x_min <= pos <= data_x_max
-                ]
-                labels = [labels[i] for i in valid_indices if i < len(labels)]
-
-            level = labels
-        elif MaidrKey.Y == key:
-            ticks = ax.get_yticks()
-            labels = [label.get_text() for label in ax.get_yticklabels()]
-
-            if hasattr(ax, "dataLim") and ax.dataLim.height != 0:
-                # Use the actual data limits rather than padded view limits
-                data_y_min, data_y_max = (
-                    ax.dataLim.y0,
-                    ax.dataLim.y0 + ax.dataLim.height,
-                )
-                # Filter tick labels to only those within the actual data range
-                valid_indices = [
-                    i for i, pos in enumerate(ticks) if data_y_min <= pos <= data_y_max
-                ]
-                labels = [labels[i] for i in valid_indices if i < len(labels)]
-
-            level = labels
+        if key in (MaidrKey.X, MaidrKey.Y):
+            # Through the same filter `extract_level_positions` uses, so the
+            # two answers are index-aligned by construction rather than by
+            # both being edited together.
+            level = [label for _, label in LevelExtractorMixin._ticks_in_view(ax, key)]
         elif MaidrKey.Z == key:
             level = [container.get_label() for container in ax.containers]
 

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -53,6 +53,47 @@ class ContainerExtractorMixin:
 
 class LevelExtractorMixin:
     @staticmethod
+    def extract_level_positions(
+        ax: Axes, key: MaidrKey = MaidrKey.X
+    ) -> Optional[List[float]]:
+        """
+        Where on the axis the labels ``extract_level`` returns are drawn.
+
+        A caller that has its own idea of what the axis positions mean -- a
+        heatmap, which knows where its own cells sit -- can only check the
+        ticks against it by knowing where they are. Kept beside
+        ``extract_level`` and filtered by the same rule, so the two answers
+        stay index-aligned however that rule changes (#526).
+
+        Parameters
+        ----------
+        ax : Axes
+            The axes to read.
+        key : MaidrKey
+            Which axis, ``X`` or ``Y``.
+
+        Returns
+        -------
+        list of float or None
+            One position per label, or ``None`` for a key that has none.
+        """
+        if ax is None or key not in (MaidrKey.X, MaidrKey.Y):
+            return None
+
+        if MaidrKey.X == key:
+            ticks = ax.get_xticks()
+            span = ax.dataLim.width if hasattr(ax, "dataLim") else 0
+            low = ax.dataLim.x0 if span else None
+        else:
+            ticks = ax.get_yticks()
+            span = ax.dataLim.height if hasattr(ax, "dataLim") else 0
+            low = ax.dataLim.y0 if span else None
+
+        if low is None or span == 0:
+            return [float(tick) for tick in ticks]
+        return [float(tick) for tick in ticks if low <= tick <= low + span]
+
+    @staticmethod
     def extract_level(ax: Axes, key: MaidrKey = MaidrKey.X) -> Optional[List[str]]:
         """Retrieve label texts from Axes based on the specified Maidr key."""
         if ax is None:

--- a/tests/core/plot/test_heatmap_cell_names.py
+++ b/tests/core/plot/test_heatmap_cell_names.py
@@ -281,3 +281,42 @@ def test_cells_too_close_to_separate_at_six_figures_get_longer_names():
 
     assert len(set(names)) == 3
     assert [float(name) for name in names] == [1e9 + 0.5, 1e9 + 1.5, 1e9 + 2.5]
+
+
+def test_a_pcolor_grid_is_named_like_the_mesh_it_shares_a_contract_with():
+    """
+    ``pcolor``'s `PolyQuadMesh` keeps its coordinates the same way.
+
+    Pinned to values rather than left to the shape check the parametrised
+    test makes: the two classes disagree about how they store their *values*
+    -- one flattens, one does not -- so agreeing about their coordinates is
+    worth asserting rather than assuming.
+    """
+    fig, ax = plt.subplots()
+    ax.pcolor(GRID)
+    layer = _layer(fig)
+
+    assert layer[MaidrKey.DATA][MaidrKey.X] == ["0.5", "1.5", "2.5"]
+    assert layer[MaidrKey.DATA][MaidrKey.Y] == ["0.5", "1.5"]
+
+
+def test_a_gouraud_shaded_mesh_is_named_at_its_coordinates_not_between_them():
+    """
+    ``shading="gouraud"`` puts the values *at* the coordinates.
+
+    So there is one coordinate per cell rather than one per boundary, and
+    each is already the cell's position -- measured as shape ``(2, 3, 2)``
+    against the flat-shaded ``(3, 4, 2)``. Taking midpoints of a list that
+    short would name two cells from three, which is why the count decides
+    which reading applies.
+
+    The names come out as the same indices ``imshow`` and ``sns.heatmap``
+    give the same grid, which is the answer a reader should get however the
+    chart was drawn.
+    """
+    fig, ax = plt.subplots()
+    ax.pcolormesh(GRID, shading="gouraud")
+    layer = _layer(fig)
+
+    assert layer[MaidrKey.DATA][MaidrKey.X] == ["0", "1", "2"]
+    assert layer[MaidrKey.DATA][MaidrKey.Y] == ["0", "1"]

--- a/tests/core/plot/test_heatmap_cell_names.py
+++ b/tests/core/plot/test_heatmap_cell_names.py
@@ -35,7 +35,6 @@ import numpy as np  # noqa: E402
 import pytest  # noqa: E402
 import seaborn as sns  # noqa: E402
 
-import maidr  # noqa: E402
 from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 

--- a/tests/core/plot/test_heatmap_cell_names.py
+++ b/tests/core/plot/test_heatmap_cell_names.py
@@ -1,0 +1,225 @@
+"""A numeric-axis heatmap was labelled with its axis ticks, not its cells (#526).
+
+``HeatPlot`` filled ``x`` and ``y`` from the axes' **tick labels**. On a
+categorical axis those are the cells: ``sns.heatmap`` puts one fixed tick at
+the centre of every cell and labels it, so the axis already names the grid. On
+a numeric axis they are not, and there are usually more of them than there are
+cells. Measured on matplotlib 3.9.4, every case below drawing a 2 x 3 grid:
+
+    ax.hist2d(a, b, bins=(3, 2))    2 x 3    9 x labels    7 y labels
+    ax.pcolormesh(z)                2 x 3    7 x labels    9 y labels
+    ax.imshow(z)                    2 x 3    7 x labels    9 y labels
+    sns.heatmap(z)                  2 x 3    3 x labels    2 y labels
+
+Nothing raised, the layer rendered, and the counts and values were right, so a
+reader moving to the second of three columns was read a number off matplotlib's
+tick locator -- chosen to look tidy on an axis -- with no way to tell it was
+somebody else's coordinate.
+
+Every one of these artists knows its own boundaries: a mesh carries them as its
+coordinates, an image as its extent. A cell is named by its **centre** rather
+than by the range it covers, following ``HexbinPoint``, which carries a bin's
+centre for the same reasons -- one label per column in the grammar, announced
+on every move of the cursor, and the spacing between consecutive centres is the
+cell width already.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: E402
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+#: A 2 x 3 grid of distinct values, so a transposed reading cannot pass.
+GRID = np.arange(6, dtype=float).reshape(2, 3)
+
+_RNG = np.random.default_rng(20260821)
+#: Samples that fall into a 3 x 2 binning without an empty bin.
+A = _RNG.normal(size=200)
+B = _RNG.normal(size=200)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _layer(fig) -> dict:
+    """
+    The single layer a figure registered.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        The figure to read.
+
+    Returns
+    -------
+    dict
+        Its one layer.
+    """
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    layers = [layer for row in grid for cell in row for layer in cell["layers"]]
+    assert len(layers) == 1
+    return layers[0]
+
+
+def _shape(layer: dict) -> tuple[int, int]:
+    """
+    How many rows and columns the emitted grid has.
+
+    Parameters
+    ----------
+    layer : dict
+        The emitted layer.
+
+    Returns
+    -------
+    tuple of int
+        ``(rows, columns)``.
+    """
+    points = layer[MaidrKey.DATA][MaidrKey.POINTS]
+    return len(points), len(points[0])
+
+
+@pytest.mark.parametrize(
+    "name, draw",
+    [
+        ("hist2d", lambda ax: ax.hist2d(A, B, bins=(3, 2))),
+        ("pcolormesh", lambda ax: ax.pcolormesh(GRID)),
+        ("pcolor", lambda ax: ax.pcolor(GRID)),
+        ("imshow", lambda ax: ax.imshow(GRID)),
+        ("heatmap", lambda ax: sns.heatmap(GRID, ax=ax)),
+    ],
+)
+def test_every_heatmap_names_one_cell_per_cell(name, draw):
+    """
+    However the grid is drawn, there is a name for each of its cells.
+
+    The count is the whole defect: a label list longer than the grid cannot be
+    a list of the grid's names, whatever the numbers in it are.
+    """
+    fig, ax = plt.subplots()
+    draw(ax)
+
+    layer = _layer(fig)
+    rows, columns = _shape(layer)
+
+    assert (rows, columns) == (2, 3), name
+    assert len(layer[MaidrKey.DATA][MaidrKey.X]) == columns, name
+    assert len(layer[MaidrKey.DATA][MaidrKey.Y]) == rows, name
+
+
+def test_a_binned_grid_is_named_by_the_centres_of_its_bins():
+    """
+    ``hist2d``'s cells are named from the edges it binned to.
+
+    Asked of the artist rather than recomputed here: the bins are chosen from
+    the data's range, so a test that wrote the numbers down would be pinning
+    this sample rather than the reading.
+    """
+    fig, ax = plt.subplots()
+    _, x_edges, y_edges, _ = ax.hist2d(A, B, bins=(3, 2))
+
+    layer = _layer(fig)
+    expected_x = [(x_edges[i] + x_edges[i + 1]) / 2 for i in range(3)]
+    expected_y = [(y_edges[i] + y_edges[i + 1]) / 2 for i in range(2)]
+
+    # Six significant figures, which is what a name is rounded to.
+    assert [float(name) for name in layer[MaidrKey.DATA][MaidrKey.X]] == pytest.approx(
+        expected_x, rel=1e-5
+    )
+    assert [float(name) for name in layer[MaidrKey.DATA][MaidrKey.Y]] == pytest.approx(
+        expected_y, rel=1e-5
+    )
+
+
+def test_an_image_names_its_cells_by_index_as_a_categorical_heatmap_does():
+    """
+    ``imshow``'s default extent puts cell *i* at *i*, and that is its name.
+
+    The same grid through ``sns.heatmap`` is named ``0``, ``1``, ``2`` off a
+    categorical axis, and an image drawn from the same array should not
+    disagree with it about what its columns are called.
+    """
+    fig, ax = plt.subplots()
+    ax.imshow(GRID)
+    image = _layer(fig)
+
+    figure, axes = plt.subplots()
+    sns.heatmap(GRID, ax=axes)
+    categorical = _layer(figure)
+
+    assert [float(name) for name in image[MaidrKey.DATA][MaidrKey.X]] == [0.0, 1.0, 2.0]
+    assert [float(name) for name in image[MaidrKey.DATA][MaidrKey.Y]] == [0.0, 1.0]
+    assert [float(name) for name in categorical[MaidrKey.DATA][MaidrKey.X]] == [
+        0.0,
+        1.0,
+        2.0,
+    ]
+
+
+def test_an_image_drawn_from_the_bottom_names_its_rows_in_the_order_it_emits_them():
+    """
+    ``origin="lower"`` puts array row 0 at the bottom, and it is still row 0.
+
+    ``get_extent()`` reports its ends bottom-then-top whichever way up the
+    image is drawn -- ``(-0.5, 2.5, 1.5, -0.5)`` for ``upper`` and
+    ``(-0.5, 2.5, -0.5, 1.5)`` for ``lower`` -- so reading them in the order
+    given names the rows backwards for one of the two. The values are emitted
+    in array order either way, so the names have to be.
+    """
+    fig, ax = plt.subplots()
+    ax.imshow(GRID, origin="lower")
+    layer = _layer(fig)
+
+    assert layer[MaidrKey.DATA][MaidrKey.POINTS][0] == [0.0, 1.0, 2.0]
+    assert [float(name) for name in layer[MaidrKey.DATA][MaidrKey.Y]] == [0.0, 1.0]
+
+
+def test_a_caller_who_names_the_cells_themselves_keeps_their_names():
+    """
+    Ticks that *are* the cells are still the answer.
+
+    This is what ``sns.heatmap`` relies on, and what a caller labelling a
+    numeric grid by hand relies on too. The check is on where the ticks sit,
+    not on how many there are: a locator that happened to draw three ticks on
+    a three-column grid would otherwise have its numbers taken as the names.
+    """
+    fig, ax = plt.subplots()
+    ax.pcolormesh(GRID)
+    ax.set_xticks([0.5, 1.5, 2.5], ["left", "middle", "right"])
+    ax.set_yticks([0.5, 1.5], ["bottom", "top"])
+
+    layer = _layer(fig)
+
+    assert layer[MaidrKey.DATA][MaidrKey.X] == ["left", "middle", "right"]
+    assert layer[MaidrKey.DATA][MaidrKey.Y] == ["bottom", "top"]
+
+
+def test_ticks_that_merely_count_right_do_not_become_the_names():
+    """
+    Three ticks in the wrong places are not three cell names.
+
+    The tick positions are compared against the cells rather than counted,
+    because a count alone is a coincidence a chart can hit: here the axis
+    carries exactly one tick per column and not one of them is on a column.
+    """
+    fig, ax = plt.subplots()
+    ax.pcolormesh(GRID)
+    ax.set_xticks([0.0, 1.0, 2.0], ["zero", "one", "two"])
+
+    layer = _layer(fig)
+
+    assert layer[MaidrKey.DATA][MaidrKey.X] == ["0.5", "1.5", "2.5"]

--- a/tests/core/plot/test_heatmap_cell_names.py
+++ b/tests/core/plot/test_heatmap_cell_names.py
@@ -222,3 +222,62 @@ def test_ticks_that_merely_count_right_do_not_become_the_names():
     layer = _layer(fig)
 
     assert layer[MaidrKey.DATA][MaidrKey.X] == ["0.5", "1.5", "2.5"]
+
+
+def test_a_mesh_is_named_by_the_centres_between_its_own_coordinates():
+    """
+    ``pcolormesh`` cells sit between the coordinates the mesh carries.
+
+    Pinned exactly rather than only counted, because this is the branch that
+    reads a mesh's own coordinates and the one the axis-alignment assumption
+    below lives in.
+    """
+    fig, ax = plt.subplots()
+    ax.pcolormesh(GRID)
+    layer = _layer(fig)
+
+    assert layer[MaidrKey.DATA][MaidrKey.X] == ["0.5", "1.5", "2.5"]
+    assert layer[MaidrKey.DATA][MaidrKey.Y] == ["0.5", "1.5"]
+
+
+def test_a_mesh_whose_columns_do_not_share_an_x_is_not_given_column_names():
+    """
+    A curvilinear mesh has no one name per column, and is not handed one.
+
+    ``pcolormesh(X, Y, Z)`` accepts a fully two-dimensional ``X``. Sheared,
+    a 2 x 3 has x edges of ``[0, 1, 2, 3]`` on its first row and
+    ``[0.3, 1.3, 2.3, 3.3]`` on its second, so naming every column after the
+    row that happens to come first would give a reader a coordinate that is
+    true of one row of the grid and of no other.
+
+    What it falls back to -- the axis ticks -- is the reading #526 is about,
+    and for this one shape it is unchanged: a grid whose cells cannot be
+    located is left exactly as it was rather than given names invented for
+    it.
+    """
+    columns, rows = np.meshgrid(np.arange(4.0), np.arange(3.0))
+    sheared = columns + 0.3 * rows
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(sheared, rows, GRID)
+    layer = _layer(fig)
+
+    assert len(layer[MaidrKey.DATA][MaidrKey.X]) != 3
+
+
+def test_cells_too_close_to_separate_at_six_figures_get_longer_names():
+    """
+    Two cells with one name would tell a reader they had not moved.
+
+    Six significant figures is short enough to say on every move and enough
+    for any ordinary grid, but centres around 1e9 spaced by 1 all round to
+    the same six, so the precision is raised until the names differ.
+    """
+    edges = np.array([1e9, 1e9 + 1, 1e9 + 2, 1e9 + 3])
+    fig, ax = plt.subplots()
+    ax.pcolormesh(edges, np.array([0.0, 1.0, 2.0]), GRID)
+
+    names = _layer(fig)[MaidrKey.DATA][MaidrKey.X]
+
+    assert len(set(names)) == 3
+    assert [float(name) for name in names] == [1e9 + 0.5, 1e9 + 1.5, 1e9 + 2.5]


### PR DESCRIPTION
Closes #526.

## What was wrong

`HeatPlot._extract_plot_data` filled `x` and `y` from `extract_level`, which reads the axes' **tick labels**. Reproduced on matplotlib 3.9.4 / seaborn 0.13.2, every case drawing a **2 × 3** grid:

| call | grid | x labels | y labels | |
|---|---|---|---|---|
| `ax.hist2d(a, b, bins=(3, 2))` | 2 × 3 | **9** | **7** | ✗ |
| `ax.pcolormesh(z)` | 2 × 3 | **7** | **9** | ✗ |
| `ax.imshow(z)` | 2 × 3 | **7** | **9** | ✗ |
| `sns.heatmap(z)` | 2 × 3 | 3 | 2 | ✓ |

```
hist2d      x: ['−2.0','−1.5','−1.0','−0.5','0.0','0.5','1.0','1.5','2.0']
            y: ['−3','−2','−1','0','1','2','3']
```

`sns.heatmap` lines up because its axis is categorical and its ticks *are* the cells. Every numeric-axis heatmap disagreed, and nothing raised — the counts and values were right, so a reader moving to the second of three columns was read a number off matplotlib's tick locator with no way to tell it was somebody else's coordinate.

## After

```
hist2d      x: ['-1.6648', '-0.19792', '1.26896']   y: ['-2.0627', '1.35646']
pcolormesh  x: ['0.5', '1.5', '2.5']                y: ['0.5', '1.5']
imshow      x: ['0', '1', '2']                      y: ['0', '1']
sns.heatmap x: ['0', '1', '2']                      y: ['0', '1']      (unchanged)
```

## Centre, not edges — and why

The issue left this open deliberately, so here is the reasoning rather than a preference.

`HeatmapData.x` and `.y` in the core grammar are `string[]` — **one label per column**, with no per-cell `min`/`max` the way `HistPoint` has. Both a centre and an edge range fit in a string, so the question is which a reader wants at a cell.

`HexbinPoint` already answers it for the same family, and its own documentation gives the reason: *"The centre is carried per bin rather than derived from a lattice origin and a cell size"* — a bin is named by where it is. The label is announced on **every move of the cursor**, an edge range roughly doubles that announcement's length, and consecutive centres already give the width by their spacing. So: centre, consistent with the neighbouring decision.

Formatted `.6g`, and deliberately **not** `self._fmt`: that is the caller's format for the cell *values* — what `sns.heatmap` annotates a cell with — and a coordinate is not one of those.

## Which answer wins

The ticks are checked against the cells rather than assumed to be them, so a chart that names its own grid keeps its names. The check is on **where the ticks sit**, not on how many there are — a locator that happened to draw one tick per column would otherwise have its numbers taken as the names, and there is a test for exactly that.

`extract_level_positions` is new, next to `extract_level` and filtered by the same rule, so the labels and their positions stay index-aligned however that rule changes.

## An image's row order

`get_extent()` reports its two ends bottom-then-top **whichever way up the image is drawn**:

```
origin="upper"   extent = (-0.5, 2.5,  1.5, -0.5)
origin="lower"   extent = (-0.5, 2.5, -0.5,  1.5)
```

Row 0 is at −0.5 in both, so which end it sits against comes from `origin`, not from the order. Reading them in the given order names the rows backwards for one of the two, and the values are emitted in array order either way — so the names have to be. There is a test per origin, and each pins one direction of the constant.

## Falsification

| mutation | result |
|---|---|
| go back to the tick labels unconditionally | 8 of 10 red |
| accept the ticks whenever the *count* matches, without checking where they are | the coincidence test red |
| `first, last = bottom, top` (ignore `origin`) | the default-`imshow` test red |
| `first, last = top, bottom` (the opposite constant) | the `origin="lower"` test red |

Suite: 2552 passed, 18 skipped. `ruff check --diff` clean.

## Noted, out of scope

For `ax.imshow(z, origin="lower")` array row 0 is drawn at the **bottom**, and it is still emitted first — while `HeatmapData` documents rows as top-first. That is the xability/maidr#971 family of defect, it predates this change, and this change neither causes nor hides it: each row is now named with its own coordinate, which is true either way; only which direction <kbd>↑</kbd> walks is affected. Worth filing separately rather than folding in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_