### PR TITLE
fix(line): name each series from the legend entry that is its own

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -306,16 +306,43 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
         # leaves one entry against two lines, and both were announced
         # "revenue" -- the hidden one taking the name of the series after it.
         #
-        # Equal lengths keep the positional pairing, which is what the two
-        # cases that rely on it need: `ax.legend(["A", "B"])` renames every
-        # series positionally and means to, and a seaborn `hue` split names
-        # its groups in the legend while the lines themselves carry `_child`
-        # sentinels (#502). Only when the legend is *shorter* is it matched
-        # against the lines matplotlib would have put in it.
+        # Equal lengths do not settle it either, because the legend may be in
+        # a different order from the axes: `ax.legend(handles=[q, p])` is how
+        # a caller reorders one without redrawing, and pairing by position
+        # then announced each series under the other's name (#578). The
+        # handles cannot be used to recover the pairing -- measured, they are
+        # proxy artists and `handle is line` is False for every drawn line --
+        # but the *text* still identifies the series, so a legend that is a
+        # permutation of the lines' own names is matched by name.
+        #
+        # The test is only that the two sets agree, which is narrower than it
+        # looks and was arrived at by deleting the parts that turned out not
+        # to be. Requiring every line to be *named* adds nothing: an unnamed
+        # line contributes "" to the set, and matplotlib renders no legend
+        # entry for one, so the sets cannot agree anyway. Requiring the names
+        # to be *unique* adds nothing either: two lines called the same thing
+        # are announced by that name whichever of them an entry is paired
+        # with. Both guards survived every mutation, so neither is here.
+        #
+        # Anything short of agreement falls back to position, which is what
+        # the two cases that rely on it need: `ax.legend(["A", "B"])` renames
+        # every series positionally and means to -- its texts are *not* the
+        # lines' names, which is exactly what tells the two apart -- and a
+        # seaborn `hue` split names its groups in the legend while the lines
+        # themselves carry `_child` sentinels (#502).
+        #
+        # Only when the legend is *shorter* is it matched against the lines
+        # matplotlib would have put in it.
         named = [index for index, line in enumerate(all_lines) if series_name(line)]
+        own = [series_name(line) for line in all_lines]
         from_legend: dict = {}
         if len(legend_labels) == len(all_lines):
-            from_legend = dict(enumerate(legend_labels))
+            renaming = set(legend_labels) == set(own)
+            # Nothing to record when the legend only restates the names the
+            # lines already carry: each line then answers for itself below,
+            # in its own order, which is the whole point.
+            if not renaming:
+                from_legend = dict(enumerate(legend_labels))
         elif len(legend_labels) == len(named):
             from_legend = dict(zip(named, legend_labels))
 

--- a/tests/core/plot/test_series_naming.py
+++ b/tests/core/plot/test_series_naming.py
@@ -178,3 +178,43 @@ def test_a_legend_shorter_than_the_series_still_renames_the_one_it_names() -> No
     assert _names(ax) == [None, "Renamed"]
 
     plt.close(fig)
+
+
+def test_a_legend_given_an_explicit_order_still_names_each_line_itself() -> None:
+    """`ax.legend(handles=[...])` reorders a legend without redrawing, and
+    pairing by position then announced each series under the other's name
+    (#578). The legend's handles are proxy artists, so the pairing is
+    recovered from the text instead."""
+    fig, ax = plt.subplots()
+    (first,) = ax.plot([1, 2, 3], [1, 2, 3], label="p")
+    (second,) = ax.plot([1, 2, 3], [3, 2, 1], label="q")
+    ax.legend(handles=[second, first])
+
+    assert [text.get_text() for text in ax.legend_.get_texts()] == ["q", "p"]
+    assert _names(ax) == ["p", "q"]
+
+    plt.close(fig)
+
+
+def test_an_ordinary_legend_is_unaffected_by_that() -> None:
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3], label="p")
+    ax.plot([1, 2, 3], [3, 2, 1], label="q")
+    ax.legend()
+
+    assert _names(ax) == ["p", "q"]
+
+    plt.close(fig)
+
+
+def test_two_series_sharing_a_name_keep_the_positional_pairing() -> None:
+    """Matching by name needs the names to identify a line; two lines called
+    the same thing cannot be told apart that way, so position stands."""
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3], label="same")
+    ax.plot([1, 2, 3], [3, 2, 1], label="same")
+    ax.legend()
+
+    assert _names(ax) == ["same", "same"]
+
+    plt.close(fig)


### PR DESCRIPTION
Closes #578, which I filed off the measurement done while fixing #575 in #576.

`ax.legend(handles=[...])` reorders a legend without redrawing anything — largest series first, say. Legend texts were paired with lines by position, so a legend in a different order from the axes handed every line the wrong name:

```python
p, = ax.plot(x, y, label="p")
q, = ax.plot(x, z, label="q")
ax.legend(handles=[q, p])
# announced ["q", "p"] for lines drawn p, q
```

Each series under the other's name. Nothing errors and the values are right; only the names are exchanged, which is the reading most likely to be believed.

## Why the obvious repair doesn't work

`Legend.legend_handles` exists (`legendHandles` was removed in 3.9), but its entries are **proxy artists** — measured, `handle is line` is `False` for every drawn line — so the pairing cannot be recovered from the legend object. The *text* still identifies the series, so a legend whose texts are the lines' own names, in any order, is matched by name instead, and each line then answers for itself.

## The condition is narrower than my first version

It is just `set(legend_labels) == set(own)`. I arrived there by deleting what mutation testing showed was not load-bearing — two guards I had written and could not justify:

- **every line must be named** — an unnamed line contributes `""` to the set, and matplotlib renders no legend entry for one, so the sets cannot agree anyway;
- **the names must be unique** — two lines called the same thing are announced by that name whichever entry each is paired with.

Both survived every mutation. Rather than ship unexercised conditions I removed them and re-falsified; the comment records why they are absent, so the next reader does not add them back.

Anything short of agreement keeps the positional pairing, which the two cases relying on it need: `ax.legend(["A", "B"])` renames positionally and means to — its texts are *not* the lines' names, which is exactly what tells the two apart — and a seaborn `hue` split names its groups in the legend while the lines carry `_child` sentinels (#502).

## Verification

`test_series_naming.py` is now 18 tests. Mutations on the simplified condition, each applied alone against a restored baseline — all three killed:

| mutation | result |
| --- | --- |
| always positional when lengths agree | 1 failed |
| legend never consulted when lengths agree | 2 failed |
| order-sensitive comparison (defeats the reorder fix) | 1 failed |

Four behaviours re-measured end to end after the change: reordered legend → `["p", "q"]`; `ax.legend(["A","B"])` → `["A", "B"]`; seaborn hue → `["a", "b"]`; shorter legend with a rename → `[None, "Renamed"]`.

Full suite: 2771 passed, 18 skipped. `ruff check` clean on every touched file.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_