### PR TITLE
fix(hist): read a multi-dataset histogram instead of raising on it

### DIFF
--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -383,7 +383,26 @@ class FigureManager:
     def get_axes(
         artist: Artist | Axes | BarContainer | dict | list | None,
     ) -> Any:
-        """Recursively extract Axes objects from the input artist or container."""
+        """
+        Recursively extract Axes objects from the input artist or container.
+
+        The list branch **recurses** rather than reading ``.axes`` off each
+        element, because a list does not promise to hold artists.
+        ``Axes.hist`` returns one for every multi-dataset call and fills it
+        with whatever the ``histtype`` drew -- a ``BarContainer`` per dataset
+        for ``bar`` and ``barstacked``, a list of ``Polygon``\ s for ``step``
+        and ``stepfilled``. Neither has ``.axes``, so all four raised from the
+        caller's own ``ax.hist(...)`` line, naming matplotlib rather than the
+        accessibility layer that actually failed (#553)::
+
+            ax.hist([a, b], bins=2)
+            AttributeError: 'BarContainer' object has no attribute 'axes'
+
+        Nothing found is ``None`` rather than a bare ``StopIteration``, which
+        is the answer every caller here is written for and the shape of
+        failure #388, #520 and #529 removed from the extractors for the same
+        reason.
+        """
         if artist is None:
             return None
         elif isinstance(artist, Axes):
@@ -391,20 +410,33 @@ class FigureManager:
         elif isinstance(artist, BarContainer):
             # Get axes from the first occurrence of any child artist
             return next(
-                child_artist.axes
-                for child_artist in artist.get_children()
-                if isinstance(child_artist.axes, Axes)
+                (
+                    child_artist.axes
+                    for child_artist in artist.get_children()
+                    if isinstance(child_artist.axes, Axes)
+                ),
+                None,
             )
         elif isinstance(artist, Artist):
             return artist.axes
         elif isinstance(artist, dict):
             return next(
-                _artist.axes
-                for _artists in artist.values()
-                for _artist in _artists
-                if isinstance(_artist.axes, Axes)
+                (
+                    _artist.axes
+                    for _artists in artist.values()
+                    for _artist in _artists
+                    if isinstance(_artist.axes, Axes)
+                ),
+                None,
             )
         elif isinstance(artist, list):
             return next(
-                _artist.axes for _artist in artist if isinstance(_artist.axes, Axes)
+                (
+                    resolved
+                    for resolved in (
+                        FigureManager.get_axes(_artist) for _artist in artist
+                    )
+                    if isinstance(resolved, Axes)
+                ),
+                None,
             )

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -42,13 +42,59 @@ def mpl_hist(
 
     # Extract the histogram data points for MAIDR from the plots.
     ax = FigureManager.get_axes(plot)
-    # Hand the layer the container this call drew. Without it the layer looks
-    # one up from the axes, and every histogram on one axes resolves to the
-    # first -- two `ax.hist()` calls both announced the first one's bins.
-    FigureManager.create_maidr(ax, PlotType.HIST, **{DRAWN_BARS: plot})
+    # One layer per dataset, each handed the container it was drawn as.
+    #
+    # `Axes.hist` returns a *list* of containers whenever it was given a list
+    # of datasets, and reading one of them would announce one distribution and
+    # drop the rest -- so a two-dataset call is two layers, which is what
+    # `sns.histplot(hue=...)` gets from the scatter split of #544 and what a
+    # reader moving between them expects.
+    #
+    # A `barstacked` call is read the same way, and measured rather than
+    # assumed: each container's bar *heights* are still its own dataset's
+    # counts, and the stacking lives in the bars' `bottom`. So the counts
+    # announced are right either way; only the fact that they are stacked is
+    # not said, which is the reading `stacked_bar` would add.
+    #
+    # Nothing is registered where there is no container to read. That is the
+    # `histtype="step"` and `"stepfilled"` case: both draw a `Polygon` per
+    # dataset and leave `ax.containers` empty, so the layer registered for
+    # them raised `ExtractionError` at render and took the figure with it.
+    # Declining is not the same as reading it -- filed as #555 -- but a chart
+    # that falls back to a picture beats one that dies.
+    for container in _drawn_containers(plot):
+        FigureManager.create_maidr(ax, PlotType.HIST, **{DRAWN_BARS: container})
 
     # Return to the caller.
     return n, bins, plot
+
+
+def _drawn_containers(plot: Any) -> list:
+    """
+    The bar containers one ``Axes.hist`` call drew, in dataset order.
+
+    ``Axes.hist`` returns its third value in three shapes and the caller's
+    arguments do not say which: a single ``BarContainer`` for one dataset, a
+    list of them for several, and a list of ``Polygon`` lists for the two step
+    histtypes, which create no container at all. Asked of the return value
+    rather than of the axes, so a call registers exactly what it drew and
+    never a neighbour's bars.
+
+    Parameters
+    ----------
+    plot : Any
+        The third element of what ``Axes.hist`` returned.
+
+    Returns
+    -------
+    list
+        Every ``BarContainer`` this call drew, possibly empty.
+    """
+    if isinstance(plot, BarContainer):
+        return [plot]
+    if isinstance(plot, (list, tuple)):
+        return [entry for entry in plot if isinstance(entry, BarContainer)]
+    return []
 
 
 def _containers_of(ax: Axes | None) -> list:

--- a/tests/core/plot/test_multi_dataset_histogram.py
+++ b/tests/core/plot/test_multi_dataset_histogram.py
@@ -1,0 +1,117 @@
+"""
+A multi-dataset ``ax.hist([a, b])`` raises before anything is read (#553).
+
+Passing a list of datasets is the documented way to draw two distributions in
+one call, and it killed the figure from the **plotting line**, not from render
+or ``save_html``::
+
+    ax.hist([np.zeros(10) + 1, np.zeros(10) + 50], bins=2)
+    AttributeError: 'BarContainer' object has no attribute 'axes'
+
+`Axes.hist` returns `(n, bins, patches)`, and `patches` is a single
+`BarContainer` for one dataset but a **list** for several -- of containers for
+``histtype="bar"`` and ``"barstacked"``, of `Polygon` lists for ``"step"`` and
+``"stepfilled"``. `FigureManager.get_axes` treated any list as a list of
+artists and read `.axes` off the first element, which neither has, so all four
+histtypes raised.
+
+Two things follow from the fix, and both are asserted here rather than
+assumed:
+
+- **one layer per dataset.** Reading one container would announce one
+  distribution and silently drop the rest, which is the defect #527 fixed for
+  a pair of separate calls.
+- **nothing registered where there is no container.** The step histtypes
+  create none, and the layer registered for them raised `ExtractionError` at
+  render -- a pre-existing failure, unrelated to the list, filed as #555.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from maidr.core.figure_manager import FigureManager
+from maidr.exception import UnsupportedPlotError
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _counts(fig) -> list:
+    """Every hist layer's per-bin counts, in registration order."""
+    return [
+        [point["y"] for point in plot.schema["data"]]
+        for plot in FigureManager.get_maidr(fig).plots
+    ]
+
+
+def _two_datasets() -> list:
+    """Ten in one bin, then four and six across both."""
+    return [np.array([1.0] * 10), np.array([1.0] * 4 + [3.0] * 6)]
+
+
+@pytest.mark.parametrize("histtype", ["bar", "barstacked"])
+def test_a_multi_dataset_histogram_no_longer_raises(histtype):
+    fig, ax = plt.subplots()
+
+    ax.hist(_two_datasets(), bins=2, histtype=histtype)  # must not raise
+
+    assert len(FigureManager.get_maidr(fig).plots) == 2
+
+
+@pytest.mark.parametrize("histtype", ["step", "stepfilled"])
+def test_a_step_histogram_no_longer_raises_either(histtype):
+    # The list branch was only half of it: these two put *lists of Polygons*
+    # in the list, so they raised on `'list' object has no attribute 'axes'`.
+    fig, ax = plt.subplots()
+
+    ax.hist(_two_datasets(), bins=2, histtype=histtype)  # must not raise
+
+    # And nothing is registered, because there is no container to read. The
+    # chart takes the static-image fallback rather than raising at render.
+    with pytest.raises(UnsupportedPlotError):
+        FigureManager.get_maidr(fig)
+
+
+def test_each_dataset_is_announced_as_its_own_layer():
+    fig, ax = plt.subplots()
+    ax.hist(_two_datasets(), bins=2)
+
+    assert _counts(fig) == [[10.0, 0.0], [4.0, 6.0]]
+
+
+def test_a_stacked_histogram_announces_each_datasets_own_counts():
+    # Measured rather than assumed: `barstacked` puts the stacking in the
+    # bars' `bottom` and leaves each container's *heights* as its own
+    # dataset's counts -- 10/0 and 4/6, not the cumulative 10/0 and 14/6 that
+    # `n` reports. So the counts announced are right; only the fact that they
+    # are stacked is not said.
+    fig, ax = plt.subplots()
+    ax.hist(_two_datasets(), bins=2, histtype="barstacked")
+
+    assert _counts(fig) == [[10.0, 0.0], [4.0, 6.0]]
+
+
+def test_a_single_dataset_histogram_is_unchanged():
+    fig, ax = plt.subplots()
+    ax.hist(np.array([1.0] * 10), bins=2)
+
+    assert len(_counts(fig)) == 1
+
+
+def test_a_step_histogram_renders_instead_of_dying():
+    # The pre-existing half: a step histogram registered a layer that
+    # `HistPlot` could not read, and `render` died on the whole figure.
+    # Declining to register is not the same as reading it (#555), but a chart
+    # that falls back to a picture beats one that raises.
+    import maidr
+
+    fig, ax = plt.subplots()
+    ax.hist(np.array([1.0] * 10), bins=2, histtype="step")
+
+    assert len(maidr.render(fig)._repr_html_()) > 0


### PR DESCRIPTION
Closes #553. Files #555 (see below).

## What happens

`ax.hist([a, b])` — the documented way to draw two distributions in one call — killed the figure from the **user's own plotting line**, not from render or `save_html`:

```python
ax.hist([np.zeros(10) + 1, np.zeros(10) + 50], bins=2)
AttributeError: 'BarContainer' object has no attribute 'axes'
```

All four histtypes did it. Two of them with a different message, which is what pinned the shape:

```
bar, barstacked   'BarContainer' object has no attribute 'axes'
step, stepfilled  'list' object has no attribute 'axes'
```

`Axes.hist` returns `(n, bins, patches)`, and `patches` is a single `BarContainer` for one dataset but a **list** for several — of containers for `bar`/`barstacked`, of `Polygon` lists for the two step forms. `FigureManager.get_axes` treated any list as a list of *artists* and read `.axes` off the first element, which neither has.

## The change

`get_axes`'s list branch now **recurses through `get_axes` itself**, so a list of containers and a list of lists both resolve — a list does not promise to hold artists, and this one demonstrably doesn't. Every branch also answers `None` rather than raising a bare `StopIteration`, which is the shape of failure #388, #520 and #529 removed from the extractors for exactly this reason.

## The reading, which had to be decided

With the crash gone, the issue's larger half: how many layers should a multi-dataset histogram emit? **One per dataset.** Reading one container would announce one distribution and silently drop the rest — the defect #527 just fixed for a pair of *separate* calls — and #544's hue split is the same answer to the same question. Each layer is bound to its own container through the `DRAWN_BARS` keyword #527 added.

`barstacked` is read the same way, and that is measured rather than assumed:

```
histtype       container heights           n (returned)
bar            [10, 0]  and [4, 6]         [[10,0], [4,6]]
barstacked     [10, 0]  and [4, 6]         [[10,0], [14,6]]   ← cumulative
                        bottoms [10, 0]
```

Each container's **heights** are still its own dataset's counts; the stacking lives in the bars' `bottom`. So the counts announced are right either way, and only the *fact* that they are stacked goes unsaid — which is what a `stacked_bar` reading would add, and not something this issue decides.

## A pre-existing crash the same guard fixes

Nothing is registered where there is no `BarContainer` to read. That is the two step histtypes, which create none — and the layer registered for them raised `ExtractionError` **at render**, taking the whole figure down, single-dataset or not:

```python
ax.hist(np.array([1.0] * 10), bins=2, histtype="step")
maidr.render(fig)
ExtractionError: Error extracting data for hist plot type from <class 'NoneType'>.
```

Confirmed on unmodified `main`. A step histogram now takes the static-image fallback instead. Declining is not the same as reading it — filed as **#555**, where the data is all there (`n` and `bins` are exact) and the fix is to route it to the reading `StairsPlot` and `SteppedHistPlot` already give the same chart — but a chart that falls back to a picture beats one that dies.

## Tests

`tests/core/plot/test_multi_dataset_histogram.py`, 8 cases: all four histtypes no longer raise, each dataset announced as its own layer, `barstacked` announcing per-dataset counts, the single-dataset regression guard, and a step histogram rendering instead of dying.

Falsified with four mutations, each applied alone — restore the old list branch (6 fail), register one layer for the whole call (7), register even with no container (3), only the first dataset gets a layer (4). Baseline restored at 8/8.

`ruff check` clean on the changed files, `uvx ruff@0.3.4 check --diff .` (CI's pin) exit 0, full suite **2582 passed, 18 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_