### PR TITLE
fix(triplot): decline a triangulation mesh instead of reading it as a line

### DIFF
--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -26,6 +26,7 @@ from . import (  # noqa: E402, F401
     pieplot,
     pointplot,
     scatterplot,
+    triplot,
     spanplot,
     stairs,
     regplot,

--- a/maidr/patch/triplot.py
+++ b/maidr/patch/triplot.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import wrapt
 from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
 
 from maidr.core.context_manager import ContextManager
 from maidr.patch.common import _draw_quietly
 
 
 @wrapt.patch_function_wrapper(Axes, "triplot")
-def triplot(wrapped, instance, args, kwargs):
+def triplot(wrapped, instance, args, kwargs) -> list[Line2D]:
     """
     Draw a patched ``Axes.triplot`` and register nothing for it.
 
@@ -52,8 +53,8 @@ def triplot(wrapped, instance, args, kwargs):
 
     Returns
     -------
-    list
-        Whatever ``triplot`` returned.
+    list of Line2D
+        Whatever ``triplot`` returned -- the mesh's lines and its markers.
     """
     if ContextManager.is_internal_context():
         return _draw_quietly(wrapped, args, kwargs)

--- a/maidr/patch/triplot.py
+++ b/maidr/patch/triplot.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import wrapt
+from matplotlib.axes import Axes
+
+from maidr.core.context_manager import ContextManager
+from maidr.patch.common import _draw_quietly
+
+
+@wrapt.patch_function_wrapper(Axes, "triplot")
+def triplot(wrapped, instance, args, kwargs):
+    """
+    Draw a patched ``Axes.triplot`` and register nothing for it.
+
+    A triangulation mesh is not a series, and until this it was announced as
+    one. ``triplot`` draws the mesh by handing the flattened edge list to
+    ``Axes.plot``::
+
+        tri_lines = ax.plot(tri_lines_x.ravel(), tri_lines_y.ravel(), ...)
+
+    so the line patch saw an ordinary plot call and registered a LINE layer.
+    Measured on eight scattered points: a line of **thirty-two** points, x
+    running 0.04 -> 0.64 -> 0.04 -> 0.27, the first point appearing again as
+    the third (#572).
+
+    That is the mesh's edge traversal -- three vertices per triangle and a
+    separator -- not a sequence of observations. A line trace tells a reader
+    there is a trend through ordered values and offers to play it as one;
+    here there is no order, points repeat, and the count bears no relation to
+    the data. Worse than being unread, because nothing about it looks wrong.
+
+    Declined rather than given a reading. The mesh states which points were
+    joined, and no trace in the core carries that -- the same conclusion
+    `quiver`, `barbs` and `streamplot` reach for a vector at a place. A
+    `triplot` is usually drawn *under* a `tricontour`, and that half reads;
+    on its own the figure falls back to a picture, which is what a chart maidr
+    cannot read is supposed to do.
+
+    Suppressed by drawing inside the internal context, so the inner ``plot``
+    calls register nothing -- the decline has to happen here rather than at
+    extraction, because a layer that refuses while the schema is built takes
+    the whole figure with it (#564).
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Axes.triplot``.
+    instance : Any
+        The axes it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    list
+        Whatever ``triplot`` returned.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)

--- a/tests/core/plot/test_unread_families.py
+++ b/tests/core/plot/test_unread_families.py
@@ -1,0 +1,177 @@
+"""
+What a mesh, a filled contour and a vector field are read as (#572, #568).
+
+Every call here draws something maidr has no trace for. The point of the
+file is that they say so by registering *nothing* -- the figure falls back
+to a picture, or reads whatever else is on the axes -- rather than being
+given a reading that is wrong.
+
+``ax.triplot`` was the exception and the reason this exists. It draws a
+triangulation mesh by handing the flattened edge list to ``Axes.plot``::
+
+    tri_lines = ax.plot(tri_lines_x.ravel(), tri_lines_y.ravel(), ...)
+
+so the line patch saw an ordinary plot call and announced a LINE layer of
+thirty-two points for a chart of eight, x running 0.04 -> 0.64 -> 0.04 ->
+0.27 with the first point repeating as the third. A line trace offers a
+reader a trend through ordered observations; a mesh has no order.
+
+The filled contours are the interesting decline, because their unfilled
+twins *do* read. Measured on one field with ``levels=[1, 2, 4]``:
+
+    contour   3 paths, each at one level        (z = 1.0 / 2.0 / 4.0)
+    contourf  2 paths, each spanning two        (path 0: z = 1.0 -> 2.0)
+
+A filled contour draws the bands *between* levels, so calling one of those
+outlines a level's own curve would be right for about half its vertices.
+That is the rule xability/r-maidr's `Ggplot2ContourLayerProcessor` already
+states for `geom_contour_filled()`, and the two bindings agreeing is worth
+keeping.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+from maidr.exception import UnsupportedPlotError
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def triangulation() -> tuple:
+    rng = np.random.default_rng(0)
+    x, y = rng.uniform(0, 1, 8), rng.uniform(0, 1, 8)
+    return x, y, x**2 + y**2
+
+
+@pytest.fixture
+def field() -> tuple:
+    grid = np.linspace(-2, 2, 9)
+    x, y = np.meshgrid(grid, grid)
+    return grid, x, y, x**2 + y**2
+
+
+def _layers(fig) -> list:
+    try:
+        return [plot.type.value for plot in FigureManager.get_maidr(fig).plots]
+    except UnsupportedPlotError:
+        return []
+
+
+def test_a_triangulation_mesh_is_not_announced_as_a_line(triangulation):
+    x, y, _ = triangulation
+    fig, ax = plt.subplots()
+    ax.triplot(x, y)
+
+    assert _layers(fig) == []
+    # And the figure is still a picture rather than nothing at all.
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+@pytest.mark.parametrize("mesh_first", [True, False])
+def test_a_mesh_under_a_contour_does_not_cost_it_its_reading(
+    triangulation, mesh_first
+):
+    # The way `triplot` is actually used: drawn beneath a `tricontour` to
+    # show where the samples were. That half reads, and must keep reading
+    # whichever order the two were drawn in.
+    x, y, z = triangulation
+    fig, ax = plt.subplots()
+    if mesh_first:
+        ax.triplot(x, y)
+        ax.tricontour(x, y, z)
+    else:
+        ax.tricontour(x, y, z)
+        ax.triplot(x, y)
+
+    assert _layers(fig) == ["contour"]
+
+
+def test_an_ordinary_line_after_a_mesh_still_reads(triangulation):
+    # The decline is done by drawing inside the internal context, which is a
+    # thing that could leak: if it did, every later call on the figure would
+    # register nothing. Pinned because the failure would be silent and total.
+    x, y, _ = triangulation
+    fig, ax = plt.subplots()
+    ax.triplot(x, y)
+    ax.plot([1, 2, 3], [4, 5, 6])
+
+    assert _layers(fig) == ["line"]
+
+
+def test_an_unfilled_contour_reads(field):
+    # The control for the two below: this is the same chart with lines
+    # instead of bands, and it is read.
+    _, x, y, z = field
+    fig, ax = plt.subplots()
+    ax.contour(x, y, z)
+
+    assert _layers(fig) == ["contour"]
+
+
+def test_a_filled_contour_path_spans_two_levels(field):
+    # The measurement the decline rests on, asserted rather than described.
+    # An unfilled path sits at one level; a filled one runs between two, so
+    # announcing it as a level's own curve would be right for half of it.
+    _, x, y, z = field
+
+    fig, ax = plt.subplots()
+    lines = ax.contour(x, y, z, levels=[1, 2, 4])
+    for path in lines.get_paths():
+        heights = (path.vertices**2).sum(axis=1)
+        assert heights.max() - heights.min() < 0.5
+
+    fig, ax = plt.subplots()
+    bands = ax.contourf(x, y, z, levels=[1, 2, 4])
+    spans = [
+        np.ptp((path.vertices**2).sum(axis=1)) for path in bands.get_paths()
+    ]
+    assert all(span > 0.5 for span in spans)
+
+
+@pytest.mark.parametrize("draw", ["contourf", "tricontourf", "tripcolor"])
+def test_a_filled_contour_is_declined(field, triangulation, draw):
+    _, x, y, z = field
+    tx, ty, tz = triangulation
+
+    fig, ax = plt.subplots()
+    if draw == "contourf":
+        ax.contourf(x, y, z)
+    elif draw == "tricontourf":
+        ax.tricontourf(tx, ty, tz)
+    else:
+        ax.tripcolor(tx, ty, tz)
+
+    assert _layers(fig) == []
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+@pytest.mark.parametrize("draw", ["quiver", "barbs", "streamplot", "fill"])
+def test_a_chart_with_no_trace_to_be_read_as_is_declined(field, draw):
+    # A vector at a place carries a speed *and* a direction, which no trace
+    # holds; `ax.fill` draws a closed polygon, which states no series. Pinned
+    # together so that a future reading for one of them is a decision rather
+    # than an accident.
+    grid, x, y, _ = field
+
+    fig, ax = plt.subplots()
+    if draw == "quiver":
+        ax.quiver([0, 1], [0, 1], [1, 1], [1, 1])
+    elif draw == "barbs":
+        ax.barbs([0, 1], [0, 1], [1, 1], [1, 1])
+    elif draw == "streamplot":
+        ax.streamplot(grid, grid, np.ones_like(x), np.ones_like(y))
+    else:
+        ax.fill([0, 1, 2, 0], [0, 2, 0, 0])
+
+    assert _layers(fig) == []
+    assert len(maidr.render(fig)._repr_html_()) > 0

--- a/tests/core/plot/test_unread_families.py
+++ b/tests/core/plot/test_unread_families.py
@@ -122,6 +122,14 @@ def test_a_filled_contour_path_spans_two_levels(field):
     # The measurement the decline rests on, asserted rather than described.
     # An unfilled path sits at one level; a filled one runs between two, so
     # announcing it as a level's own curve would be right for half of it.
+    #
+    # This one reads matplotlib's own output, with no maidr patch in the way,
+    # which makes it the odd test here: it pins an assumption about
+    # `contourf` rather than a behaviour of ours. If a future matplotlib
+    # changes how it builds those vertices this fails without anything in
+    # maidr having regressed -- so it wants reading, not just re-running.
+    # Kept because the decision not to patch `contourf` rests on it, and an
+    # assumption nothing checks is how the two bindings drift apart.
     _, x, y, z = field
 
     fig, ax = plt.subplots()
@@ -175,3 +183,18 @@ def test_a_chart_with_no_trace_to_be_read_as_is_declined(field, draw):
 
     assert _layers(fig) == []
     assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+@pytest.mark.parametrize("label", ["fit", "smooth", "regression"])
+def test_a_mesh_labelled_like_a_fit_is_still_declined(triangulation, label):
+    # The interaction review asked about, measured rather than traced.
+    # `regplot.patched_plot` registers a SMOOTH layer when a plot call's
+    # label matches `SMOOTH_KEYWORDS`, and `triplot` reaches `Axes.plot` --
+    # so a mesh labelled "fit" is the shape where a second patch on the same
+    # method could slip a layer through the decline. It does not: the
+    # `common()` call that would register checks the context itself.
+    x, y, _ = triangulation
+    fig, ax = plt.subplots()
+    ax.triplot(x, y, label=label)
+
+    assert _layers(fig) == []


### PR DESCRIPTION
Closes #572. This finishes what #568 left over — and the outcome is not what I expected when I listed that remainder.

## The one that was actually wrong

Everything left in #568 was on my list as "unread". Measuring found that six of the seven decline **correctly**, and the seventh doesn't decline at all — it reads, and says something false.

```python
rng = np.random.default_rng(0)
tx, ty = rng.uniform(0, 1, 8), rng.uniform(0, 1, 8)
ax.triplot(tx, ty)
```

```
type:   line
points: 32                     ← the chart draws 8
first 6 x: 0.0410, 0.6370, 0.0410, 0.2698, 0.0165, 0.6370
                   ↑ the first point again, third in the series
```

`triplot` draws the mesh by handing the flattened edge list to `Axes.plot`:

```python
tri_lines = ax.plot(tri_lines_x.ravel(), tri_lines_y.ravel(), **kw_lines)
```

so the line patch sees an ordinary plot call. The "series" is an edge traversal — three vertices per triangle and a separator — not a sequence of observations. A line trace tells a reader there is a trend through ordered values and offers to play it; here there is no order, points repeat, and the count bears no relation to the data. **Worse than being unread, because nothing about it looks wrong.**

Declined by drawing inside the internal context so the inner `plot` calls register nothing. It has to happen in the patch: a layer that refuses while the schema is built takes the whole figure with it (#564).

## What I got wrong about the rest

I had `contourf` down as an obvious gap — the filled twin of a call that reads. It isn't. Measured on one field with `levels=[1, 2, 4]`:

| | paths | each path's z range |
| --- | --- | --- |
| `contour` | 3 | one level each (1.0 / 2.0 / 4.0) |
| `contourf` | 2 | **two** — path 0 runs 1.0 → 2.0 |

A filled contour draws the bands *between* levels, so announcing one of those outlines as a level's own curve would be right for about half its vertices. That is exactly the rule xability/r-maidr's `Ggplot2ContourLayerProcessor` already states for `geom_contour_filled()`, reached there by reading `level` as a factor of intervals. Both bindings agreeing is worth keeping, so this PR **asserts the measurement** rather than describing it — the test compares path z-spans directly.

Final state of the remainder, each checked rather than assumed:

| call | today | verdict |
| --- | --- | --- |
| `contourf`, `tricontourf`, `tripcolor` | no layers | correct — bands between levels |
| `ax.fill` | no layers | correct — a closed polygon states no series |
| `quiver`, `barbs`, `streamplot` | no layers | correct — no trace holds a vector at a place |
| **`triplot`** | **line, 32 points** | **fixed** |

All six were declining correctly but nothing pinned it, so a future reading for any of them would have been an accident rather than a decision. They're pinned now.

## Neighbours

A `triplot` is usually drawn *under* a `tricontour`. That half still reads, in either drawing order. An ordinary `plot` after a `triplot` still reads too — which pins that the internal context doesn't leak, a failure that would be silent and total.

## Verification

Full suite `2714 passed, 18 skipped`; `ruff check --diff` clean.

Two mutations: unregistering the patch fails 3 (the mesh reads again), and leaking the context by entering it without a `with` fails the same 3 — the second because the *contour* then stops registering too, which is the leak the third test guards.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_