### PR TITLE
feat(gantt): read hlines and vlines as the schedule of intervals they draw

### DIFF
--- a/maidr/core/plot/gantt.py
+++ b/maidr/core/plot/gantt.py
@@ -158,29 +158,34 @@ class GanttPlot(MaidrPlot):
             float(finite[:, 1].max()),
         )
 
-    def _lane_name(self, low: float, high: float) -> str | float:
+    def _lane_name(self, low: float, high: float, axis=None) -> str | float:
         """
         What to call the lane a bar spanning ``low`` to ``high`` sits in.
 
         Parameters
         ----------
         low, high : float
-            The bar's y extent.
+            The bar's extent along the lane axis.
+        axis : Axis, optional
+            The axis the lanes are laid out on. The y axis by default, which
+            is where ``broken_barh`` puts them; ``SpanPlot`` passes the x axis
+            for a set of vertical spans, whose lanes run the other way.
 
         Returns
         -------
         str or float
             The tick label naming it, or its centre when no single tick does.
         """
+        axis = self.ax.get_yaxis() if axis is None else axis
         centre = (low + high) / 2
-        if not isinstance(self.ax.get_yaxis().get_major_locator(), FixedLocator):
+        if not isinstance(axis.get_major_locator(), FixedLocator):
             # An axis matplotlib chose the ticks for. Several land inside a
             # bar and none of them is its name.
             return centre
 
         inside = [
             text.get_text()
-            for position, text in zip(self.ax.get_yticks(), self.ax.get_yticklabels())
+            for position, text in zip(axis.get_ticklocs(), axis.get_ticklabels())
             if low <= position <= high and text.get_text()
         ]
         # Exactly one, or the label is a guess between candidates rather than

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -13,7 +13,6 @@ from maidr.core.plot.contour import ContourPlot
 from maidr.core.plot.errorbar import ErrorBarPlot
 from maidr.core.plot.eventplot import DRAWN_EVENTS, EventPlot
 from maidr.core.plot.gantt import GanttPlot
-from maidr.core.plot.spanplot import DRAWN_SPANS, SpanPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
 from maidr.core.plot.heatmap import HeatPlot
 from maidr.core.plot.hexbinplot import HexbinPlot
@@ -24,6 +23,7 @@ from maidr.core.plot.pieplot import PiePlot
 from maidr.core.plot.pointplot import PointPlot
 from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.regplot import SmoothPlot
+from maidr.core.plot.spanplot import DRAWN_SPANS, SpanPlot
 from maidr.core.plot.stairs import StairsPlot
 from maidr.core.plot.stepped_histogram import SteppedHistPlot
 from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, StepHistPlot

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -13,6 +13,7 @@ from maidr.core.plot.contour import ContourPlot
 from maidr.core.plot.errorbar import ErrorBarPlot
 from maidr.core.plot.eventplot import DRAWN_EVENTS, EventPlot
 from maidr.core.plot.gantt import GanttPlot
+from maidr.core.plot.spanplot import DRAWN_SPANS, SpanPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
 from maidr.core.plot.heatmap import HeatPlot
 from maidr.core.plot.hexbinplot import HexbinPlot
@@ -76,6 +77,14 @@ class MaidrPlotFactory:
         elif PlotType.BOXEN == plot_type:
             return BoxenPlot(single_ax, **kwargs)
         elif PlotType.GANTT == plot_type:
+            # Two calls draw this chart and they are shaped oppositely.
+            # `broken_barh` draws one lane per call and hands back a
+            # `PolyCollection` of corners; `hlines`/`vlines` draw every lane
+            # in one call and hand back a `LineCollection` of segments. The
+            # layer is the same either way, so the type cannot say which, and
+            # the artist the patch passes does (#568).
+            if DRAWN_SPANS in kwargs:
+                return SpanPlot(single_ax, **kwargs)
             return GanttPlot(single_ax, **kwargs)
         elif PlotType.CONTOUR == plot_type:
             return ContourPlot(single_ax, **kwargs)

--- a/maidr/core/plot/spanplot.py
+++ b/maidr/core/plot/spanplot.py
@@ -16,11 +16,54 @@ DRAWN_SPANS = "_maidr_spans"
 #: Key saying which way the spans run: ``True`` for ``hlines``.
 SPANS_ALONG_X = "_maidr_spans_along_x"
 
-#: How close two coordinates must be to count as the same lane, relative to
-#: the span of the lane axis. Segment ends come back exactly as the caller
-#: gave them -- a `LineCollection` stores them, it does not serialise a path
-#: -- so this exists for a caller who computed a lane rather than typing it.
-_TOLERANCE = 1e-9
+#: How far apart a segment's two lane coordinates may be and still count as
+#: level. Absolute, and deliberately left that way: the scale this wants is
+#: the *magnitude* of the coordinates, where float spacing lives, and the
+#: only scale available here is the spread of the lanes, which is a
+#: different quantity -- three lanes a second apart at epoch scale spread by
+#: 2 while their float spacing is nearer 2e-7. So a relative version built
+#: from what this function knows would not answer the question it looks like
+#: it answers. Unresolved rather than solved; it costs nothing today because
+#: `hlines` and `vlines` give both ends of a segment the *same* float, so
+#: the comparison is exactly zero and any tolerance passes. It would matter
+#: only for a hand-built `LineCollection` at large magnitude.
+_LEVEL_TOLERANCE = 1e-9
+
+#: How close two of a chart's ends must be to count as the same end, as a
+#: fraction of the extent the chart covers along the axis the intervals run
+#: on. Relative because the question is about the chart's own scale, and
+#: because the shared coordinate is often zero, which has no magnitude to be
+#: relative to.
+#:
+#: Exact equality was not enough. `hlines` and `vlines` hand back the
+#: caller's own floats untouched, so a literal baseline is bit-identical
+#: across segments -- but a *computed* one need not be. Measured:
+#: ``tops * 0.1 - tops / 10`` is elementwise zero in arithmetic and
+#: ``[5.55e-17, 0.0, 0.0, 0.0]`` in floats, so four lollipop stems stopped
+#: sharing a baseline and were read as a schedule announcing "0 to 8" for a
+#: chart that means "8".
+_SHARED_END_TOLERANCE = 1e-9
+
+
+def _same_within(values: list, extent: float) -> bool:
+    """
+    Whether every value is the same coordinate, to the chart's own scale.
+
+    Parameters
+    ----------
+    values : list of float
+        The coordinates to compare.
+    extent : float
+        How far the chart reaches on the axis these lie on. Zero collapses
+        the test to exact equality, which is the right answer when there is
+        no scale to be relative to.
+
+    Returns
+    -------
+    bool
+        True when the values differ by no more than the tolerance.
+    """
+    return max(values) - min(values) <= abs(extent) * _SHARED_END_TOLERANCE
 
 
 def read_spans(collection, along_x: bool) -> list | None:
@@ -52,7 +95,7 @@ def read_spans(collection, along_x: bool) -> list | None:
         if ends.shape != (2, 2) or not np.all(np.isfinite(ends)):
             return None
         lane, other = ends[0][lane_axis], ends[1][lane_axis]
-        if abs(lane - other) > _TOLERANCE:
+        if abs(lane - other) > _LEVEL_TOLERANCE:
             # Not level on its lane axis, so it is not an interval in one.
             return None
         spans.append((lane, ends[0][span_axis], ends[1][span_axis]))
@@ -91,9 +134,16 @@ def states_an_interval(spans: list) -> bool:
     looks stricter than it needs to be, and relax it. ``test_spanplot.py``
     pins the declined case for the same reason.
     """
-    starts = {start for _, start, _ in spans}
-    ends = {end for _, _, end in spans}
-    return len(starts) > 1 and len(ends) > 1
+    starts = [start for _, start, _ in spans]
+    ends = [end for _, _, end in spans]
+    # Judged against how far the chart reaches along the axis the intervals
+    # run on. Exact equality would let a baseline the caller *computed* slip
+    # through as "not shared" and turn a lollipop into a schedule; measured
+    # on `vlines(x, tops * 0.1 - tops / 10, tops)`, which is zero in
+    # arithmetic, `[5.55e-17, 0.0, 0.0, 0.0]` in floats, and read as a gantt
+    # announcing "0 to 8" for a chart that means "8".
+    extent = max(max(starts), max(ends)) - min(min(starts), min(ends))
+    return not _same_within(starts, extent) and not _same_within(ends, extent)
 
 
 def draws_a_schedule(collection, along_x: bool) -> bool:

--- a/maidr/core/plot/spanplot.py
+++ b/maidr/core/plot/spanplot.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import uuid
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+
+from maidr.core.enum import MaidrKey
+from maidr.core.plot.gantt import GanttPlot
+from maidr.exception import ExtractionError
+
+#: Key the patch passes the ``LineCollection`` its own call drew under.
+DRAWN_SPANS = "_maidr_spans"
+
+#: Key saying which way the spans run: ``True`` for ``hlines``.
+SPANS_ALONG_X = "_maidr_spans_along_x"
+
+#: How close two coordinates must be to count as the same lane, relative to
+#: the span of the lane axis. Segment ends come back exactly as the caller
+#: gave them -- a `LineCollection` stores them, it does not serialise a path
+#: -- so this exists for a caller who computed a lane rather than typing it.
+_TOLERANCE = 1e-9
+
+
+def read_spans(collection, along_x: bool) -> list | None:
+    """
+    Each segment as ``(lane, start, end)``, or ``None`` when this is not a
+    set of spans.
+
+    Parameters
+    ----------
+    collection : LineCollection or None
+        The artist the call drew.
+    along_x : bool
+        True when the intervals run along x, as ``hlines`` draws them.
+
+    Returns
+    -------
+    list of tuple or None
+        One entry per segment, in draw order.
+    """
+    if not isinstance(collection, LineCollection):
+        return None
+
+    lane_axis = 1 if along_x else 0
+    span_axis = 1 - lane_axis
+
+    spans: list[tuple[float, float, float]] = []
+    for segment in collection.get_segments():
+        ends = np.asarray(segment, dtype=float)
+        if ends.shape != (2, 2) or not np.all(np.isfinite(ends)):
+            return None
+        lane, other = ends[0][lane_axis], ends[1][lane_axis]
+        if abs(lane - other) > _TOLERANCE:
+            # Not level on its lane axis, so it is not an interval in one.
+            return None
+        spans.append((lane, ends[0][span_axis], ends[1][span_axis]))
+
+    return spans or None
+
+
+def states_an_interval(spans: list) -> bool:
+    """
+    Whether the spans measure something, rather than sharing a baseline.
+
+    Parameters
+    ----------
+    spans : list of tuple
+        Each segment as ``(lane, start, end)``.
+
+    Returns
+    -------
+    bool
+        True when neither end is the same on every segment.
+    """
+    starts = {start for _, start, _ in spans}
+    ends = {end for _, _, end in spans}
+    return len(starts) > 1 and len(ends) > 1
+
+
+def draws_a_schedule(collection, along_x: bool) -> bool:
+    """
+    Whether a call's collection is a set of measured intervals.
+
+    Asked by the patch **before** the layer is registered, not by the layer
+    when it is read. A layer that refuses at extraction takes the whole
+    figure with it -- which is the defect #564 was about -- so a `vlines`
+    that draws a lollipop's stems must register nothing at all, exactly as
+    it did before this reading existed.
+
+    Parameters
+    ----------
+    collection : LineCollection or None
+        The artist the call drew.
+    along_x : bool
+        True when the intervals run along x.
+
+    Returns
+    -------
+    bool
+        True when the call drew a schedule.
+    """
+    spans = read_spans(collection, along_x)
+    return spans is not None and states_an_interval(spans)
+
+
+class SpanPlot(GanttPlot):
+    """
+    A schedule of intervals drawn by ``Axes.hlines`` or ``Axes.vlines``.
+
+    The same chart ``broken_barh`` draws and the same layer it emits, from a
+    call shaped the other way round: **one call draws every lane**, and hands
+    back a single ``LineCollection`` whose ``get_segments()`` gives both ends
+    of every segment exactly -- nothing inverted, nothing rounded, since a
+    collection stores its ends rather than serialising a path.
+
+    Measured on matplotlib 3.9.4::
+
+        ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+        [[0, 1], [5, 1]]   [[2, 2], [7, 2]]   [[4, 3], [6, 3]]
+
+    Three lanes at 1, 2 and 3, running 0-5, 2-7 and 4-6.
+
+    What is not a schedule
+    ----------------------
+    Three other charts wear these two calls, and the rule that separates them
+    is the one xability/maidr#1100 settled for Observable's `rule` mark and
+    #1122 for Vega-Lite's:
+
+        if every line shares an end, that end is the frame or the baseline
+        rather than anything measured, and the mark is handed back
+
+    - ``vlines(x, 0, y)`` is a lollipop's stems: every segment starts at the
+      baseline, and read as spans they announce "0 to 8" where the chart
+      means "8" -- which the markers drawn at their tips already say.
+    - ``hlines(y, 0, 5)`` is a set of reference lines drawn across the frame:
+      every segment is the same interval, which no row of the data states.
+    - A call holding one segment cannot be told from either, since a single
+      end trivially agrees with itself. That is the cost the same rule pays
+      on the other two adapters, and it is paid here for the same reason.
+
+    A segment that is not level on its lane axis is not a span at all --
+    ``hlines`` and ``vlines`` cannot draw one, but a caller may hand the
+    layer a collection that does -- and the whole layer is declined rather
+    than the one segment dropped, so a chart is never announced as a subset
+    of itself.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        spans = kwargs.pop(DRAWN_SPANS, None)
+        self._spans = spans if isinstance(spans, LineCollection) else None
+        # `hlines` lays its intervals along x and its lanes down y, which is
+        # what `GanttTrace` calls horizontal and what `broken_barh` draws.
+        self._along_x = bool(kwargs.pop(SPANS_ALONG_X, True))
+        super().__init__(ax, collections=[])
+
+    def _extract_plot_data(self) -> dict:
+        """
+        Read the collection as intervals nested by the lane they sit in.
+
+        Returns
+        -------
+        dict
+            ``{"points": [[{"x", "start", "end"}, ...], ...], "lanes": [...]}``
+            -- the same payload ``broken_barh`` produces.
+
+        Raises
+        ------
+        ExtractionError
+            When the call drew nothing this class can read as a schedule.
+        """
+        spans = read_spans(self._spans, self._along_x)
+        if spans is None or not states_an_interval(spans):
+            raise ExtractionError(self.type, self.ax)
+
+        axis = self.ax.get_yaxis() if self._along_x else self.ax.get_xaxis()
+
+        # Lanes in first-seen order, which is the order the segments were
+        # drawn in and therefore the order the elements sit in the SVG.
+        order: list[float] = []
+        grouped: dict[float, list[tuple[float, float]]] = {}
+        for lane, start, end in spans:
+            if lane not in grouped:
+                order.append(lane)
+                grouped[lane] = []
+            grouped[lane].append((start, end))
+
+        lanes = [self._lane_name(lane, lane, axis) for lane in order]
+        points = [
+            [
+                {MaidrKey.X: name, MaidrKey.START: start, MaidrKey.END: end}
+                for start, end in grouped[lane]
+            ]
+            for lane, name in zip(order, lanes)
+        ]
+
+        if self._spans.get_gid() is None:
+            self._spans.set_gid(f"maidr-{uuid.uuid4()}")
+
+        self._elements.clear()
+        self._elements.append(self._spans)
+
+        self._contiguous = all(
+            [lane for lane, _, _ in spans].count(lane) == len(grouped[lane])
+            and self._runs_together(spans, lane)
+            for lane in order
+        )
+
+        return {MaidrKey.POINTS: points, MaidrKey.LANES: lanes}
+
+    @staticmethod
+    def _runs_together(spans: list[tuple[float, float, float]], lane: float) -> bool:
+        """
+        Whether one lane's segments were drawn without another lane between.
+
+        Parameters
+        ----------
+        spans : list of tuple
+            Each segment as ``(lane, start, end)``, in draw order.
+        lane : float
+            The lane to check.
+
+        Returns
+        -------
+        bool
+            True when the lane's segments occupy consecutive draw positions.
+        """
+        at = [index for index, (drawn, _, _) in enumerate(spans) if drawn == lane]
+        return at == list(range(at[0], at[0] + len(at)))
+
+    def _get_selector(self) -> list[str]:
+        """
+        Return one selector addressing every drawn segment, in draw order.
+
+        ``GanttTrace`` takes a flat element list and slices it into lanes by
+        their lengths, so one selector over the whole collection is what this
+        chart needs -- there is one collection, not one per lane.
+
+        Withheld when a lane's segments are not consecutive in draw order.
+        The count would still match, so the core would not withdraw them
+        itself, and the slicing would then hand a lane somebody else's
+        segments: ``hlines([1, 2, 1], ...)`` draws lane 1 twice with lane 2
+        in between. Leaving the layer unhighlighted is what a schedule
+        already does when its lanes do not follow row order.
+
+        Returns
+        -------
+        list of str
+            The selector, or empty when the order cannot be trusted.
+        """
+        if self._spans is None or self._spans.get_gid() is None:
+            return []
+        if not getattr(self, "_contiguous", False):
+            return []
+        return [f"g[id='{self._spans.get_gid()}'] > path"]

--- a/maidr/core/plot/spanplot.py
+++ b/maidr/core/plot/spanplot.py
@@ -73,6 +73,23 @@ def states_an_interval(spans: list) -> bool:
     -------
     bool
         True when neither end is the same on every segment.
+
+    Notes
+    -----
+    This declines when *either* end is shared, not only when both are, and
+    that costs one real schedule: several tasks that all begin on the same
+    day, ``hlines([1, 2, 3], [0, 0, 0], [5, 7, 6])``, is turned away. The
+    reason is that nothing in the geometry separates it from a lollipop's
+    stems, which are also "one shared start, differing ends" and which read
+    as spans announce "0 to 8" for a chart that means "8". One of the two has
+    to lose, and announcing a measurement the chart does not make is the worse
+    outcome -- so the shared-start schedule falls back to a static image,
+    which is at least a picture.
+
+    Recorded here as well as in :class:`SpanPlot`'s docstring because a reader
+    who arrives at this function alone would otherwise see only a rule that
+    looks stricter than it needs to be, and relax it. ``test_spanplot.py``
+    pins the declined case for the same reason.
     """
     starts = {start for _, start, _ in spans}
     ends = {end for _, _, end in spans}

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -26,6 +26,7 @@ from . import (  # noqa: E402, F401
     pieplot,
     pointplot,
     scatterplot,
+    spanplot,
     stairs,
     regplot,
     kdeplot,

--- a/maidr/patch/gantt.py
+++ b/maidr/patch/gantt.py
@@ -105,11 +105,28 @@ def _lane_of(ax: Axes) -> GanttPlot | None:
         # updates the bookkeeping behind iteration, so `get` mutates shared
         # state rather than only observing it.
         return None
+    # `type(... ) is` rather than `isinstance`, because what is being looked
+    # for is not "a gantt-shaped layer" but "a layer `add_lane` can actually
+    # extend" -- and those are no longer the same set. `SpanPlot` subclasses
+    # `GanttPlot` to reuse its schema and its lane naming, but reads its lanes
+    # from the segments the patch handed it, never from `self._collections`.
+    # So an `isinstance` match here let a `broken_barh` call following an
+    # `hlines` on the same axes append its `PolyCollection` to a `SpanPlot`,
+    # where extraction never looks: the lane was drawn, accepted without
+    # error, and appeared in no announcement. Measured on
+    # `hlines(...)` then `broken_barh([(0, 3)], (10, 9))`, which read three
+    # lanes for the four it drew.
+    #
+    # Excluded here rather than refused in `SpanPlot.add_lane`, because a
+    # refusal would have to raise out of the caller's own `ax.broken_barh(...)`
+    # to be heard, and a plotting call that throws is worse than two layers.
+    # Left out of the merge, the `broken_barh` registers its own lane and both
+    # charts read -- which is what the reverse drawing order already did.
     return next(
         (
             plot
             for plot in registered.plots
-            if isinstance(plot, GanttPlot) and plot.ax is ax
+            if type(plot) is GanttPlot and plot.ax is ax
         ),
         None,
     )

--- a/maidr/patch/spanplot.py
+++ b/maidr/patch/spanplot.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import wrapt
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.spanplot import (
+    DRAWN_SPANS,
+    SPANS_ALONG_X,
+    draws_a_schedule,
+)
+from maidr.patch.common import _draw_quietly
+
+
+def _spans(wrapped, instance, args, kwargs, along_x: bool) -> LineCollection:
+    """
+    Draw a patched ``hlines`` or ``vlines`` and register the schedule it drew.
+
+    Both draw one segment per row of the data, and both hand back a single
+    ``LineCollection`` carrying every end exactly. That is a gantt -- an
+    interval per lane -- and it registered nothing at all, so a figure made
+    of them fell back to a picture whose numbers were in the call (#568).
+
+    The reading is declined for the shapes that are not schedules, and the
+    decision is made **here**, before anything is registered: a layer that
+    refuses at extraction takes the whole figure with it, which is the defect
+    #564 was about. A `vlines` drawing a lollipop's stems therefore registers
+    nothing at all, exactly as it did before this reading existed, and the
+    figure keeps whatever the rest of it says.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Axes.hlines`` or ``Axes.vlines``.
+    instance : Any
+        The axes it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+    along_x : bool
+        True for ``hlines``, whose intervals run along x.
+
+    Returns
+    -------
+    LineCollection
+        Whatever the wrapped function returned.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        drawn = _draw_quietly(wrapped, args, kwargs)
+
+    if not isinstance(drawn, LineCollection):
+        return drawn
+
+    if not draws_a_schedule(drawn, along_x):
+        return drawn
+
+    ax = FigureManager.get_axes(drawn)
+    FigureManager.create_maidr(
+        ax,
+        PlotType.GANTT,
+        **{DRAWN_SPANS: drawn, SPANS_ALONG_X: along_x},
+    )
+    return drawn
+
+
+@wrapt.patch_function_wrapper(Axes, "hlines")
+def hlines(wrapped, instance, args, kwargs) -> LineCollection:
+    """Register an ``Axes.hlines`` call as a MAIDR gantt layer."""
+    return _spans(wrapped, instance, args, kwargs, along_x=True)
+
+
+@wrapt.patch_function_wrapper(Axes, "vlines")
+def vlines(wrapped, instance, args, kwargs) -> LineCollection:
+    """
+    Register an ``Axes.vlines`` call as a MAIDR gantt layer.
+
+    The same chart with the axes exchanged: the lanes run along x and the
+    intervals down y. `GanttTrace` navigates lanes and intervals rather than
+    x and y, so the two need no orientation to tell them apart -- only which
+    axis the lanes were laid out on, which is what `SpanPlot` is told.
+    """
+    return _spans(wrapped, instance, args, kwargs, along_x=False)

--- a/maidr/patch/spanplot.py
+++ b/maidr/patch/spanplot.py
@@ -59,6 +59,17 @@ def _spans(wrapped, instance, args, kwargs, along_x: bool) -> LineCollection:
     if not draws_a_schedule(drawn, along_x):
         return drawn
 
+    # Registered as its own layer every time, with no equivalent of
+    # `gantt._lane_of`/`add_lane`. Deliberate, and the asymmetry with the
+    # sibling patch follows from the two calls being shaped differently: a
+    # `broken_barh` call draws *one* lane, so lanes have to accumulate across
+    # calls for a schedule to exist at all, whereas one `hlines` call already
+    # draws the whole schedule. Merging a second one in would join two
+    # complete charts into a chart neither call made.
+    #
+    # The two therefore stay separable, which also lets them keep their own
+    # lane axes: nothing stops an `hlines` and a `vlines` sharing an axes, and
+    # they lay their lanes out on opposite axes.
     ax = FigureManager.get_axes(drawn)
     FigureManager.create_maidr(
         ax,

--- a/tests/core/plot/test_spanplot.py
+++ b/tests/core/plot/test_spanplot.py
@@ -308,3 +308,40 @@ def test_a_schedule_whose_tasks_share_a_start_is_declined():
 
     assert _layers(fig) == []
     assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_an_hlines_and_a_vlines_share_an_axes_and_keep_their_own_lane_axis():
+    # `patch/spanplot.py` claims exactly this, and until now nothing checked
+    # it. The substantive half is not that two layers appear -- it is that
+    # each names its lanes off the axis *it* laid them out on, since the two
+    # calls run in opposite directions and `SpanPlot` is told which by
+    # `SPANS_ALONG_X` alone. Given different tick labels on x and y, a layer
+    # reading the wrong axis would come back with the other one's names, or
+    # with bare numbers when the position matched no tick.
+    fig, ax = plt.subplots()
+    ax.set_yticks([1, 2, 3], labels=["alpha", "beta", "gamma"])
+    ax.set_xticks([10, 20], labels=["left", "right"])
+    ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+    ax.vlines([10, 20], [0, 1], [4, 9])
+
+    schemas = _all_schemas(fig)
+    assert [schema["data"]["lanes"] for schema in schemas] == [
+        ["alpha", "beta", "gamma"],
+        ["left", "right"],
+    ]
+
+
+def test_one_unreadable_segment_declines_the_whole_call():
+    # The asymmetry with `GanttPlot._corners`, which drops a bad path and
+    # keeps the rest of its lane. `read_spans` returns None for the call
+    # instead, so a chart is never announced as a subset of itself -- a
+    # reader given two of three tasks has no way to know a third existed.
+    # Documented on the class; pinned here so the trade-off enforces itself.
+    import numpy as np
+
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], [0, 2, np.nan], [5, 7, 6])
+
+    assert _layers(fig) == []
+    # And the figure still renders, as a picture rather than nothing.
+    assert len(maidr.render(fig)._repr_html_()) > 0

--- a/tests/core/plot/test_spanplot.py
+++ b/tests/core/plot/test_spanplot.py
@@ -345,3 +345,72 @@ def test_one_unreadable_segment_declines_the_whole_call():
     assert _layers(fig) == []
     # And the figure still renders, as a picture rather than nothing.
     assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_a_computed_baseline_is_still_a_lollipop():
+    # Review asked whether float noise could dodge the decline, and it could.
+    # `tops * 0.1 - tops / 10` is elementwise zero in arithmetic and
+    # `[5.55e-17, 0.0, 0.0, 0.0]` in floats, so an exact comparison saw four
+    # stems that no longer shared a baseline and read them as a schedule --
+    # announcing "0 to 8" for a chart that means "8". The comparison is now
+    # made against the chart's own extent instead.
+    import numpy as np
+
+    tops = np.array([3.0, 8.0, 5.0, 9.0])
+    baseline = tops * 0.1 - tops / 10.0
+    assert len(set(baseline.tolist())) > 1, "fixture must actually be noisy"
+
+    fig, ax = plt.subplots()
+    ax.vlines([1, 2, 3, 4], baseline, tops)
+
+    assert _layers(fig) == []
+
+
+def test_a_schedule_laid_out_in_epoch_seconds_still_reads():
+    # The shared-end tolerance is a fraction of the chart's extent, so it
+    # had to be checked that scaling it up does not make a real schedule's
+    # differing ends look shared. Here the extent is 700 and the tolerance
+    # 7e-7, while the starts differ by 200.
+    #
+    # Not a test of the levelness tolerance, which stays absolute -- both
+    # ends of an `hlines` segment are the *same* float, so that comparison
+    # is exactly zero at any scale.
+    base = 1_700_000_000.0
+    fig, ax = plt.subplots()
+    ax.hlines(
+        [1, 2, 3],
+        [base, base + 200, base + 400],
+        [base + 500, base + 700, base + 600],
+    )
+
+    schema = _rendered(fig)
+    assert schema["type"] == "gantt"
+    assert _spans(schema) == [
+        [(base, base + 500)],
+        [(base + 200, base + 700)],
+        [(base + 400, base + 600)],
+    ]
+
+
+def test_a_segment_that_is_not_level_is_still_refused():
+    # The tolerance became relative, not absent. A collection whose segment
+    # slopes across lanes is not an interval in one, and the whole layer is
+    # declined rather than the segment flattened onto a lane it never sat in.
+    from matplotlib.collections import LineCollection
+
+    from maidr.core.plot.spanplot import read_spans
+
+    sloped = LineCollection([[[0, 1], [5, 2]], [[2, 3], [7, 3]]])
+    assert read_spans(sloped, along_x=True) is None
+
+
+def test_a_stem_plot_is_unchanged_by_this_reading():
+    # `stem` draws the lollipop shape and reaches `vlines` the same way
+    # `acorr`/`xcorr` do, so review asked where it lands. It registers a
+    # `line` layer off its marker tips, exactly as it did before this
+    # reading existed -- pinned so the span patch cannot start claiming it.
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3, 4], [3, 8, 5, 9])
+
+    assert _layers(fig) == ["line"]
+    assert len(maidr.render(fig)._repr_html_()) > 0

--- a/tests/core/plot/test_spanplot.py
+++ b/tests/core/plot/test_spanplot.py
@@ -1,0 +1,203 @@
+"""
+``ax.hlines`` and ``ax.vlines`` drew a schedule and registered nothing (#568).
+
+Both draw one segment per row and hand back a single ``LineCollection``
+whose ``get_segments()`` gives both ends exactly -- a collection stores its
+ends rather than serialising a path, so there is nothing to invert and
+nothing to round. Measured on matplotlib 3.9.4::
+
+    ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+    [[0, 1], [5, 1]]   [[2, 2], [7, 2]]   [[4, 3], [6, 3]]
+
+Three lanes at 1, 2 and 3 running 0-5, 2-7 and 4-6: the same chart
+``broken_barh`` draws and the same layer it emits, from a call shaped the
+other way round -- **one call draws every lane**.
+
+What is *not* a schedule is decided by the rule xability/maidr#1100 settled
+for Observable's `rule` mark and #1122 for Vega-Lite's: if every segment
+shares an end, that end is the frame or the baseline rather than anything
+measured. A lollipop's stems all start at zero; reference lines all span the
+same interval; and a single segment cannot be told from either, since one
+end trivially agrees with itself.
+
+The decision is made in the **patch**, before anything registers. A layer
+that refuses at extraction takes the whole figure with it, which is the
+defect #564 was about -- so a declined call registers nothing at all and the
+rest of the figure reads as it always did.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pytest
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+from maidr.exception import UnsupportedPlotError
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _layers(fig) -> list:
+    try:
+        return [plot.type.value for plot in FigureManager.get_maidr(fig).plots]
+    except UnsupportedPlotError:
+        return []
+
+
+def _schema(fig) -> dict:
+    plots = FigureManager.get_maidr(fig).plots
+    assert len(plots) == 1
+    return plots[0].schema
+
+
+def _rendered(fig) -> dict:
+    maidr.render(fig)._repr_html_()
+    return _schema(fig)
+
+
+def _spans(schema) -> list:
+    return [
+        [(point["start"], point["end"]) for point in lane]
+        for lane in schema["data"]["points"]
+    ]
+
+
+def test_horizontal_lines_read_as_the_schedule_they_draw():
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+
+    schema = _rendered(fig)
+    assert schema["type"] == "gantt"
+    assert schema["data"]["lanes"] == [1.0, 2.0, 3.0]
+    assert _spans(schema) == [[(0.0, 5.0)], [(2.0, 7.0)], [(4.0, 6.0)]]
+
+
+def test_vertical_lines_read_the_same_way_with_the_axes_exchanged():
+    # The lanes run along x and the intervals down y. `GanttTrace` navigates
+    # lanes and intervals rather than x and y, so the two need no orientation
+    # to tell them apart -- only which axis the lanes were laid out on.
+    fig, ax = plt.subplots()
+    ax.vlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+
+    schema = _rendered(fig)
+    assert schema["type"] == "gantt"
+    assert schema["data"]["lanes"] == [1.0, 2.0, 3.0]
+    assert _spans(schema) == [[(0.0, 5.0)], [(2.0, 7.0)], [(4.0, 6.0)]]
+
+
+def test_a_lane_is_named_by_the_tick_the_author_put_inside_it():
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+    ax.set_yticks([1, 2, 3], labels=["design", "build", "ship"])
+
+    schema = _rendered(fig)
+    assert schema["data"]["lanes"] == ["design", "build", "ship"]
+    assert [point["x"] for lane in schema["data"]["points"] for point in lane] == [
+        "design",
+        "build",
+        "ship",
+    ]
+
+
+def test_an_unlabelled_lane_keeps_its_position():
+    # Left alone, matplotlib picks the ticks and several land on a lane --
+    # none of which is its name. The position is always true.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+
+    assert _rendered(fig)["data"]["lanes"] == [1.0, 2.0, 3.0]
+
+
+def test_a_lollipops_stems_register_nothing():
+    # Every segment starts at the baseline. Read as spans they announce
+    # "0 to 8" where the chart means "8", and the markers at their tips
+    # already carry that.
+    fig, ax = plt.subplots()
+    ax.vlines([1, 2, 3], 0, [5, 7, 6])
+
+    assert _layers(fig) == []
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_reference_lines_register_nothing():
+    # Every segment is the same interval, which no row of the data states.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], 0, 5)
+
+    assert _layers(fig) == []
+
+
+def test_a_single_span_registers_nothing():
+    # One segment cannot be told from either of the two above: a single end
+    # trivially agrees with itself. The same cost the rule pays on the other
+    # two adapters, paid here for the same reason.
+    fig, ax = plt.subplots()
+    ax.hlines([1], [0], [5])
+
+    assert _layers(fig) == []
+
+
+def test_a_chart_beside_a_lollipop_is_untouched():
+    # What deciding in the patch buys: a declined call registers nothing, so
+    # it cannot refuse at extraction and take the figure with it.
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    ax.vlines([0, 1], 0, [1, 2])
+
+    assert _layers(fig) == ["bar"]
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_the_spans_are_highlighted_through_the_collection_that_drew_them():
+    # One selector over the whole collection, not one per lane: there is one
+    # artist, and `GanttTrace` slices a flat element list into lanes by their
+    # lengths.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+
+    selectors = _rendered(fig)["selectors"]
+    assert len(selectors) == 1
+    assert selectors[0].endswith("> path")
+    assert "maidr-" in selectors[0]
+
+
+def test_a_lane_drawn_twice_out_of_order_is_left_unhighlighted():
+    # `hlines([1, 2, 1], ...)` draws lane 1, then lane 2, then lane 1 again.
+    # The element count still matches, so the core would not withdraw the
+    # selectors itself -- it slices the flat list by lane length and would
+    # hand lane 1's second interval to lane 2. Withheld rather than wrong.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 1], [0, 2, 6], [5, 7, 9])
+
+    schema = _rendered(fig)
+    assert schema["data"]["lanes"] == [1.0, 2.0]
+    assert _spans(schema) == [[(0.0, 5.0), (6.0, 9.0)], [(2.0, 7.0)]]
+    assert schema["selectors"] == []
+
+
+def test_a_lane_drawn_twice_in_a_row_keeps_its_highlighting():
+    # Consecutive, so the flat order and the lane order agree. This is what
+    # makes the test above a check on the ordering rather than on repeats.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 1, 2], [0, 6, 2], [5, 9, 7])
+
+    schema = _rendered(fig)
+    assert _spans(schema) == [[(0.0, 5.0), (6.0, 9.0)], [(2.0, 7.0)]]
+    assert len(schema["selectors"]) == 1
+
+
+def test_broken_barh_still_reads_as_it_did():
+    # The other call that draws this chart, and the one `GanttPlot` is shaped
+    # for. Both emit the same layer; only the artist they hand over differs.
+    fig, ax = plt.subplots()
+    ax.broken_barh([(0, 3), (5, 1)], (10, 9))
+    ax.broken_barh([(3, 5)], (20, 9))
+
+    schema = _rendered(fig)
+    assert schema["type"] == "gantt"
+    assert _spans(schema) == [[(0.0, 3.0), (5.0, 6.0)], [(3.0, 8.0)]]

--- a/tests/core/plot/test_spanplot.py
+++ b/tests/core/plot/test_spanplot.py
@@ -221,3 +221,90 @@ def test_broken_barh_still_reads_as_it_did():
     schema = _rendered(fig)
     assert schema["type"] == "gantt"
     assert _spans(schema) == [[(0.0, 3.0), (5.0, 6.0)], [(3.0, 8.0)]]
+
+
+def _all_schemas(fig) -> list:
+    maidr.render(fig)._repr_html_()
+    return [plot.schema for plot in FigureManager.get_maidr(fig).plots]
+
+
+@pytest.mark.parametrize("spans_first", [True, False])
+def test_a_broken_barh_beside_an_hlines_keeps_its_own_lane(spans_first):
+    # `gantt._lane_of` used to match on `isinstance(plot, GanttPlot)`, and
+    # `SpanPlot` subclasses `GanttPlot`. So a `broken_barh` following an
+    # `hlines` on the same axes appended its `PolyCollection` to the span
+    # layer, which reads its lanes from the segments it was handed and never
+    # looks at `_collections`: the lane was drawn, accepted without error,
+    # and announced nowhere. Measured as three lanes read for the four drawn.
+    #
+    # Parametrised over the drawing order because only one of the two was
+    # ever broken -- the reverse order registered two layers all along -- and
+    # a fix that made them agree by breaking the other would pass a
+    # single-order test.
+    fig, ax = plt.subplots()
+    if spans_first:
+        ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+        ax.broken_barh([(0, 3)], (10, 9))
+    else:
+        ax.broken_barh([(0, 3)], (10, 9))
+        ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+
+    schemas = _all_schemas(fig)
+    assert len(schemas) == 2
+
+    lanes = [schema["data"]["lanes"] for schema in schemas]
+    assert sorted(len(lane) for lane in lanes) == [1, 3]
+    # Every drawn interval is announced by one layer or the other.
+    drawn = sorted(
+        (point["start"], point["end"])
+        for schema in schemas
+        for lane in schema["data"]["points"]
+        for point in lane
+    )
+    assert drawn == [(0.0, 3.0), (0.0, 5.0), (2.0, 7.0), (4.0, 6.0)]
+
+
+def test_two_broken_barh_calls_still_merge_into_one_chart():
+    # The reason `_lane_of` exists, and the behaviour the fix above must not
+    # cost: `broken_barh` draws *one* lane per call, so a two-lane schedule
+    # is two calls that have to become one layer. Asserted beside the mixed
+    # case so narrowing the lookup any further would fail here.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+    ax.broken_barh([(0, 3)], (10, 9))
+    ax.broken_barh([(2, 4)], (20, 9))
+
+    schemas = _all_schemas(fig)
+    assert len(schemas) == 2
+    assert sorted(len(schema["data"]["lanes"]) for schema in schemas) == [2, 3]
+
+
+def test_two_hlines_calls_stay_two_charts():
+    # The deliberate asymmetry with `broken_barh`, pinned so it reads as a
+    # decision rather than an oversight. One `hlines` call already draws a
+    # whole schedule, so merging a second in would join two complete charts
+    # into one neither call made.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2], [0, 2], [5, 7])
+    ax.hlines([4, 5], [1, 3], [6, 8])
+
+    schemas = _all_schemas(fig)
+    assert len(schemas) == 2
+    assert [schema["data"]["lanes"] for schema in schemas] == [
+        [1.0, 2.0],
+        [4.0, 5.0],
+    ]
+
+
+def test_a_schedule_whose_tasks_share_a_start_is_declined():
+    # The cost of the shared-end rule, stated rather than left to be found.
+    # These are three real tasks all beginning on day 0, and nothing in the
+    # geometry separates them from a lollipop's stems -- which are also one
+    # shared start and differing ends, and which read as spans would announce
+    # "0 to 8" for a chart that means "8". Declining is the side that never
+    # announces a measurement the chart does not make.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], [0, 0, 0], [5, 7, 6])
+
+    assert _layers(fig) == []
+    assert len(maidr.render(fig)._repr_html_()) > 0

--- a/tests/core/plot/test_spanplot.py
+++ b/tests/core/plot/test_spanplot.py
@@ -191,6 +191,26 @@ def test_a_lane_drawn_twice_in_a_row_keeps_its_highlighting():
     assert len(schema["selectors"]) == 1
 
 
+@pytest.mark.parametrize("draw", ["acorr", "xcorr"])
+def test_a_correlogram_registers_nothing(draw):
+    # These draw through `vlines`, so they inherit whatever their segments
+    # say -- and every one of them runs from the baseline to the
+    # correlation, which is the lollipop shape. Pinned because the reading
+    # reaches them without either function being patched.
+    import numpy as np
+
+    # Long enough for the default `maxlags=10`, and deterministic.
+    first = np.sin(np.arange(40, dtype=float))
+    fig, ax = plt.subplots()
+    if draw == "acorr":
+        ax.acorr(first)
+    else:
+        ax.xcorr(first, first[::-1])
+
+    assert _layers(fig) == []
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
 def test_broken_barh_still_reads_as_it_did():
     # The other call that draws this chart, and the one `GanttPlot` is shaped
     # for. Both emit the same layer; only the artist they hand over differs.


### PR DESCRIPTION
Closes #568.

## What was wrong

`Axes.hlines` and `Axes.vlines` draw one segment per row of the data and hand back a single `LineCollection` whose `get_segments()` gives both ends exactly — a collection stores its ends rather than serialising a path, so there is nothing to invert and nothing to round. Measured on matplotlib 3.9.4:

```python
ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
# [[0, 1], [5, 1]]   [[2, 2], [7, 2]]   [[4, 3], [6, 3]]
```

Three lanes at 1, 2 and 3 running 0–5, 2–7 and 4–6. That is the chart `broken_barh` draws and the layer it emits (#524), and it registered **nothing at all** — so a figure made of them fell back to a static image whose numbers were sitting in the call.

## Its own class, sharing one rule

`broken_barh` draws **one lane per call** and hands over the corners of a `PolyCollection`; these draw **every lane in one call**. `GanttPlot` is shaped for the first and `SpanPlot` for the second, and the factory picks by the artist the patch passes rather than by type, since both emit the same layer.

The lane-naming rule is shared rather than copied: a lane is called by the single **explicit** tick inside it and by its position otherwise (the rule #533 settled for `broken_barh`), generalised to read whichever axis the lanes were laid out on — y for `hlines`, x for `vlines`.

| call | reads as |
| --- | --- |
| `hlines([1,2,3], [0,2,4], [5,7,6])` | `gantt`, lanes `1, 2, 3` |
| `vlines([1,2,3], [0,2,4], [5,7,6])` | the same, lanes along x |
| the above with `set_yticks(labels=[…])` | lanes `design, build, ship` |
| `vlines([1,2,3], 0, [5,7,6])` — lollipop stems | nothing |
| `hlines([1,2,3], 0, 5)` — reference lines | nothing |
| `hlines([1], [0], [5])` — one segment | nothing |
| `broken_barh(…)` | unchanged |

## What is not a schedule

The rule xability/maidr#1100 settled for Observable's `rule` mark and #1122 for Vega-Lite's:

> if every line shares an end, that end is the frame or the baseline rather than anything measured, and the mark is handed back

- a lollipop's stems all start at zero, and read as spans they announce "0 to 8" where the chart means "8" — which the markers at their tips already carry;
- reference lines all span the same interval, which no row of the data states;
- a single segment cannot be told from either, since one end trivially agrees with itself. That is the cost the same rule pays on both other adapters, paid here for the same reason.

**The decision is made in the patch, before anything registers.** A layer that refuses at extraction takes the whole figure with it — the defect #564 was about — so a declined call registers nothing at all, and a bar chart drawn beside a lollipop still reads. That is asserted.

## Highlighting

One selector over the whole collection, not one per lane: there is one artist, and `GanttTrace` slices a flat element list into lanes by their lengths.

It is **withheld** when a lane's segments are not consecutive in draw order. `hlines([1, 2, 1], …)` draws lane 1 either side of lane 2; the element count still matches, so the core would not withdraw the selectors itself, and its slicing would hand lane 2 somebody else's interval. Leaving the layer unhighlighted is what a schedule already does when its lanes do not follow row order.

## Tests

`tests/core/plot/test_spanplot.py`, 12 cases.

The pair worth naming is **"a lane drawn twice out of order is left unhighlighted"** and **"a lane drawn twice in a row keeps its highlighting"** — together they make the first a check on the *ordering* rather than on repeats, which a single test could not distinguish.

Falsified — each mutation applied alone against the fixed baseline:

| mutation | result |
| --- | --- |
| every shape accepted as a schedule | 4 failures — the stems, the reference lines, the single span, and the bar chart beside them |
| the contiguity guard removed | the out-of-order lane keeps selectors and fails |
| the decision moved out of the patch | the same 4 — the layer registers and then refuses at render |
| `vlines` told its lanes run the other way | the vertical case fails |
| lanes never named by their ticks | the named-lane case fails |

Full suite: `2672 passed, 18 skipped`. `ruff check --diff` clean on the changed files.

## Left where it was

The rest of the sweep in #568 is unchanged: `quiver`, `barbs` and `streamplot` have no trace type in the core to register as, `ax.fill` draws a closed polygon, and `tricontourf`/`tripcolor` are the filled half of a split whose line half already reads. `acorr` and `xcorr` draw through `vlines`, so they now inherit whatever their segments say — measured, both draw from a common baseline and are declined.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_