### PR TITLE
fix(heatmap): tell a picture from a grid of values instead of dying on both

### DIFF
--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -292,4 +292,15 @@ class HeatPlot(
         else:
             self._support_highlighting = False
 
+        # A mask is a grid of numbers as much as a grid of counts is, and
+        # `ax.spy()` draws nothing else: its whole purpose is to show where a
+        # matrix is non-zero. It only failed at the default format --
+        # `self._fmt` is `""` unless seaborn's caller set one, and
+        # `format(np.True_, "")` is `"True"`, which `float` refuses. With any
+        # numeric format it already worked: `format(np.True_, ".2f")` is
+        # `"1.00"`. Converting first gives the same 1 and 0 under every
+        # format instead of only some of them (#564).
+        if array.dtype == bool:
+            array = array.astype(float)
+
         return [list(map(lambda x: float(format(x, self._fmt)), row)) for row in array]

--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -162,7 +162,9 @@ def heat(wrapped, _, args, kwargs) -> Axes | AxesImage | Collection:
     Axes or AxesImage or Collection
         Whatever the wrapped function returned: an ``Axes`` from seaborn, an
         ``AxesImage`` from ``imshow``, or the mesh the two ``pcolor`` variants
-        render.
+        render. The draw always happens; the return is the same either way.
+        No layer is registered when the artist turns out to hold a colour
+        image rather than a grid of values -- see :func:`_is_colour_image`.
     """
     # `seaborn.heatmap` draws through `Axes.pcolormesh`, and both are patched
     # here. Without this guard the inner call registers a second HEAT layer for

--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -61,6 +61,40 @@ def _grid_of(plot, ax: Axes | None):
     return drawn[-1] if drawn else None
 
 
+def _is_colour_image(grid) -> bool:
+    """
+    Whether the artist holds a picture rather than a grid of values.
+
+    ``ax.imshow`` accepts three shapes: an ``(M, N)`` array of scalars, which
+    is a heatmap, and ``(M, N, 3)`` / ``(M, N, 4)`` arrays whose last axis is
+    **colour**. The last two are photographs and rendered images, and there is
+    no number per cell to announce -- no value, and nothing for the colourbar
+    the ``z`` axis describes to mean.
+
+    Registered as a heatmap they did not merely read badly, they killed the
+    figure: ``HeatPlot`` formats each cell with ``float(format(x, fmt))``, and
+    for a row of an RGB image ``x`` is a length-3 array, so ``render`` raised
+    ``ValueError: could not convert string to float: '[0.5 0.5 0.5]'`` and
+    took every other chart on the figure with it (#564).
+
+    Declining leaves the image drawn and unregistered, which is what
+    ``ax.quiver`` and ``ax.streamplot`` already do -- the figure renders, and
+    a bar chart beside the picture keeps working.
+
+    Parameters
+    ----------
+    grid : Any
+        The artist :func:`_grid_of` found, or None.
+
+    Returns
+    -------
+    bool
+        True when the artist's array carries colour rather than values.
+    """
+    array = getattr(grid, "get_array", lambda: None)()
+    return array is not None and getattr(array, "ndim", 0) >= 3
+
+
 def _declares_fmt(wrapped: Callable) -> bool:
     """
     Whether a patched function takes ``fmt`` as a parameter of its own.
@@ -157,7 +191,13 @@ def heat(wrapped, _, args, kwargs) -> Axes | AxesImage | Collection:
 
     # Extract the heatmap data points for MAIDR from the plots.
     ax = FigureManager.get_axes(plot)
-    optional_params[DRAWN_GRID] = _grid_of(plot, ax)
+    grid = _grid_of(plot, ax)
+
+    # An RGB or RGBA image is not a heatmap -- see `_is_colour_image`.
+    if _is_colour_image(grid):
+        return plot
+
+    optional_params[DRAWN_GRID] = grid
     FigureManager.create_maidr(ax, PlotType.HEAT, **optional_params)
 
     # Return to the caller.

--- a/tests/core/plot/test_image_grid_kinds.py
+++ b/tests/core/plot/test_image_grid_kinds.py
@@ -42,6 +42,7 @@ import pytest
 
 import maidr
 from maidr.core.figure_manager import FigureManager
+from maidr.exception import UnsupportedPlotError
 
 
 @pytest.fixture(autouse=True)
@@ -59,7 +60,10 @@ def _types(fig) -> list:
     """Every layer's type, or an empty list when the figure registered none."""
     try:
         return [plot.type.value for plot in FigureManager.get_maidr(fig).plots]
-    except Exception:  # noqa: BLE001 - no Maidr at all is the case under test
+    except UnsupportedPlotError:
+        # A figure with nothing registered is the case under test, and this is
+        # the exception the API's own fallback catches -- named rather than
+        # swallowed as "anything", so a *different* failure still fails.
         return []
 
 

--- a/tests/core/plot/test_image_grid_kinds.py
+++ b/tests/core/plot/test_image_grid_kinds.py
@@ -1,0 +1,174 @@
+"""
+A heat layer assumed every grid it was handed was scalar (#564).
+
+``ax.imshow`` accepts three shapes. ``(M, N)`` of numbers is a heatmap;
+``(M, N, 3)`` and ``(M, N, 4)`` are **pictures**, their last axis colour
+rather than value. A boolean ``(M, N)`` mask is a fourth case, and the one
+``ax.spy()`` draws.
+
+All three of the last ones raised at *render*, after the plotting line had
+returned, from one line of ``HeatPlot``::
+
+    [list(map(lambda x: float(format(x, self._fmt)), row)) for row in array]
+
+``self._fmt`` is ``""`` unless seaborn's caller set one, and ``format`` with
+an empty spec is ``str``: ``'True'`` for a numpy bool, ``'[0.5 0.5 0.5]'``
+for a row of an RGB image. Measured before the fix::
+
+    ax.imshow(np.zeros((2, 2, 3)) + 0.5)
+    ValueError: could not convert string to float: '[0.5 0.5 0.5]'
+
+    ax.spy(np.eye(3))
+    ValueError: could not convert string to float: 'True'
+
+and it was never confined to that axes -- a bar chart drawn beside the
+picture died with it.
+
+The two get different answers, which is the point of this file:
+
+- **a mask is read.** True and False are 1 and 0, and showing where a matrix
+  is non-zero is the whole purpose of ``spy()``. It only failed at the
+  default format; ``format(np.True_, ".2f")`` was already ``"1.00"``.
+- **a colour image is not registered.** There is no number per cell to
+  announce and nothing for the colourbar to mean, so the layer is declined
+  and the figure renders without it -- what ``ax.quiver`` already does.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _points(fig) -> list:
+    """Every heat layer's grid of values, in registration order."""
+    return [plot.schema["data"]["points"] for plot in FigureManager.get_maidr(fig).plots]
+
+
+def _types(fig) -> list:
+    """Every layer's type, or an empty list when the figure registered none."""
+    try:
+        return [plot.type.value for plot in FigureManager.get_maidr(fig).plots]
+    except Exception:  # noqa: BLE001 - no Maidr at all is the case under test
+        return []
+
+
+# ---------------------------------------------------------------------------
+# A boolean grid is read
+# ---------------------------------------------------------------------------
+
+
+def test_a_sparsity_pattern_reads_as_ones_and_zeros():
+    fig, ax = plt.subplots()
+    ax.spy(np.eye(3))
+
+    maidr.render(fig)._repr_html_()  # must not raise
+
+    assert _points(fig) == [
+        [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+    ]
+
+
+def test_a_boolean_image_reads_the_same_way():
+    fig, ax = plt.subplots()
+    ax.imshow(np.array([[True, False], [False, True]]))
+
+    assert _points(fig) == [[[1.0, 0.0], [0.0, 1.0]]]
+
+
+def test_a_boolean_mesh_reads_the_same_way():
+    # `pcolormesh` reaches the formatting through a different artist class and
+    # a different reshape, so the mask has to be handled where the values are
+    # rather than where `imshow` happens to arrive.
+    fig, ax = plt.subplots()
+    ax.pcolormesh(np.array([[True, False], [False, True]]))
+
+    assert _points(fig) == [[[1.0, 0.0], [0.0, 1.0]]]
+
+
+def test_a_mask_reads_the_same_under_an_explicit_format():
+    # The defect was only ever at the default format -- `format(np.True_,
+    # ".2f")` was already "1.00" -- so a fix that special-cased the empty
+    # spelling would pass every assertion above and change what a seaborn
+    # caller's format produced. Both spellings must give the same 1 and 0.
+    import seaborn as sns
+
+    fig, ax = plt.subplots()
+    sns.heatmap(np.array([[True, False], [False, True]]), fmt=".2f", ax=ax)
+
+    assert _points(fig) == [[[1.0, 0.0], [0.0, 1.0]]]
+
+
+def test_a_numeric_grid_is_unchanged():
+    fig, ax = plt.subplots()
+    ax.imshow(np.arange(4).reshape(2, 2))
+
+    assert _points(fig) == [[[0.0, 1.0], [2.0, 3.0]]]
+
+
+# ---------------------------------------------------------------------------
+# A colour image is not a heatmap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("channels", [3, 4])
+def test_a_colour_image_registers_no_layer(channels):
+    fig, ax = plt.subplots()
+    ax.imshow(np.zeros((2, 2, channels)) + 0.5)
+
+    assert len(maidr.render(fig)._repr_html_()) > 0  # must not raise
+    assert _types(fig) == []
+
+
+def test_an_integer_colour_image_is_declined_too():
+    # `imshow` takes RGB as floats in 0..1 or as uint8 in 0..255, and the
+    # dtype is what a value-shaped test would key on. What makes it a picture
+    # is the third axis, not what is stored along it.
+    fig, ax = plt.subplots()
+    ax.imshow(np.zeros((2, 2, 3), dtype=np.uint8))
+
+    assert len(maidr.render(fig)._repr_html_()) > 0
+    assert _types(fig) == []
+
+
+def test_a_chart_beside_a_picture_survives_it():
+    # The blind spot the crash really cost: an unreadable image took every
+    # other chart in the figure with it, because the render walks all layers.
+    fig, (left, right) = plt.subplots(1, 2)
+    left.bar(["x", "y"], [1, 2])
+    right.imshow(np.zeros((2, 2, 3)) + 0.5)
+
+    assert len(maidr.render(fig)._repr_html_()) > 0
+    assert _types(fig) == ["bar"]
+
+
+def test_a_picture_beside_a_grid_leaves_the_grid_its_own_values():
+    # Declining must remove the layer, not shift which artist the surviving
+    # one binds to: `_grid_of` falls back to the *last* grid on the axes, and
+    # the picture is drawn after the mesh here.
+    fig, ax = plt.subplots()
+    ax.pcolormesh(np.arange(4).reshape(2, 2))
+    ax.imshow(np.zeros((2, 2, 3)) + 0.5)
+
+    assert _types(fig) == ["heat"]
+    assert _points(fig) == [[[0.0, 1.0], [2.0, 3.0]]]
+
+
+def test_a_grayscale_image_is_still_a_heatmap():
+    # Two dimensions and no colour axis: a photograph in one channel is read
+    # as the grid of intensities it is, which is the pre-existing behaviour
+    # and the line the decline must not cross.
+    fig, ax = plt.subplots()
+    ax.imshow(np.array([[0.0, 0.5], [1.0, 0.25]]))
+
+    assert _points(fig) == [[[0.0, 0.5], [1.0, 0.25]]]


### PR DESCRIPTION
Closes #564.

## What was wrong

`ax.imshow` accepts three shapes: `(M, N)` of numbers is a heatmap, and `(M, N, 3)` / `(M, N, 4)` are **pictures**, their last axis colour rather than value. A boolean `(M, N)` mask is a fourth case, and the one `ax.spy()` draws.

All three of the last ones raised at **render**, after the plotting line had returned:

```python
ax.imshow(np.zeros((2, 2, 3)) + 0.5)
#> ValueError: could not convert string to float: '[0.5 0.5 0.5]'

ax.spy(np.eye(3))
#> ValueError: could not convert string to float: 'True'
```

and it was never confined to the offending axes — the render walks every layer, so a bar chart drawn beside a photograph died with it:

```python
fig, (a, b) = plt.subplots(1, 2)
a.bar(["x", "y"], [1, 2])
b.imshow(photo)
maidr.render(fig)      #> ValueError
```

One line of `HeatPlot` assumed every grid it was handed was scalar:

```python
[list(map(lambda x: float(format(x, self._fmt)), row)) for row in array]
```

`self._fmt` defaults to `""` — it exists for `seaborn.heatmap`'s cell annotations — and `format` with an empty spec is `str`. For a numpy bool that is `'True'`; for a row of an RGB image, `x` is a length-3 array and it is `'[0.5 0.5 0.5]'`.

| call | array | before | after |
| --- | --- | --- | --- |
| `imshow(m)` | `(2, 2) int64` | `heat` | unchanged |
| `imshow(bool)` | `(2, 2) bool` | **ValueError** | `heat`, 1 and 0 |
| `spy(m)` | `(3, 3) bool` | **ValueError** | `heat`, the sparsity pattern |
| `pcolormesh(bool)` | `(2, 2) bool` | **ValueError** | `heat`, 1 and 0 |
| `imshow(rgb)` / `imshow(rgba)` / `imshow(rgb_uint8)` | `(2, 2, 3\|4)` | **ValueError** | no layer; figure renders |
| `bar` beside `imshow(rgb)` | — | **ValueError** | the bar chart reads |

## The two need different answers

**A mask is read.** `True` and `False` are 1 and 0, and showing where a matrix is non-zero is the whole purpose of `spy()`. The array is converted rather than the formatting special-cased, because the defect was only ever at the *default* format — `format(np.True_, ".2f")` was already `"1.00"`, so a fix keyed on the empty spelling would leave a seaborn caller's `fmt` producing something different from everyone else's. Both spellings now give the same numbers, which is asserted.

**A colour image is not registered.** There is no number per cell to announce and nothing for the colourbar the `z` axis describes to mean. Declining leaves the image drawn and unregistered, which is what `ax.quiver` and `ax.streamplot` already do: the figure renders, emits the existing "plot type(s) not yet supported … falling back to static image" warning, and anything else on it keeps working. Inventing a reading — a luminance, a channel mean — would announce a number the chart does not show.

The test is on the **third axis, not the dtype**: `imshow` takes RGB as floats in 0..1 or as `uint8` in 0..255, and a dtype-shaped guard would let the integer spelling through. A two-dimensional greyscale image stays a heatmap, which is the line the decline must not cross.

## Tests

`tests/core/plot/test_image_grid_kinds.py`, 11 cases, each driven through a real `maidr.render()`.

Falsified — each mutation applied alone against the fixed baseline:

| mutation | result |
| --- | --- |
| the boolean coercion removed | 3 failures — `spy`, boolean `imshow`, boolean `pcolormesh` |
| `_is_colour_image` always False | 5 failures, including the bar chart beside the picture |
| `ndim >= 4` instead of `>= 3` | the same 5 |
| `ndim >= 2`, declining every grid | 7 failures — every reading case, including the greyscale image |

Full suite: `2636 passed, 18 skipped`. `ruff check --diff` clean on the changed files.

## Found by a sweep, recorded in the issue rather than fixed here

The issue carries the rest of the sweep over unpatched `Axes` methods. None of the others raises; each is silence or an asymmetry. The one worth its own issue is **`fill_betweenx`**, which registers no layer while `fill_between` reads as `area` (#339) — the same chart written the other way round. `tricontourf` and `tripcolor` are the same line-versus-filled split, with `tricontour` already reading as `contour`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_