### PR TITLE
feat(hist): read a step-outlined histogram instead of falling back

### DIFF
--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -25,6 +25,7 @@ from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.regplot import SmoothPlot
 from maidr.core.plot.stairs import StairsPlot
 from maidr.core.plot.stepped_histogram import SteppedHistPlot
+from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, StepHistPlot
 from maidr.core.plot.stepplot import StepPlot
 from maidr.core.plot.violin_kde_plot import ViolinKdePlot
 from maidr.core.plot.violin_box_plot import ViolinBoxPlot
@@ -105,6 +106,13 @@ class MaidrPlotFactory:
             # find and the call hands its `PolyCollection` over instead.
             if isinstance(kwargs.get("collection"), PolyCollection):
                 return SteppedHistPlot(single_ax, **kwargs)
+            # `ax.hist(histtype="step"/"stepfilled")` draws a `Polygon` per
+            # dataset and leaves no container either, so the call hands over
+            # the counts and edges it already returned (#555).
+            counts = kwargs.get(STEP_COUNTS)
+            edges = kwargs.get(STEP_EDGES)
+            if counts is not None and edges is not None:
+                return StepHistPlot(single_ax, counts, edges, **kwargs)
             return HistPlot(single_ax, **kwargs)
         elif PlotType.LINE == plot_type:
             if PlotDetectionUtils.is_mplfinance_line_plot(single_ax, **kwargs):

--- a/maidr/core/plot/stairs.py
+++ b/maidr/core/plot/stairs.py
@@ -68,20 +68,48 @@ class StairsPlot(HistPlot):
             "horz" if self._step_patch.orientation == "horizontal" else "vert"
         )
 
-        data = []
-        for index, value in enumerate(values):
-            low = float(edges[index])
-            high = float(edges[index + 1])
-            # A bin with no position is nowhere to navigate to, and a bare
-            # `NaN` or `Infinity` in the payload is not JSON -- `JSON.parse`
-            # rejects the whole schema and the chart never initialises (#427).
-            if not (math.isfinite(low) and math.isfinite(high)):
-                continue
-            data.append(
-                self._bin_point(self._orientation, low, high - low, _reading(value))
-            )
+        return bins_to_points(self._orientation, values, edges)
 
-        return data
+
+def bins_to_points(orientation: str, values: Any, edges: Any) -> list[dict]:
+    """
+    One point per bin, from a pair of counts and edges.
+
+    Shared by every spelling of a pre-binned histogram that hands its numbers
+    over rather than leaving a ``BarContainer`` to find: ``Axes.stairs``, which
+    keeps them on its ``StepPatch``, and ``Axes.hist(histtype="step")``, whose
+    counts and edges are the first two things it returns (#555). Both draw the
+    same chart as one outline, and reading them through one function is what
+    keeps them announcing it identically.
+
+    Parameters
+    ----------
+    orientation : str
+        ``"horz"`` when the bins run up the y axis, ``"vert"`` otherwise.
+    values : Any
+        One count per bin.
+    edges : Any
+        One more edge than there are counts, in bin order.
+
+    Returns
+    -------
+    list of dict
+        One point per bin, in the order the bins were given.
+    """
+    data = []
+    for index, value in enumerate(values):
+        low = float(edges[index])
+        high = float(edges[index + 1])
+        # A bin with no position is nowhere to navigate to, and a bare
+        # `NaN` or `Infinity` in the payload is not JSON -- `JSON.parse`
+        # rejects the whole schema and the chart never initialises (#427).
+        if not (math.isfinite(low) and math.isfinite(high)):
+            continue
+        data.append(
+            HistPlot._bin_point(orientation, low, high - low, _reading(value))
+        )
+
+    return data
 
 
 def _reading(value: Any) -> float | None:

--- a/maidr/core/plot/step_histogram.py
+++ b/maidr/core/plot/step_histogram.py
@@ -1,0 +1,86 @@
+"""StepHistPlot -- the histogram ``Axes.hist(histtype="step")`` draws as an outline."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from matplotlib.axes import Axes
+
+from maidr.core.plot.histogram import HistPlot
+from maidr.core.plot.stairs import bins_to_points
+
+#: Keys the patch passes a step histogram's own numbers under.
+STEP_COUNTS = "_maidr_step_counts"
+STEP_EDGES = "_maidr_step_edges"
+#: And the orientation the caller asked for, which nothing else records.
+STEP_ORIENTATION = "_maidr_step_orientation"
+
+
+class StepHistPlot(HistPlot):
+    """
+    A histogram whose bars were drawn as one outline rather than as bars.
+
+    ``histtype="step"`` and ``"stepfilled"`` draw a ``Polygon`` per dataset and
+    leave ``ax.containers`` empty, so :class:`HistPlot` -- which reads a
+    ``BarContainer`` -- had nothing to find. The layer was registered anyway
+    and raised ``ExtractionError`` when it was rendered, taking the whole
+    figure with it (#555)::
+
+        ax.hist(np.array([1.0] * 10), bins=2, histtype="step")
+        maidr.render(fig)
+        ExtractionError: Error extracting data for hist plot type from <class 'NoneType'>.
+
+    Nothing has to be recovered from the outline. ``Axes.hist`` returns
+    ``(n, bins, patches)`` whatever the histtype, and the first two *are* the
+    counts and the edges -- so the patch hands them over and this reads them,
+    the same way :class:`~maidr.core.plot.stairs.StairsPlot` reads the pair a
+    ``StepPatch`` carries. Both go through ``bins_to_points`` so the two
+    spellings of one chart announce it identically.
+
+    Highlighting is declined for the reason ``StairsPlot`` declines it: the
+    outline is a single element covering every bin, so a selector naming it
+    would outline the whole histogram at every bin and tell a low-vision
+    reader nothing about which bin they are on. The reading still ships,
+    because the chart was an error before -- there is no highlight being taken
+    away, and ``histtype="bar"`` draws the same histogram with a patch per bin
+    for anyone who needs both.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the outline was drawn on.
+    counts : Any
+        One count per bin, as ``Axes.hist`` returned them.
+    edges : Any
+        One more edge than there are counts, in bin order.
+    **kwargs : dict
+        Ignored; accepted so the factory can forward what it was given.
+    """
+
+    def __init__(self, ax: Axes, counts: Any, edges: Any, **kwargs) -> None:
+        self._counts = counts
+        self._edges = edges
+        # Which way the bins run, from the caller's own `orientation=`.
+        #
+        # There is nowhere else to get it. `HistPlot` reads it off the
+        # `BarContainer` matplotlib annotates, and a step histtype makes no
+        # container -- the `Polygon` it draws instead records nothing about
+        # which axis the bins were laid along. Without this a horizontal step
+        # histogram announced as vertical, with its counts read as positions.
+        self._declared_orientation = (
+            "horz" if kwargs.get(STEP_ORIENTATION) == "horizontal" else "vert"
+        )
+        super().__init__(ax)
+        self._support_highlighting = False
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        Read one point per bin off the numbers the call returned.
+
+        Returns
+        -------
+        list of dict
+            One point per bin, in the order the bins were given.
+        """
+        self._orientation = self._declared_orientation
+        return bins_to_points(self._orientation, self._counts, self._edges)

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -16,6 +16,7 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.histogram import DRAWN_BARS
+from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, STEP_ORIENTATION
 from maidr.core.plot.stepped_histogram import reads as _reads_outline
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
 
@@ -56,17 +57,65 @@ def mpl_hist(
     # announced are right either way; only the fact that they are stacked is
     # not said, which is the reading `stacked_bar` would add.
     #
-    # Nothing is registered where there is no container to read. That is the
-    # `histtype="step"` and `"stepfilled"` case: both draw a `Polygon` per
-    # dataset and leave `ax.containers` empty, so the layer registered for
-    # them raised `ExtractionError` at render and took the figure with it.
-    # Declining is not the same as reading it -- filed as #555 -- but a chart
-    # that falls back to a picture beats one that dies.
-    for container in _drawn_containers(plot):
-        FigureManager.create_maidr(ax, PlotType.HIST, **{DRAWN_BARS: container})
+    containers = _drawn_containers(plot)
+    if containers:
+        for container in containers:
+            FigureManager.create_maidr(ax, PlotType.HIST, **{DRAWN_BARS: container})
+        return plot
+
+    # No container to read means `histtype="step"` or `"stepfilled"`, which
+    # draw a `Polygon` per dataset. Nothing has to be recovered from the
+    # outline: `n` and `bins` above *are* the counts and the edges, so they
+    # are handed over and `StepHistPlot` reads them (#555).
+    #
+    # One layer per dataset here too, for the same reason the container branch
+    # emits one: a multi-dataset call returns a list of count arrays, and
+    # reading one would announce a single distribution and drop the rest.
+    for counts in _step_counts(n):
+        FigureManager.create_maidr(
+            ax,
+            PlotType.HIST,
+            **{
+                STEP_COUNTS: counts,
+                STEP_EDGES: bins,
+                # Read from the caller's kwargs because the `Polygon` a step
+                # histtype draws records nothing about it, unlike the
+                # `BarContainer` the bar histtypes leave.
+                STEP_ORIENTATION: kwargs.get("orientation"),
+            },
+        )
 
     # Return to the caller.
     return n, bins, plot
+
+
+def _step_counts(n: Any) -> list:
+    """
+    The per-dataset count arrays one ``Axes.hist`` call produced.
+
+    ``n`` is a flat array of counts for a single dataset and a list of them
+    for several, which is the same shape split the third return value has --
+    so the two branches of the patch stay symmetrical rather than one of them
+    quietly reading only the first distribution.
+
+    Told apart by the *elements* rather than by the container's type: both
+    forms are array-like, and both have a length. A first element that is
+    itself a sequence is what says the call was given several datasets.
+
+    Parameters
+    ----------
+    n : Any
+        The first element of what ``Axes.hist`` returned.
+
+    Returns
+    -------
+    list
+        One count array per dataset, possibly empty.
+    """
+    counts = list(n) if n is not None and len(n) else []
+    if counts and hasattr(counts[0], "__len__"):
+        return counts
+    return [counts] if counts else []
 
 
 def _drawn_containers(plot: Any) -> list:

--- a/tests/core/plot/test_multi_dataset_histogram.py
+++ b/tests/core/plot/test_multi_dataset_histogram.py
@@ -24,6 +24,10 @@ assumed:
 - **nothing registered where there is no container.** The step histtypes
   create none, and the layer registered for them raised `ExtractionError` at
   render -- a pre-existing failure, unrelated to the list, filed as #555.
+  That half has since been superseded: #555 gave those two a reading of their
+  own, so they are read rather than skipped. The assertions below were updated
+  in place rather than deleted, because what they are really pinning is that
+  every histtype comes back with **both** distributions.
 """
 
 from __future__ import annotations
@@ -33,7 +37,6 @@ import numpy as np
 import pytest
 
 from maidr.core.figure_manager import FigureManager
-from maidr.exception import UnsupportedPlotError
 
 
 @pytest.fixture(autouse=True)
@@ -72,10 +75,13 @@ def test_a_step_histogram_no_longer_raises_either(histtype):
 
     ax.hist(_two_datasets(), bins=2, histtype=histtype)  # must not raise
 
-    # And nothing is registered, because there is no container to read. The
-    # chart takes the static-image fallback rather than raising at render.
-    with pytest.raises(UnsupportedPlotError):
-        FigureManager.get_maidr(fig)
+    # This asserted that *nothing* was registered when it was written, which
+    # was the honest reading of the interim state: there was no container to
+    # read, so the chart took the static-image fallback rather than raising at
+    # render. #555 gave the step histtypes a reading of their own -- the
+    # counts and edges the call already returned -- so they are now one layer
+    # per dataset like every other histtype. See `test_step_histogram.py`.
+    assert _counts(fig) == [[10.0, 0.0], [4.0, 6.0]]
 
 
 def test_each_dataset_is_announced_as_its_own_layer():
@@ -107,8 +113,8 @@ def test_a_single_dataset_histogram_is_unchanged():
 def test_a_step_histogram_renders_instead_of_dying():
     # The pre-existing half: a step histogram registered a layer that
     # `HistPlot` could not read, and `render` died on the whole figure.
-    # Declining to register is not the same as reading it (#555), but a chart
-    # that falls back to a picture beats one that raises.
+    # It fell back to a picture after this fix and is read outright after
+    # #555; what this pins either way is that it does not raise.
     import maidr
 
     fig, ax = plt.subplots()

--- a/tests/core/plot/test_step_histogram.py
+++ b/tests/core/plot/test_step_histogram.py
@@ -1,0 +1,146 @@
+"""
+`ax.hist(histtype="step")` is registered but cannot be read (#555).
+
+A step-outlined histogram registered a `hist` layer and then raised when that
+layer was rendered, taking the whole figure with it::
+
+    ax.hist(np.array([1.0] * 10), bins=2, histtype="step")
+    maidr.render(fig)
+    ExtractionError: Error extracting data for hist plot type from <class 'NoneType'>.
+
+`HistPlot` reads a `BarContainer`, and only two of matplotlib's four histtypes
+make one::
+
+    histtype       returns                 ax.containers
+    bar            BarContainer            1
+    barstacked     BarContainer            1
+    step           [Polygon]               0
+    stepfilled     [Polygon]               0
+
+#553 stopped the crash by registering nothing where there was no container, so
+a step histogram fell back to a static image. This reads it instead.
+
+Nothing is recovered from the outline. `Axes.hist` returns `(n, bins, patches)`
+whatever the histtype, and the first two *are* the counts and the edges — so
+the patch hands them over and `StepHistPlot` reads them, through the same
+`bins_to_points` that `StairsPlot` uses for the pair a `StepPatch` carries.
+Two spellings of one chart, announced identically.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _layers(fig) -> list:
+    return FigureManager.get_maidr(fig).plots
+
+
+def _counts(fig) -> list:
+    """Every hist layer's per-bin counts, in registration order."""
+    return [
+        [point["y"] for point in plot.schema["data"]] for plot in _layers(fig)
+    ]
+
+
+def _edges(fig, index: int = 0) -> list:
+    """One layer's bin boundaries."""
+    points = _layers(fig)[index].schema["data"]
+    return [point["xMin"] for point in points] + [points[-1]["xMax"]]
+
+
+def _one() -> np.ndarray:
+    return np.array([1.0] * 10)
+
+
+def _two() -> list:
+    return [np.array([1.0] * 10), np.array([1.0] * 4 + [3.0] * 6)]
+
+
+@pytest.mark.parametrize("histtype", ["step", "stepfilled"])
+def test_a_step_histogram_is_read_rather_than_dropped(histtype):
+    fig, ax = plt.subplots()
+    ax.hist(_one(), bins=2, histtype=histtype)
+
+    assert len(_layers(fig)) == 1
+    assert _counts(fig) == [[0.0, 10.0]]
+
+
+@pytest.mark.parametrize("histtype", ["step", "stepfilled"])
+def test_a_step_histogram_renders_without_raising(histtype):
+    # The regression: this raised `ExtractionError` from inside `render`, so
+    # the whole figure died rather than one layer.
+    fig, ax = plt.subplots()
+    ax.hist(_one(), bins=2, histtype=histtype)
+
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_a_step_histogram_reads_the_same_bins_a_bar_one_does():
+    # The point of routing both through `bins_to_points`: the same data drawn
+    # two ways is the same chart, and a reader should not be able to tell
+    # which histtype the author picked from what they hear.
+    bar_fig, bar_ax = plt.subplots()
+    bar_ax.hist(_one(), bins=2)
+
+    step_fig, step_ax = plt.subplots()
+    step_ax.hist(_one(), bins=2, histtype="step")
+
+    assert _counts(step_fig) == _counts(bar_fig)
+    assert _edges(step_fig) == _edges(bar_fig)
+
+
+def test_a_multi_dataset_step_histogram_is_one_layer_per_dataset():
+    # The same rule the container branch follows (#553): reading one would
+    # announce a single distribution and drop the rest.
+    fig, ax = plt.subplots()
+    ax.hist(_two(), bins=2, histtype="step")
+
+    assert _counts(fig) == [[10.0, 0.0], [4.0, 6.0]]
+
+
+def test_every_histtype_announces_the_same_two_distributions():
+    # The strongest form of the previous two, across all four spellings.
+    readings = {}
+    for histtype in ("bar", "barstacked", "step", "stepfilled"):
+        fig, ax = plt.subplots()
+        ax.hist(_two(), bins=2, histtype=histtype)
+        readings[histtype] = _counts(fig)
+
+    assert readings == {
+        "bar": [[10.0, 0.0], [4.0, 6.0]],
+        "barstacked": [[10.0, 0.0], [4.0, 6.0]],
+        "step": [[10.0, 0.0], [4.0, 6.0]],
+        "stepfilled": [[10.0, 0.0], [4.0, 6.0]],
+    }
+
+
+def test_a_step_histogram_declines_highlighting():
+    # For the reason `StairsPlot` declines it: the outline is a single element
+    # covering every bin, so a selector naming it would outline the whole
+    # histogram at every bin and tell a low-vision reader nothing about which
+    # bin they are on. Announcing the bins is still a strict gain -- the chart
+    # was an error before, so no highlight is being taken away.
+    fig, ax = plt.subplots()
+    ax.hist(_one(), bins=2, histtype="step")
+
+    layer = _layers(fig)[0]
+    assert layer.schema.get("selectors") in (None, "", [])
+
+
+def test_a_horizontal_step_histogram_keeps_its_orientation():
+    fig, ax = plt.subplots()
+    ax.hist(_one(), bins=2, histtype="step", orientation="horizontal")
+
+    assert _layers(fig)[0].schema["orientation"] == "horz"


### PR DESCRIPTION
Closes #555.

## What happens

`ax.hist(histtype="step")` and `"stepfilled"` draw a `Polygon` per dataset and leave `ax.containers` empty, so `HistPlot` — which reads a `BarContainer` — had nothing to find. The layer was registered anyway and raised when it was rendered, taking the whole figure with it:

```python
ax.hist(np.array([1.0] * 10), bins=2, histtype="step")
maidr.render(fig)
ExtractionError: Error extracting data for hist plot type from <class 'NoneType'>.
```

#553 stopped the crash by registering nothing where there was no container, which left the chart a static image. This reads it.

## Nothing is recovered from the outline

`Axes.hist` returns `(n, bins, patches)` whatever the histtype, and the first two **are** the counts and the edges. So the patch hands them over and `StepHistPlot` reads them — the same shape `StairsPlot` gets from a `StepPatch`.

Both now go through one `bins_to_points`, lifted out of `StairsPlot`, so the two spellings of one chart announce it *identically* rather than merely similarly. Measured across all four histtypes on the same two datasets:

```
bar          [[10, 0], [4, 6]]
barstacked   [[10, 0], [4, 6]]
step         [[10, 0], [4, 6]]
stepfilled   [[10, 0], [4, 6]]
```

One layer per dataset here too, for the reason the container branch emits one (#553): a multi-dataset call returns a list of count arrays, and reading one would announce a single distribution and drop the rest.

## The orientation had to be carried, not read back

`HistPlot` takes the orientation off the `BarContainer` matplotlib annotates. A step histtype makes no container, and the `Polygon` it draws records nothing about which axis the bins were laid along — so a horizontal step histogram announced as **vertical**, with its counts read as positions.

Worth flagging how that surfaced: my first version wrote a comment saying "the caller's `orientation=` is what decided it, and the patch is what saw it" while not actually passing it through. The test caught it, and the comment is now true.

## Highlighting stays declined

For the reason `StairsPlot` declines it: the outline is a **single element covering every bin**, so a selector naming it would outline the whole histogram at every bin and tell a low-vision reader nothing about which bin they are on. The reading is still a strict gain — the chart was an error before, so no highlight is being taken away, and `histtype="bar"` draws the same histogram with a patch per bin for anyone who needs both.

## Tests

`tests/core/plot/test_step_histogram.py`, 9 cases: both step histtypes read, both render without raising, a step histogram reading the same bins and edges a bar one does, multi-dataset split, all four histtypes agreeing, highlighting declined, and orientation preserved.

Falsified with five mutations, each applied alone — don't register at all (7 fail), only the first dataset (2), treat a multi-dataset `n` as one flat array (2), ignore the declared orientation (1), claim highlighting (1). Baseline restored at 9/9.

**Two assertions in #553's tests were updated in place.** They pinned the interim "registers nothing" state, which this deliberately replaces — so they now assert that every histtype comes back with both distributions, which is what they were really about. The module docstring saying so is corrected too.

`ruff check` clean on the changed files, `uvx ruff@0.3.4 check --diff .` (CI's pin) exit 0, full suite **2591 passed, 18 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_