### PR TITLE
fix(kde): name each curve of a hue-grouped density, not just its bars

### DIFF
--- a/maidr/core/plot/histogram.py
+++ b/maidr/core/plot/histogram.py
@@ -5,6 +5,7 @@ from matplotlib.container import BarContainer
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
+from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.exception import ExtractionError
 from maidr.util.mixin import ContainerExtractorMixin, DictMergerMixin
 
@@ -13,12 +14,6 @@ from maidr.util.mixin import ContainerExtractorMixin, DictMergerMixin
 #: way.
 DRAWN_BARS = "_maidr_bars"
 
-#: Key the patch passes this layer's hue group name under, when the chart has
-#: one. A ``histplot(hue=...)`` draws one container per group and so becomes
-#: one layer per group (#558); without a name the reader is offered several
-#: ``hist`` layers over one axis with nothing to tell them apart, which is the
-#: position xability/maidr#828 added ``MaidrLayer.name`` for.
-GROUP_NAME = "_maidr_group_name"
 
 
 class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
@@ -42,7 +37,8 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         self._own_bars = own_bars if isinstance(own_bars, BarContainer) else None
         # The hue group this layer's container belongs to, when the patch
         # could name it. `None` is the ungrouped case and every chart that
-        # drew no legend.
+        # drew no legend. Opted into here rather than read by `MaidrPlot`;
+        # see `GROUP_NAME` for why that is per class.
         group_name = kwargs.pop(GROUP_NAME, None)
         self._group_name = group_name if isinstance(group_name, str) else None
         super().__init__(ax, PlotType.HIST)

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -12,6 +12,27 @@ from maidr.util.mixin import FormatExtractorMixin
 import uuid
 
 
+#: Key a patch passes a layer's group name under.
+#:
+#: A chart that draws one layer per group -- a hue-split histogram, one KDE
+#: curve per level -- leaves a reader several layers of a kind over one axis
+#: with nothing to tell them apart, which is the position
+#: ``MaidrLayer.name`` was added for (xability/maidr#828).
+#:
+#: Defined here because more than one layer type answers to it, and
+#: **honoured per class** rather than read by this base: most subclasses call
+#: ``super().__init__(ax, PlotType.X)`` without forwarding their keyword
+#: arguments, so a key read here would arrive for some layer types and be
+#: swallowed by the rest -- a promise kept by accident of how each
+#: constructor happens to be written. ``HistPlot`` and ``SmoothPlot`` opt in
+#: today, each in one visible line.
+#:
+#: ``ScatterPlot`` and ``EventPlot`` name their layers by other means -- a hue
+#: split and row labels -- and are unaffected, being passed neither this key
+#: nor anything that collides with it.
+GROUP_NAME = "_maidr_group_name"
+
+
 class MaidrPlot(ABC, FormatExtractorMixin):
     """
     Abstract base class for plots managed by the MAIDR system.
@@ -58,6 +79,8 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         # MAIDR data
         self.type = plot_type
         self._schema = {}
+
+
 
     def render(self) -> dict:
         """

--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.collections import PolyCollection
-from maidr.core.plot.maidr_plot import MaidrPlot
+from maidr.core.plot.maidr_plot import GROUP_NAME, MaidrPlot
 from maidr.exception.extraction_error import ExtractionError
 import numpy as np
 from maidr.core.enum.plot_type import PlotType
@@ -39,11 +39,30 @@ class SmoothPlot(MaidrPlot):
         ax : Axes
             The matplotlib axes object containing the regression line.
         """
+        # The hue group this curve belongs to, when the patch could name it.
+        # A `kdeplot(hue=...)` draws one curve per level and both were
+        # announced identically before (#558). Opted into here rather than
+        # read by `MaidrPlot`; see `GROUP_NAME` for why that is per class.
+        group_name = kwargs.get(GROUP_NAME, None)
+        self._group_name = group_name if isinstance(group_name, str) else None
         super().__init__(ax, PlotType.SMOOTH)
         self._smooth_gid = None
         self._regression_line = kwargs.get("regression_line", None)
         self._poly_gid = kwargs.get("poly_gid", None)
         self._is_polycollection = kwargs.get("is_polycollection", False)
+
+    def render(self) -> dict:
+        """
+        Add the group's name when the curve is one of several.
+
+        The same field, and for the same reason, as ``HistPlot``: several
+        ``smooth`` layers over one axis with nothing to tell them apart leave
+        a reader hearing the identical announcement twice.
+        """
+        schema = super().render()
+        if self._group_name:
+            schema[MaidrKey.NAME] = self._group_name
+        return schema
 
     def _get_selector(self):
         """

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -15,7 +15,9 @@ import uuid
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.core.plot.histogram import DRAWN_BARS, GROUP_NAME
+from maidr.core.plot.histogram import DRAWN_BARS
+from maidr.core.plot.maidr_plot import GROUP_NAME
+from maidr.patch.kdeplot import _curve_names
 from maidr.core.plot.scatterplot import _named_colours, _rgba
 from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, STEP_ORIENTATION
 from maidr.core.plot.stepped_histogram import reads as _reads_outline
@@ -167,7 +169,7 @@ def _containers_of(ax: Axes | None) -> list:
 
 def _new_bar_containers(ax: Axes | None, before: list) -> list[BarContainer]:
     """
-    The ``BarContainer``\ s a call just added to an axes, in draw order.
+    The bar containers a call just added to an axes, in draw order.
 
     Compared by identity against the snapshot. Not because value comparison
     would be wrong -- measured, two containers over identical data compare
@@ -579,18 +581,22 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
         # Find the KDE line(s) and register as SMOOTH
         axes = ax if isinstance(ax, Axes) else getattr(ax, "axes", None)
         if axes is not None:
-            for line in axes.get_lines():
-                if isinstance(line, Line2D):
-                    if line.get_gid() is None:
-                        gid = f"maidr-{uuid.uuid4()}"
-                        line.set_gid(gid)
-                    common(
-                        PlotType.SMOOTH,
-                        lambda *a, **k: axes,
-                        instance,
-                        args,
-                        dict(kwargs, regression_line=line),
-                    )
+            # The overlay is drawn one curve per hue group too, so it is named
+            # the same way the bars beneath it are -- otherwise a chart with
+            # both would announce two named histograms and two anonymous
+            # curves over the same axis (#558).
+            curves = [line for line in axes.get_lines() if isinstance(line, Line2D)]
+            for line, name in zip(curves, _curve_names(axes, curves)):
+                if line.get_gid() is None:
+                    gid = f"maidr-{uuid.uuid4()}"
+                    line.set_gid(gid)
+                common(
+                    PlotType.SMOOTH,
+                    lambda *a, **k: axes,
+                    instance,
+                    args,
+                    dict(kwargs, regression_line=line, **{GROUP_NAME: name}),
+                )
     return ax
 
 

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -11,6 +11,8 @@ from matplotlib.collections import PolyCollection
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.contour import tag
+from maidr.core.plot.maidr_plot import GROUP_NAME
+from maidr.core.plot.scatterplot import _handle_colour, _rgba
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
 from maidr.core.context_manager import ContextManager
 from maidr.util.svg_utils import unique_lines_by_xy
@@ -84,6 +86,187 @@ def _register_field(ax: Axes | None, before: list) -> None:
         FigureManager.create_maidr(ax, PlotType.CONTOUR, contour_set=drawn)
 
 
+def _curve_names(ax: Axes, curves: list) -> list:
+    """
+    Name each KDE curve from the legend swatch drawn in its colour.
+
+    A ``kdeplot(hue=...)`` draws one curve per group and both distributions
+    are announced -- but with nothing to tell them apart, so a reader hears
+    the identical announcement twice (#558). The colours are what separate
+    them on screen and the legend is what names those colours, which is the
+    match ``scatterplot.hue_groups`` already makes point by point and
+    ``patch/histogram`` container by container.
+
+    Not by position. Measured on seaborn 0.13.2 the legend runs the reverse of
+    the draw order -- curves drawn orange then blue against entries listed
+    ``['y', 'x']`` -- so pairing them off gives each curve the other group's
+    name.
+
+    Every reason to decline leaves the curves unnamed rather than naming them
+    wrongly: no legend, a curve no swatch claims, or a swatch that names two
+    things. A lone curve is left unnamed whatever the legend says, because a
+    name on the only layer of a chart reads as though there were another to
+    tell it from.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    curves : list
+        The KDE lines, in draw order.
+
+    Returns
+    -------
+    list
+        One entry per curve, naming it or ``None``.
+    """
+    return _names_for(ax, [_rgba(curve.get_color()) for curve in curves])
+
+
+def _fill_names(ax: Axes, fills: list) -> list:
+    """
+    Name each filled KDE band from the legend swatch drawn in its colour.
+
+    ``kdeplot(hue=..., fill=True)`` draws no lines at all -- measured, two
+    groups give two ``PolyCollection`` bands and no ``Line2D`` at all -- so the
+    curve match above never sees them. A band's ``get_facecolor`` carries the
+    same translucent colour its swatch does, which is the whole difference.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    fills : list
+        The bands, in draw order.
+
+    Returns
+    -------
+    list
+        One entry per band, naming it or ``None``.
+    """
+    return _names_for(ax, [_collection_colour(fill) for fill in fills])
+
+
+def _collection_colour(collection) -> tuple | None:
+    """
+    The one colour a collection is filled with, if it has one.
+
+    Parameters
+    ----------
+    collection : PolyCollection
+        The band.
+
+    Returns
+    -------
+    tuple or None
+        The rounded RGBA, or ``None`` when it is filled with several colours
+        or none.
+    """
+    colours = {_rgba(row) for row in collection.get_facecolor()}
+    if len(colours) != 1:
+        return None
+    return colours.pop()
+
+
+def _names_for(ax: Axes, colours: list) -> list:
+    """
+    Match a list of drawn colours against the legend that names them.
+
+    Two passes, and the second is not a convenience. Measured on seaborn
+    0.13.2, ``histplot(kde=True, hue=...)`` draws its overlay curves **opaque**
+    while the legend swatches carry the bars' translucency::
+
+        line   (1.0, 0.498, 0.055, 1.0)
+        swatch (1.0, 0.498, 0.055, 0.5)
+
+    Identical hue, different alpha, so an RGBA comparison names nothing at all
+    -- the chart would announce two named histograms and two anonymous curves
+    over one axis. What identifies a group is the hue, so a second pass
+    compares the three colour channels alone.
+
+    That pass is guarded: it runs only where the drawn colours are already
+    distinct without their alpha. Two artists separated *by* their opacity
+    would otherwise both take whichever name matched, and a confident wrong
+    name is worse than none.
+
+    Every other reason to decline stands: no legend, an artist no swatch
+    claims, a swatch that names two things, and a lone artist -- which needs
+    nothing to be told apart from.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    colours : list
+        One rounded RGBA per artist, or ``None`` where it has no single one.
+
+    Returns
+    -------
+    list
+        One name per entry, or ``None``.
+    """
+    if len(colours) < 2:
+        return [None] * len(colours)
+
+    legend = ax.get_legend()
+    if legend is None:
+        return [None] * len(colours)
+
+    swatches = [
+        (_handle_colour(handle), text.get_text())
+        for handle, text in zip(legend.legend_handles, legend.get_texts())
+    ]
+
+    keys = [lambda colour: colour]
+    hues = [colour[:3] for colour in colours if colour is not None]
+    if len(set(hues)) == len(hues):
+        keys.append(lambda colour: colour[:3])
+
+    for key in keys:
+        named = _match_swatches(colours, swatches, key)
+        if named:
+            return [
+                None if colour is None else named.get(key(colour))
+                for colour in colours
+            ]
+    return [None] * len(colours)
+
+
+def _match_swatches(colours: list, swatches: list, key) -> dict | None:
+    """
+    Map each swatch that a drawn artist shares a colour with to its name.
+
+    Parameters
+    ----------
+    colours : list
+        The drawn colours.
+    swatches : list
+        ``(colour, name)`` per legend entry, colour ``None`` where the handle
+        names no single one.
+    key : callable
+        What counts as "the same colour" for this pass.
+
+    Returns
+    -------
+    dict or None
+        Key to name, or ``None`` when one colour is claimed by two names --
+        a ``style=`` legend does that, and a swatch meaning two things cannot
+        name the group an artist belongs to.
+    """
+    drawn = {key(colour) for colour in colours if colour is not None}
+    named: dict = {}
+    for colour, name in swatches:
+        if colour is None:
+            continue
+        matched = key(colour)
+        if matched not in drawn:
+            continue
+        if named.get(matched, name) != name:
+            return None
+        named[matched] = name
+    return named
+
+
 def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
     """
     Register every KDE curve on one axes as a SMOOTH layer.
@@ -107,7 +290,8 @@ def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
     if ax is not None:
         # Register all unique Line2D objects
         lines = [line for line in ax.get_lines() if isinstance(line, Line2D)]
-        for kde_line in unique_lines_by_xy(lines):
+        curves = list(unique_lines_by_xy(lines))
+        for kde_line, name in zip(curves, _curve_names(ax, curves)):
             if kde_line.get_gid() is None:
                 gid = f"maidr-{uuid.uuid4()}"
                 kde_line.set_gid(gid)
@@ -116,10 +300,11 @@ def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
                 lambda *a, **k: ax,
                 instance,
                 args,
-                dict(kwargs, regression_line=kde_line),
+                dict(kwargs, regression_line=kde_line, **{GROUP_NAME: name}),
             )
         # Register all PolyCollection boundaries as SMOOTH
-        for poly in [c for c in ax.collections if isinstance(c, PolyCollection)]:
+        fills = [c for c in ax.collections if isinstance(c, PolyCollection)]
+        for poly, fill_name in zip(fills, _fill_names(ax, fills)):
             if poly.get_paths():
                 path = poly.get_paths()[0]
                 boundary = path.vertices
@@ -139,6 +324,7 @@ def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
                         regression_line=kde_line,
                         poly_gid=gid,
                         is_polycollection=True,
+                        **{GROUP_NAME: fill_name},
                     ),
                 )
 

--- a/tests/core/plot/test_hue_kde_naming.py
+++ b/tests/core/plot/test_hue_kde_naming.py
@@ -1,0 +1,193 @@
+"""
+A hue-grouped KDE names its curves (#558, the half #559 left).
+
+``sns.kdeplot(hue=...)`` draws one curve per group and #559 left both of them
+announced -- but with nothing to tell them apart, so a reader hears the
+identical announcement twice::
+
+    smooth(name=None, n=1), smooth(name=None, n=1)
+
+Several ``smooth`` layers over one axis with nothing to tell them apart is the
+position ``MaidrLayer.name`` was added for (xability/maidr#828). Each is named
+from the legend swatch drawn in **its own colour**, which is the match
+``scatterplot.hue_groups`` makes point by point and ``patch/histogram``
+container by container.
+
+Not by position: measured on seaborn 0.13.2 the legend runs the reverse of the
+draw order -- curves drawn orange then blue against entries listed
+``['y', 'x']`` -- so pairing them off gives each curve the other group's name.
+
+Two artists, not one. Measured, ``fill=True`` draws **no lines at all**: two
+groups give two ``PolyCollection`` bands and zero ``Line2D`` curves, so a fix
+that only matched lines would leave the filled spelling of the same chart
+anonymous.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {"a": rng.normal(size=60), "g": rng.choice(["x", "y"], size=60)}
+    )
+
+
+def _names(fig) -> list:
+    """Each layer's group name, or None where it carries none."""
+    return [plot.schema.get("name") for plot in FigureManager.get_maidr(fig).plots]
+
+
+def test_each_curve_is_named_from_the_legend():
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", hue="g", ax=ax)
+
+    assert len(ax.get_lines()) == 2
+    assert _names(fig) == ["x", "y"]
+
+
+def test_a_filled_kde_is_named_too():
+    # The branch a line-only match misses: no `Line2D` at all, two bands.
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", hue="g", fill=True, ax=ax)
+
+    assert len(ax.get_lines()) == 0
+    assert len(ax.collections) == 2
+    assert _names(fig) == ["x", "y"]
+
+
+def test_a_name_is_matched_by_colour_rather_than_by_position():
+    # The trap: seaborn lists the legend in the reverse of the draw order, so
+    # zipping curves against legend entries gives each the other's name.
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", hue="g", ax=ax)
+
+    assert [text.get_text() for text in ax.get_legend().get_texts()] == ["y", "x"]
+    assert _names(fig) == ["x", "y"]
+
+
+def test_an_ungrouped_kde_is_one_unnamed_curve():
+    # Nothing to be told apart from, and a name would read as though there
+    # were.
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", ax=ax)
+
+    assert _names(fig) == [None]
+
+
+def test_a_suppressed_legend_leaves_the_curves_unnamed():
+    # `legend=False` takes away the only thing that names the colours. The
+    # curves are still read; inventing labels for them would not be better.
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", hue="g", legend=False, ax=ax)
+
+    assert len(_names(fig)) == 2
+    assert _names(fig) == [None, None]
+
+
+def test_a_histogram_s_kde_overlay_is_named_beside_its_bars():
+    # `histplot(kde=True, hue=...)` draws both, and #559 named only the bars.
+    fig, ax = plt.subplots()
+    sns.histplot(data=_frame(), x="a", hue="g", bins=5, kde=True, ax=ax)
+
+    assert sorted(name for name in _names(fig) if name) == ["x", "x", "y", "y"]
+
+
+# ---------------------------------------------------------------------------
+# The guard on the second matching pass, which no seaborn chart reaches.
+#
+# Comparing the three colour channels alone is what lets an opaque overlay
+# curve find the translucent swatch that names it. Two artists separated *by*
+# their opacity would then both match the same swatch, so the pass runs only
+# where the drawn colours are already distinct without their alpha. Nothing
+# seaborn draws puts two hue levels on one hue, so this is asserted against
+# the function directly rather than through a chart.
+# ---------------------------------------------------------------------------
+
+
+class _Handle:
+    """A legend handle that names one colour, the way seaborn's do."""
+
+    def __init__(self, colour):
+        self._colour = colour
+
+    def get_facecolor(self):
+        return self._colour
+
+
+class _Text:
+    """A legend entry's label."""
+
+    def __init__(self, text):
+        self._text = text
+
+    def get_text(self):
+        return self._text
+
+
+class _Legend:
+    """Just enough legend for the colour match."""
+
+    def __init__(self, entries):
+        self.legend_handles = [_Handle(colour) for colour, _ in entries]
+        self._texts = [_Text(name) for _, name in entries]
+
+    def get_texts(self):
+        return self._texts
+
+
+class _Axes:
+    """Just enough axes to carry a legend."""
+
+    def __init__(self, legend):
+        self._legend = legend
+
+    def get_legend(self):
+        return self._legend
+
+
+def test_the_hue_pass_names_an_opaque_artist_from_a_translucent_swatch():
+    from maidr.patch.kdeplot import _names_for
+
+    legend = _Legend([((0.1, 0.4, 0.7, 0.5), "y"), ((1.0, 0.5, 0.05, 0.5), "x")])
+    drawn = [(1.0, 0.5, 0.05, 1.0), (0.1, 0.4, 0.7, 1.0)]
+
+    assert _names_for(_Axes(legend), drawn) == ["x", "y"]
+
+
+def test_the_hue_pass_declines_when_two_artists_share_a_hue():
+    from maidr.patch.kdeplot import _names_for
+
+    # Both drawn in the same colour at different opacities. Whichever swatch
+    # the hue matched would claim both, so neither is named.
+    legend = _Legend([((0.1, 0.4, 0.7, 0.5), "y"), ((1.0, 0.5, 0.05, 0.5), "x")])
+    drawn = [(1.0, 0.5, 0.05, 1.0), (1.0, 0.5, 0.05, 0.3)]
+
+    assert _names_for(_Axes(legend), drawn) == [None, None]
+
+
+def test_an_exact_match_is_preferred_to_the_hue_pass():
+    from maidr.patch.kdeplot import _names_for
+
+    # Where the alphas already agree, the first pass answers and the guard on
+    # the second never comes into it -- which is what keeps a chart whose
+    # groups really are told apart by opacity working, so long as it names
+    # them exactly.
+    legend = _Legend([((1.0, 0.5, 0.05, 1.0), "opaque"), ((1.0, 0.5, 0.05, 0.3), "faint")])
+    drawn = [(1.0, 0.5, 0.05, 1.0), (1.0, 0.5, 0.05, 0.3)]
+
+    assert _names_for(_Axes(legend), drawn) == ["opaque", "faint"]


### PR DESCRIPTION
Part of #558 — the half #559 left.

## What happens

#559 read every group of a hue-grouped histogram and named them. The curves beside them stayed anonymous. `sns.kdeplot(hue=...)` draws one per group and both were announced identically:

```
smooth(name=None, n=1), smooth(name=None, n=1)
```

Both distributions *are* read — this is not dropped data — but a reader hears the same clause twice with no way to know which one they are on. That is the position `MaidrLayer.name` was added for (xability/maidr#828).

## Three artists, not one

Each measured rather than assumed:

| chart | what it draws | before | after |
| --- | --- | --- | --- |
| `kdeplot(hue=g)` | 2 `Line2D` | `None, None` | `x, y` |
| `kdeplot(hue=g, fill=True)` | **0 lines**, 2 `PolyCollection` | `None, None` | `x, y` |
| `histplot(hue=g, kde=True)` | 2 containers + 2 lines | `x, y, None, None` | `x, y, x, y` |

`fill=True` drawing no `Line2D` at all is the one that matters: a line-only match would leave the filled spelling of the same chart anonymous. And `histplot(kde=True)` registers its overlay through its own branch, so it would otherwise announce two named histograms and two anonymous curves over one axis.

## The overlay needed a second matching pass

Measured, seaborn draws the overlay **opaque** while the legend swatch carries the bars' translucency:

```
line   (1.0, 0.498, 0.055, 1.0)
swatch (1.0, 0.498, 0.055, 0.5)
```

Identical hue, different alpha, so an RGBA comparison names nothing at all. What identifies a group is the hue, so a second pass compares the three colour channels alone.

**It is guarded.** The hue pass runs only where the drawn colours are already distinct without their alpha — two artists separated *by* their opacity would otherwise both take whichever swatch the hue matched, and a confident wrong name is worse than none. An exact RGBA match is still tried first, so a chart whose groups really are told apart by opacity keeps working.

Nothing seaborn draws puts two hue levels on one hue, so that guard is asserted against `_names_for` **directly** rather than through a chart — three cases with a stubbed legend.

## Where the key lives

`GROUP_NAME` moves to `maidr_plot.py`, since a second layer type now answers to it, and is honoured **per class** rather than read by the base. That is deliberate: most subclasses call `super().__init__(ax, PlotType.X)` without forwarding their keyword arguments, so a key read in the base would arrive for some layer types and be silently swallowed by the rest — a promise kept by accident of how each constructor happens to be written. `HistPlot` and `SmoothPlot` opt in, each in one visible line, and the constant's docstring says so.

## Tests

9 cases in `tests/core/plot/test_hue_kde_naming.py`. Falsified with six mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| drop the hue pass | 1 |
| `SmoothPlot` ignores the name | 4 |
| name by legend position | 3 |
| leave the fill branch unnamed | 1 |
| leave the histogram's overlay unnamed | 1 |
| drop the distinctness guard | 1 |

`uvx ruff@0.3.4 check --diff .` (CI's pin) exit 0; full suite **2614 passed, 18 skipped**.

## Still not named, and measured why

`sns.pairplot(df, hue=...)` puts two KDE layers on every diagonal panel, and they stay anonymous. The reason is timing, not the match: seaborn draws the diagonals as filled bands and adds the legend to the **figure** afterwards, so at the moment each panel registers there is no legend anywhere —

```
_curve_names: 2 fills, ax legend=False, fig legends=0
after:        fig legends=1, axes legends=[False] * 6
```

Naming them would mean either deferring the match to render time or reading a legend that does not exist yet. That is the same constraint `hue_groups` already records for a scatter whose legend is built after the fact, and it is a change to *when* a layer decides what it says rather than to how it matches — so it is left for its own issue rather than guessed at here. #558 records it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_