### PR TITLE
fix(hue): name a pairplot's diagonals from the legend it builds afterwards

### DIFF
--- a/maidr/core/plot/histogram.py
+++ b/maidr/core/plot/histogram.py
@@ -39,8 +39,13 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         # could name it. `None` is the ungrouped case and every chart that
         # drew no legend. Opted into here rather than read by `MaidrPlot`;
         # see `GROUP_NAME` for why that is per class.
+        # A string names the group now; a callable names it at render, which
+        # is what a `pairplot` needs -- its legend does not exist until every
+        # panel has been drawn (#561).
         group_name = kwargs.pop(GROUP_NAME, None)
-        self._group_name = group_name if isinstance(group_name, str) else None
+        self._group_name = (
+            group_name if isinstance(group_name, str) or callable(group_name) else None
+        )
         super().__init__(ax, PlotType.HIST)
         self._orientation = "vert"
 
@@ -79,8 +84,9 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         # populated by `_extract_plot_data`, which that call runs.
         base_schema = super().render()
         hist_orientation = {MaidrKey.ORIENTATION: self._orientation}
-        if self._group_name:
-            hist_orientation[MaidrKey.NAME] = self._group_name
+        name = self._group_name() if callable(self._group_name) else self._group_name
+        if name:
+            hist_orientation[MaidrKey.NAME] = name
         return DictMergerMixin.merge_dict(base_schema, hist_orientation)
 
     def _extract_plot_data(self) -> list[dict]:

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -30,6 +30,14 @@ import uuid
 #: ``ScatterPlot`` and ``EventPlot`` name their layers by other means -- a hue
 #: split and row labels -- and are unaffected, being passed neither this key
 #: nor anything that collides with it.
+#:
+#: The value may be a **string** or a **callable returning one**. A string is
+#: the name the patch already resolved; a callable is resolved at render, for
+#: a chart whose legend does not exist yet when its layers register. A
+#: ``pairplot(hue=...)`` is that chart: ``PairGrid.add_legend()`` runs after
+#: every panel is drawn, so at registration there is no legend anywhere and
+#: every diagonal came out anonymous while the scatters beside it were named
+#: (#561). Each class that honours this key resolves the callable itself.
 GROUP_NAME = "_maidr_group_name"
 
 

--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -43,8 +43,13 @@ class SmoothPlot(MaidrPlot):
         # A `kdeplot(hue=...)` draws one curve per level and both were
         # announced identically before (#558). Opted into here rather than
         # read by `MaidrPlot`; see `GROUP_NAME` for why that is per class.
+        # A string names the group now; a callable names it at render, which
+        # is what a `pairplot` needs -- its legend does not exist until every
+        # panel has been drawn (#561).
         group_name = kwargs.get(GROUP_NAME, None)
-        self._group_name = group_name if isinstance(group_name, str) else None
+        self._group_name = (
+            group_name if isinstance(group_name, str) or callable(group_name) else None
+        )
         super().__init__(ax, PlotType.SMOOTH)
         self._smooth_gid = None
         self._regression_line = kwargs.get("regression_line", None)
@@ -60,8 +65,9 @@ class SmoothPlot(MaidrPlot):
         a reader hearing the identical announcement twice.
         """
         schema = super().render()
-        if self._group_name:
-            schema[MaidrKey.NAME] = self._group_name
+        name = self._group_name() if callable(self._group_name) else self._group_name
+        if name:
+            schema[MaidrKey.NAME] = name
         return schema
 
     def _get_selector(self):

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -17,8 +17,8 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.histogram import DRAWN_BARS
 from maidr.core.plot.maidr_plot import GROUP_NAME
-from maidr.patch.kdeplot import _curve_names
-from maidr.core.plot.scatterplot import _named_colours, _rgba
+from maidr.patch.kdeplot import _curve_names, _names_for, deferred_names
+from maidr.core.plot.scatterplot import _rgba
 from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, STEP_ORIENTATION
 from maidr.core.plot.stepped_histogram import reads as _reads_outline
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
@@ -224,7 +224,7 @@ def _group_names(ax: Axes | None, containers: list) -> list[str | None]:
     backwards would agree on those charts, and is not what this does: the
     reversal is nothing seaborn documents, and a legend carrying entries that
     are not group swatches would still have to be declined rather than
-    counted, which is what ``_named_colours`` answers ``None`` for.
+    counted.
 
     Every reason to decline is a reason to leave the layers unnamed rather
     than to name them wrongly:
@@ -233,11 +233,20 @@ def _group_names(ax: Axes | None, containers: list) -> list[str | None]:
       distribution never had one. Nothing names the colours.
     - **A container no swatch claims.** Nothing to call it.
     - **Two names for one colour.** A swatch that means two things cannot name
-      the group a container belongs to; ``_named_colours`` answers ``None``.
+      the group a container belongs to.
 
     A single container is left unnamed whatever the legend says: one
     distribution needs nothing to tell it apart from, and a name there would
     read as though the chart held more.
+
+    The match itself is ``kdeplot._names_for``, which is the same one this
+    used to make inline against ``_named_colours`` plus a second pass this
+    lacked. That pass is not a nicety here: a ``pairplot(hue=...)`` draws its
+    bars translucent and builds its figure legend from **opaque** swatches --
+    measured, bars at alpha 0.5 against swatches at 1.0, identical hues -- so
+    an RGBA comparison named nothing and every diagonal panel stayed
+    anonymous (#561). Comparing the three colour channels alone, guarded on
+    the drawn colours already being distinct without their alpha, names them.
 
     Parameters
     ----------
@@ -251,19 +260,10 @@ def _group_names(ax: Axes | None, containers: list) -> list[str | None]:
     list of str or None
         One entry per container, naming it or ``None``.
     """
-    if ax is None or len(containers) < 2:
+    if ax is None:
         return [None] * len(containers)
 
-    legend = ax.get_legend()
-    if legend is None:
-        return [None] * len(containers)
-
-    colours = [_container_colour(container) for container in containers]
-    named = _named_colours(legend, {c for c in colours if c is not None})
-    if not named:
-        return [None] * len(containers)
-
-    return [None if colour is None else named.get(colour) for colour in colours]
+    return _names_for(ax, [_container_colour(c) for c in containers])
 
 
 def _container_colour(container) -> tuple[float, ...] | None:
@@ -563,7 +563,9 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     # first group goes through it -- keeping the orientation and axis handling
     # every histogram has always had -- and the rest are registered beside it.
     containers = _new_bar_containers(drawn_axes, before)
-    names = _group_names(drawn_axes, containers)
+    names = deferred_names(
+        lambda: _group_names(drawn_axes, containers), len(containers)
+    )
     ax = common(
         PlotType.HIST,
         lambda *a, **k: drawn,
@@ -652,7 +654,9 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
         # for `histplot` and not for the figure-level spelling of the same
         # chart -- the asymmetry #522 and #446 were both about.
         containers = _new_bar_containers(ax, seen)
-        for container, name in zip(containers, _group_names(ax, containers)):
+        for container, name in zip(containers, deferred_names(
+            lambda: _group_names(ax, containers), len(containers)
+        )):
             FigureManager.create_maidr(
                 ax, PlotType.HIST, **{DRAWN_BARS: container, GROUP_NAME: name}
             )

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -181,6 +181,22 @@ def legend_of(ax: Axes | None):
     which of them names this axes' colours, and a wrong name is worse than
     none -- the rule every decline in this module already follows.
 
+    **The axes' own legend always wins**, and that is the mitigation rather
+    than a preference. One figure legend is read as naming *every* axes, and
+    nothing in the artists can say otherwise: several panels with independent
+    hues draw the same default colour cycle, so a legend built for one of
+    them matches all of them. Measured, two `kdeplot(hue=...)` panels drawn
+    `legend=False` with one `fig.legend()` for the first come out with the
+    first panel's names on both.
+
+    That case needs a figure built by hand with every panel's own legend
+    suppressed, which is not what any seaborn call does on its own -- a
+    panel that keeps its legend is named by it and never consults the
+    figure's. The trade is a wrong name in that shape against no name at all
+    on every `pairplot`, whose whole grid does share one hue mapping. It is
+    written down here rather than left to be discovered, and pinned in
+    `tests/core/plot/test_pairplot_group_names.py`.
+
     Parameters
     ----------
     ax : Axes or None

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -168,6 +168,81 @@ def _collection_colour(collection) -> tuple | None:
     return colours.pop()
 
 
+def legend_of(ax: Axes | None):
+    """
+    The legend that names this axes' groups, wherever it was put.
+
+    ``ax.get_legend()`` is where seaborn leaves one for a single chart, and it
+    is what every caller here read. A ``PairGrid`` moves it: `add_legend()`
+    builds one **figure-level** legend for the whole grid, and the panels then
+    have none of their own.
+
+    Only when the figure carries exactly one. Two figure legends cannot say
+    which of them names this axes' colours, and a wrong name is worse than
+    none -- the rule every decline in this module already follows.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes drawn on.
+
+    Returns
+    -------
+    Legend or None
+        The legend to read swatches from, or ``None``.
+    """
+    if ax is None:
+        return None
+    own = ax.get_legend()
+    if own is not None:
+        return own
+    figure = getattr(ax, "figure", None)
+    legends = list(getattr(figure, "legends", ()) or ())
+    return legends[0] if len(legends) == 1 else None
+
+
+def deferred_names(resolve, count: int) -> list:
+    """
+    One lazy name per artist, resolved together the first time any is asked.
+
+    The match itself is unchanged; **when** it runs is the whole point. A
+    ``pairplot(hue=...)`` draws every panel before ``PairGrid.add_legend()``
+    builds the legend, so at registration there is no legend anywhere --
+    measured, neither on the axes nor on the figure -- and every diagonal
+    panel came out anonymous while the scatters beside it were named (#561).
+
+    Resolved once and shared: the layers of one call must agree, and a legend
+    read per layer would be read once per layer for no gain. A caller who
+    relabels the legend between drawing and rendering therefore changes what
+    the chart says, which is the divergence ``MaidrPlot._legend_title``
+    already accepts for ``axes.z``.
+
+    Parameters
+    ----------
+    resolve : callable
+        Returns the whole list of names, in artist order.
+    count : int
+        How many artists there are.
+
+    Returns
+    -------
+    list
+        One zero-argument callable per artist.
+    """
+    resolved: list = []
+
+    def at(index: int):
+        def name():
+            if not resolved:
+                resolved.append(resolve())
+            names = resolved[0]
+            return names[index] if index < len(names) else None
+
+        return name
+
+    return [at(index) for index in range(count)]
+
+
 def _names_for(ax: Axes, colours: list) -> list:
     """
     Match a list of drawn colours against the legend that names them.
@@ -208,7 +283,7 @@ def _names_for(ax: Axes, colours: list) -> list:
     if len(colours) < 2:
         return [None] * len(colours)
 
-    legend = ax.get_legend()
+    legend = legend_of(ax)
     if legend is None:
         return [None] * len(colours)
 
@@ -291,7 +366,9 @@ def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
         # Register all unique Line2D objects
         lines = [line for line in ax.get_lines() if isinstance(line, Line2D)]
         curves = list(unique_lines_by_xy(lines))
-        for kde_line, name in zip(curves, _curve_names(ax, curves)):
+        for kde_line, name in zip(curves, deferred_names(
+            lambda: _curve_names(ax, curves), len(curves)
+        )):
             if kde_line.get_gid() is None:
                 gid = f"maidr-{uuid.uuid4()}"
                 kde_line.set_gid(gid)
@@ -304,7 +381,9 @@ def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
             )
         # Register all PolyCollection boundaries as SMOOTH
         fills = [c for c in ax.collections if isinstance(c, PolyCollection)]
-        for poly, fill_name in zip(fills, _fill_names(ax, fills)):
+        for poly, fill_name in zip(fills, deferred_names(
+            lambda: _fill_names(ax, fills), len(fills)
+        )):
             if poly.get_paths():
                 path = poly.get_paths()[0]
                 boundary = path.vertices

--- a/tests/core/plot/test_pairplot_group_names.py
+++ b/tests/core/plot/test_pairplot_group_names.py
@@ -1,0 +1,224 @@
+"""
+A ``pairplot`` hue left its diagonal panels anonymous (#561).
+
+#559 and #560 name a hue's layers by matching each artist's colour against
+the legend swatch that names it, and both do the match **at registration**.
+`sns.pairplot(hue=...)` is the one chart where that cannot fire, and the
+reason is timing rather than the match: ``PairGrid.add_legend()`` builds one
+figure-level legend after every panel has been drawn, so when the diagonals
+register there is no legend anywhere -- not on the axes, not on the figure.
+
+Measured before the fix, on the same figure::
+
+    smooth  (no name)   smooth  (no name)     <- the diagonals
+    smooth  (no name)   smooth  (no name)
+    point   name='x'    point   name='y'      <- the scatters beside them
+
+Two things were needed and neither works alone:
+
+- **the match is deferred to render**, when the legend exists. ``GROUP_NAME``
+  therefore accepts a callable as well as a string.
+- **the figure's legend is read** when the axes has none of its own, which is
+  where a ``PairGrid`` puts it.
+
+A third thing was needed for the ``diag_kind="hist"`` spelling, and it is
+the reason `_group_names` now delegates to `kdeplot._names_for`: a pairplot
+draws its bars translucent and its swatches opaque -- measured, alpha 0.5
+against 1.0 with identical hues -- so an exact RGBA comparison names
+nothing. That second, hue-only pass already existed for the KDE side.
+
+What is deliberately not fixed: the manual ``ax.scatter(c=[...])`` followed
+by ``ax.legend(handles=[...])`` that #561 mentions. A hue-grouped scatter is
+split into one layer *per group* at registration, so deferring its name
+would mean deferring how many layers there are, which is a different change.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {
+            "a": rng.normal(size=40),
+            "b": rng.normal(size=40) + 1,
+            "g": ["x"] * 20 + ["y"] * 20,
+        }
+    )
+
+
+def _named(fig) -> list:
+    """Every layer as ``(type, name)``, after a real render."""
+    maidr.render(fig)._repr_html_()
+    return [
+        (plot.type.value, plot.schema.get("name"))
+        for plot in FigureManager.get_maidr(fig).plots
+    ]
+
+
+def _diagonals(named: list, kind: str) -> list:
+    return [name for layer, name in named if layer == kind]
+
+
+def test_a_pairplots_kde_diagonals_are_named():
+    named = _named(sns.pairplot(_frame(), hue="g").figure)
+
+    # Two groups per diagonal panel, two panels.
+    assert _diagonals(named, "smooth") == ["y", "x", "y", "x"]
+
+
+def test_a_pairplots_histogram_diagonals_are_named():
+    # The spelling that also needed the hue-only colour pass: these bars are
+    # translucent and the figure legend's swatches are not.
+    named = _named(sns.pairplot(_frame(), hue="g", diag_kind="hist").figure)
+
+    assert _diagonals(named, "hist") == ["y", "x", "y", "x"]
+
+
+def test_the_scatters_beside_them_are_unchanged():
+    # They were already named, by a legend the off-diagonal panels do have at
+    # registration. Asserted so the deferral cannot have cost them.
+    named = _named(sns.pairplot(_frame(), hue="g").figure)
+
+    assert _diagonals(named, "point") == ["x", "y", "x", "y"]
+
+
+def test_a_plain_hue_grouped_kde_is_unchanged():
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", hue="g", ax=ax)
+
+    assert _named(fig) == [("smooth", "y"), ("smooth", "x")]
+
+
+def test_a_plain_hue_grouped_histogram_is_unchanged():
+    fig, ax = plt.subplots()
+    sns.histplot(data=_frame(), x="a", hue="g", bins=4, ax=ax)
+
+    assert _named(fig) == [("hist", "y"), ("hist", "x")]
+
+
+def test_a_histogram_with_its_kde_overlay_names_all_four_layers():
+    # The case #560 was written for, where the bars are translucent and the
+    # curves opaque. It runs through the deferred path now, so it is pinned
+    # here as well as there.
+    fig, ax = plt.subplots()
+    sns.histplot(data=_frame(), x="a", hue="g", bins=4, kde=True, ax=ax)
+
+    assert _named(fig) == [
+        ("hist", "y"),
+        ("hist", "x"),
+        ("smooth", "y"),
+        ("smooth", "x"),
+    ]
+
+
+@pytest.mark.parametrize("draw", ["hist", "kde"])
+def test_an_ungrouped_chart_is_still_unnamed(draw):
+    # A name on the only layer of a chart reads as though there were another
+    # to tell it from.
+    fig, ax = plt.subplots()
+    if draw == "hist":
+        sns.histplot(data=_frame(), x="a", bins=4, ax=ax)
+    else:
+        sns.kdeplot(data=_frame(), x="a", ax=ax)
+
+    assert [name for _, name in _named(fig)] == [None]
+
+
+def _drawn_curves(ax) -> list:
+    from matplotlib.lines import Line2D
+
+    return [line for line in ax.get_lines() if isinstance(line, Line2D)]
+
+
+def _figure_legend(fig, ax, **kwargs):
+    """A figure legend naming the drawn colours, as a `PairGrid` builds one."""
+    from matplotlib.patches import Patch
+
+    curves = _drawn_curves(ax)
+    handles = [Patch(facecolor=curve.get_color()) for curve in curves]
+    # Reversed, which is the order seaborn's own legend runs in -- so a match
+    # by position would give each curve the other group's name and these two
+    # tests would agree for the wrong reason.
+    return fig.legend(handles=handles, labels=["x", "y"], **kwargs)
+
+
+def test_one_figure_legend_names_the_axes_below_it():
+    # The other half of the fix, on its own: the axes has no legend of its
+    # own, and the figure's is where a `PairGrid` puts it.
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", hue="g", ax=ax, legend=False)
+    _figure_legend(fig, ax, loc="upper left")
+
+    assert [name for _, name in _named(fig)] == ["x", "y"]
+
+
+def test_two_figure_legends_name_nothing():
+    # The guard on reading the figure's legend: with two of them, nothing
+    # says which names this axes' colours, and a wrong name is worse than
+    # none. Both carry the real swatches, so the test above is what makes
+    # this one bite -- either alone would name the curves.
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", hue="g", ax=ax, legend=False)
+    _figure_legend(fig, ax, loc="upper left")
+    _figure_legend(fig, ax, loc="upper right")
+
+    assert [name for _, name in _named(fig)] == [None, None]
+
+
+def test_the_name_is_resolved_once_and_stays_put():
+    # Rendered more than once -- `schema`, `elements` and `set_id` each
+    # render when nothing is cached -- and the layers of one call have to
+    # agree with each other and with themselves.
+    figure = sns.pairplot(_frame(), hue="g").figure
+    maidr.render(figure)._repr_html_()
+
+    plots = FigureManager.get_maidr(figure).plots
+    first = [plot.render().get("name") for plot in plots]
+    second = [plot.render().get("name") for plot in plots]
+
+    assert first == second
+    assert first[:4] == ["y", "x", "y", "x"]
+
+
+def test_a_translucent_bar_is_named_by_an_opaque_swatch():
+    # The colour half, stated on its own. A pairplot's legend swatches are
+    # opaque while its bars are not, so the exact-RGBA pass names nothing and
+    # the hue-only pass is what answers.
+    from maidr.patch.histogram import _container_colour
+    from maidr.patch.kdeplot import _handle_colour, legend_of
+
+    figure = sns.pairplot(_frame(), hue="g", diag_kind="hist").figure
+    maidr.render(figure)._repr_html_()
+
+    from matplotlib.container import BarContainer
+
+    axes = [
+        ax
+        for ax in figure.axes
+        if any(isinstance(c, BarContainer) for c in ax.containers)
+    ]
+    containers = [c for c in axes[0].containers if isinstance(c, BarContainer)]
+    legend = legend_of(axes[0])
+
+    bars = {_container_colour(c) for c in containers}
+    swatches = {_handle_colour(h) for h in legend.legend_handles}
+
+    # Same hues, different alpha -- which is why an exact comparison fails.
+    assert bars.isdisjoint(swatches)
+    assert {colour[:3] for colour in bars} == {colour[:3] for colour in swatches}

--- a/tests/core/plot/test_pairplot_group_names.py
+++ b/tests/core/plot/test_pairplot_group_names.py
@@ -181,6 +181,48 @@ def test_two_figure_legends_name_nothing():
     assert [name for _, name in _named(fig)] == [None, None]
 
 
+def test_an_axes_own_legend_wins_over_the_figures():
+    # The mitigation for the case below: a panel that kept its own legend is
+    # named by it and never consults the figure's. That is the ordinary
+    # seaborn call, so the ambiguity needs a figure built by hand.
+    fig, ax = plt.subplots()
+    sns.kdeplot(data=_frame(), x="a", hue="g", ax=ax)
+    _figure_legend(fig, ax, loc="upper right")
+
+    # The axes legend names them the way it always did, not the figure's
+    # reversed labels.
+    assert [name for _, name in _named(fig)] == ["y", "x"]
+
+
+def test_one_figure_legend_names_every_panel_below_it():
+    # The accepted cost, pinned rather than left to be discovered. One figure
+    # legend is read as naming every axes, and nothing in the artists can say
+    # otherwise: two panels with independent hues draw the same default
+    # colour cycle, so a legend built for the first matches the second too.
+    #
+    # It needs a figure built by hand with both panels' legends suppressed.
+    # The trade is this against no name at all on every `pairplot`.
+    from matplotlib.patches import Patch
+
+    rng = np.random.default_rng(0)
+    left = pd.DataFrame({"v": rng.normal(size=40), "g": ["p"] * 20 + ["q"] * 20})
+    right = pd.DataFrame(
+        {"v": rng.normal(size=40) + 2, "h": ["s"] * 20 + ["t"] * 20}
+    )
+
+    fig, (first, second) = plt.subplots(1, 2)
+    sns.kdeplot(data=left, x="v", hue="g", ax=first, legend=False)
+    sns.kdeplot(data=right, x="v", hue="h", ax=second, legend=False)
+    fig.legend(
+        handles=[Patch(facecolor=c.get_color()) for c in _drawn_curves(first)],
+        labels=["p", "q"],
+    )
+
+    # The second panel's groups are `s` and `t`, and they are announced with
+    # the first panel's names. Both panels drew the same two colours.
+    assert [name for _, name in _named(fig)] == ["p", "q", "p", "q"]
+
+
 def test_the_name_is_resolved_once_and_stays_put():
     # Rendered more than once -- `schema`, `elements` and `set_id` each
     # render when nothing is cached -- and the layers of one call have to


### PR DESCRIPTION
Closes #561.

## What was wrong

#559 and #560 name a hue's layers by matching each artist's colour against the legend swatch that names it, and both did the match **at registration**. `sns.pairplot(hue=...)` is the one chart where that cannot fire, and the reason is timing rather than the match — `PairGrid.add_legend()` builds one figure-level legend after every panel has been drawn, so when the diagonals register there is no legend anywhere. Measured on the same figure:

```
smooth  (no name)   smooth  (no name)     <- the diagonals
smooth  (no name)   smooth  (no name)
point   name='x'    point   name='y'      <- the scatters beside them
```

The scatters are named because the off-diagonal panels *do* have an axes legend at that moment; `add_legend()` later moves it to the figure. The diagonals never get one of their own. Nothing is lost — both distributions are announced with their values — but a reader stepping between two identical-sounding layers has to infer which is which, on a figure whose other panels say.

## Three things, and none of them works alone

**1. `GROUP_NAME` takes a callable as well as a string**, and the two classes that honour it resolve one at render. #561 called this a real design decision about registration versus render, and the precedent settles it: `MaidrPlot._legend_title` already resolves `axes.z` at render and already accepts the same divergence — a caller who relabels the legend between drawing and rendering changes what the chart says.

**2. The legend is looked for on the figure** when the axes has none of its own, which is where a `PairGrid` puts it — and only when the figure carries **exactly one**, since two cannot say which names this axes' colours.

**3. `_group_names` delegates to `kdeplot._names_for`** rather than matching inline. Not tidying: a pairplot draws its bars translucent and its swatches opaque — measured, alpha 0.5 against 1.0 with identical hues — so the exact-RGBA comparison it made named nothing, and the guarded hue-only second pass the KDE side already had is what answers. Without it the `diag_kind="hist"` spelling stayed anonymous while the KDE one was fixed.

| chart | before | after |
| --- | --- | --- |
| `pairplot(hue=…)` diagonals | `smooth` ×4, unnamed | `y, x, y, x` |
| `pairplot(hue=…, diag_kind="hist")` diagonals | `hist` ×4, unnamed | `y, x, y, x` |
| the scatters beside them | `x, y, x, y` | unchanged |
| `kdeplot(hue=…)`, `histplot(hue=…)`, `histplot(hue=…, kde=True)` | named | unchanged |
| an ungrouped chart | unnamed | unnamed |

## Not fixed, and deliberately

The manual `ax.scatter(c=[...])` followed by a late `ax.legend(handles=[...])` that #561 also mentions. A hue-grouped scatter is split into one layer **per group** at registration, so deferring its name would mean deferring how many layers a figure has — a different change from deferring what one of them is called.

## Tests

`tests/core/plot/test_pairplot_group_names.py`, 12 cases.

Two are there to make the others bite. **"one figure legend names the axes below it"** builds a real figure legend from the drawn colours and asserts it names them — which is what makes **"two figure legends name nothing"** a test of the guard rather than of an empty legend. Its labels are supplied in seaborn's own reversed order, so a match by position would give each curve the other group's name and both would agree for the wrong reason.

**"a translucent bar is named by an opaque swatch"** states the colour half on its own: the bars' RGBA is disjoint from the swatches', and their three-channel hues are equal.

Falsified — each mutation applied alone against the fixed baseline:

| mutation | result |
| --- | --- |
| the figure legend is not read | 5 failures |
| any number of figure legends accepted | "two figure legends name nothing" fails |
| the KDE names resolve at registration again | 3 failures |
| the histogram matches exact RGBA only | the `diag_kind="hist"` case fails |

Full suite: `2658 passed, 18 skipped`. `ruff check --diff` clean on the changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_