### PR TITLE
fix(ecdf): name each curve of a hue-grouped ECDF from its own colour

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -4,7 +4,9 @@ from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
 
 from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.plot.scatterplot import _rgba
 from maidr.util.artist_label import series_name
+from maidr.util.legend_names import names_for
 from maidr.util.confidence_band import band_edges_at
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.plot.maidr_plot import MaidrPlot
@@ -290,6 +292,7 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
             return None
 
         # Try to get series names from legend
+        ax_legend_source = self.ax
         legend_labels = []
         if self.ax.legend_ is not None:
             legend_labels = [text.get_text() for text in self.ax.legend_.get_texts()]
@@ -337,11 +340,32 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
         own = [series_name(line) for line in all_lines]
         from_legend: dict = {}
         if len(legend_labels) == len(all_lines):
-            renaming = set(legend_labels) == set(own)
+            # Before either of those: the *colour* each line was drawn in is
+            # what the legend swatch beside a name actually refers to, and it
+            # survives an order the position does not. seaborn draws an ECDF's
+            # hue levels in the reverse of its legend order, so pairing by
+            # position gave every curve the other group's name (#582) -- the
+            # defect `patch/kdeplot` avoids for a density by this same match,
+            # and `scatterplot.hue_groups` point by point.
+            #
+            # `names_for` declines rather than guesses: no legend, a line no
+            # swatch claims, a swatch naming two lines, or fewer than two
+            # lines to tell apart. Position is the fallback for all of those,
+            # so nothing that was named before stops being named.
+            by_colour = names_for(ax_legend_source, [_rgba(line.get_color()) for line in all_lines])
+            if any(name is not None for name in by_colour):
+                # A line no swatch claimed is recorded as `None` rather than
+                # filtered out, because the lookup below falls through to the
+                # line's own name on a `None` either way. Filtering it was
+                # tried and removed: no test could tell the two apart.
+                from_legend = dict(enumerate(by_colour))
+                renaming = False
+            else:
+                renaming = set(legend_labels) == set(own)
             # Nothing to record when the legend only restates the names the
             # lines already carry: each line then answers for itself below,
             # in its own order, which is the whole point.
-            if not renaming:
+            if not renaming and not from_legend:
                 from_legend = dict(enumerate(legend_labels))
         elif len(legend_labels) == len(named):
             from_legend = dict(zip(named, legend_labels))

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -12,9 +12,13 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.contour import tag
 from maidr.core.plot.maidr_plot import GROUP_NAME
-from maidr.core.plot.scatterplot import _handle_colour, _rgba
+# `_handle_colour` and `legend_of` are re-exported rather than used here:
+# both moved out when the colour matching became shared, and both are
+# imported from this module by name elsewhere.
+from maidr.core.plot.scatterplot import _handle_colour, _rgba  # noqa: F401
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
 from maidr.core.context_manager import ContextManager
+from maidr.util.legend_names import legend_of, names_for as _names_for  # noqa: F401
 from maidr.util.svg_utils import unique_lines_by_xy
 
 
@@ -168,55 +172,6 @@ def _collection_colour(collection) -> tuple | None:
     return colours.pop()
 
 
-def legend_of(ax: Axes | None):
-    """
-    The legend that names this axes' groups, wherever it was put.
-
-    ``ax.get_legend()`` is where seaborn leaves one for a single chart, and it
-    is what every caller here read. A ``PairGrid`` moves it: `add_legend()`
-    builds one **figure-level** legend for the whole grid, and the panels then
-    have none of their own.
-
-    Only when the figure carries exactly one. Two figure legends cannot say
-    which of them names this axes' colours, and a wrong name is worse than
-    none -- the rule every decline in this module already follows.
-
-    **The axes' own legend always wins**, and that is the mitigation rather
-    than a preference. One figure legend is read as naming *every* axes, and
-    nothing in the artists can say otherwise: several panels with independent
-    hues draw the same default colour cycle, so a legend built for one of
-    them matches all of them. Measured, two `kdeplot(hue=...)` panels drawn
-    `legend=False` with one `fig.legend()` for the first come out with the
-    first panel's names on both.
-
-    That case needs a figure built by hand with every panel's own legend
-    suppressed, which is not what any seaborn call does on its own -- a
-    panel that keeps its legend is named by it and never consults the
-    figure's. The trade is a wrong name in that shape against no name at all
-    on every `pairplot`, whose whole grid does share one hue mapping. It is
-    written down here rather than left to be discovered, and pinned in
-    `tests/core/plot/test_pairplot_group_names.py`.
-
-    Parameters
-    ----------
-    ax : Axes or None
-        The axes drawn on.
-
-    Returns
-    -------
-    Legend or None
-        The legend to read swatches from, or ``None``.
-    """
-    if ax is None:
-        return None
-    own = ax.get_legend()
-    if own is not None:
-        return own
-    figure = getattr(ax, "figure", None)
-    legends = list(getattr(figure, "legends", ()) or ())
-    return legends[0] if len(legends) == 1 else None
-
-
 def deferred_names(resolve, count: int) -> list:
     """
     One lazy name per artist, resolved together the first time any is asked.
@@ -257,105 +212,6 @@ def deferred_names(resolve, count: int) -> list:
         return name
 
     return [at(index) for index in range(count)]
-
-
-def _names_for(ax: Axes, colours: list) -> list:
-    """
-    Match a list of drawn colours against the legend that names them.
-
-    Two passes, and the second is not a convenience. Measured on seaborn
-    0.13.2, ``histplot(kde=True, hue=...)`` draws its overlay curves **opaque**
-    while the legend swatches carry the bars' translucency::
-
-        line   (1.0, 0.498, 0.055, 1.0)
-        swatch (1.0, 0.498, 0.055, 0.5)
-
-    Identical hue, different alpha, so an RGBA comparison names nothing at all
-    -- the chart would announce two named histograms and two anonymous curves
-    over one axis. What identifies a group is the hue, so a second pass
-    compares the three colour channels alone.
-
-    That pass is guarded: it runs only where the drawn colours are already
-    distinct without their alpha. Two artists separated *by* their opacity
-    would otherwise both take whichever name matched, and a confident wrong
-    name is worse than none.
-
-    Every other reason to decline stands: no legend, an artist no swatch
-    claims, a swatch that names two things, and a lone artist -- which needs
-    nothing to be told apart from.
-
-    Parameters
-    ----------
-    ax : Axes
-        The axes drawn on, for its legend.
-    colours : list
-        One rounded RGBA per artist, or ``None`` where it has no single one.
-
-    Returns
-    -------
-    list
-        One name per entry, or ``None``.
-    """
-    if len(colours) < 2:
-        return [None] * len(colours)
-
-    legend = legend_of(ax)
-    if legend is None:
-        return [None] * len(colours)
-
-    swatches = [
-        (_handle_colour(handle), text.get_text())
-        for handle, text in zip(legend.legend_handles, legend.get_texts())
-    ]
-
-    keys = [lambda colour: colour]
-    hues = [colour[:3] for colour in colours if colour is not None]
-    if len(set(hues)) == len(hues):
-        keys.append(lambda colour: colour[:3])
-
-    for key in keys:
-        named = _match_swatches(colours, swatches, key)
-        if named:
-            return [
-                None if colour is None else named.get(key(colour))
-                for colour in colours
-            ]
-    return [None] * len(colours)
-
-
-def _match_swatches(colours: list, swatches: list, key) -> dict | None:
-    """
-    Map each swatch that a drawn artist shares a colour with to its name.
-
-    Parameters
-    ----------
-    colours : list
-        The drawn colours.
-    swatches : list
-        ``(colour, name)`` per legend entry, colour ``None`` where the handle
-        names no single one.
-    key : callable
-        What counts as "the same colour" for this pass.
-
-    Returns
-    -------
-    dict or None
-        Key to name, or ``None`` when one colour is claimed by two names --
-        a ``style=`` legend does that, and a swatch meaning two things cannot
-        name the group an artist belongs to.
-    """
-    drawn = {key(colour) for colour in colours if colour is not None}
-    named: dict = {}
-    for colour, name in swatches:
-        if colour is None:
-            continue
-        matched = key(colour)
-        if matched not in drawn:
-            continue
-        if named.get(matched, name) != name:
-            return None
-        named[matched] = name
-    return named
 
 
 def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:

--- a/maidr/util/legend_names.py
+++ b/maidr/util/legend_names.py
@@ -1,0 +1,155 @@
+"""Name a chart's groups from the legend that names their colours."""
+
+from __future__ import annotations
+
+from matplotlib.axes import Axes
+
+from maidr.core.plot.scatterplot import _handle_colour
+
+
+def legend_of(ax: Axes | None):
+    """
+    The legend that names this axes' groups, wherever it was put.
+
+    ``ax.get_legend()`` is where seaborn leaves one for a single chart, and it
+    is what every caller here read. A ``PairGrid`` moves it: `add_legend()`
+    builds one **figure-level** legend for the whole grid, and the panels then
+    have none of their own.
+
+    Only when the figure carries exactly one. Two figure legends cannot say
+    which of them names this axes' colours, and a wrong name is worse than
+    none -- the rule every decline in this module already follows.
+
+    **The axes' own legend always wins**, and that is the mitigation rather
+    than a preference. One figure legend is read as naming *every* axes, and
+    nothing in the artists can say otherwise: several panels with independent
+    hues draw the same default colour cycle, so a legend built for one of
+    them matches all of them. Measured, two `kdeplot(hue=...)` panels drawn
+    `legend=False` with one `fig.legend()` for the first come out with the
+    first panel's names on both.
+
+    That case needs a figure built by hand with every panel's own legend
+    suppressed, which is not what any seaborn call does on its own -- a
+    panel that keeps its legend is named by it and never consults the
+    figure's. The trade is a wrong name in that shape against no name at all
+    on every `pairplot`, whose whole grid does share one hue mapping. It is
+    written down here rather than left to be discovered, and pinned in
+    `tests/core/plot/test_pairplot_group_names.py`.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes drawn on.
+
+    Returns
+    -------
+    Legend or None
+        The legend to read swatches from, or ``None``.
+    """
+    if ax is None:
+        return None
+    own = ax.get_legend()
+    if own is not None:
+        return own
+    figure = getattr(ax, "figure", None)
+    legends = list(getattr(figure, "legends", ()) or ())
+    return legends[0] if len(legends) == 1 else None
+
+
+def names_for(ax: Axes, colours: list) -> list:
+    """
+    Match a list of drawn colours against the legend that names them.
+
+    Two passes, and the second is not a convenience. Measured on seaborn
+    0.13.2, ``histplot(kde=True, hue=...)`` draws its overlay curves **opaque**
+    while the legend swatches carry the bars' translucency::
+
+        line   (1.0, 0.498, 0.055, 1.0)
+        swatch (1.0, 0.498, 0.055, 0.5)
+
+    Identical hue, different alpha, so an RGBA comparison names nothing at all
+    -- the chart would announce two named histograms and two anonymous curves
+    over one axis. What identifies a group is the hue, so a second pass
+    compares the three colour channels alone.
+
+    That pass is guarded: it runs only where the drawn colours are already
+    distinct without their alpha. Two artists separated *by* their opacity
+    would otherwise both take whichever name matched, and a confident wrong
+    name is worse than none.
+
+    Every other reason to decline stands: no legend, an artist no swatch
+    claims, a swatch that names two things, and a lone artist -- which needs
+    nothing to be told apart from.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    colours : list
+        One rounded RGBA per artist, or ``None`` where it has no single one.
+
+    Returns
+    -------
+    list
+        One name per entry, or ``None``.
+    """
+    if len(colours) < 2:
+        return [None] * len(colours)
+
+    legend = legend_of(ax)
+    if legend is None:
+        return [None] * len(colours)
+
+    swatches = [
+        (_handle_colour(handle), text.get_text())
+        for handle, text in zip(legend.legend_handles, legend.get_texts())
+    ]
+
+    keys = [lambda colour: colour]
+    hues = [colour[:3] for colour in colours if colour is not None]
+    if len(set(hues)) == len(hues):
+        keys.append(lambda colour: colour[:3])
+
+    for key in keys:
+        named = _match_swatches(colours, swatches, key)
+        if named:
+            return [
+                None if colour is None else named.get(key(colour))
+                for colour in colours
+            ]
+    return [None] * len(colours)
+
+
+def _match_swatches(colours: list, swatches: list, key) -> dict | None:
+    """
+    Map each swatch that a drawn artist shares a colour with to its name.
+
+    Parameters
+    ----------
+    colours : list
+        The drawn colours.
+    swatches : list
+        ``(colour, name)`` per legend entry, colour ``None`` where the handle
+        names no single one.
+    key : callable
+        What counts as "the same colour" for this pass.
+
+    Returns
+    -------
+    dict or None
+        Key to name, or ``None`` when one colour is claimed by two names --
+        a ``style=`` legend does that, and a swatch meaning two things cannot
+        name the group an artist belongs to.
+    """
+    drawn = {key(colour) for colour in colours if colour is not None}
+    named: dict = {}
+    for colour, name in swatches:
+        if colour is None:
+            continue
+        matched = key(colour)
+        if matched not in drawn:
+            continue
+        if named.get(matched, name) != name:
+            return None
+        named[matched] = name
+    return named

--- a/tests/core/plot/test_ecdf_hue_naming.py
+++ b/tests/core/plot/test_ecdf_hue_naming.py
@@ -1,0 +1,98 @@
+"""A hue-grouped ECDF names each curve from its own colour (#582).
+
+seaborn draws an ECDF's hue levels in the reverse of its legend order, so
+pairing the two by position gives every curve the other group's name. The
+groups here are chosen so that cannot be argued with: `low` is 1-5 and
+`high` is 100-500, with no overlap, so which curve holds which data is a
+fact about the numbers rather than about the order they were drawn in.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import seaborn as sns
+
+from maidr.core.enum import MaidrKey
+from maidr.core.figure_manager import FigureManager
+
+LOW = [1, 2, 3, 4, 5]
+HIGH = [100, 200, 300, 400, 500]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    return pd.DataFrame({"x": LOW + HIGH, "grp": ["low"] * 5 + ["high"] * 5})
+
+
+def _named_series(fig) -> list:
+    """Each series as (announced name, whether it holds the `low` data)."""
+    out = []
+    for plot in FigureManager.get_maidr(fig).plots:
+        for series in plot.schema[MaidrKey.DATA]:
+            xs = [
+                point[MaidrKey.X]
+                for point in series
+                if isinstance(point.get(MaidrKey.X), (int, float))
+            ]
+            out.append((series[0].get(MaidrKey.Z), max(xs) <= 50))
+    return out
+
+
+def test_each_ecdf_curve_is_named_for_the_data_it_holds() -> None:
+    fig, ax = plt.subplots()
+    sns.ecdfplot(_frame(), x="x", hue="grp", ax=ax)
+
+    assert sorted(_named_series(fig)) == sorted([("low", True), ("high", False)])
+
+
+def test_the_legend_really_does_run_the_other_way() -> None:
+    """What makes the test above a test. If seaborn ever draws an ECDF in
+    legend order this stops holding, and pairing by position would no longer
+    be wrong -- so the reason for the fix would be worth re-reading."""
+    fig, ax = plt.subplots()
+    sns.ecdfplot(_frame(), x="x", hue="grp", ax=ax)
+
+    assert [text.get_text() for text in ax.legend_.get_texts()] == ["low", "high"]
+    first = ax.lines[0].get_xydata()[:, 0]
+    drawn_first_is_low = max(value for value in first if value < float("inf")) <= 50
+    assert not drawn_first_is_low
+
+
+def test_a_three_group_ecdf_names_every_curve_for_its_own_data() -> None:
+    frame = pd.DataFrame(
+        {
+            "x": LOW + HIGH + [1000, 2000, 3000, 4000, 5000],
+            "grp": ["low"] * 5 + ["high"] * 5 + ["huge"] * 5,
+        }
+    )
+    fig, ax = plt.subplots()
+    sns.ecdfplot(frame, x="x", hue="grp", ax=ax)
+
+    by_name = {}
+    for plot in FigureManager.get_maidr(fig).plots:
+        for series in plot.schema[MaidrKey.DATA]:
+            xs = [
+                point[MaidrKey.X]
+                for point in series
+                if isinstance(point.get(MaidrKey.X), (int, float))
+            ]
+            by_name[series[0].get(MaidrKey.Z)] = max(xs)
+
+    assert by_name["low"] == 5
+    assert by_name["high"] == 500
+    assert by_name["huge"] == 5000
+
+
+def test_an_ungrouped_ecdf_is_left_unnamed() -> None:
+    """One curve needs nothing to be told apart from."""
+    fig, ax = plt.subplots()
+    sns.ecdfplot(pd.DataFrame({"x": LOW}), x="x", ax=ax)
+
+    assert [name for name, _ in _named_series(fig)] == [None]


### PR DESCRIPTION
Closes #582.

`sns.ecdfplot(hue=...)` draws one curve per group, and py-maidr named them from the legend by position. seaborn draws an ECDF's hue levels in the **reverse** of its legend order, so with two groups every point of both curves was announced under the wrong name.

Measured with groups that cannot be confused — `low` is 1–5, `high` is 100–500, no overlap:

```
legend texts : ['low', 'high']
line 0       : x in [100, 500]      <- the "high" data
line 1       : x in [1, 5]          <- the "low" data

announced z='low'   x in [100, 500]    wrong
announced z='high'  x in [1, 5]        wrong
```

Nothing errors and no value is altered. Only the names are exchanged — the reading a user is least able to catch, since the numbers look right and the curve they belong to is the one thing the chart was drawn to compare.

## The fix

The match `patch/kdeplot` already makes for a density, and `scatterplot.hue_groups` makes point by point: a legend swatch names the **colour** it is drawn in, and colour survives an order that position does not. That colour matching moves out of `patch/kdeplot` into `util/legend_names` so the line family can use it too. `patch/histogram` and three existing test modules import `_names_for`/`legend_of`/`_handle_colour` from `patch/kdeplot` by name, so those stay importable there rather than being moved out from under them.

Position remains the fallback, so nothing that was named before stops being named. `names_for` declines rather than guesses — no legend, a line no swatch claims, a swatch naming two lines, fewer than two lines to tell apart — and every decline falls through to the pairing that was already there.

## Why this call and not its neighbours

The contrast is what localises the bug, and I measured it rather than assuming:

| call | before | after |
| --- | --- | --- |
| `ecdfplot(hue=)` | names swapped | correct |
| `kdeplot(hue=)` | correct (named by colour since #560) | unchanged |
| `lineplot(hue=)` | correct | unchanged |

`kdeplot`'s own docstring already said seaborn's legend "runs the reverse of the draw order" — the ECDF is simply the case that never got the same treatment. This is #502's defect surviving in a call #502 did not cover.

## Verification

`tests/core/plot/test_ecdf_hue_naming.py`, 4 tests — two groups, three groups, an ungrouped ECDF left unnamed, and one test that asserts **seaborn really does draw in the other order**, so that if that ever changes the reason for this fix is re-read rather than silently preserved.

Mutations, each applied alone against a restored baseline:

| mutation | result |
| --- | --- |
| colour matching disabled (back to position) | 2 failed |
| positional overwrites the colour match | 3 failed |
| unmatched lines recorded as `None` rather than filtered | **survived** |

The third survived because the lookup falls through to the line's own name on a `None` either way — so I removed the filtering rather than keep an unexercised branch, and said so in the comment. Same call as in #581.

Everything from #575, #578 and #502 re-measured end to end and unchanged: `ax.legend(["A","B"])` → `["A","B"]`; `ax.legend(handles=[q,p])` → `["p","q"]`; seaborn hue lineplot → `["a","b"]`; shorter legend with a rename → `[None,"Renamed"]`.

Full suite: 2775 passed, 18 skipped. `ruff check` clean.

Also filed while sweeping, not addressed here: #583 — `histplot(element="step"/"poly", fill=False)` registers no layer at all.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_