### PR TITLE
fix(area): name the axis a sideways band was actually drawn against

### DIFF
--- a/maidr/core/plot/areaplot.py
+++ b/maidr/core/plot/areaplot.py
@@ -57,6 +57,61 @@ class AreaPlot(MaidrPlot):
         self._series = list(kwargs.pop("series", []))
         self._labels = list(kwargs.pop("labels", []))
         self._collections = list(kwargs.pop("collections", []))
+        # `fill_betweenx` draws the same band with the axes exchanged: the
+        # positions run down the page and the magnitudes out along x. The
+        # numbers still go into the fields the trace reads them from -- see
+        # `render` for why the titles move instead of the data.
+        self._transposed = bool(kwargs.pop("transposed", False))
+
+    def render(self) -> dict:
+        """
+        Build the layer, exchanging the two axis titles for a sideways band.
+
+        `fill_betweenx(y, x1)` fills between the vertical positions `y` and
+        the horizontal curve `x1`, so its positions belong to the y axis and
+        its magnitudes to the x axis -- the mirror of every other chart this
+        class reads. Emitted unchanged, the two spellings produced byte-
+        identical payloads for charts that are transposes of each other, and
+        every number was announced under the other axis' title (#566).
+
+        The **titles** move rather than the data, which is deliberate twice
+        over:
+
+        - the core sonifies an area trace's `y` and steps along its `x`, so
+          putting the positions in `y` would pitch `[1, 2, 3, 4]` -- a rising
+          ramp on every sideways band ever drawn, whatever the data says;
+        - `orientation` is the field that says a chart is drawn sideways, and
+          `src/util/orientation.ts` marks `AREA` as not oriented on purpose,
+          so emitting one would be a promise the core does not keep.
+
+        The same exchange, for the same reason, is what the core's Vega-Lite
+        adapter does to a horizontal waterfall.
+
+        What it does not fix is navigation: left and right still walk the
+        trace's `x`, which for a sideways band is the vertical axis. That is
+        what `orientation` would carry, and it cannot be said for an area
+        trace today.
+
+        Returns
+        -------
+        dict
+            The layer, with `axes.x` and `axes.y` exchanged when the band was
+            drawn sideways.
+        """
+        maidr_schema = super().render()
+
+        if not self._transposed:
+            return maidr_schema
+
+        # After `super().render()` rather than in `_extract_axes_data`,
+        # because the format config is merged into each `AxisConfig` there: a
+        # currency formatter set on the x axis describes the horizontal
+        # numbers, which are the ones this moves.
+        axes = maidr_schema.get(MaidrKey.AXES)
+        if isinstance(axes, dict) and MaidrKey.X in axes and MaidrKey.Y in axes:
+            axes[MaidrKey.X], axes[MaidrKey.Y] = axes[MaidrKey.Y], axes[MaidrKey.X]
+
+        return maidr_schema
 
     def _extract_plot_data(self) -> list[list[dict]]:
         if self._x is None or not self._series:

--- a/maidr/patch/fillbetween.py
+++ b/maidr/patch/fillbetween.py
@@ -243,9 +243,9 @@ def fill_betweenx(wrapped, instance, args, kwargs) -> Collection:
     The same chart with the axes exchanged: the shared axis is ``y`` and the
     magnitude runs along ``x``. Emitted as an area either way, since what a
     band measures does not change with which way it is drawn -- but which
-    axis each number is *read against* does, and saying so is what
-    ``transposed`` carries. Without it the two spellings produced identical
-    payloads for charts that are transposes of each other (#566).
+    axis each number is *read against* does, and ``transposed`` is what says
+    so. See :meth:`maidr.core.plot.areaplot.AreaPlot.render` for what it
+    moves and why that rather than the data (#566).
     """
     return _fill(wrapped, instance, args, kwargs, "y", "x1", "x2", transposed=True)
 

--- a/maidr/patch/fillbetween.py
+++ b/maidr/patch/fillbetween.py
@@ -142,7 +142,16 @@ def _magnitudes(wrapped, args: tuple, kwargs: dict, position: str, value: str):
     return positions, values
 
 
-def _fill(wrapped, instance, args, kwargs, position: str, value: str, other: str):
+def _fill(
+    wrapped,
+    instance,
+    args,
+    kwargs,
+    position: str,
+    value: str,
+    other: str,
+    transposed: bool = False,
+):
     """
     Draw a patched fill call and register the area it produced, when it is one.
 
@@ -168,6 +177,10 @@ def _fill(wrapped, instance, args, kwargs, position: str, value: str, other: str
         The parameter naming the curve.
     other : str
         The parameter naming the second edge.
+    transposed : bool
+        True for ``fill_betweenx``, whose positions run down the page and
+        whose magnitudes run out along x. Passed through to the layer, which
+        exchanges the two axis titles -- see ``AreaPlot.render``.
 
     Returns
     -------
@@ -212,6 +225,7 @@ def _fill(wrapped, instance, args, kwargs, position: str, value: str, other: str
         series=[values],
         labels=[kwargs["label"]] if isinstance(kwargs.get("label"), str) else [],
         collections=[collection],
+        transposed=transposed,
     )
 
     return collection
@@ -228,9 +242,12 @@ def fill_betweenx(wrapped, instance, args, kwargs) -> Collection:
 
     The same chart with the axes exchanged: the shared axis is ``y`` and the
     magnitude runs along ``x``. Emitted as an area either way, since what a
-    band measures does not change with which way it is drawn.
+    band measures does not change with which way it is drawn -- but which
+    axis each number is *read against* does, and saying so is what
+    ``transposed`` carries. Without it the two spellings produced identical
+    payloads for charts that are transposes of each other (#566).
     """
-    return _fill(wrapped, instance, args, kwargs, "y", "x1", "x2")
+    return _fill(wrapped, instance, args, kwargs, "y", "x1", "x2", transposed=True)
 
 
 # Patch matplotlib functions. `AreaPlot` is reached through the factory, so

--- a/tests/core/plot/test_sideways_area.py
+++ b/tests/core/plot/test_sideways_area.py
@@ -36,6 +36,7 @@ import pytest
 
 from maidr.core.enum import MaidrKey
 from maidr.core.figure_manager import FigureManager
+from maidr.exception import UnsupportedPlotError
 
 POSITIONS = np.array([1.0, 2.0, 3.0, 4.0])
 MAGNITUDES = np.array([2.0, 4.0, 3.0, 5.0])
@@ -157,9 +158,9 @@ def test_no_orientation_is_claimed():
     fig, ax = _titled_axes()
     ax.fill_betweenx(POSITIONS, MAGNITUDES)
 
-    schema = _schema(fig)
-    assert MaidrKey.ORIENTATION not in schema
-    assert "orientation" not in schema
+    # One assertion, not two: `MaidrKey` subclasses `str`, so the enum member
+    # and the bare spelling are the same key.
+    assert MaidrKey.ORIENTATION not in _schema(fig)
 
 
 @pytest.mark.parametrize("sideways", [False, True])
@@ -173,8 +174,6 @@ def test_a_band_between_two_curves_still_registers_nothing(sideways):
         ax.fill_betweenx(POSITIONS, MAGNITUDES - 1, MAGNITUDES + 1)
     else:
         ax.fill_between(POSITIONS, MAGNITUDES - 1, MAGNITUDES + 1)
-
-    from maidr.exception import UnsupportedPlotError
 
     with pytest.raises(UnsupportedPlotError):
         FigureManager.get_maidr(fig)

--- a/tests/core/plot/test_sideways_area.py
+++ b/tests/core/plot/test_sideways_area.py
@@ -1,0 +1,180 @@
+"""
+A sideways band was announced against the wrong axis titles (#566).
+
+``fill_betweenx(y, x1)`` fills between the vertical positions ``y`` and the
+horizontal curve ``x1``, so its positions belong to the y axis and its
+magnitudes to the x axis -- the mirror of every other chart ``AreaPlot``
+reads. Emitted unchanged, the two spellings produced **byte-identical**
+payloads for charts that are transposes of each other::
+
+    ax.set_xlabel("horizontal"); ax.set_ylabel("vertical")
+    ax.fill_between(X, V)    # axes x=horizontal y=vertical, points (1,2)...
+    ax.fill_betweenx(X, V)   # axes x=horizontal y=vertical, points (1,2)...
+
+so a reader was told "horizontal 1, vertical 2" where the chart draws the
+point at vertical 1, horizontal 2.
+
+The **titles** move rather than the data, and this file pins both halves of
+that, because each is wrong on its own:
+
+- moving the data would put the positions in ``y``, which the core sonifies,
+  pitching ``[1, 2, 3, 4]`` -- a rising ramp on every sideways band ever
+  drawn, whatever the data says;
+- emitting ``orientation`` would be a promise the core does not keep:
+  ``src/util/orientation.ts`` marks ``AREA`` as not oriented on purpose.
+
+The same exchange, for the same reason, is what the core's Vega-Lite adapter
+does to a horizontal waterfall.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import numpy as np
+import pytest
+
+from maidr.core.enum import MaidrKey
+from maidr.core.figure_manager import FigureManager
+
+POSITIONS = np.array([1.0, 2.0, 3.0, 4.0])
+MAGNITUDES = np.array([2.0, 4.0, 3.0, 5.0])
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _titled_axes():
+    fig, ax = plt.subplots()
+    ax.set_xlabel("horizontal")
+    ax.set_ylabel("vertical")
+    return fig, ax
+
+
+def _schema(fig) -> dict:
+    plots = FigureManager.get_maidr(fig).plots
+    assert len(plots) == 1
+    return plots[0].schema
+
+
+def _labels(schema) -> tuple:
+    axes = schema["axes"]
+    return axes[MaidrKey.X.value]["label"], axes[MaidrKey.Y.value]["label"]
+
+
+def _points(schema) -> list:
+    return [
+        (point[MaidrKey.X], point[MaidrKey.Y]) for point in schema["data"][0]
+    ]
+
+
+def test_a_sideways_band_names_each_axis_it_was_drawn_against():
+    fig, ax = _titled_axes()
+    ax.fill_betweenx(POSITIONS, MAGNITUDES)
+
+    # The positions run down the page and the magnitudes out along x, so the
+    # trace's `x` field holds vertical numbers and its `y` field horizontal
+    # ones -- which is what the titles now say.
+    assert _labels(_schema(fig)) == ("vertical", "horizontal")
+
+
+def test_an_upright_band_is_unchanged():
+    fig, ax = _titled_axes()
+    ax.fill_between(POSITIONS, MAGNITUDES)
+
+    assert _labels(_schema(fig)) == ("horizontal", "vertical")
+
+
+def test_a_stackplot_is_unchanged():
+    # `stackplot` reaches the same class and is never sideways. Asserted
+    # because the swap is a flag on the layer rather than on the call, and a
+    # flag defaulting the wrong way would transpose every area chart.
+    fig, ax = _titled_axes()
+    ax.stackplot(POSITIONS, MAGNITUDES)
+
+    assert _labels(_schema(fig)) == ("horizontal", "vertical")
+
+
+def test_the_magnitudes_stay_where_the_trace_pitches_them():
+    # The half that must NOT move. The core sonifies an area trace's `y`; put
+    # the positions there and every sideways band plays a rising ramp,
+    # whatever its data. Asserted as the same points the upright spelling
+    # emits, since that is exactly the field layout being preserved.
+    fig, ax = _titled_axes()
+    ax.fill_betweenx(POSITIONS, MAGNITUDES)
+
+    assert _points(_schema(fig)) == [(1.0, 2.0), (2.0, 4.0), (3.0, 3.0), (4.0, 5.0)]
+
+
+def test_the_two_spellings_differ_in_their_titles_and_nowhere_else():
+    # What the defect was: identical payloads for transposed charts. The two
+    # are compared directly rather than each against a literal, so they
+    # cannot quietly converge again.
+    upright, upright_ax = _titled_axes()
+    upright_ax.fill_between(POSITIONS, MAGNITUDES)
+    sideways, sideways_ax = _titled_axes()
+    sideways_ax.fill_betweenx(POSITIONS, MAGNITUDES)
+
+    one, other = _schema(upright), _schema(sideways)
+
+    assert _points(one) == _points(other)
+    assert _labels(one) != _labels(other)
+    assert _labels(one) == tuple(reversed(_labels(other)))
+
+
+def test_a_number_format_travels_with_the_title_it_describes():
+    # A formatter set on the x axis describes the horizontal numbers, which
+    # for a sideways band are the ones in `y`. The swap therefore has to
+    # happen after the format is merged into each `AxisConfig`, not while the
+    # labels are being read.
+    fig, ax = _titled_axes()
+    ax.xaxis.set_major_formatter(mticker.StrMethodFormatter("${x:,.0f}"))
+    ax.fill_betweenx(POSITIONS, MAGNITUDES)
+
+    axes = _schema(fig)["axes"]
+    assert axes[MaidrKey.Y.value]["format"]["type"] == "currency"
+    assert "format" not in axes[MaidrKey.X.value]
+
+
+def test_a_number_format_stays_put_for_an_upright_band():
+    fig, ax = _titled_axes()
+    ax.xaxis.set_major_formatter(mticker.StrMethodFormatter("${x:,.0f}"))
+    ax.fill_between(POSITIONS, MAGNITUDES)
+
+    axes = _schema(fig)["axes"]
+    assert axes[MaidrKey.X.value]["format"]["type"] == "currency"
+    assert "format" not in axes[MaidrKey.Y.value]
+
+
+def test_no_orientation_is_claimed():
+    # `orientation` is the field that says a chart is drawn sideways, and the
+    # core marks AREA as not oriented on purpose -- it navigates along the
+    # series either way. Emitting one would be a promise nothing keeps, the
+    # shape xability/maidr#949 named.
+    fig, ax = _titled_axes()
+    ax.fill_betweenx(POSITIONS, MAGNITUDES)
+
+    schema = _schema(fig)
+    assert MaidrKey.ORIENTATION not in schema
+    assert "orientation" not in schema
+
+
+@pytest.mark.parametrize("sideways", [False, True])
+def test_a_band_between_two_curves_still_registers_nothing(sideways):
+    # Symmetric, and deliberately so (#339): the band's content is the gap
+    # rather than either edge. Pinned here because the sweep that found this
+    # issue first mis-read the two-curve form as an asymmetry between the two
+    # spellings, and it is not one.
+    fig, ax = _titled_axes()
+    if sideways:
+        ax.fill_betweenx(POSITIONS, MAGNITUDES - 1, MAGNITUDES + 1)
+    else:
+        ax.fill_between(POSITIONS, MAGNITUDES - 1, MAGNITUDES + 1)
+
+    from maidr.exception import UnsupportedPlotError
+
+    with pytest.raises(UnsupportedPlotError):
+        FigureManager.get_maidr(fig)

--- a/tests/core/test_fill_between.py
+++ b/tests/core/test_fill_between.py
@@ -210,8 +210,17 @@ def test_fill_betweenx_is_the_same_chart_turned_over():
     is the same layer type -- and the arguments have to be read from their
     own parameter names rather than by position, since `x1` sits where `y1`
     does.
+
+    Which axis each number is *read against* does change, and that is the one
+    thing "turned over" costs: the two `AxisConfig` entries are exchanged, so
+    the positions are announced under the y axis' title and the magnitudes
+    under the x axis' (#566). The data stays where the trace sonifies it,
+    which is why the two assertions below are unchanged. See
+    `tests/core/plot/test_sideways_area.py`.
     """
     fig, ax = plt.subplots()
+    ax.set_xlabel("horizontal")
+    ax.set_ylabel("vertical")
     ax.fill_betweenx(X, Y)
 
     assert _layers(fig) == [PlotType.AREA]
@@ -219,6 +228,9 @@ def test_fill_betweenx_is_the_same_chart_turned_over():
     points = _layer(fig)["data"][0]
     assert [point["x"] for point in points] == X.tolist()
     assert [point["y"] for point in points] == Y.tolist()
+
+    axes = _layer(fig)["axes"]
+    assert (axes["x"]["label"], axes["y"]["label"]) == ("vertical", "horizontal")
 
 
 def test_a_stackplot_still_reads_as_a_stack():


### PR DESCRIPTION
Closes #566.

## What was wrong

Two calls that draw transposes of each other produced **identical** payloads:

```python
ax.set_xlabel("horizontal"); ax.set_ylabel("vertical")

ax.fill_between(X, V)     # X = [1,2,3,4], V = [2,4,3,5]
ax.fill_betweenx(X, V)
# both: axes x="horizontal" y="vertical", points (1,2) (2,4) (3,3) (4,5)
```

`fill_betweenx(y, x1)` fills between the vertical positions `y` and the horizontal curve `x1`. So in the second call `[1, 2, 3, 4]` are **heights** and `[2, 4, 3, 5]` are the **magnitudes** reaching out along x. A reader was told "horizontal 1, vertical 2" where the chart draws that point at vertical 1, horizontal 2 — every number under the other axis' title.

The patch already read the arguments correctly (`_fill(..., position="y", value="x1", other="x2")`) and then handed them over as `x=positions, series=[values]`, so the two spellings differed nowhere after it. The docstring said as much, and it was half right: what a band *measures* does not change with which way it is drawn — which axis each number is *read against* does.

## Why the titles move and not the data

Both of the obvious-looking fixes are wrong, and each is pinned by a test.

**Moving the data** would put the positions in `y`, which the core sonifies. Every sideways band would then play `[1, 2, 3, 4]` — a rising ramp whatever the data says, because those are positions, not magnitudes.

**Emitting `orientation: "horz"`** would be a promise the core does not keep. `src/util/orientation.ts` marks `TraceType.AREA` as **not** oriented, deliberately:

> An area trace is a line with a fill, and it is navigated as one: along the series, then between series. Which way the band is drawn changes nothing about that, so — as with LINE, STEP and SMOOTH — there is no orientation to announce.

and that record's own header warns that reading it as though it answered the data-layout question "is how two bindings came to emit a horizontal bar with a category name where the magnitude belongs".

So the two `AxisConfig` entries are exchanged instead, **after** the format config is merged into each — a currency formatter set on the x axis describes the horizontal numbers, which are the ones that move. The core's Vega-Lite adapter does exactly this, for exactly this reason, on a horizontal waterfall — a type whose axes it cannot swap either.

| call | axes before | axes after | points |
| --- | --- | --- | --- |
| `fill_between(x, y)` | x=horizontal, y=vertical | unchanged | unchanged |
| `fill_betweenx(y, x)` | x=horizontal, y=vertical | **x=vertical, y=horizontal** | unchanged |
| `stackplot(x, y)` | x=horizontal, y=vertical | unchanged | unchanged |

## What it does not fix

Navigation. Left and right still walk the trace's `x`, which for a sideways band is the vertical axis, so the right arrow moves the reader up the chart. That is what `orientation` would carry, and whether `AREA` should join the oriented types is a core question with a rationale already written down against it — recorded in #566 rather than decided here.

## Tests

`tests/core/plot/test_sideways_area.py`, 10 cases.

Two of them exist to pin the halves that must **not** move: `test_the_magnitudes_stay_where_the_trace_pitches_them` and `test_no_orientation_is_claimed`. Another compares the two spellings directly rather than each against a literal, so they cannot quietly converge back into the identical payloads this fixes.

The last one pins something the sweep got wrong on the way here: the **three**-argument form of both spellings registers nothing, symmetrically, which is #339's deliberate decision — the band's content is the gap rather than either edge. I first mis-read that as an asymmetry between `fill_between` and `fill_betweenx` and said so in #564; [corrected there](https://github.com/xability/py-maidr/issues/564#issuecomment-5374579218), and now pinned so nobody re-reads it that way.

Falsified — each mutation applied alone against the fixed baseline:

| mutation | result |
| --- | --- |
| `fill_betweenx` not marked transposed | 3 failures |
| only the label strings swap, not the whole `AxisConfig` | the number-format test fails |
| the data is swapped instead of the titles | the magnitudes test and the two-spellings test fail |
| `transposed` defaults to True | `stackplot` is transposed and fails |

Full suite: `2646 passed, 18 skipped`. `ruff check --diff` clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_