### PR TITLE
feat(core): read a correlogram as the lollipop chart it draws

### DIFF
--- a/maidr/core/plot/lollipop.py
+++ b/maidr/core/plot/lollipop.py
@@ -4,6 +4,8 @@ import math
 import uuid
 
 from matplotlib.axes import Axes
+from matplotlib.artist import Artist
+from matplotlib.collections import LineCollection
 from matplotlib.container import StemContainer
 
 from maidr.core.enum import MaidrKey, PlotType
@@ -13,6 +15,17 @@ from maidr.core.plot import MaidrPlot
 #: Handed over rather than swept for, because the chart leaves two `Line2D`
 #: artists on the axes and only the container says which is which (#527).
 DRAWN_STEM = "_maidr_stem"
+
+#: The keyword a correlogram hands its `(positions, values)` under. `acorr`
+#: and `xcorr` return the numbers they plotted, so the layer is given those
+#: rather than made to recover them from the artists -- the shape `ax.stairs`
+#: (#536) and `ax.hist(histtype="step")` (#556) already use, and the only
+#: way to read the `usevlines=True` spelling, whose stems say the value in
+#: their *length* rather than in a coordinate a mark sits at.
+DRAWN_MARKS = "_maidr_marks"
+
+#: The artist carrying one element per mark, for highlighting.
+MARK_ARTIST = "_maidr_mark_artist"
 
 
 def marks(container: StemContainer) -> list[tuple[int, float, float]]:
@@ -65,6 +78,33 @@ def marks(container: StemContainer) -> list[tuple[int, float, float]]:
 
     return drawn
 
+
+
+def finite(given: tuple) -> list[tuple[int, float, float]]:
+    """
+    The drawable pairs of a chart that handed over its numbers directly.
+
+    Parameters
+    ----------
+    given : tuple
+        The ``(positions, values)`` the call returned.
+
+    Returns
+    -------
+    list of (int, float, float)
+        For every drawable mark: its index among the drawn elements, and its
+        two coordinates.
+    """
+    positions, values = given
+
+    drawn = []
+    for position, value in zip(positions, values):
+        x, y = float(position), float(value)
+        if not math.isfinite(x) or not math.isfinite(y):
+            continue
+        drawn.append((len(drawn), x, y))
+
+    return drawn
 
 def is_horizontal(container: StemContainer) -> bool:
     """
@@ -121,22 +161,33 @@ class LollipopPlot(MaidrPlot):
         container = kwargs.get(DRAWN_STEM, None)
         self._container = container if isinstance(container, StemContainer) else None
 
-        # Resolved here rather than at extraction because `render()` builds
-        # the axes payload *before* the data payload, so `_extract_axes_data`
-        # would otherwise be asked which way the chart runs before anything
-        # had looked -- the defect #571's rug plot shipped with.
-        self._horizontal = (
-            is_horizontal(self._container) if self._container is not None else False
-        )
+        if self._container is not None:
+            self._points = marks(self._container)
+            self._artist: Artist | None = self._container.markerline
+            # Resolved here rather than at extraction because `render()`
+            # builds the axes payload *before* the data payload, so
+            # `_extract_axes_data` would otherwise be asked which way the
+            # chart runs before anything had looked -- the defect #571's rug
+            # plot shipped with.
+            self._horizontal = is_horizontal(self._container)
+        else:
+            given = kwargs.get(DRAWN_MARKS, None)
+            self._points = finite(given) if given is not None else []
+            self._artist = kwargs.get(MARK_ARTIST, None)
+            # A correlogram stands its lags along x and its correlations up
+            # from zero, which is the default orientation. There is no
+            # spelling of `acorr` that turns it, so this is not read back off
+            # anything -- it is what the call can only have drawn.
+            self._horizontal = False
 
-        # The element indices `_get_selector` addresses, filled by extraction.
-        self._drawn: list[int] = []
+        # The element indices `_get_selector` addresses.
+        self._drawn = [index for index, _, _ in self._points]
 
         # Stamped here rather than read later: matplotlib assigns a gid at
         # *draw* time and the schema is built first, so a layer that waited
         # would announce correctly and highlight nothing.
-        if self._container is not None and self._container.markerline.get_gid() is None:
-            self._container.markerline.set_gid(f"maidr-{uuid.uuid4()}")
+        if self._artist is not None and self._artist.get_gid() is None:
+            self._artist.set_gid(f"maidr-{uuid.uuid4()}")
 
     def _extract_plot_data(self) -> list[dict]:
         """
@@ -151,13 +202,7 @@ class LollipopPlot(MaidrPlot):
         list of dict
             The marks, in the order the chart holds them.
         """
-        if self._container is None:
-            return []
-
-        drawn = marks(self._container)
-        self._drawn = [index for index, _, _ in drawn]
-
-        return [{MaidrKey.X: x, MaidrKey.Y: y} for _, x, y in drawn]
+        return [{MaidrKey.X: x, MaidrKey.Y: y} for _, x, y in self._points]
 
     def render(self) -> dict:
         """
@@ -186,11 +231,21 @@ class LollipopPlot(MaidrPlot):
         :class:`~maidr.core.plot.hexbinplot.HexbinPlot` gives: the ``<defs>``
         ahead of the marks would shift every count by one.
         """
-        gid = (
-            self._container.markerline.get_gid() if self._container is not None else None
-        )
+        gid = self._artist.get_gid() if self._artist is not None else None
         if gid is None:
             return []
+
+        # A `LineCollection` -- the stems a correlogram draws -- is written as
+        # one `<g>` of bare `<path>` children, one per segment, measured by
+        # parsing the SVG rather than by matching on it: 21 segments give 21
+        # direct `<path>` children and nothing else. A marker-only `Line2D`
+        # nests its marks inside a clip-path `<g>` and shares one shape from
+        # a `<defs>`, so it needs the descendant form and a `<use>`.
+        if isinstance(self._artist, LineCollection):
+            return [
+                f"g[id='{gid}'] > path:nth-of-type({index + 1})"
+                for index in self._drawn
+            ]
 
         return [
             f"g[id='{gid}'] use:nth-of-type({index + 1})" for index in self._drawn

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -14,6 +14,7 @@ from . import (  # noqa: E402, F401
     clear,
     colorbar,
     contour,
+    correlogram,
     errorbar,
     eventplot,
     fillbetween,

--- a/maidr/patch/correlogram.py
+++ b/maidr/patch/correlogram.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import wrapt
+from matplotlib.axes import Axes
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.lollipop import DRAWN_MARKS, MARK_ARTIST, finite
+from maidr.patch.common import _draw_quietly
+
+
+def _register(instance: Axes, drawn: tuple) -> None:
+    """
+    Register the correlogram a patched call drew, where it drew one.
+
+    ``Axes.acorr`` and ``Axes.xcorr`` return ``(lags, correlations, artist,
+    extra)`` whichever way they were drawn, so the numbers come from the
+    return value rather than back out of the artists. That matters for the
+    default spelling: with ``usevlines=True`` the values live in the
+    *lengths* of a ``LineCollection``'s segments, and nothing sits at the
+    correlation for a reader to find.
+
+    Parameters
+    ----------
+    instance : Axes
+        The axes drawn on.
+    drawn : tuple
+        Whatever the wrapped call returned.
+    """
+    lags, correlations, artist = drawn[0], drawn[1], drawn[2]
+
+    # Nothing drawable is not registered, rather than registered empty: a
+    # layer a reader can walk into and find no points is #421's shape.
+    if not finite((lags, correlations)):
+        return
+
+    ax = FigureManager.get_axes(artist)
+    if ax is None:
+        ax = instance
+
+    FigureManager.create_maidr(
+        ax,
+        PlotType.LOLLIPOP,
+        **{DRAWN_MARKS: (lags, correlations), MARK_ARTIST: artist},
+    )
+
+
+@wrapt.patch_function_wrapper(Axes, "acorr")
+def acorr(wrapped, instance, args, kwargs) -> tuple:
+    """
+    Draw a patched ``Axes.acorr`` and register the correlogram it produced.
+
+    A correlogram is one correlation per lag, marked at its value -- the
+    lollipop shape #574 gave ``Axes.stem``, reached through two different
+    sets of artists depending on one keyword, and read wrongly both ways
+    before this (#577).
+
+    With the default ``usevlines=True`` the chart is a ``LineCollection`` of
+    stems from zero plus a horizontal reference line, and **neither** was
+    read: the stems share an end, so the span reading refuses them by the
+    rule xability/maidr#1100 settled, and the reference line is declined for
+    the reason #176 gives. Both declines are right on their own, and together
+    they left twenty-one real measurements announced nowhere. The stems were
+    declined on the grounds that "the markers at their tips already carry
+    that" -- and in this spelling there are no markers.
+
+    With ``usevlines=False`` the values arrive as a marker-only ``Line2D``
+    and were announced as a line, asserting a continuity between lags that
+    the chart does not draw.
+
+    Both are now the same one layer. The internal context is what makes that
+    a replacement rather than an addition: `vlines`, `axhline` and `plot` are
+    all patched, and this call reaches the reader through whichever of them
+    it used.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Axes.acorr``.
+    instance : Any
+        The axes it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    tuple
+        Whatever ``acorr`` returned, unchanged.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        drawn = _draw_quietly(wrapped, args, kwargs)
+
+    _register(instance, drawn)
+    return drawn
+
+
+@wrapt.patch_function_wrapper(Axes, "xcorr")
+def xcorr(wrapped, instance, args, kwargs) -> tuple:
+    """
+    Draw a patched ``Axes.xcorr`` and register the correlogram it produced.
+
+    The same chart as :func:`acorr` against two series rather than one --
+    ``Axes.acorr`` is literally ``xcorr(x, x)`` -- so it is read the same
+    way. Patched separately rather than relying on one delegating to the
+    other, because `acorr` calls `xcorr` internally and the internal context
+    would then swallow the registration.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Axes.xcorr``.
+    instance : Any
+        The axes it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    tuple
+        Whatever ``xcorr`` returned, unchanged.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    with ContextManager.set_internal_context():
+        drawn = _draw_quietly(wrapped, args, kwargs)
+
+    _register(instance, drawn)
+    return drawn

--- a/tests/core/plot/test_correlogram.py
+++ b/tests/core/plot/test_correlogram.py
@@ -1,0 +1,181 @@
+"""`acorr` and `xcorr` are one chart drawn two ways, read the same way (#577)."""
+
+from __future__ import annotations
+
+import io
+import re
+import xml.etree.ElementTree as ElementTree
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import maidr
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.exception import UnsupportedPlotError
+
+SERIES = np.sin(np.arange(40, dtype=float))
+SVG_NS = "{http://www.w3.org/2000/svg}"
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _layers(fig) -> list:
+    try:
+        return [plot.type for plot in FigureManager.get_maidr(fig).plots]
+    except UnsupportedPlotError:
+        return []
+
+
+def _schema(fig) -> dict:
+    plots = FigureManager.get_maidr(fig).plots
+    assert len(plots) == 1
+    return plots[0].schema
+
+
+@pytest.mark.parametrize("draw", ["acorr", "xcorr"])
+@pytest.mark.parametrize("usevlines", [True, False])
+def test_a_correlogram_is_one_lollipop_layer(draw: str, usevlines: bool) -> None:
+    fig, ax = plt.subplots()
+    if draw == "acorr":
+        ax.acorr(SERIES, usevlines=usevlines)
+    else:
+        ax.xcorr(SERIES, SERIES[::-1], usevlines=usevlines)
+
+    assert _layers(fig) == [PlotType.LOLLIPOP]
+
+
+@pytest.mark.parametrize("usevlines", [True, False])
+def test_both_spellings_announce_the_same_numbers(usevlines: bool) -> None:
+    """The keyword changes which artists are drawn, not what the chart says."""
+    fig, ax = plt.subplots()
+    lags, correlations, _, _ = ax.acorr(SERIES, usevlines=usevlines)
+
+    data = _schema(fig)[MaidrKey.DATA]
+    assert [entry[MaidrKey.X] for entry in data] == [float(lag) for lag in lags]
+    assert [entry[MaidrKey.Y] for entry in data] == [
+        float(value) for value in correlations
+    ]
+
+
+def test_the_two_spellings_agree_with_each_other() -> None:
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES)
+    stems = _schema(fig)[MaidrKey.DATA]
+
+    other, axis = plt.subplots()
+    axis.acorr(SERIES, usevlines=False)
+    markers = _schema(other)[MaidrKey.DATA]
+
+    assert stems == markers
+
+
+def test_the_reference_line_is_not_announced() -> None:
+    """`usevlines=True` draws a horizontal line at zero; it is not data."""
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES)
+
+    assert PlotType.LINE not in _layers(fig)
+    values = [entry[MaidrKey.Y] for entry in _schema(fig)[MaidrKey.DATA]]
+    assert len(values) == 21
+
+
+def test_the_chart_is_announced_vertically() -> None:
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES)
+
+    assert _schema(fig)[MaidrKey.ORIENTATION] == "vert"
+
+
+def test_the_lag_at_zero_correlates_perfectly_with_itself() -> None:
+    """A sanity check on the numbers themselves, not just their shape."""
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES)
+
+    data = _schema(fig)[MaidrKey.DATA]
+    at_zero = next(entry for entry in data if entry[MaidrKey.X] == 0.0)
+    assert at_zero[MaidrKey.Y] == pytest.approx(1.0)
+
+
+def test_every_mark_has_a_selector_of_its_own() -> None:
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES)
+
+    schema = _schema(fig)
+    selectors = schema[MaidrKey.SELECTOR]
+    assert len(selectors) == len(schema[MaidrKey.DATA])
+    assert len(set(selectors)) == len(selectors)
+
+
+def test_the_stems_are_addressed_as_the_paths_they_are_drawn_as() -> None:
+    """Measured by parsing the SVG: one bare `<path>` child per segment."""
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES)
+
+    schema = _schema(fig)
+    gid = re.search(r"g\[id='([^']+)'\]", schema[MaidrKey.SELECTOR][0]).group(1)
+    assert "> path:nth-of-type(1)" in schema[MaidrKey.SELECTOR][0]
+
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="svg")
+    buffer.seek(0)
+    root = ElementTree.fromstring(buffer.read())
+
+    group = next(g for g in root.iter(f"{SVG_NS}g") if g.get("id") == gid)
+    children = [child for child in group if child.tag == f"{SVG_NS}path"]
+    assert len(children) == 21
+    assert {child.tag for child in group} == {f"{SVG_NS}path"}
+
+
+def test_the_markers_are_addressed_as_the_uses_they_are_drawn_as() -> None:
+    """The other spelling nests its marks and shares one shape from a defs."""
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES, usevlines=False)
+
+    schema = _schema(fig)
+    assert "use:nth-of-type(1)" in schema[MaidrKey.SELECTOR][0]
+    assert "> path" not in schema[MaidrKey.SELECTOR][0]
+
+
+def test_a_chart_beside_a_correlogram_is_untouched() -> None:
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    ax.acorr(SERIES)
+
+    assert sorted(layer.value for layer in _layers(fig)) == ["bar", "lollipop"]
+
+
+def test_a_line_drawn_after_a_correlogram_is_still_read() -> None:
+    """Drawing quietly must not silence the caller's own plot."""
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES)
+    ax.plot([1, 2, 3], [1, 2, 3])
+
+    assert sorted(layer.value for layer in _layers(fig)) == ["line", "lollipop"]
+
+
+def test_a_correlogram_with_nothing_drawable_registers_no_layer() -> None:
+    fig, ax = plt.subplots()
+    ax.acorr(np.full(40, np.nan))
+
+    with pytest.raises(UnsupportedPlotError):
+        FigureManager.get_maidr(fig)
+
+
+def test_the_chart_renders() -> None:
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES)
+
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_maxlags_decides_how_many_marks_there_are() -> None:
+    fig, ax = plt.subplots()
+    ax.acorr(SERIES, maxlags=4)
+
+    assert len(_schema(fig)[MaidrKey.DATA]) == 9

--- a/tests/core/plot/test_spanplot.py
+++ b/tests/core/plot/test_spanplot.py
@@ -192,11 +192,13 @@ def test_a_lane_drawn_twice_in_a_row_keeps_its_highlighting():
 
 
 @pytest.mark.parametrize("draw", ["acorr", "xcorr"])
-def test_a_correlogram_registers_nothing(draw):
-    # These draw through `vlines`, so they inherit whatever their segments
-    # say -- and every one of them runs from the baseline to the
-    # correlation, which is the lollipop shape. Pinned because the reading
-    # reaches them without either function being patched.
+def test_a_correlogram_is_not_claimed_by_the_span_reading(draw):
+    # These draw through `vlines`, so without a patch of their own they
+    # inherit whatever their segments say -- and every one of them runs from
+    # the baseline to the correlation, which is the lollipop shape rather
+    # than a schedule of intervals. They are read as `lollipop` by their own
+    # patch now (#577); pinned here so the span patch cannot start claiming
+    # them and announcing "0 to 0.6" where the chart means "0.6".
     import numpy as np
 
     # Long enough for the default `maxlags=10`, and deterministic.
@@ -207,7 +209,7 @@ def test_a_correlogram_registers_nothing(draw):
     else:
         ax.xcorr(first, first[::-1])
 
-    assert _layers(fig) == []
+    assert _layers(fig) == ["lollipop"]
     assert len(maidr.render(fig)._repr_html_()) > 0
 
 


### PR DESCRIPTION
Closes #577. Builds on #579.

`Axes.acorr` and `Axes.xcorr` draw one correlation per lag, marked at its value — the lollipop shape #574 gave `Axes.stem`, reached through two different sets of artists depending on one keyword. Both readings were wrong, in **opposite** directions.

| call | artists drawn | layers before | layers now |
| --- | --- | --- | --- |
| `acorr(x)` | `LineCollection` of 21 stems + a 2-point line at y=0 | **none** | `lollipop` |
| `acorr(x, usevlines=False)` | one `Line2D`, marker `o`, linestyle `None` | **`line`** | `lollipop` |

**The default spelling was silent.** Both artists were declined, and each decline is right on its own — the stems share an end, by the rule maidr#1100 settled and #568 applied here; the horizontal line is a reference line, which #176 says must not pollute a chart. Together they left twenty-one real measurements announced nowhere and the figure falling back to a picture. The stems were declined on the grounds that "the markers at their tips already carry that" — and in this spelling there are no markers.

**The other spelling was misread**, as a line asserting a continuity between lags the chart does not draw. That is #574's defect again.

The two now agree point for point, which is asserted directly.

## Two decisions worth flagging

**The numbers come from the return value, not the artists.** Both calls return `(lags, correlations, artist, extra)` however they drew — the shape `ax.stairs` (#536) and `ax.hist(histtype="step")` (#556) already use. Here it is the only option: with `usevlines=True` the values live in the *lengths* of the segments, and nothing sits at the correlation to read.

**The selector shape was measured by parsing the SVG, not by matching on it.** A `LineCollection` is written as one `<g>` of bare `<path>` children — 21 segments, 21 direct children, no `<defs>`, no nesting — so it takes `> path:nth-of-type(n)`. A marker-only `Line2D` nests its marks in a clip-path `<g>` and shares one shape from a `<defs>`, so it takes the descendant form and `use`. An earlier regex over the same markup counted **26** and would have shipped the wrong numbering; the test now parses the SVG and asserts both the count and that the group has no other children.

`xcorr` is patched separately rather than left to inherit from `acorr`: `acorr` calls `xcorr` internally, and the internal context that suppresses the `vlines`/`axhline`/`plot` patches would swallow the registration.

## Verification

`tests/core/plot/test_correlogram.py`, 18 tests — both calls × both spellings, agreement between the spellings, the reference line excluded, `maxlags`, a chart with nothing drawable, a bar and a line drawn alongside, and the lag-0 autocorrelation asserted to be 1.0 so the numbers themselves are checked rather than only their shape.

Every mutation applied alone against a restored baseline; all five killed:

| mutation | result |
| --- | --- |
| drawn without the internal context | 16 failed |
| stems addressed as `<use>` | 3 failed |
| `finite()` keeps non-finite pairs | 2 failed |
| registers a chart with nothing drawable | 3 failed |
| coordinates swapped | 14 failed |

Full suite: 2768 passed, 18 skipped. `ruff check` clean on every touched file.

`test_spanplot.py::test_a_correlogram_registers_nothing` pinned the old silence; its real intent was that the *span* patch must not claim these stems, which it still asserts under a name that says so.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_