### PR TITLE
feat(core): read Axes.stem as the lollipop chart it draws

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ The `maidr/patch/` modules use `wrapt` to intercept matplotlib/seaborn plot call
 
 ### Supported Plot Types
 
-Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, BOXEN, COUNT, DODGED, ERRORBAR, HEAT, HEXBIN, HIST, LINE, AREA, STACKED_AREA, NORMALIZED_AREA, PIE, SCATTER, STACKED, NORMALIZED, STEP, SMOOTH, CANDLESTICK, VIOLIN_KDE, VIOLIN_BOX.
+Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, BOXEN, CONTOUR, COUNT, DODGED, ERRORBAR, GANTT, HEAT, HEXBIN, HIST, LINE, LOLLIPOP, AREA, STACKED_AREA, NORMALIZED_AREA, PIE, SCATTER, STACKED, NORMALIZED, STEP, SMOOTH, CANDLESTICK, VIOLIN_KDE, VIOLIN_BOX.
 
 Note that `maidr/plotly/` builds its MAIDR schema in Python and therefore needs its own
 handling per plot type, whereas `maidr/altair/` delegates entirely to the upstream

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -34,6 +34,13 @@ class PlotType(str, Enum):
     HEXBIN = "hexbin"
     HIST = "hist"
     LINE = "line"
+    #: One value per position, each marked and joined to a baseline.
+    #: `Axes.stem` is matplotlib's spelling. A distinct type from `BAR`
+    #: only in what is drawn at the position -- the core builds both on
+    #: `BarTrace` -- and a distinct type from `LINE` in a way that matters:
+    #: the marks are not joined to each other, and the baseline is a frame
+    #: rather than a series (#574).
+    LOLLIPOP = "lollipop"
     #: A filled band between a series and a baseline. Emitted for a single
     #: `stackplot` band, which has nothing stacked on it.
     AREA = "area"

--- a/maidr/core/plot/lollipop.py
+++ b/maidr/core/plot/lollipop.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import math
+import uuid
+
+from matplotlib.axes import Axes
+from matplotlib.container import StemContainer
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot import MaidrPlot
+
+#: The keyword the stem patch hands its container to this layer under.
+#: Handed over rather than swept for, because the chart leaves two `Line2D`
+#: artists on the axes and only the container says which is which (#527).
+DRAWN_STEM = "_maidr_stem"
+
+
+def marks(container: StemContainer) -> list[tuple[int, float, float]]:
+    """
+    The marks a stem plot drew, each with the element that carries it.
+
+    ``StemContainer`` holds three artists and only one of them is data. The
+    ``markerline`` carries a mark per value; the ``stemlines`` join each mark
+    to the baseline, and the ``baseline`` is a single segment from the first
+    position to the last. The stems and the baseline are how the chart is
+    *drawn* -- neither carries a number the markers do not already carry, and
+    the baseline's own value is the bottom of the frame rather than an
+    observation. So the marks are the whole reading.
+
+    The coordinates come back as matplotlib drew them, not reinterpreted into
+    position and magnitude. That is the bar family's contract, measured
+    rather than assumed: ``ax.barh(["a"], [4])`` emits ``{x: 4.0, y: "a"}``
+    under ``orientation: "horz"``, so a horizontal chart puts the *magnitude*
+    in ``x``. A horizontal stem's ``markerline`` already holds exactly that,
+    and swapping the pair here would undo it.
+
+    Non-finite values are dropped, and that is why the element index is
+    returned rather than assumed. Measured: ``ax.stem([1,2,3,4], [4, nan, 2,
+    7])`` leaves four points in ``get_xydata()`` and writes **three**
+    ``<use>`` elements -- matplotlib skips a mark it cannot place. Numbering
+    the announced marks from their place in the data would then put every
+    highlight after the gap on its neighbour's mark, which is #429.
+
+    Parameters
+    ----------
+    container : StemContainer
+        What ``Axes.stem`` returned.
+
+    Returns
+    -------
+    list of (int, float, float)
+        For every drawable mark: its index among the drawn elements, and its
+        two coordinates as drawn.
+    """
+    xydata = container.markerline.get_xydata()
+    if xydata is None or not len(xydata):  # type: ignore[arg-type]
+        return []
+
+    drawn = []
+    for point in xydata:
+        x, y = float(point[0]), float(point[1])
+        if not math.isfinite(x) or not math.isfinite(y):
+            continue
+        drawn.append((len(drawn), x, y))
+
+    return drawn
+
+
+def is_horizontal(container: StemContainer) -> bool:
+    """
+    Whether the stems stand along x rather than up from the axis.
+
+    ``Axes.stem(..., orientation="horizontal")`` is not recorded anywhere on
+    the container, so it is read back off the baseline: a vertical chart's
+    baseline runs across the positions at one value, and a horizontal one's
+    runs down them. Its two ends are compared rather than its slope, because
+    a one-mark chart draws a baseline of zero length and the comparison then
+    has to fall somewhere -- vertical, matching the default the caller did
+    not override.
+
+    Parameters
+    ----------
+    container : StemContainer
+        What ``Axes.stem`` returned.
+
+    Returns
+    -------
+    bool
+        True when the values run along x.
+    """
+    ends = container.baseline.get_xydata()
+    if ends is None or len(ends) < 2:  # type: ignore[arg-type]
+        return False
+
+    first, last = ends[0], ends[-1]
+    return float(first[0]) == float(last[0]) and float(first[1]) != float(last[1])
+
+
+class LollipopPlot(MaidrPlot):
+    """
+    A stem plot, read as the lollipop chart it draws.
+
+    ``Axes.stem`` marks one value per position and joins each mark to a
+    baseline. The core has a trace for that shape: ``lollipop``, which
+    ``factory.ts`` constructs as a ``BarTrace`` outright -- a category and a
+    magnitude -- on the grounds that a dot plot, a bar chart and a lollipop
+    differ in what is drawn at the position rather than in how the chart is
+    read.
+
+    Not a line, which is what it used to be read as (#574). ``markerline``'s
+    line style is ``"None"``: matplotlib draws no segment between the marks,
+    because a stem plot is not claiming its positions are joined. Announcing
+    it as a line asserts a continuity the chart declines to draw, and it
+    brought the baseline in as a second series -- a flat two-point "line" at
+    zero, which is a decoration of the drawing rather than an observation.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        super().__init__(ax, PlotType.LOLLIPOP)
+
+        container = kwargs.get(DRAWN_STEM, None)
+        self._container = container if isinstance(container, StemContainer) else None
+
+        # Resolved here rather than at extraction because `render()` builds
+        # the axes payload *before* the data payload, so `_extract_axes_data`
+        # would otherwise be asked which way the chart runs before anything
+        # had looked -- the defect #571's rug plot shipped with.
+        self._horizontal = (
+            is_horizontal(self._container) if self._container is not None else False
+        )
+
+        # The element indices `_get_selector` addresses, filled by extraction.
+        self._drawn: list[int] = []
+
+        # Stamped here rather than read later: matplotlib assigns a gid at
+        # *draw* time and the schema is built first, so a layer that waited
+        # would announce correctly and highlight nothing.
+        if self._container is not None and self._container.markerline.get_gid() is None:
+            self._container.markerline.set_gid(f"maidr-{uuid.uuid4()}")
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        One entry per mark, at the coordinates the chart drew it at.
+
+        Which of the two is the magnitude is said by ``orientation`` rather
+        than by the field a number sits in -- see :func:`marks` for the
+        measurement the bar family's convention rests on.
+
+        Returns
+        -------
+        list of dict
+            The marks, in the order the chart holds them.
+        """
+        if self._container is None:
+            return []
+
+        drawn = marks(self._container)
+        self._drawn = [index for index, _, _ in drawn]
+
+        return [{MaidrKey.X: x, MaidrKey.Y: y} for _, x, y in drawn]
+
+    def render(self) -> dict:
+        """
+        The base schema, plus which way the stems stand.
+
+        ``orientation`` is a sibling of ``type`` rather than an entry in
+        ``axes``, which holds only ``x``/``y``/``z``. Declaring the
+        orientation without swapping the payload is the whole contract for
+        the bar family; declaring one without the other in either direction
+        is the defect #480 and r-maidr#189 both had.
+        """
+        schema = super().render()
+        schema[MaidrKey.ORIENTATION] = "horz" if self._horizontal else "vert"
+        return schema
+
+    def _get_selector(self) -> str | list[str]:
+        """
+        Address each mark by the element matplotlib drew for it.
+
+        Measured: a marker-only ``Line2D`` is written as one ``<g>`` carrying
+        the marker's shape in a ``<defs>`` and one ``<use>`` per drawn mark.
+        A descendant combinator rather than a child one, because matplotlib
+        nests the marks inside a clip-path ``<g>`` of its own.
+
+        ``nth-of-type`` rather than ``nth-child`` for the reason
+        :class:`~maidr.core.plot.hexbinplot.HexbinPlot` gives: the ``<defs>``
+        ahead of the marks would shift every count by one.
+        """
+        gid = (
+            self._container.markerline.get_gid() if self._container is not None else None
+        )
+        if gid is None:
+            return []
+
+        return [
+            f"g[id='{gid}'] use:nth-of-type({index + 1})" for index in self._drawn
+        ]

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -18,6 +18,7 @@ from maidr.core.plot.heatmap import HeatPlot
 from maidr.core.plot.hexbinplot import HexbinPlot
 from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
+from maidr.core.plot.lollipop import LollipopPlot
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.core.plot.pieplot import PiePlot
 from maidr.core.plot.pointplot import PointPlot
@@ -129,6 +130,8 @@ class MaidrPlotFactory:
                 return MplfinanceLinePlot(single_ax, **kwargs)
             else:
                 return MultiLinePlot(single_ax, **kwargs)
+        elif PlotType.LOLLIPOP == plot_type:
+            return LollipopPlot(single_ax, **kwargs)
         elif PlotType.STEP == plot_type:
             return StepPlot(single_ax, **kwargs)
         elif PlotType.PIE == plot_type:

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -23,6 +23,7 @@ from . import (  # noqa: E402, F401
     highlight,
     histogram,
     lineplot,
+    stem,
     pieplot,
     pointplot,
     scatterplot,

--- a/maidr/patch/stem.py
+++ b/maidr/patch/stem.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import wrapt
+from matplotlib.axes import Axes
+from matplotlib.container import StemContainer
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.lollipop import DRAWN_STEM, marks
+from maidr.patch.common import _draw_quietly
+
+
+@wrapt.patch_function_wrapper(Axes, "stem")
+def stem(wrapped, instance, args, kwargs) -> StemContainer:
+    """
+    Draw a patched ``Axes.stem`` and register the lollipop chart it produced.
+
+    The internal context is what makes this a *replacement* reading rather
+    than an extra one. ``Axes.stem`` draws its marks and its baseline by
+    calling ``Axes.plot`` twice, and both of those are patched: left alone,
+    the chart registers a line layer whose second series is the baseline --
+    a flat two-point segment at the bottom of the frame, announced as data
+    (#574). Drawing quietly and registering once here is the same shape the
+    triangulation patch uses to decline a mesh, applied to a chart that has
+    a reading rather than none.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Axes.stem``.
+    instance : Any
+        The axes it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    StemContainer
+        Whatever ``stem`` returned, unchanged.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        container = _draw_quietly(wrapped, args, kwargs)
+
+    if not isinstance(container, StemContainer):
+        return container
+
+    # A chart with nothing drawable is not registered, rather than registered
+    # empty: a layer a reader can walk into and find no points is the
+    # phantom-layer shape of #421. `ax.stem([], [])` is the plain case, and
+    # a series that is entirely non-finite is the one that looks drawn.
+    if not marks(container):
+        return container
+
+    ax = FigureManager.get_axes(container.markerline)
+    kwargs.pop("ax", None)
+    FigureManager.create_maidr(
+        ax,
+        PlotType.LOLLIPOP,
+        **dict(kwargs, **{DRAWN_STEM: container}),
+    )
+
+    return container

--- a/tests/core/plot/test_spanplot.py
+++ b/tests/core/plot/test_spanplot.py
@@ -404,13 +404,14 @@ def test_a_segment_that_is_not_level_is_still_refused():
     assert read_spans(sloped, along_x=True) is None
 
 
-def test_a_stem_plot_is_unchanged_by_this_reading():
+def test_a_stem_plot_is_not_claimed_by_the_span_reading():
     # `stem` draws the lollipop shape and reaches `vlines` the same way
-    # `acorr`/`xcorr` do, so review asked where it lands. It registers a
-    # `line` layer off its marker tips, exactly as it did before this
-    # reading existed -- pinned so the span patch cannot start claiming it.
+    # `acorr`/`xcorr` do, so review asked where it lands. It is read by its
+    # own patch, as the `lollipop` its marks make (#574) -- pinned here so
+    # the span patch cannot start claiming it and announcing the stems as a
+    # schedule of intervals.
     fig, ax = plt.subplots()
     ax.stem([1, 2, 3, 4], [3, 8, 5, 9])
 
-    assert _layers(fig) == ["line"]
+    assert _layers(fig) == ["lollipop"]
     assert len(maidr.render(fig)._repr_html_()) > 0

--- a/tests/core/plot/test_stem_lollipop.py
+++ b/tests/core/plot/test_stem_lollipop.py
@@ -1,0 +1,273 @@
+"""A stem plot is read as the lollipop it draws, baseline excluded."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.exception import UnsupportedPlotError
+
+
+def _layers(fig) -> list:
+    return FigureManager.get_maidr(fig).plots
+
+
+def test_a_stem_plot_is_one_lollipop_layer() -> None:
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+
+    layers = _layers(fig)
+    assert [layer.type for layer in layers] == [PlotType.LOLLIPOP]
+
+    plt.close(fig)
+
+
+def test_the_marks_are_the_data() -> None:
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+
+    schema = _layers(fig)[0].schema
+    assert schema[MaidrKey.DATA] == [
+        {MaidrKey.X: 1.0, MaidrKey.Y: 4.0},
+        {MaidrKey.X: 2.0, MaidrKey.Y: 9.0},
+        {MaidrKey.X: 3.0, MaidrKey.Y: 2.0},
+    ]
+
+    plt.close(fig)
+
+
+def test_the_baseline_is_not_announced_as_a_series() -> None:
+    """The defect #574 was filed for: a flat two-point line at the bottom.
+
+    Asserted on the *shape* of the payload rather than by looking for the
+    baseline's coordinates, because a lollipop's data is a flat list -- a
+    second series could only arrive by the layer becoming a line again.
+    """
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+
+    data = _layers(fig)[0].schema[MaidrKey.DATA]
+    assert all(isinstance(entry, dict) for entry in data)
+    assert len(data) == 3
+
+    # The baseline sits at y=0 across the whole chart; no announced mark does.
+    assert {entry[MaidrKey.Y] for entry in data} == {4.0, 9.0, 2.0}
+
+    plt.close(fig)
+
+
+def test_the_baseline_a_caller_moved_is_not_announced_either() -> None:
+    """`bottom=` moves the baseline onto the values' own scale."""
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2], bottom=3)
+
+    data = _layers(fig)[0].schema[MaidrKey.DATA]
+    assert len(data) == 3
+    assert 3.0 not in {entry[MaidrKey.Y] for entry in data}
+
+    plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "orientation", "expected"),
+    [
+        (
+            {},
+            "vert",
+            [(1.0, 4.0), (2.0, 9.0), (3.0, 2.0)],
+        ),
+        (
+            {"orientation": "horizontal"},
+            "horz",
+            # The bar family puts the magnitude in `x` when horizontal --
+            # measured off `ax.barh`, which emits {x: 4.0, y: "a"}.
+            [(4.0, 1.0), (9.0, 2.0), (2.0, 3.0)],
+        ),
+    ],
+)
+def test_the_orientation_is_declared_and_the_payload_matches_it(
+    kwargs: dict, orientation: str, expected: list
+) -> None:
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2], **kwargs)
+
+    schema = _layers(fig)[0].schema
+    assert schema[MaidrKey.ORIENTATION] == orientation
+    assert [
+        (entry[MaidrKey.X], entry[MaidrKey.Y]) for entry in schema[MaidrKey.DATA]
+    ] == expected
+
+    plt.close(fig)
+
+
+def test_a_mark_matplotlib_could_not_place_is_skipped_with_its_selector() -> None:
+    """Four values, one of them non-finite, leave three marks and three
+    elements -- and the third selector must address the third element, not
+    the fourth."""
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3, 4], [4.0, float("nan"), 2.0, 7.0])
+
+    schema = _layers(fig)[0].schema
+    data = schema[MaidrKey.DATA]
+    selectors = schema[MaidrKey.SELECTOR]
+
+    assert [entry[MaidrKey.X] for entry in data] == [1.0, 3.0, 4.0]
+    assert len(selectors) == 3
+    assert selectors[-1].endswith("use:nth-of-type(3)")
+
+    plt.close(fig)
+
+
+def test_every_mark_has_a_selector_of_its_own() -> None:
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+
+    schema = _layers(fig)[0].schema
+    selectors = schema[MaidrKey.SELECTOR]
+
+    assert len(selectors) == len(schema[MaidrKey.DATA])
+    assert len(set(selectors)) == len(selectors)
+    assert all(selector.startswith("g[id='maidr-") for selector in selectors)
+
+    plt.close(fig)
+
+
+def test_a_stem_plot_registers_no_line_layer() -> None:
+    """The marks are not joined; announcing a line would say they are."""
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+
+    assert PlotType.LINE not in {layer.type for layer in _layers(fig)}
+
+    plt.close(fig)
+
+
+def test_a_line_drawn_beside_a_stem_is_still_read() -> None:
+    """Drawing the stem quietly must not silence the caller's own plot."""
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+    ax.plot([1, 2, 3], [1, 2, 3])
+
+    assert {layer.type for layer in _layers(fig)} == {
+        PlotType.LOLLIPOP,
+        PlotType.LINE,
+    }
+
+    plt.close(fig)
+
+
+def test_a_line_drawn_before_a_stem_is_still_read() -> None:
+    """The other draw order, because only one direction can be broken."""
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3])
+    ax.stem([1, 2, 3], [4, 9, 2])
+
+    assert {layer.type for layer in _layers(fig)} == {
+        PlotType.LOLLIPOP,
+        PlotType.LINE,
+    }
+
+    plt.close(fig)
+
+
+def test_a_line_read_beside_a_stem_holds_only_its_own_points() -> None:
+    """The line must not pick up the stem's marker or baseline artists."""
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+    ax.plot([1, 2, 3], [1, 2, 3])
+
+    line = next(
+        layer for layer in _layers(fig) if layer.type == PlotType.LINE
+    )
+    series = line.schema[MaidrKey.DATA]
+    assert len(series) == 1
+    assert [entry[MaidrKey.Y] for entry in series[0]] == [1.0, 2.0, 3.0]
+
+    plt.close(fig)
+
+
+def test_a_chart_with_nothing_drawable_registers_no_layer() -> None:
+    """An empty layer is one a reader can walk into and find nothing (#421).
+
+    Nothing registered means the figure has no `Maidr` at all, which is the
+    same answer any unread chart gives -- so the chart falls back to a
+    picture rather than shipping a layer with no points.
+    """
+    fig, ax = plt.subplots()
+    ax.stem([1, 2], [float("nan"), float("nan")])
+
+    with pytest.raises(UnsupportedPlotError):
+        FigureManager.get_maidr(fig)
+
+    plt.close(fig)
+
+
+def test_the_chart_renders() -> None:
+    import maidr
+
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+    plt.close(fig)
+
+
+def test_the_selectors_address_elements_the_svg_actually_has() -> None:
+    """The selector shape is measured against the drawing, not assumed."""
+    import io
+    import re
+
+    fig, ax = plt.subplots()
+    ax.stem([1, 2, 3], [4, 9, 2])
+
+    schema = _layers(fig)[0].schema
+    gid = re.search(r"g\[id='([^']+)'\]", schema[MaidrKey.SELECTOR][0]).group(1)
+
+    buffer = io.StringIO()
+    fig.savefig(buffer, format="svg")
+    svg = buffer.getvalue()
+
+    group = re.search(rf'<g id="{re.escape(gid)}".*?</g>\s*</g>', svg, re.S)
+    assert group is not None
+    assert group.group(0).count("<use") == 3
+
+    plt.close(fig)
+
+
+def test_a_single_mark_is_read_as_vertical() -> None:
+    """A one-mark chart draws a baseline of zero length, so the orientation
+    cannot be read off its slope; the default is what the caller did not
+    override."""
+    fig, ax = plt.subplots()
+    ax.stem([1], [4])
+
+    schema = _layers(fig)[0].schema
+    assert schema[MaidrKey.ORIENTATION] == "vert"
+    assert schema[MaidrKey.DATA] == [{MaidrKey.X: 1.0, MaidrKey.Y: 4.0}]
+
+    plt.close(fig)
+
+
+def test_the_marks_are_read_in_the_order_they_were_given() -> None:
+    """Unlike an event plot's row, a stem is not sorted by matplotlib."""
+    fig, ax = plt.subplots()
+    ax.stem([3, 1, 2], [4, 9, 2])
+
+    data = _layers(fig)[0].schema[MaidrKey.DATA]
+    assert [entry[MaidrKey.X] for entry in data] == [3.0, 1.0, 2.0]
+
+    plt.close(fig)
+
+
+def test_the_layer_reads_a_numpy_series() -> None:
+    fig, ax = plt.subplots()
+    ax.stem(np.array([1, 2, 3]), np.array([4.0, 9.0, 2.0]))
+
+    data = _layers(fig)[0].schema[MaidrKey.DATA]
+    assert [entry[MaidrKey.Y] for entry in data] == [4.0, 9.0, 2.0]
+
+    plt.close(fig)


### PR DESCRIPTION
Closes #574.

`ax.stem` marks one value per position and joins each mark to a baseline — the shape the core already has a trace for. `lollipop` is a `TraceType` that `src/model/factory.ts` constructs as a `BarTrace` outright, on the grounds that a dot plot, a bar chart and a lollipop differ in what is drawn at the position rather than in how the chart is read.

py-maidr read it as a `line` with **two** series:

```
data = [[{x: 1, y: 4}, {x: 2, y: 9}, {x: 3, y: 2}],
        [{x: 1, y: 0}, {x: 3, y: 0}]]
```

Three things wrong there:

- the second series is the **baseline** — `StemContainer` puts two `Line2D` on the axes and only one is data — so a reader arrowing through found a second "line" two points long and flat at zero. That is the defect #176 and #563 fixed for reference lines, arriving through a different door;
- the marks were announced as a line at all, though `markerline.get_linestyle()` is `"None"`: matplotlib draws no segment between them, because a stem plot does not claim its positions are joined;
- `z` was `"_nolegend_"` on every point, fixed separately in #576.

Now:

```
type = lollipop, orientation = vert
data = [{x: 1.0, y: 4.0}, {x: 2.0, y: 9.0}, {x: 3.0, y: 2.0}]
```

## Two things measured rather than assumed

**Which coordinate is the magnitude.** The bar family swaps `x` and `y` when horizontal, so I checked what py-maidr actually emits rather than reasoning from the name: `ax.barh(["a"], [4])` gives `{x: 4.0, y: "a"}` under `orientation: "horz"`. A horizontal stem's `markerline` already holds that pair, so the coordinates go out **as drawn** and the swap is left to the core. My first version reinterpreted them into position/magnitude and would have emitted the horizontal case backwards.

**Which element carries a mark.** `ax.stem([1,2,3,4], [4, nan, 2, 7])` leaves four points in `get_xydata()` and writes **three** `<use>` elements — matplotlib skips a mark it cannot place. Selectors are numbered by the drawn elements, not by the data, which is the off-by-one #429 is about.

## Scope

Registration happens in the patch with the draw wrapped in the internal context: `Axes.stem` builds its marks and its baseline by calling `Axes.plot` twice and both are patched, so the line layer has to be prevented rather than filtered afterwards. A chart with nothing drawable registers no layer at all rather than an empty one (#421). The stems themselves are dropped deliberately — each runs from the baseline to its mark and carries no number the mark does not already carry.

`test_spanplot.py::test_a_stem_plot_is_unchanged_by_this_reading` pinned the old `line` reading; its real intent was that the *span* patch must not claim a stem, so it now asserts `["lollipop"]` under a name that says that.

## Verification

`tests/core/plot/test_stem_lollipop.py`, 18 tests — both orientations, `bottom=`, a non-finite mark and its selector, a line drawn before *and* after the stem, a one-mark chart, and one test that saves the figure and counts the `<use>` elements the selectors address, so the selector shape is checked against the drawing rather than assumed.

Every mutation applied alone against a restored baseline; all seven killed:

| mutation | result |
| --- | --- |
| registers a `line` instead | 14 failed |
| draws without the internal context | 13 failed |
| keeps non-finite marks | 2 failed |
| numbers marks by their place in the data | 1 failed |
| orientation always vertical | 1 failed |
| zero-length baseline read as horizontal | 1 failed |
| registers a chart with nothing drawable | 1 failed |

Full suite: 2750 passed, 18 skipped. `ruff check` clean on every touched file.

The stale `PlotType` list in `CLAUDE.md` is refreshed from the enum in passing — it was already missing `CONTOUR` and `GANTT`, and adding `LOLLIPOP` alone would have left it wrong in a new way.

Follow-up filed: #577 — `acorr`/`xcorr` are the same chart through different artists, silent one way and read as a line the other.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_