### PR TITLE
fix(extract): bind a layer to the artist its own call drew

### DIFF
--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -16,6 +16,10 @@ from maidr.util.mixin import (
     ScalarMappableExtractorMixin,
 )
 
+#: Key the patch passes the artist its own call drew under. Named like
+#: ``scatterplot.DRAWN_POINTS`` and read the same way.
+DRAWN_GRID = "_maidr_grid"
+
 
 class HeatPlot(
     MaidrPlot, LevelExtractorMixin, ScalarMappableExtractorMixin, DictMergerMixin
@@ -23,6 +27,22 @@ class HeatPlot(
     def __init__(self, ax: Axes, **kwargs) -> None:
         self._z_label = kwargs.pop("z_label", "Z")
         self._fmt = kwargs.pop("fmt", "")
+        # The grid this layer's own call drew, when the patch could say.
+        # `None` falls back to searching the axes, which resolves *per axes*
+        # and so hands every heatmap on one axes the same artist: two
+        # `ax.pcolormesh()` calls were both announced with the first mesh's
+        # values, the second chart's numbers appearing nowhere and nothing
+        # raising (#527).
+        #
+        # Guarded on the type rather than on presence, the way
+        # `ScatterPlot._own_points` is: `seaborn.heatmap` is patched through
+        # the same wrapper and returns an `Axes`, not the mesh.
+        own_grid = kwargs.pop(DRAWN_GRID, None)
+        self._own_grid = (
+            own_grid
+            if isinstance(own_grid, (QuadMesh, PolyQuadMesh, AxesImage))
+            else None
+        )
         super().__init__(ax, PlotType.HEAT)
 
     def render(self) -> dict:
@@ -47,7 +67,14 @@ class HeatPlot(
         return axes_data
 
     def _extract_plot_data(self) -> dict:
-        plot = self.extract_scalar_mappable(self.ax)
+        # The artist this layer was registered for, not whichever one a search
+        # of the axes turns up first. `extract_scalar_mappable` resolves per
+        # axes and therefore cannot tell two meshes apart -- it is still the
+        # fallback, for a producer that registers a heatmap without saying
+        # which artist drew it.
+        plot = self._own_grid
+        if plot is None:
+            plot = self.extract_scalar_mappable(self.ax)
         data = self._extract_scalar_mappable_data(plot)
 
         if data is None:

--- a/maidr/core/plot/histogram.py
+++ b/maidr/core/plot/histogram.py
@@ -8,9 +8,31 @@ from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
 from maidr.util.mixin import ContainerExtractorMixin, DictMergerMixin
 
+#: Key the patch passes the container its own call drew under. Named like
+#: ``heatmap.DRAWN_GRID`` and ``scatterplot.DRAWN_POINTS``, and read the same
+#: way.
+DRAWN_BARS = "_maidr_bars"
+
 
 class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
-    def __init__(self, ax: Axes) -> None:
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        # The bars this layer's own call drew, when the patch could say.
+        # `None` falls back to searching the axes, which resolves *per axes*
+        # and so hands every histogram on one axes the same container: two
+        # `ax.hist()` calls were both announced with the first one's bins, the
+        # second distribution appearing nowhere and nothing raising. Found by
+        # the audit #527 asked for, and the same defect it records for
+        # heatmaps.
+        #
+        # Guarded on the type, like `HeatPlot._own_grid` and
+        # `ScatterPlot._own_points`. `ax.hist([a, b])` returns a *list* of
+        # containers rather than one, which this would decline -- though that
+        # case cannot arrive today: the patch resolves its axes from the same
+        # return value and raises on a list before any layer exists (#553).
+        # So the guard is structural rather than a live path, and stays for
+        # when that call is made to work.
+        own_bars = kwargs.pop(DRAWN_BARS, None)
+        self._own_bars = own_bars if isinstance(own_bars, BarContainer) else None
         super().__init__(ax, PlotType.HIST)
         self._orientation = "vert"
 
@@ -44,7 +66,14 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         return DictMergerMixin.merge_dict(base_schema, hist_orientation)
 
     def _extract_plot_data(self) -> list[dict]:
-        plot = self.extract_container(self.ax, BarContainer)
+        # The container this layer was registered for, not whichever one a
+        # search of the axes turns up first. `extract_container` resolves per
+        # axes and cannot tell two histograms apart; it is still the fallback,
+        # for a producer that registers a histogram without saying which
+        # container drew it.
+        plot = self._own_bars
+        if plot is None:
+            plot = self.extract_container(self.ax, BarContainer)
         self._orientation = self._extract_orientation(plot)
         data = self._extract_bar_container_data(plot)
 

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -105,7 +105,7 @@ class MaidrPlotFactory:
             # find and the call hands its `PolyCollection` over instead.
             if isinstance(kwargs.get("collection"), PolyCollection):
                 return SteppedHistPlot(single_ax, **kwargs)
-            return HistPlot(single_ax)
+            return HistPlot(single_ax, **kwargs)
         elif PlotType.LINE == plot_type:
             if PlotDetectionUtils.is_mplfinance_line_plot(single_ax, **kwargs):
                 return MplfinanceLinePlot(single_ax, **kwargs)

--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -9,10 +9,56 @@ from matplotlib.axes import Axes
 from matplotlib.collections import Collection
 from matplotlib.image import AxesImage
 
+from matplotlib.collections import PolyQuadMesh, QuadMesh
+
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.heatmap import DRAWN_GRID
 from maidr.patch.common import _draw_quietly, wrap_seaborn
+
+
+def _grid_of(plot, ax: Axes | None):
+    """
+    The mesh or image a call drew, if it can be had.
+
+    Preferring the return value is the whole point: a layer that looks its
+    artist up from the axes later resolves *per axes*, so two heatmaps drawn
+    on one axes both read the first one's values (#527).
+
+    The fallback takes the **last** grid rather than the first, which is where
+    it parts company with ``extract_scalar_mappable``. That helper answers
+    "which artist is this axes' heatmap", and reasonably says the first; this
+    one answers "which artist did the call that is registering right now
+    draw", and matplotlib appends artists in draw order -- measured, a second
+    ``pcolormesh`` on the same axes arrives after the first in
+    ``get_children()``, and ``seaborn.heatmap`` beside an existing mesh leaves
+    its own last, carrying its own values.
+
+    Parameters
+    ----------
+    plot : Any
+        Whatever the patched function returned. ``Axes.imshow`` returns an
+        ``AxesImage``, ``Axes.pcolormesh`` a ``QuadMesh``, ``Axes.pcolor`` a
+        ``PolyQuadMesh``, and ``seaborn.heatmap`` the axes.
+    ax : Axes or None
+        The axes drawn on.
+
+    Returns
+    -------
+    QuadMesh or PolyQuadMesh or AxesImage or None
+        The grid, or ``None`` when neither the return value nor the axes
+        offers one.
+    """
+    grids = (QuadMesh, PolyQuadMesh, AxesImage)
+    if isinstance(plot, grids):
+        return plot
+    drawn = [
+        artist
+        for artist in (getattr(ax, "get_children", list)() or ())
+        if isinstance(artist, grids)
+    ]
+    return drawn[-1] if drawn else None
 
 
 def _declares_fmt(wrapped: Callable) -> bool:
@@ -111,6 +157,7 @@ def heat(wrapped, _, args, kwargs) -> Axes | AxesImage | Collection:
 
     # Extract the heatmap data points for MAIDR from the plots.
     ax = FigureManager.get_axes(plot)
+    optional_params[DRAWN_GRID] = _grid_of(plot, ax)
     FigureManager.create_maidr(ax, PlotType.HEAT, **optional_params)
 
     # Return to the caller.

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -15,6 +15,7 @@ import uuid
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.histogram import DRAWN_BARS
 from maidr.core.plot.stepped_histogram import reads as _reads_outline
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
 
@@ -41,7 +42,10 @@ def mpl_hist(
 
     # Extract the histogram data points for MAIDR from the plots.
     ax = FigureManager.get_axes(plot)
-    FigureManager.create_maidr(ax, PlotType.HIST)
+    # Hand the layer the container this call drew. Without it the layer looks
+    # one up from the axes, and every histogram on one axes resolves to the
+    # first -- two `ax.hist()` calls both announced the first one's bins.
+    FigureManager.create_maidr(ax, PlotType.HIST, **{DRAWN_BARS: plot})
 
     # Return to the caller.
     return n, bins, plot
@@ -63,6 +67,45 @@ def _containers_of(ax: Axes | None) -> list:
     into one.
     """
     return list(getattr(ax, "containers", ()) or ())
+
+
+def _new_bar_container(ax: Axes | None, before: list) -> BarContainer | None:
+    """
+    The ``BarContainer`` a call just added to an axes, if it added one.
+
+    Compared by identity against the snapshot. Not because value comparison
+    would be wrong -- measured, two containers over identical data compare
+    **unequal**, because ``BarContainer`` extends ``tuple`` over ``Rectangle``
+    artists and those compare by identity -- but because "is this the same
+    object" is the question actually being asked, and it cannot become wrong
+    if matplotlib ever gives the container value semantics.
+
+    The **first** new one when a call added several, which is what
+    ``extract_container`` answers and so what the fallback would have found.
+    Agreement is the only reason to prefer it: the choice is unobservable on
+    every input that reaches here, because a call adding several containers is
+    a hue-grouped ``histplot``, whose groups share one binning -- measured,
+    first and last give the same bin edges and the same reading.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes drawn on.
+    before : list
+        The containers the axes held before the call, by reference.
+
+    Returns
+    -------
+    BarContainer or None
+        The container this call added, or ``None`` when it added none.
+    """
+    added = [
+        container
+        for container in (getattr(ax, "containers", ()) or ())
+        if isinstance(container, BarContainer)
+        and not any(container is seen for seen in before)
+    ]
+    return added[0] if added else None
 
 
 def _drew_bars(plot: Any, before: list) -> bool:
@@ -117,11 +160,7 @@ def _drew_bars(plot: Any, before: list) -> bool:
         return False
     if ax is None or not ax.containers:
         return False
-    return any(
-        isinstance(container, BarContainer)
-        and not any(container is seen for seen in before)
-        for container in ax.containers
-    )
+    return _new_bar_container(ax, before) is not None
 
 
 def _meshes_of(ax: Axes | None) -> list:
@@ -328,8 +367,24 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
             )
         return drawn
 
-    # Register the histogram as HIST as before
-    ax = common(PlotType.HIST, lambda *a, **k: drawn, instance, args, kwargs)
+    # Register the histogram as HIST as before, naming the container this
+    # call drew. Passed through `kwargs` the way the SMOOTH registration below
+    # passes `regression_line`. Without it the layer searches the axes and
+    # every histogram on one axes resolves to the first -- a `histplot` drawn
+    # beside an `ax.hist()` announced the matplotlib call's bins.
+    #
+    # Looked up on the *drawn* axes rather than the prospective one, which is
+    # None whenever the caller did not pass `ax=`. `before` is then empty and
+    # every container reads as new, but the answer is still the newest one,
+    # which is still this call's.
+    drawn_axes = FigureManager.get_axes(drawn)
+    ax = common(
+        PlotType.HIST,
+        lambda *a, **k: drawn,
+        instance,
+        args,
+        dict(kwargs, **{DRAWN_BARS: _new_bar_container(drawn_axes, before)}),
+    )
     # Only register KDE overlay as SMOOTH if kde=True was set
     kde_enabled = kwargs.get("kde", False)
     if kde_enabled:
@@ -395,8 +450,11 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
         drawn = _draw_quietly(wrapped, args, kwargs)
 
     for ax in plotter_axes(instance):
-        if _drew_bars(ax, before.get(id(ax), [])):
-            FigureManager.create_maidr(ax, PlotType.HIST)
+        seen = before.get(id(ax), [])
+        if _drew_bars(ax, seen):
+            FigureManager.create_maidr(
+                ax, PlotType.HIST, **{DRAWN_BARS: _new_bar_container(ax, seen)}
+            )
 
     return drawn
 

--- a/tests/core/plot/test_own_artist_binding.py
+++ b/tests/core/plot/test_own_artist_binding.py
@@ -1,0 +1,255 @@
+"""
+A layer reads whichever artist a search of its axes turns up first (#527).
+
+Two heatmaps on one axes were both read from the first one's mesh, and the
+audit that issue asked for found the identical defect in ``HistPlot``. Both
+are fixed here, so this file covers the binding rather than one chart type.
+
+``HeatPlot`` found its artist by searching the axes rather than by being told
+which one it was registered for, so every heatmap on an axes resolved to the
+same mesh. Measured on matplotlib 3.9.4 before the fix::
+
+    ax.pcolormesh(np.arange(6).reshape(2, 3))          # 0..5
+    ax.pcolormesh(np.arange(100, 106).reshape(2, 3))   # 100..105
+
+    heat [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+    heat [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+
+Two layers, both the first mesh, nothing raised. The second chart's numbers
+appeared nowhere and a reader navigating two layers heard the same values in
+each with no way to tell one was a copy.
+
+The layer is now bound to the artist its own call drew, the way
+``ScatterPlot._own_points`` already was for #426. The fallback matters
+separately and is asserted too: ``seaborn.heatmap`` returns an ``Axes`` rather
+than its mesh, so the patch has to find it on the axes -- and must take the
+**last** grid, not the first, because the call that is registering right now
+drew the newest one.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+from matplotlib.container import BarContainer
+
+from maidr.core.figure_manager import FigureManager
+
+
+def _bins(points) -> list:
+    """Each bin's lower edge, which is what says *which* distribution it is."""
+    return [point["xMin"] for point in points]
+
+
+def _points(fig) -> list:
+    """Every heat layer's grid of values, in registration order."""
+    maidr = FigureManager.get_maidr(fig)
+    return [plot.schema["data"]["points"] for plot in maidr.plots]
+
+
+def _hist_points(fig) -> list:
+    """Every hist layer's bins, in registration order."""
+    maidr = FigureManager.get_maidr(fig)
+    return [plot.schema["data"] for plot in maidr.plots]
+
+
+def _elements(fig) -> list:
+    """The artist each heat layer will highlight through."""
+    maidr = FigureManager.get_maidr(fig)
+    return [plot.elements[0] if plot.elements else None for plot in maidr.plots]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def test_two_meshes_on_one_axes_each_read_their_own_values():
+    fig, ax = plt.subplots()
+    ax.pcolormesh(np.arange(6).reshape(2, 3))
+    ax.pcolormesh(np.arange(100, 106).reshape(2, 3))
+
+    assert _points(fig) == [
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
+        [[100.0, 101.0, 102.0], [103.0, 104.0, 105.0]],
+    ]
+
+
+def test_two_images_on_one_axes_each_read_their_own_values():
+    # `imshow` returns an `AxesImage` rather than a mesh, and reaches the same
+    # branch by a different type -- which is the point of naming all three.
+    fig, ax = plt.subplots()
+    ax.imshow(np.arange(6).reshape(2, 3))
+    ax.imshow(np.arange(100, 106).reshape(2, 3))
+
+    assert _points(fig) == [
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
+        [[100.0, 101.0, 102.0], [103.0, 104.0, 105.0]],
+    ]
+
+
+def test_a_pcolor_beside_a_pcolormesh_keeps_them_apart():
+    # `pcolor` draws a `PolyQuadMesh` and `pcolormesh` a `QuadMesh`, so this
+    # pairing would survive a fix that only told two artists of one class
+    # apart.
+    fig, ax = plt.subplots()
+    ax.pcolor(np.arange(6).reshape(2, 3))
+    ax.pcolormesh(np.arange(100, 106).reshape(2, 3))
+
+    assert _points(fig) == [
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
+        [[100.0, 101.0, 102.0], [103.0, 104.0, 105.0]],
+    ]
+
+
+def test_a_seaborn_heatmap_beside_a_mesh_reads_its_own_values():
+    # `seaborn.heatmap` returns the axes, so the artist has to be found rather
+    # than taken from the return value. Taking the *first* grid -- which is
+    # what `extract_scalar_mappable` answers -- would hand seaborn's layer the
+    # mesh drawn before it.
+    fig, ax = plt.subplots()
+    ax.pcolormesh(np.arange(6).reshape(2, 3))
+    sns.heatmap(np.arange(100, 106).reshape(2, 3), ax=ax)
+
+    assert _points(fig) == [
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]],
+        [[100.0, 101.0, 102.0], [103.0, 104.0, 105.0]],
+    ]
+
+
+def test_each_layer_highlights_the_grid_it_announces():
+    # The blind spot: audio, text and braille would all read correctly off the
+    # fix above while the wrong mesh lit up, because the element registered
+    # for highlighting is the same artist the values were read from. Asserted
+    # as identity against the artists the calls returned.
+    fig, ax = plt.subplots()
+    first = ax.pcolormesh(np.arange(6).reshape(2, 3))
+    second = ax.pcolormesh(np.arange(100, 106).reshape(2, 3))
+
+    assert _elements(fig) == [first, second]
+
+
+def test_one_heatmap_alone_is_unchanged():
+    fig, ax = plt.subplots()
+    ax.pcolormesh(np.arange(6).reshape(2, 3))
+
+    assert _points(fig) == [[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]]
+
+
+def test_a_layer_told_nothing_still_finds_the_axes_heatmap():
+    # The documented fallback, exercised directly: a producer that registers a
+    # heatmap without naming the artist keeps the behaviour it has always had.
+    from maidr.core.plot.heatmap import HeatPlot
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(np.arange(6).reshape(2, 3))
+
+    assert HeatPlot(ax).schema["data"]["points"] == [
+        [0.0, 1.0, 2.0],
+        [3.0, 4.0, 5.0],
+    ]
+
+
+def test_a_layer_told_a_grid_that_is_not_one_falls_back_rather_than_breaking():
+    # Guarded on the type, not on presence -- the same rule
+    # `ScatterPlot._own_points` follows, because the seaborn wrapper hands the
+    # axes through the same keyword.
+    from maidr.core.plot.heatmap import DRAWN_GRID, HeatPlot
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(np.arange(6).reshape(2, 3))
+
+    plot = HeatPlot(ax, **{DRAWN_GRID: ax})
+    assert plot.schema["data"]["points"] == [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+
+
+# ---------------------------------------------------------------------------
+# The audit the issue asked for
+#
+# "Anything that resolves its artist from `self.ax` at extraction time has the
+# same exposure whenever two of a kind share an axes." Measured across the
+# extractors that do: two `ax.bar()` calls read correctly (the patch already
+# hands each layer its own container), and so do two `ax.plot()` calls. Two
+# `ax.hist()` calls did not -- the identical defect, in `HistPlot`:
+#
+#     ax.hist(np.zeros(10) + 1, bins=2)
+#     ax.hist(np.zeros(10) + 50, bins=2)
+#
+#     hist [{'x': 0.75, 'xMin': 0.5, ...}, ...]
+#     hist [{'x': 0.75, 'xMin': 0.5, ...}, ...]   <- the first one's bins
+#
+# so it is fixed here rather than filed, being the same defect in the same
+# family.
+# ---------------------------------------------------------------------------
+
+
+def test_two_histograms_on_one_axes_each_read_their_own_bins():
+    fig, ax = plt.subplots()
+    ax.hist(np.zeros(10) + 1, bins=2)
+    ax.hist(np.zeros(10) + 50, bins=2)
+
+    first, second = _hist_points(fig)
+    assert _bins(first) == [0.5, 1.0]
+    assert _bins(second) == [49.5, 50.0]
+
+
+def test_a_seaborn_histogram_beside_a_matplotlib_one_reads_its_own_bins():
+    # The seaborn wrapper returns the axes, so it finds its container by
+    # diffing the axes against a snapshot taken before the call -- which it
+    # already did to decide whether to register at all. It now hands the
+    # container it found to the layer instead of letting the layer search.
+    fig, ax = plt.subplots()
+    ax.hist(np.zeros(10) + 1, bins=2)
+    sns.histplot(x=np.zeros(10) + 50.0, bins=2, ax=ax)
+
+    first, second = _hist_points(fig)
+    assert _bins(first) == [0.5, 1.0]
+    assert _bins(second)[0] == pytest.approx(49.5, abs=1.0)
+    assert _bins(second)[0] > 40
+
+
+def test_one_histogram_alone_is_unchanged():
+    fig, ax = plt.subplots()
+    ax.hist(np.zeros(10) + 1, bins=2)
+
+    assert _bins(_hist_points(fig)[0]) == [0.5, 1.0]
+
+
+def test_two_identical_histograms_are_still_told_apart():
+    # Two calls with the same numbers: the containers are distinct objects
+    # holding distinct artists. Measured, they compare *unequal* -- a
+    # `BarContainer` is a tuple over `Rectangle`s, which compare by identity --
+    # so a value comparison would separate them too. Pinned because the
+    # snapshot diff is what decides which container a layer is handed, and a
+    # pair that a future matplotlib gave value semantics to would collapse
+    # into one and hand the second layer the first's bars.
+    fig, ax = plt.subplots()
+    sns.histplot(x=np.zeros(10) + 1.0, bins=2, ax=ax)
+    sns.histplot(x=np.zeros(10) + 1.0, bins=2, ax=ax)
+
+    containers = [c for c in ax.containers if isinstance(c, BarContainer)]
+    assert len(containers) == 2
+
+    bound = [plot._own_bars for plot in FigureManager.get_maidr(fig).plots]
+    assert bound[0] is containers[0]
+    assert bound[1] is containers[1]
+
+
+def test_a_hue_grouped_histogram_reads_as_it_always_did():
+    # A call that adds several containers at once. `_new_bar_container` takes
+    # the first, which is what `extract_container` -- the fallback -- would
+    # have found, so naming the container changed nothing here. Measured
+    # against unmodified `main`: bins [1.0, 25.5] before and after.
+    frame = pd.DataFrame(
+        {"v": [1, 1, 1, 50, 50, 50], "g": ["a", "a", "a", "b", "b", "b"]}
+    )
+    fig, ax = plt.subplots()
+    sns.histplot(frame, x="v", hue="g", bins=2, ax=ax)
+
+    layers = _hist_points(fig)
+    assert len(layers) == 1
+    assert _bins(layers[0]) == [1.0, 25.5]


### PR DESCRIPTION
Closes #527. Files #553 (see below).

## What happens

`HeatPlot` found its artist by searching the axes rather than by being told which one it was registered for, so every heatmap on an axes resolved to the same mesh:

```python
ax.pcolormesh(np.arange(6).reshape(2, 3))          # 0..5
ax.pcolormesh(np.arange(100, 106).reshape(2, 3))   # 100..105
```

```
heat [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
heat [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
```

Two layers, both the first mesh. The second chart's numbers appear nowhere and nothing raises — the reader navigates two layers, hears the same values in each, and has no way to tell one is a copy.

## The change

The layer is handed the artist its own call drew, the way `ScatterPlot._own_points` already was for #426. The axes search stays as the fallback for a producer that registers a heatmap without naming an artist, and the binding is guarded on type — `seaborn.heatmap` is patched through the same wrapper and returns an `Axes`.

For that seaborn case the patch has to find the mesh on the axes, and takes the **last** grid rather than the first. That is where it parts company with `extract_scalar_mappable`: that helper answers "which artist is this axes' heatmap" and reasonably says the first; this one answers "which artist did the call registering *right now* draw", and matplotlib appends artists in draw order (measured).

## The audit the issue asked for

> Anything that resolves its artist from `self.ax` at extraction time has the same exposure whenever two of a kind share an axes.

Measured across the extractors that do:

| chart | two of a kind on one axes |
| --- | --- |
| `ax.bar` | correct — each layer already gets its own container |
| `ax.plot` | correct |
| `ax.hist` | **the identical defect** — both layers announce the first histogram's bins |

So `HistPlot` is fixed here too, on both the matplotlib path (which has the container in hand) and the seaborn `histplot` path (which already diffed the axes against a snapshot to decide whether to register at all, and now hands over what it found). Same family, same fix shape — filing it separately would have left the audit's own finding unfixed while claiming to have audited.

## A separate crash the audit surfaced — filed, not folded in

`ax.hist([a, b])`, the documented way to draw two distributions in one call, raises on **unmodified `main`**:

```
AttributeError: 'BarContainer' object has no attribute 'axes'
```

from the user's own plotting line, because the patch hands a list of containers to `get_axes`. Filed as #553 rather than fixed here: it is a call that *raises* rather than one that mis-reads, and the larger half of it is a decision — a multi-dataset histogram could reasonably emit one layer, one per dataset, or a `stacked` reading under `histtype='barstacked'`.

## Tests

`tests/core/plot/test_own_artist_binding.py`, 13 cases across both halves: two meshes, two images, `pcolor` beside `pcolormesh`, a seaborn heatmap beside a mesh, **each layer highlighting the grid it announces**, the single-chart regression guard, the documented fallback, a non-artist handed in; then two `ax.hist` calls, a `histplot` beside an `ax.hist`, the single-histogram guard, two *identical* histograms told apart by identity, and a hue-grouped `histplot` reading exactly as it did before.

Falsified with nine mutations, each applied alone. All the load-bearing ones are caught:

| mutation | result |
| --- | --- |
| never pass the drawn grid (pre-fix) | 5 failed |
| axes fallback takes the first grid | 1 failed |
| layer ignores the bound grid | 5 failed |
| accept an unguarded value | 1 failed |
| matplotlib `hist` stops naming its container | 1 failed |
| seaborn `histplot` stops naming its container | 2 failed |
| layer ignores the bound container | 2 failed |

Two mutations **survive**, and that is reported rather than papered over:

- `_new_bar_container` returning the last new container instead of the first. A call adding several is a hue-grouped `histplot`, whose groups share one binning — measured, first and last give the same bin edges and the same reading. The two answers are equivalent on every reachable input, so the code takes the one `extract_container` would have found and the test pins the *reading* instead of the choice.
- comparing containers by value instead of identity. My first comment claimed value comparison would collide; measuring says otherwise — two `BarContainer`s over identical data compare **unequal**, being tuples over `Rectangle`s that compare by identity. The comment is corrected, identity is kept because it is the exact question, and the test pins the outcome that must not regress.

`ruff check` clean, `uvx ruff@0.3.4 check --diff .` (CI's pin) exit 0, full suite **2574 passed, 18 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_