### PR TITLE
fix(hist): read every group of a hue-grouped histogram, not just the first

### DIFF
--- a/maidr/core/plot/histogram.py
+++ b/maidr/core/plot/histogram.py
@@ -13,6 +13,13 @@ from maidr.util.mixin import ContainerExtractorMixin, DictMergerMixin
 #: way.
 DRAWN_BARS = "_maidr_bars"
 
+#: Key the patch passes this layer's hue group name under, when the chart has
+#: one. A ``histplot(hue=...)`` draws one container per group and so becomes
+#: one layer per group (#558); without a name the reader is offered several
+#: ``hist`` layers over one axis with nothing to tell them apart, which is the
+#: position xability/maidr#828 added ``MaidrLayer.name`` for.
+GROUP_NAME = "_maidr_group_name"
+
 
 class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
     def __init__(self, ax: Axes, **kwargs) -> None:
@@ -33,6 +40,11 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         # when that call is made to work.
         own_bars = kwargs.pop(DRAWN_BARS, None)
         self._own_bars = own_bars if isinstance(own_bars, BarContainer) else None
+        # The hue group this layer's container belongs to, when the patch
+        # could name it. `None` is the ungrouped case and every chart that
+        # drew no legend.
+        group_name = kwargs.pop(GROUP_NAME, None)
+        self._group_name = group_name if isinstance(group_name, str) else None
         super().__init__(ax, PlotType.HIST)
         self._orientation = "vert"
 
@@ -58,11 +70,21 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         return "horz" if plot.orientation == "horizontal" else "vert"
 
     def render(self) -> dict:
-        """Add ``orientation`` to the base schema."""
+        """
+        Add ``orientation`` to the base schema, and the group's name when the
+        layer reads one distribution of several.
+
+        ``MaidrLayer.name`` is the field xability/maidr#828 added so two
+        layers of a kind can be told apart, which is exactly where a
+        hue-grouped histogram leaves a reader. Distinct from ``title``, which
+        every layer of a figure carries and which names the *chart*.
+        """
         # Read after the super call, not before: `self._orientation` is
         # populated by `_extract_plot_data`, which that call runs.
         base_schema = super().render()
         hist_orientation = {MaidrKey.ORIENTATION: self._orientation}
+        if self._group_name:
+            hist_orientation[MaidrKey.NAME] = self._group_name
         return DictMergerMixin.merge_dict(base_schema, hist_orientation)
 
     def _extract_plot_data(self) -> list[dict]:

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -15,7 +15,8 @@ import uuid
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.core.plot.histogram import DRAWN_BARS
+from maidr.core.plot.histogram import DRAWN_BARS, GROUP_NAME
+from maidr.core.plot.scatterplot import _named_colours, _rgba
 from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, STEP_ORIENTATION
 from maidr.core.plot.stepped_histogram import reads as _reads_outline
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
@@ -164,9 +165,9 @@ def _containers_of(ax: Axes | None) -> list:
     return list(getattr(ax, "containers", ()) or ())
 
 
-def _new_bar_container(ax: Axes | None, before: list) -> BarContainer | None:
+def _new_bar_containers(ax: Axes | None, before: list) -> list[BarContainer]:
     """
-    The ``BarContainer`` a call just added to an axes, if it added one.
+    The ``BarContainer``\ s a call just added to an axes, in draw order.
 
     Compared by identity against the snapshot. Not because value comparison
     would be wrong -- measured, two containers over identical data compare
@@ -175,12 +176,14 @@ def _new_bar_container(ax: Axes | None, before: list) -> BarContainer | None:
     object" is the question actually being asked, and it cannot become wrong
     if matplotlib ever gives the container value semantics.
 
-    The **first** new one when a call added several, which is what
-    ``extract_container`` answers and so what the fallback would have found.
-    Agreement is the only reason to prefer it: the choice is unobservable on
-    every input that reaches here, because a call adding several containers is
-    a hue-grouped ``histplot``, whose groups share one binning -- measured,
-    first and last give the same bin edges and the same reading.
+    **All** of them, which is the correction #558 records. A call that adds
+    several is a hue-grouped ``histplot``, and this used to answer with the
+    first on the reasoning that the groups share one binning so the choice was
+    unobservable. The *edges* are shared. The counts are not -- measured, two
+    groups over one binning gave ``[0, 4, 10, 9, 5]`` and ``[1, 11, 8, 8, 4]``
+    -- so answering with one announced one distribution and left the other
+    drawn but unspoken, which is the defect #553 fixed for ``ax.hist([a, b])``
+    and #527 for two ``ax.bar`` calls.
 
     Parameters
     ----------
@@ -191,16 +194,95 @@ def _new_bar_container(ax: Axes | None, before: list) -> BarContainer | None:
 
     Returns
     -------
-    BarContainer or None
-        The container this call added, or ``None`` when it added none.
+    list of BarContainer
+        The containers this call added, possibly none.
     """
-    added = [
+    return [
         container
         for container in (getattr(ax, "containers", ()) or ())
         if isinstance(container, BarContainer)
         and not any(container is seen for seen in before)
     ]
-    return added[0] if added else None
+
+
+def _group_names(ax: Axes | None, containers: list) -> list[str | None]:
+    """
+    Name each container from the legend swatch drawn in its colour.
+
+    A ``histplot(hue=...)`` draws one container per group, every bar of it in
+    that group's colour, and the legend names those colours -- so the same
+    match ``scatterplot.hue_groups`` makes point by point works container by
+    container, one level up. The helpers are imported rather than reimplemented
+    for that reason.
+
+    Not by position. Measured on seaborn 0.13.2, the legend runs the *exact
+    reverse* of the draw order -- ``['y', 'x']`` against containers drawn
+    ``x, y``, and ``['z', 'x', 'y']`` against ``y, x, z`` -- so pairing them
+    off in order gives every layer somebody else's name. Reading the legend
+    backwards would agree on those charts, and is not what this does: the
+    reversal is nothing seaborn documents, and a legend carrying entries that
+    are not group swatches would still have to be declined rather than
+    counted, which is what ``_named_colours`` answers ``None`` for.
+
+    Every reason to decline is a reason to leave the layers unnamed rather
+    than to name them wrongly:
+
+    - **No legend.** ``legend=False`` suppresses it, and a chart with a single
+      distribution never had one. Nothing names the colours.
+    - **A container no swatch claims.** Nothing to call it.
+    - **Two names for one colour.** A swatch that means two things cannot name
+      the group a container belongs to; ``_named_colours`` answers ``None``.
+
+    A single container is left unnamed whatever the legend says: one
+    distribution needs nothing to tell it apart from, and a name there would
+    read as though the chart held more.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes drawn on, for its legend.
+    containers : list
+        The containers this call drew, in draw order.
+
+    Returns
+    -------
+    list of str or None
+        One entry per container, naming it or ``None``.
+    """
+    if ax is None or len(containers) < 2:
+        return [None] * len(containers)
+
+    legend = ax.get_legend()
+    if legend is None:
+        return [None] * len(containers)
+
+    colours = [_container_colour(container) for container in containers]
+    named = _named_colours(legend, {c for c in colours if c is not None})
+    if not named:
+        return [None] * len(containers)
+
+    return [None if colour is None else named.get(colour) for colour in colours]
+
+
+def _container_colour(container) -> tuple[float, ...] | None:
+    """
+    The one colour a container's bars are drawn in, if they share one.
+
+    Parameters
+    ----------
+    container : BarContainer
+        The bars.
+
+    Returns
+    -------
+    tuple of float or None
+        The rounded RGBA every bar shares, or ``None`` when they differ or
+        there are no bars.
+    """
+    colours = {_rgba(patch.get_facecolor()) for patch in container}
+    if len(colours) != 1:
+        return None
+    return colours.pop()
 
 
 def _drew_bars(plot: Any, before: list) -> bool:
@@ -255,7 +337,7 @@ def _drew_bars(plot: Any, before: list) -> bool:
         return False
     if ax is None or not ax.containers:
         return False
-    return _new_bar_container(ax, before) is not None
+    return bool(_new_bar_containers(ax, before))
 
 
 def _meshes_of(ax: Axes | None) -> list:
@@ -473,13 +555,24 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     # every container reads as new, but the answer is still the newest one,
     # which is still this call's.
     drawn_axes = FigureManager.get_axes(drawn)
+    # One layer per container, because a `hue` draws one container per group
+    # and reading a single one announced one distribution while leaving the
+    # rest drawn and unspoken (#558). `common` registers one layer, so the
+    # first group goes through it -- keeping the orientation and axis handling
+    # every histogram has always had -- and the rest are registered beside it.
+    containers = _new_bar_containers(drawn_axes, before)
+    names = _group_names(drawn_axes, containers)
     ax = common(
         PlotType.HIST,
         lambda *a, **k: drawn,
         instance,
         args,
-        dict(kwargs, **{DRAWN_BARS: _new_bar_container(drawn_axes, before)}),
+        dict(kwargs, **{DRAWN_BARS: containers[0], GROUP_NAME: names[0]}),
     )
+    for container, name in zip(containers[1:], names[1:]):
+        FigureManager.create_maidr(
+            drawn_axes, PlotType.HIST, **{DRAWN_BARS: container, GROUP_NAME: name}
+        )
     # Only register KDE overlay as SMOOTH if kde=True was set
     kde_enabled = kwargs.get("kde", False)
     if kde_enabled:
@@ -546,9 +639,16 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
 
     for ax in plotter_axes(instance):
         seen = before.get(id(ax), [])
-        if _drew_bars(ax, seen):
+        if not _drew_bars(ax, seen):
+            continue
+        # One layer per group here too; `displot(hue=...)` reaches only this
+        # site, so leaving it reading the first container would fix the defect
+        # for `histplot` and not for the figure-level spelling of the same
+        # chart -- the asymmetry #522 and #446 were both about.
+        containers = _new_bar_containers(ax, seen)
+        for container, name in zip(containers, _group_names(ax, containers)):
             FigureManager.create_maidr(
-                ax, PlotType.HIST, **{DRAWN_BARS: _new_bar_container(ax, seen)}
+                ax, PlotType.HIST, **{DRAWN_BARS: container, GROUP_NAME: name}
             )
 
     return drawn

--- a/tests/core/plot/test_hue_histogram.py
+++ b/tests/core/plot/test_hue_histogram.py
@@ -1,0 +1,224 @@
+"""
+A hue-grouped ``histplot`` announces every group, not just the first (#558).
+
+``sns.histplot(hue=...)`` draws one ``BarContainer`` per group. The patch used
+to register one layer and read the **first** container, so every other group
+stayed on screen and vanished from the announcement -- with nothing raising,
+which is the failure that reads as a complete single-distribution histogram.
+
+Measured on seaborn 0.13.2, sixty observations over two groups, ``bins=5``::
+
+    container 0 heights: [0, 4, 10, 9, 5]     <- group x
+    container 1 heights: [1, 11, 8, 8, 4]     <- group y
+    layer 0 hist y=[0, 4, 10, 9, 5]           <- only x was announced
+
+The container the patch chose used to be justified as unobservable, on the
+grounds that a hue's groups share one binning. The *edges* are shared; the
+counts are not, which is what the two rows above show and what these cases
+pin.
+
+The split alone is not enough. Several ``hist`` layers over one axis with
+nothing to tell them apart is the position ``MaidrLayer.name`` was added for
+(xability/maidr#828), so each is named from the legend swatch drawn in its
+own colour -- the match ``scatterplot.hue_groups`` already makes point by
+point, one level up.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame(groups: list[str], size: int = 60) -> pd.DataFrame:
+    """A frame whose values are fixed, so the counts below are reproducible."""
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {"a": rng.normal(size=size), "g": rng.choice(groups, size=size)}
+    )
+
+
+def _layers(fig) -> list[dict]:
+    """Every layer's rendered schema, in registration order."""
+    return [plot.schema for plot in FigureManager.get_maidr(fig).plots]
+
+
+def _counts(fig) -> list[list[float]]:
+    """Each layer's per-bin counts."""
+    return [[point["y"] for point in layer["data"]] for layer in _layers(fig)]
+
+
+def _names(fig) -> list:
+    """Each layer's group name, or None where it carries none."""
+    return [layer.get("name") for layer in _layers(fig)]
+
+
+def _true_counts(frame: pd.DataFrame, group: str, bins: int) -> list[int]:
+    """What the group's own histogram holds, computed independently."""
+    edges = np.histogram_bin_edges(frame.a, bins=bins)
+    counts, _ = np.histogram(frame.a[frame.g == group], bins=edges)
+    return list(counts)
+
+
+def test_each_hue_group_becomes_its_own_layer():
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, ax=ax)
+
+    assert len(ax.containers) == 2
+    assert len(_layers(fig)) == 2
+
+
+def test_each_layer_announces_its_own_group_s_counts():
+    # The heart of it: the second group used to be drawn and never spoken.
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, ax=ax)
+
+    assert _counts(fig) == [
+        [float(count) for count in _true_counts(frame, "x", 5)],
+        [float(count) for count in _true_counts(frame, "y", 5)],
+    ]
+
+
+def test_each_layer_is_named_from_the_legend():
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, ax=ax)
+
+    assert _names(fig) == ["x", "y"]
+
+
+def test_a_third_group_is_read_and_named_too():
+    # Not a restatement of the pair: the old reading dropped *every* group
+    # after the first, so the loss grew with the chart.
+    frame = _frame(["x", "y", "z"], size=90)
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, ax=ax)
+
+    assert len(ax.containers) == 3
+    assert len(_layers(fig)) == 3
+
+    # Paired rather than sorted: three names in *some* order says nothing
+    # about whether each sits on its own group's counts, which is the whole
+    # question a positional match gets wrong.
+    by_name = dict(zip(_names(fig), _counts(fig)))
+    assert sorted(by_name) == ["x", "y", "z"]
+    for group in ("x", "y", "z"):
+        assert by_name[group] == [
+            float(count) for count in _true_counts(frame, group, 5)
+        ]
+
+
+@pytest.mark.parametrize("multiple", ["layer", "stack", "dodge", "fill"])
+def test_every_layout_splits(multiple):
+    # How the groups are arranged against each other is a drawing decision and
+    # changes nothing about how many distributions there are.
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, multiple=multiple, ax=ax)
+
+    assert len(_layers(fig)) == 2
+
+
+def test_a_name_is_matched_by_colour_rather_than_by_position():
+    # The trap, measured rather than guarded against in the abstract: on this
+    # chart seaborn draws the groups x then y and lists them y then x. So
+    # zipping the containers with the legend's entries -- the obvious cheap
+    # rule -- gives every layer the *other* group's name, with its own counts
+    # underneath.
+    #
+    # Worth being exact about what these cases do and do not show. Measured on
+    # seaborn 0.13.2 the legend is the *exact reverse* of the draw order, for
+    # two groups and for three, so a positional rule that read the legend
+    # backwards would agree with the colour match on every chart here. The
+    # colour match is still what is implemented, because it does not rest on
+    # that reversal holding -- it is nothing seaborn documents -- and because
+    # it declines rather than mislabels when a legend carries entries that are
+    # not group swatches, which `_named_colours` was written for.
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, ax=ax)
+
+    legend_order = [text.get_text() for text in ax.get_legend().get_texts()]
+    assert legend_order == ["y", "x"]
+    assert _names(fig) == ["x", "y"]
+
+    # And each name really does sit on its own group's counts.
+    by_name = dict(zip(_names(fig), _counts(fig)))
+    for group in ("x", "y"):
+        assert by_name[group] == [
+            float(count) for count in _true_counts(frame, group, 5)
+        ]
+
+
+def test_a_single_level_hue_is_one_unnamed_layer():
+    # A `hue` whose column holds one value: seaborn draws a single container
+    # and still builds a legend naming its colour, which is the one case that
+    # reaches the guard. Naming the layer would be *accurate* and still wrong
+    # to say -- a name on the only layer of a chart reads as though there were
+    # another to tell it from.
+    #
+    # `label=` plus a later `ax.legend()` does not reach it, measured: the
+    # legend does not exist yet when the layer registers, so the colour match
+    # declines a step earlier for a different reason.
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame[frame.g == "x"], x="a", hue="g", bins=5, ax=ax)
+
+    assert len(ax.containers) == 1
+    assert [text.get_text() for text in ax.get_legend().get_texts()] == ["x"]
+    assert _names(fig) == [None]
+
+
+def test_an_ungrouped_histogram_is_one_unnamed_layer():
+    # A single distribution has nothing to be told apart from, and a name
+    # there would read as though the chart held more.
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", bins=5, ax=ax)
+
+    assert len(_layers(fig)) == 1
+    assert _names(fig) == [None]
+
+
+def test_a_suppressed_legend_still_reads_every_group():
+    # `legend=False` takes away the only thing that names the colours. The
+    # groups are still there and still drawn, so they are still read -- just
+    # unnamed, which is the honest answer rather than inventing labels.
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, legend=False, ax=ax)
+
+    assert len(_layers(fig)) == 2
+    assert _names(fig) == [None, None]
+
+
+def test_displot_splits_too():
+    # `displot` drives `_DistributionPlotter` directly and reaches only the
+    # second patch site, so fixing one and not the other would leave the same
+    # chart read differently through its two spellings (#446, #522).
+    frame = _frame(["x", "y"])
+    grid = sns.displot(data=frame, x="a", hue="g", bins=5)
+
+    assert len(_layers(grid.figure)) == 2
+
+
+def test_the_figure_still_renders():
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, ax=ax)
+
+    assert len(maidr.render(fig)._repr_html_()) > 0

--- a/tests/core/plot/test_own_artist_binding.py
+++ b/tests/core/plot/test_own_artist_binding.py
@@ -239,11 +239,16 @@ def test_two_identical_histograms_are_still_told_apart():
     assert bound[1] is containers[1]
 
 
-def test_a_hue_grouped_histogram_reads_as_it_always_did():
-    # A call that adds several containers at once. `_new_bar_container` takes
-    # the first, which is what `extract_container` -- the fallback -- would
-    # have found, so naming the container changed nothing here. Measured
-    # against unmodified `main`: bins [1.0, 25.5] before and after.
+def test_a_hue_grouped_histogram_gives_each_group_its_own_layer():
+    # This asserted **one** layer when it was written, on the reasoning that a
+    # hue's groups share one binning and so the container the patch picked was
+    # unobservable. The binning is shared -- both rows below still open at
+    # 1.0 and 25.5 -- but the counts are not, and reading one container
+    # announced one distribution while the other stayed drawn and unspoken
+    # (#558).
+    #
+    # What this case is really about is unchanged: a layer reads the container
+    # its own call drew. There are simply two of them.
     frame = pd.DataFrame(
         {"v": [1, 1, 1, 50, 50, 50], "g": ["a", "a", "a", "b", "b", "b"]}
     )
@@ -251,5 +256,17 @@ def test_a_hue_grouped_histogram_reads_as_it_always_did():
     sns.histplot(frame, x="v", hue="g", bins=2, ax=ax)
 
     layers = _hist_points(fig)
-    assert len(layers) == 1
-    assert _bins(layers[0]) == [1.0, 25.5]
+    assert len(layers) == 2
+    assert [_bins(layer) for layer in layers] == [[1.0, 25.5], [1.0, 25.5]]
+
+    # Three observations at 1 in one group and three at 50 in the other, which
+    # is the half the old reading threw away. Group `b` is drawn first here:
+    # seaborn's container order is not its hue order, which is why #558 names
+    # each layer by the colour of the swatch that claims it rather than by
+    # where it sits.
+    assert [[point["y"] for point in layer] for layer in layers] == [
+        [0.0, 3.0],
+        [3.0, 0.0],
+    ]
+    names = [plot.schema.get("name") for plot in FigureManager.get_maidr(fig).plots]
+    assert names == ["b", "a"]


### PR DESCRIPTION
Closes #558.

## What happens

`sns.histplot(hue=...)` draws one `BarContainer` per group. The patch registered **one layer**, read the **first** container, and every other group stayed on screen and vanished from the announcement — with nothing raising, so the chart read as a complete single-distribution histogram.

Measured on seaborn 0.13.2, sixty observations over two groups, `bins=5`:

```
container 0 heights: [0, 4, 10, 9, 5]     <- group x
container 1 heights: [1, 11, 8, 8, 4]     <- group y

layer 0 hist y=[0, 4, 10, 9, 5]           <- only x was announced
```

It did not depend on the layout, and it grew with the chart:

| call | containers | layers before | layers after |
| --- | --- | --- | --- |
| `histplot(hue=g)` | 2 | 1 | 2 |
| `histplot(hue=g, multiple="stack")` | 2 | 1 | 2 |
| `histplot(hue=g, multiple="dodge")` | 2 | 1 | 2 |
| `histplot(hue=g, multiple="fill")` | 2 | 1 | 2 |
| three groups | 3 | **1** | 3 |
| no hue | 1 | 1 | 1 |

`Axes.hist` never had this — `mpl_hist` already emits one layer per container after #553 and #555 — so the same two distributions were read through matplotlib and dropped through seaborn.

## A comment of mine that measurement falsifies

`_new_bar_container`'s docstring justified taking the first:

> …the choice is unobservable on every input that reaches here, because a call adding several containers is a hue-grouped `histplot`, whose groups share one binning — measured, first and last give the same bin edges and the same reading.

The **edges** are shared. The **counts** are not, as the two rows above show. "The same reading" was false, and the comment read as a reason not to look further — which is how the defect survived the audit that wrote it. The function is now `_new_bar_containers`, answering with all of them, and the docstring says what is actually true.

## Both sites

`sns_hist` for `histplot`, and the `_DistributionPlotter.plot_univariate_histogram` wrapper that `displot` reaches on its own. Fixing one and not the other would leave the same chart read differently through its two spellings — the asymmetry #446 and #522 were both about — so there is a case for each.

## Naming, because the split alone is not enough

Several `hist` layers over one axis with nothing to tell them apart is exactly the position `MaidrLayer.name` was added for (xability/maidr#828). Each layer is named from the legend swatch drawn in **its own colour**, reusing `scatterplot._named_colours` rather than reimplementing the match one level up.

Not by position. Measured, seaborn lists the legend in the **exact reverse** of the draw order — `['y', 'x']` against containers drawn `x, y`, and `['z', 'x', 'y']` against `y, x, z` — so pairing them off in order gives every layer somebody else's name, with its own counts underneath.

A **single** container is left unnamed even where a legend names its colour: a name on the only layer of a chart reads as though there were another to tell it from. A suppressed legend (`legend=False`) leaves the groups read but unnamed, which is the honest answer rather than inventing labels.

## Tests

14 cases in `tests/core/plot/test_hue_histogram.py`. Falsified with five mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| take only the first container | 11 |
| never name anything | 3 |
| name by legend position | 3 |
| leave the plotter site reading one container | 1 |
| name a lone container too | 2 |

**Two cases were strengthened because falsification found them weak.** The colour-match case was passed by a positional rule that read the legend *backwards*, so it now asserts the two orders outright — and records that on seaborn 0.13.2 the reversal holds, so a backwards-positional rule would agree on these charts; the colour match is still what is implemented, because that reversal is nothing seaborn documents and it declines rather than mislabels on a legend carrying non-group entries. The lone-container guard was unreachable through `label=` + `ax.legend()` — the legend does not exist yet when the layer registers — so it now uses a single-level `hue`, which does build one.

**One existing test was updated in place.** `test_a_hue_grouped_histogram_reads_as_it_always_did` pinned the one-layer state this replaces and carried the same false claim. It now asserts two layers, the shared binning that was the true half, and the counts that were the missing one — plus the names, since the draw order there is `b, a` and shows why position is the wrong key.

`uvx ruff@0.3.4 check --diff .` (CI's pin) exit 0; full suite **2605 passed, 18 skipped**.

## Not in scope

The same anonymity affects the `smooth` layers a hue-grouped `kdeplot` emits — both groups *are* announced there, just indistinguishably — and `sns.pairplot(df, hue=...)` puts two of them on every diagonal panel. That is a naming gap rather than dropped data, and it belongs in its own change; #558 records it.

`multiple="stack"` and `"fill"` are conceptually stacked and normalized histograms. Reading them as one layer per group announces every group's own counts correctly and leaves only *the fact that they are stacked* unsaid — the same trade `mpl_hist` records for `histtype="barstacked"`, and a strict improvement on announcing one group. Whether they should become `stacked_bar` / `stacked_normalized_bar` layers is a separate question.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_