### PR TITLE
fix(line): carry the interval a chart shades around a line

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -4,12 +4,15 @@ from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 
 from maidr.core.enum.maidr_key import MaidrKey
+from maidr.util.confidence_band import band_edges_at
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.exception.extraction_error import ExtractionError
 from maidr.util.mixin.extractor_mixin import LineExtractorMixin
 import math
 import uuid
+
+import numpy as np
 
 
 def _has_position(x: object) -> bool:
@@ -267,6 +270,8 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
             legend_labels = [text.get_text() for text in self.ax.legend_.get_texts()]
 
         all_lines_data = []
+        # Regions handed to an earlier series, so a band answers for one line.
+        claimed: list = []
 
         for i, line in enumerate(all_lines):
             xydata = line.get_xydata()
@@ -306,7 +311,54 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
                 if _has_position(x)
             ]
 
+            self._attach_band(line_data, claimed)
+
             if line_data:
                 all_lines_data.append(line_data)
 
         return all_lines_data if all_lines_data else None
+
+    def _attach_band(self, line_data: list, claimed: list) -> None:
+        """
+        Give each point the interval the chart shades around it, if there is
+        one.
+
+        ``sns.lineplot`` aggregates repeated x values and draws a 95%%
+        confidence band **by default**, and matplotlib's own documentation
+        writes the same chart as ``plot`` plus ``fill_between``. Either way
+        the line was announced alone, so a reader was told the trend and not
+        how well determined it is -- the gap xability/r-maidr#135 closed for
+        `geom_smooth(se = TRUE)` and #451 for a `regplot` (#562).
+
+        ``SmoothPoint``'s `yMin`/`yMax` is the shape for it, and the region is
+        identified by bracketing rather than by type; see
+        :mod:`maidr.util.confidence_band`.
+
+        Parameters
+        ----------
+        line_data : list
+            One series' points, modified in place.
+        claimed : list
+            Regions already given to an earlier series, appended to here. A
+            chart with several lines has several bands, and a wide one can
+            bracket a neighbour's samples as well as its own.
+        """
+        positions = [point[MaidrKey.X] for point in line_data]
+        values = [point[MaidrKey.Y] for point in line_data]
+        if len(positions) < 2 or not all(
+            isinstance(value, (int, float)) and not isinstance(value, bool)
+            for value in positions + values
+        ):
+            return
+
+        lower, upper, region = band_edges_at(
+            self.ax, np.asarray(positions, dtype=float),
+            np.asarray(values, dtype=float), tuple(claimed),
+        )
+        if region is None:
+            return
+
+        claimed.append(region)
+        for point, low, high in zip(line_data, lower, upper):
+            point[MaidrKey.Y_MIN] = float(low)
+            point[MaidrKey.Y_MAX] = float(high)

--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from matplotlib.axes import Axes
-from matplotlib.collections import PolyCollection
 from maidr.core.plot.maidr_plot import GROUP_NAME, MaidrPlot
 from maidr.exception.extraction_error import ExtractionError
 import numpy as np
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.util.resample_utils import resample_curve
+from maidr.util.confidence_band import band_edges_at
 from maidr.util.regression_line_utils import find_regression_line
 from maidr.util.svg_utils import (
     data_to_svg_coords,
@@ -168,23 +168,8 @@ class SmoothPlot(MaidrPlot):
         line was announced alone, so a reader was told the trend without being
         told how well determined it is.
 
-        Two things this does *not* do, each because measuring showed it wrong:
-
-        The ring is not walked positionally. seaborn shades the band with a
-        ``FillBetweenPolyCollection`` whose vertices run out along one edge and
-        back along the other; measured on a 100-sample fit, that is 203
-        vertices with individual x values appearing 2, 3 or 4 times, so a
-        position in the ring is not a fixed offset from either end. The edges
-        are recovered by taking the lowest and highest vertex at each x, which
-        is exact and needs nothing assumed about orientation.
-
-        And the result is *interpolated* rather than looked up. The curve is
-        thinned before it is emitted, and the thinning resamples to evenly
-        spaced positions rather than selecting a subset -- measured, only the
-        two endpoints of a 30-point output were among the band's own x values.
-        A lookup would therefore have attached bounds to 2 points and left 28
-        silently bare. Interpolating between vertices is also what matplotlib
-        does to draw the band, so it reads the same shape the reader sees.
+        The reading lives in :mod:`maidr.util.confidence_band`, which a plain
+        line now shares (#562); every measurement behind it is recorded there.
 
         Parameters
         ----------
@@ -200,75 +185,5 @@ class SmoothPlot(MaidrPlot):
             Lower and upper bounds at each x, or ``(None, None)`` when the
             chart draws no band (``ci=None``).
         """
-        for collection in self.ax.collections:
-            # Every shaded region is a candidate, and the bracketing test in
-            # `_edges_of` decides. Filtering on `FillBetweenPolyCollection`
-            # first looks tighter and is not portable: matplotlib split that
-            # subclass out of `PolyCollection` in 3.10, so on an older one --
-            # which the Python 3.9 floor still resolves to -- no band exists by
-            # that name and every regression silently lost its interval.
-            if not isinstance(collection, PolyCollection):
-                continue
-            bounds = self._edges_of(collection, x_data, y_data)
-            if bounds is not None:
-                return bounds
-        return None, None
-
-    def _edges_of(self, collection, x_data, y_data):
-        """
-        Read one shaded region's edges, if it is this fit's band.
-
-        A type test cannot identify it, which is why this exists. seaborn
-        draws a **violin body** with ``fill_betweenx``, so a violin is the same
-        class as a band however that class is spelled, and reading its outline
-        would announce a distribution's silhouette as a regression's
-        uncertainty. ``FillBetweenPolyCollection`` does not help either: it is
-        the subclass matplotlib 3.10 split out, absent on the older matplotlib
-        the Python 3.9 floor resolves to.
-
-        So the reading validates itself: a region is this fit's band only if it
-        brackets every fitted sample. That is the property a confidence band
-        has by construction and an unrelated shaded region does not, and it is
-        cheaper and less brittle than trying to match seaborn's artists to each
-        other.
-
-        Parameters
-        ----------
-        collection : matplotlib.collections.PolyCollection
-            A shaded region on these axes.
-        x_data : numpy.ndarray
-            The x positions the curve is emitted at.
-        y_data : numpy.ndarray
-            The fitted values at those positions.
-
-        Returns
-        -------
-        tuple or None
-            Lower and upper bounds at each x, or None when this region is not
-            this fit's band.
-        """
-        by_x: dict[float, tuple[float, float]] = {}
-        for path in collection.get_paths():
-            for x, y in path.vertices:
-                if not (np.isfinite(x) and np.isfinite(y)):
-                    continue
-                key = float(x)
-                low, high = by_x.get(key, (float(y), float(y)))
-                by_x[key] = (min(low, float(y)), max(high, float(y)))
-
-        if len(by_x) < 2:
-            return None
-
-        band_x = np.array(sorted(by_x))
-        lower = np.interp(x_data, band_x, np.array([by_x[x][0] for x in band_x]))
-        upper = np.interp(x_data, band_x, np.array([by_x[x][1] for x in band_x]))
-
-        # `np.interp` clamps outside the region's own x range, so a region that
-        # does not span the fit would still return numbers -- the bracketing
-        # test is what rejects it, not the interpolation.
-        tolerance = 1e-9
-        if not np.all(
-            (lower <= y_data + tolerance) & (y_data - tolerance <= upper)
-        ):
-            return None
+        lower, upper, _ = band_edges_at(self.ax, x_data, y_data)
         return lower, upper

--- a/maidr/util/confidence_band.py
+++ b/maidr/util/confidence_band.py
@@ -1,0 +1,159 @@
+"""
+The interval a chart shades around a line, read back off the drawing.
+
+A band is the reason many charts are drawn the way they are: it says how much
+of the trend the data supports. Announcing the line alone tells a reader the
+estimate and leaves out how well determined it is -- which is the half a
+sighted reader takes straight from the picture.
+
+Two things this deliberately does not do, each because measuring showed it
+wrong:
+
+**The ring is not walked positionally.** matplotlib shades a band with a
+polygon whose vertices run out along one edge and back along the other, and
+individual x values appear two, three or four times, so a position in the ring
+is not a fixed offset from either end. The edges are the lowest and highest
+vertex at each x, which is exact and assumes nothing about orientation.
+
+**A band is not identified by its type.** seaborn draws a violin body with
+``fill_betweenx``, so a violin is the same class as a band; and
+``FillBetweenPolyCollection``, the subclass matplotlib 3.10 split out, does not
+exist on the older matplotlib the Python 3.9 floor resolves to. So the reading
+validates itself: a region is a line's band only if it **brackets every one of
+that line's samples**, which is the property a band has by construction and an
+unrelated shaded region does not.
+
+Lifted out of ``SmoothPlot``, which read a ``regplot``'s band this way (#451),
+so a plain line can carry one too (#562).
+
+@packageDocumentation
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import PolyCollection
+
+#: How far a sample may sit outside a region and still count as bracketed.
+#:
+#: Float noise only. The band is read from the same vertices matplotlib drew,
+#: so a genuine band brackets its line to within rounding; anything looser
+#: would start accepting regions that merely overlap.
+_TOLERANCE = 1e-9
+
+
+def band_edges_at(
+    ax: Axes,
+    x_data: np.ndarray,
+    y_data: np.ndarray,
+    taken: tuple = (),
+) -> tuple:
+    """
+    The interval shaded around a series, at the positions it is emitted at.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on.
+    x_data : numpy.ndarray
+        The x positions the series is emitted at.
+    y_data : numpy.ndarray
+        The values at those positions, which a candidate region has to
+        bracket to be this series' band.
+    taken : tuple, optional
+        Regions already claimed by another series, by reference. A chart with
+        several lines has several bands, and a wide one can bracket a
+        neighbour's samples as well as its own -- so a region answers for one
+        series only.
+
+    Returns
+    -------
+    tuple
+        ``(lower, upper, collection)``, or ``(None, None, None)`` when the
+        chart shades nothing around this series.
+    """
+    for collection in ax.collections:
+        # Every shaded region is a candidate and the bracketing test decides.
+        # Filtering on `FillBetweenPolyCollection` first looks tighter and is
+        # not portable: matplotlib split that subclass out of `PolyCollection`
+        # in 3.10, so on an older one -- which the Python 3.9 floor still
+        # resolves to -- no band exists by that name and every chart silently
+        # lost its interval.
+        if not isinstance(collection, PolyCollection):
+            continue
+        if any(collection is claimed for claimed in taken):
+            continue
+        bounds = edges_of(collection, x_data, y_data)
+        if bounds is not None:
+            return bounds[0], bounds[1], collection
+    return None, None, None
+
+
+def edges_of(collection, x_data: np.ndarray, y_data: np.ndarray) -> tuple | None:
+    """
+    One shaded region's edges, if it is this series' band.
+
+    Interpolated rather than looked up. A curve is often thinned before it is
+    emitted, and the thinning resamples to evenly spaced positions rather than
+    selecting a subset -- measured on a `regplot`, only the two endpoints of a
+    30-point output were among the band's own x values, so a lookup would have
+    attached bounds to 2 points and left 28 silently bare. Interpolating
+    between vertices is also what matplotlib does to draw the band, so it
+    reads the same shape the reader sees.
+
+    Parameters
+    ----------
+    collection : matplotlib.collections.PolyCollection
+        A shaded region on the axes.
+    x_data : numpy.ndarray
+        The x positions the series is emitted at.
+    y_data : numpy.ndarray
+        The values at those positions.
+
+    Returns
+    -------
+    tuple or None
+        Lower and upper bounds at each x, or ``None`` when this region is not
+        this series' band.
+    """
+    by_x: dict = {}
+    for path in collection.get_paths():
+        for x, y in path.vertices:
+            if not (np.isfinite(x) and np.isfinite(y)):
+                continue
+            key = float(x)
+            low, high = by_x.get(key, (float(y), float(y)))
+            by_x[key] = (min(low, float(y)), max(high, float(y)))
+
+    if len(by_x) < 2:
+        return None
+
+    band_x = np.array(sorted(by_x))
+    lower = np.interp(x_data, band_x, np.array([by_x[x][0] for x in band_x]))
+    upper = np.interp(x_data, band_x, np.array([by_x[x][1] for x in band_x]))
+
+    # `np.interp` clamps outside the region's own x range, so a region that
+    # does not span the series would still return numbers -- the bracketing
+    # test is what rejects it, not the interpolation.
+    if not np.all(
+        (lower <= y_data + _TOLERANCE) & (y_data - _TOLERANCE <= upper)
+    ):
+        return None
+
+    # Bracketing alone is not enough, measured: an **area** brackets the line
+    # drawn on top of it. `ax.fill_between(x, y)` shades from the baseline up
+    # to the series, so a line at `y` sits exactly on the region's upper edge
+    # and every clause above holds -- and the chart would announce "2.0,
+    # between 0 and 2.0", an interval it does not state and whose width is the
+    # value over again.
+    #
+    # A band lies *around* a series; an area merely touches it. So a region
+    # whose edge coincides with the series throughout is not this series'
+    # interval. Isolated contact is fine, and has to be: a real band can meet
+    # its line at an endpoint.
+    on_upper = np.all(np.abs(upper - y_data) <= _TOLERANCE)
+    on_lower = np.all(np.abs(lower - y_data) <= _TOLERANCE)
+    if on_upper or on_lower:
+        return None
+    return lower, upper

--- a/tests/core/plot/test_line_confidence_band.py
+++ b/tests/core/plot/test_line_confidence_band.py
@@ -1,0 +1,190 @@
+"""
+A line carries the interval shaded around it (#562).
+
+`sns.lineplot` aggregates repeated x values and draws a 95% confidence band
+**by default**; matplotlib's own documentation writes the same chart as
+``plot`` plus ``fill_between``. Either way the line was announced alone, so a
+reader was told the trend and never that the chart shows any uncertainty at
+all -- while a `regplot` on the same page did carry its band. The gap
+xability/r-maidr#135 closed for `geom_smooth(se = TRUE)` and #451 for a
+regression.
+
+``SmoothPoint``'s `yMin`/`yMax` is the shape, and the reading is
+`SmoothPlot`'s, lifted into :mod:`maidr.util.confidence_band` so both use one.
+
+**Bracketing alone is not enough, and this is the case that shows why.**
+`ax.fill_between(x, y)` shades from the baseline up to the series, so a line
+drawn on top of its own area sits exactly on that region's upper edge and
+passes every containment test. Read as a band it announces "2.0, between 0 and
+2.0" -- an interval the chart does not state and whose width is the value over
+again. A band lies *around* a series; an area merely touches it.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+
+from maidr.core.figure_manager import FigureManager
+
+X = np.linspace(0, 10, 20)
+Y = np.sin(X) + 2.0
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _series(fig) -> list:
+    """Every line layer's series, in registration order."""
+    return [
+        series
+        for plot in FigureManager.get_maidr(fig).plots
+        if plot.type.value == "line"
+        for series in plot.schema["data"]
+    ]
+
+
+def _band(point) -> tuple | None:
+    """A point's interval, rounded, or None where it carries none."""
+    if "yMin" not in point:
+        return None
+    return round(point["yMin"], 3), round(point["yMax"], 3)
+
+
+def test_a_hand_drawn_band_reaches_the_line_s_points():
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+    ax.fill_between(X, Y - 0.3, Y + 0.3)
+
+    first = _series(fig)[0][0]
+    assert _band(first) == (round(Y[0] - 0.3, 3), round(Y[0] + 0.3, 3))
+
+
+def test_every_point_of_the_line_carries_it():
+    # Not only the first: the band is interpolated at each emitted position,
+    # because a line's samples need not be among the region's own vertices.
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+    ax.fill_between(X, Y - 0.3, Y + 0.3)
+
+    assert all(_band(point) is not None for point in _series(fig)[0])
+
+
+def test_a_seaborn_confidence_band_reaches_them_too():
+    # The band seaborn draws on its own, which is the common way to meet one.
+    rng = np.random.default_rng(0)
+    frame = pd.DataFrame(
+        {
+            "x": np.tile(X, 4),
+            "y": np.concatenate([Y + rng.normal(scale=0.3, size=X.size) for _ in range(4)]),
+        }
+    )
+    fig, ax = plt.subplots()
+    sns.lineplot(data=frame, x="x", y="y", ax=ax)
+
+    first = _series(fig)[0][0]
+    band = _band(first)
+    assert band is not None
+    assert band[0] < first["y"] < band[1]
+
+
+def test_a_line_with_nothing_shaded_around_it_carries_none():
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+
+    assert _band(_series(fig)[0][0]) is None
+
+
+def test_an_area_a_line_sits_on_is_not_an_interval():
+    # The false positive bracketing alone would accept. The line lies exactly
+    # on the area's upper edge, so "between 0 and y" would be announced at
+    # every point -- an interval the chart does not state.
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y)
+    ax.plot(X, Y)
+
+    assert _band(_series(fig)[0][0]) is None
+
+
+def test_an_area_from_an_explicit_zero_floor_is_not_one_either():
+    # `fill_between(x, y, 0)` is the same chart written out, and reaches the
+    # same guard.
+    fig, ax = plt.subplots()
+    ax.fill_between(X, Y, 0)
+    ax.plot(X, Y)
+
+    assert _band(_series(fig)[0][0]) is None
+
+
+def test_each_line_gets_its_own_band():
+    # Two lines and two bands. The lower band is wide enough to bracket only
+    # its own line, but a region is claimed by one series either way -- so
+    # this fails if the first line took both.
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+    ax.fill_between(X, Y - 0.2, Y + 0.2)
+    ax.plot(X, Y + 3)
+    ax.fill_between(X, Y + 2.8, Y + 3.2)
+
+    first, second = _series(fig)
+    assert _band(first[0]) == (round(Y[0] - 0.2, 3), round(Y[0] + 0.2, 3))
+    assert _band(second[0]) == (round(Y[0] + 2.8, 3), round(Y[0] + 3.2, 3))
+
+
+def test_a_regression_still_carries_its_own_band():
+    # The reading this shares with `SmoothPlot`, asserted from the other side
+    # so lifting it cannot quietly change what a `regplot` says.
+    rng = np.random.default_rng(0)
+    fig, ax = plt.subplots()
+    sns.regplot(x=X, y=Y + rng.normal(scale=0.2, size=X.size), ax=ax)
+
+    smooth = next(
+        plot for plot in FigureManager.get_maidr(fig).plots
+        if plot.type.value == "smooth"
+    )
+    point = smooth.schema["data"][0][0]
+    assert point["yMin"] < point["y"] < point["yMax"]
+
+
+def test_the_figure_still_renders():
+    import maidr
+
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+    ax.fill_between(X, Y - 0.3, Y + 0.3)
+
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_a_shaded_region_that_does_not_enclose_the_line_is_not_its_band():
+    # What the containment test is for. A chart may shade something that has
+    # nothing to do with this line -- seaborn draws a violin body with
+    # `fill_betweenx`, so a shaded region is not identifiable by type. Here it
+    # sits well below the line, and reading it would announce an interval the
+    # line is not even inside.
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+    ax.fill_between(X, Y - 5.0, Y - 4.0)
+
+    assert _band(_series(fig)[0][0]) is None
+
+
+def test_one_band_around_two_lines_belongs_to_one_of_them():
+    # Two lines a hair apart and a single band, wide enough to enclose both.
+    # It was drawn for the first, and the second has no interval -- so
+    # answering with the same region twice would tell a reader about an
+    # uncertainty the chart never drew for that series.
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+    ax.fill_between(X, Y - 1.0, Y + 1.0)
+    ax.plot(X, Y + 0.1)
+
+    first, second = _series(fig)
+    assert _band(first[0]) == (round(Y[0] - 1.0, 3), round(Y[0] + 1.0, 3))
+    assert _band(second[0]) is None


### PR DESCRIPTION
Closes #562.

## What happens

`sns.lineplot` aggregates repeated x values and draws a 95% confidence band **by default**; matplotlib's own documentation writes the same chart as `plot` plus `fill_between`. Either way the line was announced alone — so a reader was told the trend and never that the chart shows any uncertainty at all, while a `regplot` on the same page *did* carry its band:

| chart | layers | each point carries |
| --- | --- | --- |
| `sns.regplot(x, y)` | `point`, `smooth` | `x`, `y`, **`yMin`, `yMax`** |
| `sns.lineplot(data, x, y)` — repeated x | `line` | `x`, `y` |
| `ax.plot(x, y)` + `ax.fill_between(x, lo, hi)` | `line` | `x`, `y` |

The band really is drawn — one 20-point line and a 43-vertex `PolyCollection` around it.

## The reading is `SmoothPlot`'s, lifted

`maidr/util/confidence_band.py` now holds it, so a regression and a plain line use one reader. Every measurement behind it moved with it:

- **The ring is not walked positionally** — a band's vertices run out along one edge and back along the other, with individual x values appearing two to four times. The edges are the lowest and highest vertex at each x.
- **The bounds are interpolated, not looked up** — a thinned curve's samples need not be among the band's own x values; measured on a `regplot`, only 2 of 30 were.
- **A band is identified by bracketing, not by type** — seaborn draws a violin body with `fill_betweenx`, and `FillBetweenPolyCollection` does not exist on the older matplotlib the Python 3.9 floor resolves to.

## Bracketing alone turned out to be wrong

This is the substance beyond the lift. `ax.fill_between(x, y)` shades from the baseline up to the series, so **a line drawn on top of its own area sits exactly on that region's upper edge** and passes every containment test:

```
area then line on top   ->  line  band=(0.0, 2.0)   with y = 2.0
```

Read as a band that announces *"2.0, between 0 and 2.0"* — an interval the chart does not state, and whose width is the value over again. A band lies **around** a series; an area merely **touches** it. So a region whose edge coincides with the series *throughout* is rejected. Isolated contact stays fine, and has to: a real band can meet its line at an endpoint.

A region is also claimed by **one** series only. Two lines a hair apart with a single band between them would otherwise both report it, telling a reader about an uncertainty the chart never drew for the second.

## Tests

11 cases in `tests/core/plot/test_line_confidence_band.py`. Falsified with six mutations, each applied alone against a restored baseline:

| mutation | failures |
| --- | --- |
| lines never look for a band | 4 |
| drop the edge guard | 2 |
| drop the bracketing test | 1 |
| let a region be claimed twice | 1 |
| look bounds up instead of interpolating | 1 |

**Two of those survived the first pass, and the fixtures were the reason.** Every shaded region in them *was* the right band, so the bracketing test could not matter; and the one band did not bracket the second line, so the claim guard could not either. Two cases were added — a region well below the line, and one wide band around two close lines — and both mutations then failed. The guards are real, but they were not being exercised until the fixtures made them so.

A case asserts a `regplot` still carries its own band, from the other side, so lifting the reader cannot quietly change what a regression says.

`uvx ruff@0.3.4 check --diff .` (CI's pin) exit 0; full suite **2625 passed, 18 skipped**.

## Unchanged, and deliberately

`ax.fill_between(x, lo, hi)` **alone**, with no line, stays unread. An area whose floor follows the data is an interval, and its height is the interval's width rather than a magnitude — the rule py-maidr already applies and that `docs/observable.md` records for the JS side. Measured, that distinction is intact:

```
fill_between(x, y)        -> ['area']    <- fixed floor: a magnitude
fill_between(x, y, 0)     -> ['area']
fill_between(x, lo, hi)   -> unread      <- moving floor: an interval
```

What changes is only that a band drawn *around a line* is attached to that line's points, where the grammar has somewhere to put it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_