### PR TITLE
feat(rug): read a seaborn rug plot as the observations it marks

### DIFF
--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -23,6 +23,7 @@ from maidr.core.plot.pieplot import PiePlot
 from maidr.core.plot.pointplot import PointPlot
 from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.core.plot.regplot import SmoothPlot
+from maidr.core.plot.rugplot import DRAWN_RUG, RugPlot
 from maidr.core.plot.spanplot import DRAWN_SPANS, SpanPlot
 from maidr.core.plot.stairs import StairsPlot
 from maidr.core.plot.stepped_histogram import SteppedHistPlot
@@ -139,6 +140,11 @@ class MaidrPlotFactory:
             # through a class of its own under the same type (#548).
             if kwargs.get(DRAWN_EVENTS) is not None:
                 return EventPlot(single_ax, **kwargs)
+            # A rug's ticks are a scatter of positions for the same reason,
+            # and arrive as a plain `LineCollection` -- not an
+            # `EventCollection`, so `EventPlot` cannot read one (#250).
+            if kwargs.get(DRAWN_RUG) is not None:
+                return RugPlot(single_ax, **kwargs)
             return ScatterPlot(single_ax, **kwargs)
         elif PlotType.DODGED == plot_type or PlotType.STACKED == plot_type:
             return GroupedBarPlot(single_ax, plot_type, **kwargs)

--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -115,14 +115,17 @@ class RugPlot(MaidrPlot):
         )
         self._label = kwargs.get(RUG_LABEL, None)
 
-        # Which axis the positions lie along, resolved here rather than
-        # during extraction. `MaidrPlot.render()` builds the *axes* payload
-        # before the data, so a value settled in `_extract_plot_data` is
-        # still the default when `_extract_axes_data` reads it -- measured, a
-        # `rugplot(y=...)` then named the y axis "Rug" and left the
-        # observations it carries labelled "X".
+        # Read once, here, rather than again per render. Two reasons, and
+        # the first is correctness: `MaidrPlot.render()` builds the *axes*
+        # payload before the data, so an orientation settled in
+        # `_extract_plot_data` is still the default when
+        # `_extract_axes_data` reads it -- measured, a `rugplot(y=...)` then
+        # named the y axis "Rug" and left the observations it carries
+        # labelled "X". The second is that `render()` can run more than once
+        # for a layer, and the collection cannot change underneath it, so
+        # revalidating every segment each time buys nothing.
         read = read_rug(self._collection)
-        self._along_x = read[1] if read is not None else True
+        self._positions, self._along_x = read if read is not None else ([], True)
 
         # Assigned here rather than relied upon, for the reason `EventPlot`
         # and `HexbinPlot` give: matplotlib stamps a gid at *draw* time and
@@ -153,22 +156,15 @@ class RugPlot(MaidrPlot):
         list of dict
             One point per tick, in the order the collection holds them.
         """
-        if self._collection is None:
-            return []
-
-        read = read_rug(self._collection)
-        if read is None:
-            return []
-
-        positions, along_x = read
-
         # The coordinate across the tick is the strip the rug occupies, not a
         # height the chart measured, so it is emitted as a constant rather
         # than as the tick's own base -- which is a fraction of the axes and
         # would read as data at whatever scale the other axis happens to use.
-        if along_x:
-            return [{MaidrKey.X: position, MaidrKey.Y: 0} for position in positions]
-        return [{MaidrKey.X: 0, MaidrKey.Y: position} for position in positions]
+        if self._along_x:
+            return [
+                {MaidrKey.X: position, MaidrKey.Y: 0} for position in self._positions
+            ]
+        return [{MaidrKey.X: 0, MaidrKey.Y: position} for position in self._positions]
 
     def _extract_axes_data(self) -> dict:
         """
@@ -185,14 +181,19 @@ class RugPlot(MaidrPlot):
         axes_data[across] = self._axis_config(label=RUG_AXIS_LABEL)
         return axes_data
 
-    def _get_selector(self) -> str:
+    def _get_selector(self) -> str | list[str]:
         """
         Address each tick by the element matplotlib drew for it.
 
         One ``<g>`` carrying one ``<path>`` per segment, in draw order, which
         is the order the points were emitted in -- so a tick has an element
         of its own and the two lists line up without numbering either.
+
+        The empty case hands back ``[]`` rather than ``""`` to match
+        :meth:`~maidr.core.plot.eventplot.EventPlot._get_selector`, the
+        sibling this class is shaped after. Not reachable through the patch,
+        which only registers a layer for a collection it has read.
         """
         if self._collection is None or self._collection.get_gid() is None:
-            return ""
+            return []
         return f"g[id='{self._collection.get_gid()}'] > path"

--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -69,6 +69,17 @@ def read_rug(collection) -> tuple[list, bool] | None:
 
     # Exactly one, not "x first": a tick of zero height is constant on both
     # and marks nothing, and a sloped segment is constant on neither.
+    #
+    # The zero-height case is reachable -- `rugplot(height=0)` gives every
+    # segment two identical ends, measured as `[[1.0, 0.0], [1.0, 0.0]]` --
+    # and is declined along with the rest. A rug whose ticks have no length
+    # draws nothing a sighted reader can see either, so announcing its
+    # positions would describe a chart that is not on the screen.
+    #
+    # Compared exactly rather than within a tolerance because matplotlib
+    # duplicates the one float for the constant coordinate rather than
+    # recomputing it, so the two ends are the same value and not merely a
+    # rounding apart.
     if level_x == level_y:
         return None
 

--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import uuid
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot import MaidrPlot
+
+#: Key the patch hands this layer the ``LineCollection`` its own call drew
+#: under. Named like ``eventplot.DRAWN_EVENTS`` and read the same way: the
+#: layer is told which artist it reads rather than sweeping the axes for one,
+#: which is the distinction #426 was about.
+DRAWN_RUG = "_maidr_rug"
+
+#: Key carrying the name to announce the layer under, when there is one.
+RUG_LABEL = "_maidr_rug_label"
+
+#: What the layer's constant axis is called when the chart does not say.
+#: A rug's ticks sit in a strip against the frame rather than at a measured
+#: height, so the coordinate across the tick names the strip, not a value.
+RUG_AXIS_LABEL = "Rug"
+
+
+def read_rug(collection) -> tuple[list, bool] | None:
+    """
+    The positions a rug marks, and which axis they lie along.
+
+    A rug tick is a segment held constant on the axis carrying the data and
+    stretched across the other, so the *constant* coordinate is the
+    observation and the stretch is the tick's height. Measured on seaborn
+    0.13.2::
+
+        sns.rugplot(x=[10.251, ...])
+        [[10.251, 0.0], [10.251, 0.025]]
+
+    Parameters
+    ----------
+    collection : LineCollection or None
+        The artist the call drew.
+
+    Returns
+    -------
+    tuple of (list of float, bool) or None
+        The positions in draw order, and True when they lie along x. ``None``
+        when this is not a rug: a collection whose segments are not all held
+        constant on exactly one axis marks no single set of positions, and
+        the whole layer is declined rather than part of it read, so a chart
+        is never announced as a subset of itself.
+    """
+    if not isinstance(collection, LineCollection):
+        return None
+
+    segments = collection.get_segments()
+    if not segments:
+        return None
+
+    ends = []
+    for segment in segments:
+        pair = np.asarray(segment, dtype=float)
+        if pair.shape != (2, 2) or not np.all(np.isfinite(pair)):
+            return None
+        ends.append(pair)
+
+    level_x = all(pair[0][0] == pair[1][0] for pair in ends)
+    level_y = all(pair[0][1] == pair[1][1] for pair in ends)
+
+    # Exactly one, not "x first": a tick of zero height is constant on both
+    # and marks nothing, and a sloped segment is constant on neither.
+    if level_x == level_y:
+        return None
+
+    axis = 0 if level_x else 1
+    return [float(pair[0][axis]) for pair in ends], level_x
+
+
+class RugPlot(MaidrPlot):
+    """
+    A seaborn rug plot, read as the observations it marks.
+
+    A rug draws one short tick per observation against the frame, showing
+    where the raw data actually fell. Read as a **scatter**, for the reason
+    :class:`~maidr.core.plot.eventplot.EventPlot` gives about an event plot's
+    ticks: every tick is the same length -- ``height`` is one number for the
+    whole call -- so the height is decoration and only the position is data.
+    What the reader navigates is a series of positions, which is a scatter.
+
+    Where it differs from an event plot is the coordinate across the tick.
+    An event plot's rows sit at ``lineoffsets``, which is a real place on a
+    real axis and worth announcing; a rug's ticks sit in a strip against the
+    frame at a fraction of the axes height, which is not a measurement of
+    anything. So that axis is named :data:`RUG_AXIS_LABEL` rather than left
+    carrying the chart's own label -- a rug drawn over a ``kdeplot`` would
+    otherwise announce every observation as "Density 0", which is a number
+    the chart does not show.
+
+    A rug is routinely drawn *beside* another layer, and it registers its own
+    layer there rather than being declined as a duplicate. That is the
+    opposite call to the one xability/maidr#1124 made for Vega-Lite text
+    overlays, and for a reason: those labels sit **on** the marks they
+    duplicate, whereas a rug occupies its own strip and, next to a density
+    curve or a histogram, is the only thing in the figure stating where the
+    observations actually are. It is named so a reader can tell the two
+    apart, which is what xability/maidr#828 added ``name`` for.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        super().__init__(ax, PlotType.SCATTER)
+
+        collection = kwargs.get(DRAWN_RUG, None)
+        self._collection = (
+            collection if isinstance(collection, LineCollection) else None
+        )
+        self._label = kwargs.get(RUG_LABEL, None)
+
+        # Which axis the positions lie along, resolved here rather than
+        # during extraction. `MaidrPlot.render()` builds the *axes* payload
+        # before the data, so a value settled in `_extract_plot_data` is
+        # still the default when `_extract_axes_data` reads it -- measured, a
+        # `rugplot(y=...)` then named the y axis "Rug" and left the
+        # observations it carries labelled "X".
+        read = read_rug(self._collection)
+        self._along_x = read[1] if read is not None else True
+
+        # Assigned here rather than relied upon, for the reason `EventPlot`
+        # and `HexbinPlot` give: matplotlib stamps a gid at *draw* time and
+        # the schema is built first, so reading it later finds `None` and the
+        # layer ships announcing correctly and highlighting nothing.
+        if self._collection is not None and self._collection.get_gid() is None:
+            self._collection.set_gid(f"maidr-{uuid.uuid4()}")
+
+    def render(self) -> dict:
+        """
+        The base schema, plus the name the rug is announced under.
+
+        ``MaidrLayer.name`` is what xability/maidr#828 added so two layers of
+        a kind can be told apart, which is exactly where a reader stands with
+        a rug drawn beside a scatter of the same variable.
+        """
+        schema = super().render()
+        if self._label:
+            schema[MaidrKey.NAME] = self._label
+        return schema
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        The marked observations, as points on the axis they lie along.
+
+        Returns
+        -------
+        list of dict
+            One point per tick, in the order the collection holds them.
+        """
+        if self._collection is None:
+            return []
+
+        read = read_rug(self._collection)
+        if read is None:
+            return []
+
+        positions, along_x = read
+
+        # The coordinate across the tick is the strip the rug occupies, not a
+        # height the chart measured, so it is emitted as a constant rather
+        # than as the tick's own base -- which is a fraction of the axes and
+        # would read as data at whatever scale the other axis happens to use.
+        if along_x:
+            return [{MaidrKey.X: position, MaidrKey.Y: 0} for position in positions]
+        return [{MaidrKey.X: 0, MaidrKey.Y: position} for position in positions]
+
+    def _extract_axes_data(self) -> dict:
+        """
+        Name the axes, calling the strip the ticks sit in what it is.
+
+        The axis carrying the observations keeps the chart's own label. The
+        one across the ticks is renamed even when the caller labelled it,
+        unlike ``EventPlot``'s "Row" which only fills a blank: a rug over a
+        ``kdeplot`` has a real "Density" label on that axis, and every point
+        this layer emits sits at 0 rather than at any density.
+        """
+        axes_data = super()._extract_axes_data()
+        across = MaidrKey.Y if self._along_x else MaidrKey.X
+        axes_data[across] = self._axis_config(label=RUG_AXIS_LABEL)
+        return axes_data
+
+    def _get_selector(self) -> str:
+        """
+        Address each tick by the element matplotlib drew for it.
+
+        One ``<g>`` carrying one ``<path>`` per segment, in draw order, which
+        is the order the points were emitted in -- so a tick has an element
+        of its own and the two lists line up without numbering either.
+        """
+        if self._collection is None or self._collection.get_gid() is None:
+            return ""
+        return f"g[id='{self._collection.get_gid()}'] > path"

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -29,6 +29,7 @@ from . import (  # noqa: E402, F401
     spanplot,
     stairs,
     regplot,
+    rugplot,
     kdeplot,
     candlestick,
     mplfinance,

--- a/maidr/patch/rugplot.py
+++ b/maidr/patch/rugplot.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.rugplot import (
+    DRAWN_RUG,
+    RUG_AXIS_LABEL,
+    RUG_LABEL,
+    read_rug,
+)
+from maidr.patch.common import _draw_quietly, prospective_axes, wrap_seaborn
+
+
+def _collections_of(ax: Axes | None) -> list:
+    """
+    The collections already on an axes.
+
+    Held as the artists themselves rather than as their ids, for the reason
+    ``maidr/patch/histogram.py``'s ``_containers_of`` gives: an id compared
+    after the object it named was freed can be matched by an unrelated artist
+    allocated at the same address.
+
+    Parameters
+    ----------
+    ax : Axes, optional
+        The axes about to be drawn on, when it could be resolved.
+
+    Returns
+    -------
+    list
+        The collections present before the call.
+    """
+    return list(ax.collections) if ax is not None else []
+
+
+def _drawn_by_this_call(ax: Axes | None, before: list) -> list:
+    """
+    The collections this call added, in the order it added them.
+
+    Parameters
+    ----------
+    ax : Axes, optional
+        The axes drawn on.
+    before : list
+        What ``_collections_of`` saw beforehand.
+
+    Returns
+    -------
+    list
+        The new collections.
+    """
+    if ax is None:
+        return []
+    seen = [id(collection) for collection in before]
+    return [
+        collection
+        for collection in ax.collections
+        if id(collection) not in seen
+    ]
+
+
+def _name_for(ax: Axes, along_x: bool) -> str:
+    """
+    What to announce the rug layer as.
+
+    A rug is routinely drawn beside something else, and one call can draw two
+    -- ``rugplot(x=..., y=...)`` marks both margins. So the layers need
+    telling apart, which is what ``MaidrLayer.name`` is for
+    (xability/maidr#828).
+
+    Taken from the label on the axis the observations lie along, because
+    seaborn sets it to the column being marked and that is the name a reader
+    would use for them. Falls back to :data:`RUG_AXIS_LABEL` for a rug drawn
+    from bare arrays, where the chart never learned a name.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on.
+    along_x : bool
+        Whether the observations lie along x.
+
+    Returns
+    -------
+    str
+        The layer's name.
+    """
+    named = ax.get_xlabel() if along_x else ax.get_ylabel()
+    return named or RUG_AXIS_LABEL
+
+
+def rug(wrapped, instance, args, kwargs) -> Axes:
+    """
+    Draw a patched ``seaborn.rugplot`` and register the margins it marked.
+
+    A rug draws one short tick per observation against the frame. It drew a
+    plain ``LineCollection`` that nothing read, so a figure whose only layer
+    was a rug fell back to a picture, and a rug beside a density curve left
+    the raw observations -- the one thing the curve does not state -- unread
+    (#250).
+
+    One layer per collection, not one per call: ``rugplot(x=..., y=...)``
+    marks two margins and hands back one collection for each, and merging
+    them would announce a single series whose positions come off two
+    different axes.
+
+    The collections are found by taking a before-and-after snapshot of the
+    axes rather than by sweeping it afterwards, which is the distinction
+    #426 was about -- a rug drawn over a scatter would otherwise read the
+    scatter's collection as its own.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``seaborn.rugplot``.
+    instance : Any
+        Unused; seaborn's rugplot is a module-level function.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    Axes
+        Whatever ``rugplot`` returned.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    ax = prospective_axes(kwargs)
+    before = _collections_of(ax)
+
+    with ContextManager.set_internal_context():
+        drawn = _draw_quietly(wrapped, args, kwargs)
+
+    if ax is None:
+        ax = drawn if isinstance(drawn, Axes) else None
+    if ax is None:
+        return drawn
+
+    for collection in _drawn_by_this_call(ax, before):
+        if not isinstance(collection, LineCollection):
+            continue
+        read = read_rug(collection)
+        if read is None:
+            # Not a set of ticks held constant on one axis, so it marks no
+            # single set of positions. Declined here, before anything is
+            # registered, rather than raised at extraction -- a layer that
+            # refuses while the schema is built takes the whole figure with
+            # it, which is the defect #564 was about.
+            continue
+        FigureManager.create_maidr(
+            ax,
+            PlotType.SCATTER,
+            **{
+                DRAWN_RUG: collection,
+                RUG_LABEL: _name_for(ax, read[1]),
+            },
+        )
+
+    return drawn
+
+
+wrap_seaborn("rugplot", rug)

--- a/maidr/patch/rugplot.py
+++ b/maidr/patch/rugplot.py
@@ -77,6 +77,16 @@ def _name_for(ax: Axes, along_x: bool) -> str:
     would use for them. Falls back to :data:`RUG_AXIS_LABEL` for a rug drawn
     from bare arrays, where the chart never learned a name.
 
+    That holds when the rug's own call set the label, which is the ordinary
+    case. It does not when something *else* labelled the axis first and the
+    rug marks values of its own: measured, a `scatterplot(x="value")`
+    followed by `rugplot(x=[7.0, 8.0])` names the rug "value", after the
+    column the scatter drew rather than anything the rug marks. Accepted
+    rather than worked around -- the artist carries no record of the column
+    it came from, so the alternative is to name nothing at all, and a name
+    off the shared axis is still the axis these ticks stand on. The layer's
+    *data* is unaffected either way; only what it is announced as.
+
     Parameters
     ----------
     ax : Axes

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -228,3 +228,46 @@ def test_a_second_rug_on_the_same_axes_reads_only_its_own_ticks(frame):
         [1.0, 2.0],
         [8.0, 9.0],
     ]
+
+
+def test_a_hue_split_rug_still_marks_every_observation(frame):
+    # Review asked whether a hue split produces several collections that
+    # could be merged or dropped, given the one-layer-per-collection design.
+    # Measured: seaborn draws one collection either way and only recolours
+    # it, so a hue rug is one layer holding every observation. Pinned rather
+    # than left as an ad-hoc measurement, since the answer is seaborn's to
+    # change.
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="sex", ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert [point["x"] for point in schema["data"]] == [1.0, 2.5, 3.0, 7.25]
+
+
+def test_a_rug_under_a_hue_split_density_reads_beside_it(frame):
+    # The layered case the reading is actually for: the curves are smoothed
+    # and the rug is where the observations fell, so both belong.
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.kdeplot(frame, x="value", hue="sex", ax=ax)
+    sns.rugplot(frame, x="value", hue="sex", ax=ax)
+
+    schemas = _schemas(fig)
+    assert [schema["type"] for schema in schemas] == ["smooth", "smooth", "point"]
+    assert [point["x"] for point in schemas[-1]["data"]] == [1.0, 2.5, 3.0, 7.25]
+
+
+def test_a_name_can_come_off_an_axis_another_plot_labelled(frame):
+    # The documented limit of `_name_for`. The artist carries no record of
+    # the column it came from, so a rug drawn onto an axis something else
+    # already labelled takes that label. Pinned so the behaviour is known
+    # rather than discovered: the layer's *data* is unaffected, only what it
+    # is announced as.
+    fig, ax = plt.subplots()
+    sns.scatterplot(frame, x="value", y="other", ax=ax)
+    sns.rugplot(x=np.array([7.0, 8.0]), ax=ax)
+
+    rug = _schemas(fig)[-1]
+    assert rug["name"] == "value"
+    assert [point["x"] for point in rug["data"]] == [7.0, 8.0]

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -1,0 +1,230 @@
+"""
+``seaborn.rugplot`` drew ticks that nothing read (#250).
+
+A rug marks one short tick per observation against the frame -- the raw
+data, which a density curve beside it never states. It drew a plain
+``LineCollection`` that no patch claimed, so a figure whose only layer was a
+rug fell back to a picture, and a rug over a ``kdeplot`` left the
+observations unread.
+
+Read as a **scatter**, for the reason ``EventPlot`` gives about an event
+plot's ticks: ``height`` is one number for the whole call, so the tick's
+length is decoration and only its position is data.
+
+Measured on seaborn 0.13.2::
+
+    sns.rugplot(x=[10.251, ...])
+    [[10.251, 0.0], [10.251, 0.025]]
+
+The tick is held constant on the axis carrying the data and stretched
+across the other, so the *constant* coordinate is the observation.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.rugplot import RUG_AXIS_LABEL, read_rug
+from maidr.exception import UnsupportedPlotError
+
+import seaborn as sns
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def _quiet_seaborn():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        yield
+
+
+@pytest.fixture
+def frame() -> pd.DataFrame:
+    return pd.DataFrame({"value": [1.0, 2.5, 3.0, 7.25], "other": [4.0, 5.5, 9.0, 2.0]})
+
+
+def _layers(fig) -> list:
+    try:
+        return [plot.type.value for plot in FigureManager.get_maidr(fig).plots]
+    except UnsupportedPlotError:
+        return []
+
+
+def _schemas(fig) -> list:
+    maidr.render(fig)._repr_html_()
+    return [plot.schema for plot in FigureManager.get_maidr(fig).plots]
+
+
+def test_a_rug_registers_the_observations_it_marks(frame):
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert schema["type"] == "point"
+    assert [point["x"] for point in schema["data"]] == [1.0, 2.5, 3.0, 7.25]
+
+
+def test_the_tick_height_is_not_announced_as_a_measurement(frame):
+    # The whole reason a rug is a scatter and not a spike: every tick is the
+    # same length, so the length says nothing. Emitted as a constant rather
+    # than as the tick's own base, which is a fraction of the axes height and
+    # would read as data at whatever scale the other axis happens to use.
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", height=0.4, ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert {point["y"] for point in schema["data"]} == {0}
+
+
+def test_the_strip_the_ticks_sit_in_is_named_rather_than_left_as_a_value(frame):
+    # A rug over a `kdeplot` has a real "Density" label on the axis across
+    # the ticks, and every point this layer emits sits at 0 -- so leaving the
+    # chart's own label there announces each observation as "Density 0",
+    # which is a number the chart does not show.
+    fig, ax = plt.subplots()
+    sns.kdeplot(frame, x="value", ax=ax)
+    sns.rugplot(frame, x="value", ax=ax)
+
+    schemas = _schemas(fig)
+    rug = schemas[-1]
+    assert rug["axes"]["y"]["label"] == RUG_AXIS_LABEL
+    # The axis carrying the observations keeps the chart's own label.
+    assert rug["axes"]["x"]["label"] == "value"
+    # And the curve beside it is untouched.
+    assert schemas[0]["axes"]["y"]["label"] == "Density"
+
+
+def test_a_rug_on_y_names_the_other_axis(frame):
+    # `MaidrPlot.render()` builds the axes payload *before* the data, so
+    # resolving which axis the observations lie along during extraction left
+    # this case labelling the y axis "Rug" while the observations it carries
+    # were announced under "X".
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, y="other", ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert schema["axes"]["x"]["label"] == RUG_AXIS_LABEL
+    assert schema["axes"]["y"]["label"] == "other"
+    assert [point["y"] for point in schema["data"]] == [4.0, 5.5, 9.0, 2.0]
+
+
+def test_one_call_marking_both_margins_reads_as_two_layers(frame):
+    # Two margins, two collections, two sets of positions off two different
+    # axes. Merging them would announce one series whose coordinates come
+    # from both.
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", y="other", ax=ax)
+
+    schemas = _schemas(fig)
+    assert len(schemas) == 2
+    assert [schema["name"] for schema in schemas] == ["value", "other"]
+    assert [point["x"] for point in schemas[0]["data"]] == [1.0, 2.5, 3.0, 7.25]
+    assert [point["y"] for point in schemas[1]["data"]] == [4.0, 5.5, 9.0, 2.0]
+
+
+def test_a_rug_beside_a_scatter_reads_its_own_collection(frame):
+    # The distinction #426 was about. A rug drawn over a scatter must read
+    # the collection *its own call* added, not whichever one a sweep of the
+    # axes turns up first.
+    fig, ax = plt.subplots()
+    sns.scatterplot(frame, x="value", y="other", ax=ax)
+    sns.rugplot(frame, x="value", ax=ax)
+
+    schemas = _schemas(fig)
+    assert len(schemas) == 2
+    rug = schemas[-1]
+    assert [point["x"] for point in rug["data"]] == [1.0, 2.5, 3.0, 7.25]
+    assert {point["y"] for point in rug["data"]} == {0}
+
+
+def test_the_layer_is_named_so_it_can_be_told_from_its_neighbour(frame):
+    # `MaidrLayer.name`, which xability/maidr#828 added for exactly this.
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert schema["name"] == "value"
+
+
+def test_a_rug_of_bare_arrays_still_gets_a_name():
+    # No column to take a name from, so the layer falls back rather than
+    # arriving unnamed beside whatever else the figure holds.
+    fig, ax = plt.subplots()
+    sns.rugplot(x=np.array([1.0, 2.0, 3.0]), ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert schema["name"] == RUG_AXIS_LABEL
+
+
+def test_every_tick_has_an_element_of_its_own(frame):
+    # One `<g>` holding one `<path>` per tick, in draw order, which is the
+    # order the points were emitted in -- so the two lists line up without
+    # either being numbered.
+    import re
+
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", ax=ax)
+    html = maidr.render(fig)._repr_html_()
+
+    plot = FigureManager.get_maidr(fig).plots[0]
+    gid = plot._collection.get_gid()
+    assert plot.schema["selectors"] == f"g[id='{gid}'] > path"
+
+    group = re.search(rf'<g[^>]*id="{re.escape(gid)}"[^>]*>(.*?)</g>', html, re.S)
+    assert group is not None
+    assert len(re.findall(r"<path", group.group(1))) == len(plot.schema["data"])
+
+
+def test_a_collection_that_is_not_a_set_of_ticks_is_declined():
+    # A segment sloping across both axes is held constant on neither, so it
+    # marks no position. The whole layer is declined rather than part of it
+    # read, so a chart is never announced as a subset of itself.
+    from matplotlib.collections import LineCollection
+
+    sloped = LineCollection([[[0.0, 1.0], [5.0, 2.0]]])
+    assert read_rug(sloped) is None
+
+    # A tick of zero length is constant on both axes and names neither.
+    flat = LineCollection([[[1.0, 0.0], [1.0, 0.0]]])
+    assert read_rug(flat) is None
+
+
+def test_a_rug_no_longer_costs_the_figure_its_reading(frame):
+    # What #250 is actually about: before this, a figure whose only layer was
+    # a rug had nothing to read and fell back to a picture.
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", ax=ax)
+
+    assert _layers(fig) == ["point"]
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_a_second_rug_on_the_same_axes_reads_only_its_own_ticks(frame):
+    # The distinction #426 was about, in the form that actually bites. A
+    # scatter beside a rug is safe by accident -- its `PathCollection` is not
+    # a `LineCollection`, so even a sweep of the axes would skip it. Two rug
+    # calls are not: sweeping would have the second call register the first
+    # call's collection as well, announcing those observations twice and
+    # leaving the figure with three layers where it has two.
+    fig, ax = plt.subplots()
+    sns.rugplot(x=np.array([1.0, 2.0]), ax=ax)
+    sns.rugplot(x=np.array([8.0, 9.0]), ax=ax)
+
+    schemas = _schemas(fig)
+    assert len(schemas) == 2
+    assert [[point["x"] for point in schema["data"]] for schema in schemas] == [
+        [1.0, 2.0],
+        [8.0, 9.0],
+    ]

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -271,3 +271,16 @@ def test_a_name_can_come_off_an_axis_another_plot_labelled(frame):
     rug = _schemas(fig)[-1]
     assert rug["name"] == "value"
     assert [point["x"] for point in rug["data"]] == [7.0, 8.0]
+
+
+def test_a_rug_with_no_tick_length_is_declined():
+    # Measured: `height=0` gives every segment two identical ends,
+    # `[[1.0, 0.0], [1.0, 0.0]]`, which is constant on both axes and so names
+    # neither. Declined along with the rest, and deliberately -- a rug whose
+    # ticks have no length draws nothing a sighted reader can see either, so
+    # announcing its positions would describe a chart that is not there.
+    fig, ax = plt.subplots()
+    sns.rugplot(x=np.array([1.0, 2.0, 3.0]), height=0, ax=ax)
+
+    assert _layers(fig) == []
+    assert len(maidr.render(fig)._repr_html_()) > 0

--- a/tests/core/test_seaborn_color_probe.py
+++ b/tests/core/test_seaborn_color_probe.py
@@ -149,11 +149,15 @@ def test_a_renamed_probe_warns(monkeypatch) -> None:
 def test_a_rug_over_a_scatter_renders() -> None:
     """The phantom layer was fatal, not merely noisy.
 
-    ``rugplot`` draws its ticks as a ``LineCollection`` MAIDR does not read,
-    so the only layer it registered was the probe -- and reading that layer's
+    ``rugplot`` drew its ticks as a ``LineCollection`` MAIDR did not read, so
+    the only layer it registered was the probe -- and reading that layer's
     data raised ``ExtractionError``, which takes the whole figure with it
     rather than just its own layer. A scatter that would have read perfectly
     well produced nothing at all.
+
+    Two layers rather than one since #250: the rug now reads as a scatter of
+    the observations it marks. The probe is still what this pins, and the
+    count is what pins it -- a third layer here would be the phantom back.
     """
     frame = _frame()
     fig, ax = plt.subplots()
@@ -161,7 +165,7 @@ def test_a_rug_over_a_scatter_renders() -> None:
     sns.scatterplot(data=frame, x="value", y="value", ax=ax)
     sns.rugplot(data=frame, x="value", ax=ax)
 
-    assert _layers(fig) == [PlotType.SCATTER]
+    assert _layers(fig) == [PlotType.SCATTER, PlotType.SCATTER]
 
     # The render itself, because the layer list alone would not have caught
     # it: extraction is where the old failure happened.

--- a/tests/core/test_unsupported_fallback.py
+++ b/tests/core/test_unsupported_fallback.py
@@ -66,15 +66,23 @@ def data() -> np.ndarray:
     return np.random.default_rng(0).normal(size=20)
 
 
-def rugplot():
-    """A chart maidr does not patch. `sns.rugplot` draws a LineCollection."""
+def barbs():
+    """A chart maidr does not patch. `ax.barbs` draws a Barbs collection.
+
+    This was seaborn's rug plot until #250 gave a rug a reading of its own,
+    at which point it stopped being an example of anything unsupported. Wind
+    barbs replace it because they have no trace type in the core to be read
+    as -- a barb states a speed *and* a direction at a place, which none of
+    the existing traces carry -- so they are unlikely to acquire one by
+    accident and quietly stop testing the fallback.
+    """
     _, ax = plt.subplots()
-    sns.rugplot(x=data(), ax=ax, height=0.1)
+    ax.barbs([0, 1], [0, 1], [1, 1], [1, 1])
     return ax
 
 
 def quiver():
-    """A second unsupported chart, so nothing keys off rugplot specifically."""
+    """A second unsupported chart, so nothing keys off one of them."""
     _, ax = plt.subplots()
     ax.quiver([0, 1], [0, 1], [1, 1], [1, 1])
     return ax
@@ -91,14 +99,14 @@ def caught(call) -> tuple[object, list[str]]:
 class TestTheApiNoLongerCrashes:
     """The three functions a user is told to call."""
 
-    @pytest.mark.parametrize("chart", [rugplot, quiver])
+    @pytest.mark.parametrize("chart", [barbs, quiver])
     def test_render_returns_something(self, chart):
         chart()
         result, _ = caught(maidr.render)
 
         assert result is not None
 
-    @pytest.mark.parametrize("chart", [rugplot, quiver])
+    @pytest.mark.parametrize("chart", [barbs, quiver])
     def test_render_returns_the_picture(self, chart):
         # The point of falling back rather than raising: the user still sees
         # their plot. A fallback that returned an empty div would pass a
@@ -108,14 +116,14 @@ class TestTheApiNoLongerCrashes:
 
         assert "data:image/png;base64," in str(result)
 
-    @pytest.mark.parametrize("chart", [rugplot, quiver])
+    @pytest.mark.parametrize("chart", [barbs, quiver])
     def test_render_says_why_in_the_page(self, chart):
         chart()
         result, _ = caught(maidr.render)
 
         assert "not yet supported" in str(result)
 
-    @pytest.mark.parametrize("chart", [rugplot, quiver])
+    @pytest.mark.parametrize("chart", [barbs, quiver])
     def test_save_html_writes_a_file(self, chart, tmp_path):
         # Raising here would leave a build step that expected an artefact with
         # nothing on disk and a traceback.
@@ -131,7 +139,7 @@ class TestTheApiNoLongerCrashes:
         monkeypatch.setattr(
             "htmltools._core.Tag.show", lambda self, *a, **k: "shown"
         )
-        rugplot()
+        barbs()
 
         assert caught(maidr.show)[0] == "shown"
 
@@ -157,13 +165,13 @@ class TestTheWarningSaysSomethingUseful:
         }
         for name, call in calls.items():
             plt.close("all")
-            rugplot()
+            barbs()
             _, messages = caught(call)
 
             assert any("not yet supported" in message for message in messages), name
 
     def test_it_names_the_supported_types(self):
-        rugplot()
+        barbs()
         _, messages = caught(maidr.render)
         message = next(m for m in messages if "not yet supported" in m)
 
@@ -207,7 +215,7 @@ class TestAnEmptyFigureIsADifferentProblem:
 
     def test_a_drawn_chart_is_not_empty(self):
         # The guard: the empty test must not swallow the unsupported case.
-        rugplot()
+        barbs()
         _, messages = caught(maidr.render)
 
         assert not any("no plots on it yet" in message for message in messages)
@@ -229,7 +237,7 @@ class TestTheExceptionItself:
 
     def test_the_message_is_not_about_maidrs_bookkeeping(self):
         _, ax = plt.subplots()
-        sns.rugplot(x=data(), ax=ax, height=0.1)
+        ax.barbs([0, 1], [0, 1], [1, 1], [1, 1])
 
         with pytest.raises(UnsupportedPlotError) as raised:
             FigureManager.get_maidr(ax.get_figure())


### PR DESCRIPTION
Closes #250.

## What was wrong

`sns.rugplot` draws one short tick per observation against the frame and hands back a plain `LineCollection` that no patch claimed. Measured before the change:

```python
sns.rugplot(df, x="value")     # NO LAYERS
```

So a figure whose only layer was a rug fell back to a picture, and — the case that matters more — a rug drawn over a density curve left the raw observations unread. That is the one thing the curve does not state: a KDE is smoothed, the rug is where the data actually fell.

While measuring the neighbouring issues I also checked #252 and #251: `stripplot` and `swarmplot` already read as three `point` layers each, so this PR is only about the rug.

## What it does now

```
RugPlot  name=value   axes={"x": {"label": "value"}, "y": {"label": "Rug"}}
                      data=[{"x": 1.0, "y": 0}, {"x": 2.5, "y": 0}, ...]
```

Read as a **scatter**, for the reason `EventPlot` gives about an event plot's ticks: `height` is one number for the whole call, so a tick's length is decoration and only its position is data. A rug's ticks are held constant on the axis carrying the observations and stretched across the other, measured on seaborn 0.13.2:

```
sns.rugplot(x=[10.251, ...])
[[10.251, 0.0], [10.251, 0.025]]
```

so the *constant* coordinate is the measurement.

## Three judgement calls, stated

**The strip is renamed, not left carrying the chart's label.** An event plot's row sits at `lineoffsets`, a real place on a real axis worth announcing. A rug's ticks sit against the frame at a fraction of the axes height, which measures nothing. So that axis becomes "Rug" even when the caller labelled it — a rug over a `kdeplot` has a genuine "Density" label there, and every point this layer emits sits at 0, so keeping it would announce each observation as "Density 0", a number the chart does not show. This differs from `EventPlot`'s "Row", which only fills a blank.

**One layer per collection, not per call.** `rugplot(x=..., y=...)` marks two margins and returns one collection each; merging them would announce a single series whose coordinates come off two different axes. Each is named from the column it marks.

**A rug beside another layer is registered, not declined as a duplicate.** This is the opposite call to the one xability/maidr#1124 made for Vega-Lite text overlays, and deliberately: those labels sit *on* the marks they duplicate, whereas a rug occupies its own strip and, next to a density curve or histogram, is the only thing in the figure stating where the observations are. It carries `name` (xability/maidr#828) so a reader can tell it from its neighbour.

## A bug found in this PR's own code

`MaidrPlot.render()` builds the **axes** payload before the data, so resolving the orientation inside `_extract_plot_data` left `rugplot(y=...)` labelling the y axis "Rug" while the observations it carries were announced under "X". Now resolved in the constructor; `test_a_rug_on_y_names_the_other_axis` pins it.

## Fallback tests

`tests/core/test_unsupported_fallback.py` used a rug as its example of an unsupported chart, which it no longer is. It now uses `ax.barbs` — no trace type in the core to be read as, since a barb states a speed *and* a direction at a place — so it will not quietly stop testing the fallback. `test_seaborn_color_probe.py`'s rug-over-scatter case now expects two layers; the count is still what pins the phantom-layer regression, since a third layer there would be the probe back.

## Verification

Full suite `2697 passed, 18 skipped`; `ruff check --diff` clean. Highlighting checked against the rendered SVG — 4 ticks, 4 `<path>` children under the group, selector resolves.

Five mutations, each applied alone:

| mutation | result |
|---|---|
| resolve the orientation in extraction again | `test_a_rug_on_y_names_the_other_axis` fails |
| keep the chart's own label on the strip axis | 2 fail |
| emit the tick base instead of a constant | 2 fail |
| sweep the axes instead of taking this call's collections | `test_a_second_rug_on_the_same_axes_reads_only_its_own_ticks` fails |
| drop the layer name | 3 fail |

The fourth of those first **survived**: a scatter beside a rug is safe by accident, since a `PathCollection` is skipped anyway. Two rug calls on one axes is the case that actually bites, and that test was added after the mutation exposed the gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_