### PR TITLE
feat(hist): read the seaborn histogram outlines drawn without fill

### DIFF
--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -19,6 +19,7 @@ from maidr.core.plot.hexbinplot import HexbinPlot
 from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
 from maidr.core.plot.lollipop import LollipopPlot
+from maidr.core.plot.outlined_histogram import OUTLINE_LINE, OutlinedHistPlot
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.core.plot.pieplot import PiePlot
 from maidr.core.plot.pointplot import PointPlot
@@ -117,6 +118,11 @@ class MaidrPlotFactory:
             # find and the call hands its `PolyCollection` over instead.
             if isinstance(kwargs.get("collection"), PolyCollection):
                 return SteppedHistPlot(single_ax, **kwargs)
+            # The same two elements drawn `fill=False`, which swaps the
+            # collection for a bare `Line2D` and left the chart silent (#583).
+            outline = kwargs.get(OUTLINE_LINE)
+            if outline is not None:
+                return OutlinedHistPlot(single_ax, outline, **kwargs)
             # `ax.hist(histtype="step"/"stepfilled")` draws a `Polygon` per
             # dataset and leaves no container either, so the call hands over
             # the counts and edges it already returned (#555).

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -19,8 +19,8 @@ from maidr.core.plot.hexbinplot import HexbinPlot
 from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
 from maidr.core.plot.lollipop import LollipopPlot
-from maidr.core.plot.outlined_histogram import OUTLINE_LINE, OutlinedHistPlot
 from maidr.core.plot.maidr_plot import MaidrPlot
+from maidr.core.plot.outlined_histogram import OUTLINE_LINE, OutlinedHistPlot
 from maidr.core.plot.pieplot import PiePlot
 from maidr.core.plot.pointplot import PointPlot
 from maidr.core.plot.scatterplot import ScatterPlot

--- a/maidr/core/plot/outlined_histogram.py
+++ b/maidr/core/plot/outlined_histogram.py
@@ -75,7 +75,14 @@ class OutlinedHistPlot(HistPlot):
 
     def __init__(self, ax: Axes, line: Line2D, **kwargs) -> None:
         self._line = line
-        super().__init__(ax)
+        # Forwarded, not dropped: the patch names each outline from the
+        # legend swatch its colour matches and hands the name over under
+        # `GROUP_NAME`, which `HistPlot.__init__` is the thing that reads.
+        # Calling it with the axes alone computed every name and threw them
+        # away, leaving a `hue=` chart with two "hist" layers and no way to
+        # tell which group either announced -- the same silence this class
+        # exists to end, one level down.
+        super().__init__(ax, **kwargs)
         # One `<path>` for the whole outline, as `SteppedHistPlot` and
         # `Axes.stairs` have: there is no per-bin element for a selector to
         # name, and one naming the line would light the whole distribution up

--- a/maidr/core/plot/outlined_histogram.py
+++ b/maidr/core/plot/outlined_histogram.py
@@ -14,6 +14,23 @@ from maidr.core.plot.histogram import HistPlot
 #: layer -- the defect #527 fixed for containers.
 OUTLINE_LINE = "_maidr_outline_line"
 
+#: The keyword the histogram patch says which axis the distribution runs
+#: along under, as ``True`` for a ``histplot(y=...)`` and ``False`` for the
+#: ordinary one.
+#:
+#: Handed over because the drawing cannot always answer it and the caller
+#: always can. A stepped outline gives itself away -- its counts column
+#: closes on a repeated value, so it is never strictly ascending -- but a
+#: ``poly`` outline carries one bin centre and one count per vertex with
+#: nothing repeated, and a histogram whose counts happen to climb evenly has
+#: two ascending, evenly spaced columns and no way to tell them apart. Two
+#: bins is the everyday case: a single gap is evenly spaced whatever it
+#: holds, so *every* two-bin poly is ambiguous.
+#:
+#: Read below only to break that tie. Where the drawing answers on its own it
+#: still decides, which keeps a chart readable if this is ever absent.
+OUTLINE_HORIZONTAL = "_maidr_outline_horizontal"
+
 #: How far two bin widths may differ and still count as the same width.
 #: Relative, for the reason :mod:`maidr.core.plot.stepped_histogram` gives:
 #: the widths are data coordinates, and a histogram of nanoseconds and one of
@@ -75,6 +92,10 @@ class OutlinedHistPlot(HistPlot):
 
     def __init__(self, ax: Axes, line: Line2D, **kwargs) -> None:
         self._line = line
+        # Which axis the caller asked the distribution to run along, for the
+        # outlines whose drawing cannot say; see `OUTLINE_HORIZONTAL`.
+        told = kwargs.get(OUTLINE_HORIZONTAL, None)
+        self._told_horizontal = told if isinstance(told, bool) else None
         # Forwarded, not dropped: the patch names each outline from the
         # legend swatch its colour matches and hands the name over under
         # `GROUP_NAME`, which `HistPlot.__init__` is the thing that reads.
@@ -99,7 +120,7 @@ class OutlinedHistPlot(HistPlot):
             One point per bin, in ascending bin order, or empty when the
             outline is not one this can read.
         """
-        read = _read_line(self._line)
+        read = _read_line(self._line, self._told_horizontal)
         if read is None:
             return []
 
@@ -111,7 +132,7 @@ class OutlinedHistPlot(HistPlot):
         ]
 
 
-def reads(line: Line2D) -> bool:
+def reads(line: Line2D, horizontal: bool | None = None) -> bool:
     """
     Whether this outline is one that can be read as a histogram.
 
@@ -123,16 +144,21 @@ def reads(line: Line2D) -> bool:
     ----------
     line : Line2D
         The outline seaborn drew.
+    horizontal : bool, optional
+        Which axis the caller asked the distribution to run along, for the
+        outlines whose drawing cannot say. See :data:`OUTLINE_HORIZONTAL`.
 
     Returns
     -------
     bool
         True when the bins and counts can be recovered.
     """
-    return _read_line(line) is not None
+    return _read_line(line, horizontal) is not None
 
 
-def _read_line(line: Line2D) -> tuple[bool, list[tuple[float, float, float]]] | None:
+def _read_line(
+    line: Line2D, horizontal: bool | None = None
+) -> tuple[bool, list[tuple[float, float, float]]] | None:
     """
     Recover the orientation and ``(low, high, count)`` of every bin.
 
@@ -140,6 +166,10 @@ def _read_line(line: Line2D) -> tuple[bool, list[tuple[float, float, float]]] | 
     ----------
     line : Line2D
         The outline seaborn drew.
+    horizontal : bool, optional
+        Which axis the caller asked the distribution to run along, used only
+        where both columns read as bins. ``None`` declines that case rather
+        than picking one.
 
     Returns
     -------
@@ -153,20 +183,38 @@ def _read_line(line: Line2D) -> tuple[bool, list[tuple[float, float, float]]] | 
 
     stepped = str(line.get_drawstyle()).startswith("steps")
 
-    # Which column the bins run along, read off the drawing rather than the
-    # caller's keywords: `histplot(y=...)`, `histplot(data=df, y="v")` and a
-    # `displot` panel are three spellings of one chart and only the drawing is
-    # the same in all three. The bins are the column that ascends.
-    for horizontal, positions, values in (
-        (False, xydata[:, 0], xydata[:, 1]),
-        (True, xydata[:, 1], xydata[:, 0]),
-    ):
-        if not np.all(np.diff(positions) > 0):
-            continue
-        bins = _bins_from(positions, values, stepped)
-        if bins is not None:
-            return horizontal, bins
+    # Which column the bins run along, read off the drawing where the drawing
+    # can say. The bins ascend, so a column that does not is not them.
+    readings = [
+        (runs_up, bins)
+        for runs_up, positions, values in (
+            (False, xydata[:, 0], xydata[:, 1]),
+            (True, xydata[:, 1], xydata[:, 0]),
+        )
+        if np.all(np.diff(positions) > 0)
+        for bins in [_bins_from(positions, values, stepped)]
+        if bins is not None
+    ]
 
+    if len(readings) == 1:
+        return readings[0]
+    if not readings:
+        return None
+
+    # Both columns read as bins, so the drawing does not distinguish them and
+    # the caller has to. Taking the first was the defect: measured,
+    # `histplot(df, y="v", bins=2, element="poly", fill=False)` over counts 2
+    # and 5 came out `vert` with bin edges 0.5 to 3.5 -- the *counts* read as
+    # the axis -- and the bin centre 0.3125 announced as the count. Silently
+    # transposed, which is worse than the silence this class was written to
+    # end.
+    #
+    # `None` matches neither, so a caller that cannot say declines here. That
+    # is the same rule `_bins_from` follows for an uneven poly: a chart read
+    # wrongly is worse than one not read.
+    for runs_up, bins in readings:
+        if runs_up == horizontal:
+            return runs_up, bins
     return None
 
 

--- a/maidr/core/plot/outlined_histogram.py
+++ b/maidr/core/plot/outlined_histogram.py
@@ -1,0 +1,205 @@
+"""OutlinedHistPlot — the histogram seaborn draws as a bare line, unfilled."""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
+
+from maidr.core.plot.histogram import HistPlot
+
+#: The keyword the histogram patch hands one unfilled outline over under.
+#: Handed over rather than searched for, because a ``hue`` draws one line per
+#: group and "the line on this Axes" would read the first group once per
+#: layer -- the defect #527 fixed for containers.
+OUTLINE_LINE = "_maidr_outline_line"
+
+#: How far two bin widths may differ and still count as the same width.
+#: Relative, for the reason :mod:`maidr.core.plot.stepped_histogram` gives:
+#: the widths are data coordinates, and a histogram of nanoseconds and one of
+#: light-years both have to pass.
+_WIDTH_TOLERANCE = 1e-9
+
+
+class OutlinedHistPlot(HistPlot):
+    """
+    A histogram drawn as a bare outline, with ``fill=False``.
+
+    ``sns.histplot(element="step"|"poly", fill=False)`` draws the same
+    distribution its filled twin does -- ``fill`` is a purely visual choice
+    and changes no count -- but swaps the ``PolyCollection`` for a single
+    ``Line2D``. :class:`~maidr.core.plot.stepped_histogram.SteppedHistPlot`
+    looks for the collection, so the unfilled spelling registered nothing at
+    all and the chart fell back to a picture (#583). That is the shape of
+    #556, where four ``histtype`` s of ``ax.hist`` were read for two.
+
+    The line is easier to read than the ring its filled twin draws, because
+    it is the pre-binned histogram rather than a closed outline that has to be
+    walked out and back. Measured on seaborn 0.13.2 across both elements and
+    both orientations:
+
+    ``step`` carries the **bin edges** and one value per edge, the last count
+    repeated to close the staircase::
+
+        histplot(x=..., bins=4)   drawstyle steps-post
+            [(1, 3), (3, 3), (5, 0), (7, 2), (9, 2)]
+        histplot(y=..., bins=4)   drawstyle steps-pre
+            [(3, 1), (3, 3), (0, 5), (2, 7), (2, 9)]
+
+    Both are edges ``1, 3, 5, 7, 9`` against counts ``3, 3, 0, 2`` with the
+    last repeated -- seaborn transposes the pair and flips the drawstyle to
+    draw the same staircase the other way up, and the *array* layout is the
+    same either way. So the last value is dropped in both, and the drawstyle
+    is read only to tell a step from a poly.
+
+    ``poly`` carries the **bin centres** and one value each, with nothing
+    repeated. The edges are recovered from the spacing, which is exact when
+    the bins are even and impossible when they are not -- measured,
+    ``bins=[0, 1, 5, 10]`` gives centres ``0.5, 3.0, 7.5``, and three numbers
+    whose gaps are ``2.5`` and ``4.5`` do not say where the boundaries were.
+    Such a chart is declined rather than announced with invented edges, which
+    is the rule ``SteppedHistPlot`` already settled for the filled poly.
+
+    A stepped outline needs no such recovery and is read exactly even when the
+    bins are uneven, because it carries the edges themselves.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the distribution was drawn on.
+    line : Line2D
+        The outline this call produced.
+    **kwargs : dict
+        Ignored; accepted so the factory can forward what it was given.
+    """
+
+    def __init__(self, ax: Axes, line: Line2D, **kwargs) -> None:
+        self._line = line
+        super().__init__(ax)
+        # One `<path>` for the whole outline, as `SteppedHistPlot` and
+        # `Axes.stairs` have: there is no per-bin element for a selector to
+        # name, and one naming the line would light the whole distribution up
+        # at every bin.
+        self._support_highlighting = False
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        Read one point per bin off the outline.
+
+        Returns
+        -------
+        list of dict
+            One point per bin, in ascending bin order, or empty when the
+            outline is not one this can read.
+        """
+        read = _read_line(self._line)
+        if read is None:
+            return []
+
+        horizontal, bins = read
+        self._orientation = "horz" if horizontal else "vert"
+        return [
+            self._bin_point(self._orientation, low, high - low, count)
+            for low, high, count in bins
+        ]
+
+
+def reads(line: Line2D) -> bool:
+    """
+    Whether this outline is one that can be read as a histogram.
+
+    Asked in the patch so a chart that cannot be read registers nothing at
+    all, rather than a layer that refuses at extraction and takes the whole
+    figure with it -- the defect #564 was about.
+
+    Parameters
+    ----------
+    line : Line2D
+        The outline seaborn drew.
+
+    Returns
+    -------
+    bool
+        True when the bins and counts can be recovered.
+    """
+    return _read_line(line) is not None
+
+
+def _read_line(line: Line2D) -> tuple[bool, list[tuple[float, float, float]]] | None:
+    """
+    Recover the orientation and ``(low, high, count)`` of every bin.
+
+    Parameters
+    ----------
+    line : Line2D
+        The outline seaborn drew.
+
+    Returns
+    -------
+    tuple or None
+        ``(runs up the y axis, bins)``, or None when the outline cannot be
+        read.
+    """
+    xydata = np.asarray(line.get_xydata(), dtype=float)
+    if xydata.ndim != 2 or len(xydata) < 2 or not np.all(np.isfinite(xydata)):
+        return None
+
+    stepped = str(line.get_drawstyle()).startswith("steps")
+
+    # Which column the bins run along, read off the drawing rather than the
+    # caller's keywords: `histplot(y=...)`, `histplot(data=df, y="v")` and a
+    # `displot` panel are three spellings of one chart and only the drawing is
+    # the same in all three. The bins are the column that ascends.
+    for horizontal, positions, values in (
+        (False, xydata[:, 0], xydata[:, 1]),
+        (True, xydata[:, 1], xydata[:, 0]),
+    ):
+        if not np.all(np.diff(positions) > 0):
+            continue
+        bins = _bins_from(positions, values, stepped)
+        if bins is not None:
+            return horizontal, bins
+
+    return None
+
+
+def _bins_from(
+    positions: np.ndarray, values: np.ndarray, stepped: bool
+) -> list[tuple[float, float, float]] | None:
+    """
+    Turn one outline's positions and values into bins.
+
+    Parameters
+    ----------
+    positions : numpy.ndarray
+        The ascending coordinates the bins run along -- edges for a stepped
+        outline, centres for a poly one.
+    values : numpy.ndarray
+        The counts, with the last repeated for a stepped outline.
+    stepped : bool
+        Whether the outline was drawn with a step drawstyle.
+
+    Returns
+    -------
+    list of tuple, or None
+        The bins in ascending order, or None when they cannot be recovered.
+    """
+    if stepped:
+        if len(positions) < 2:
+            return None
+        return [
+            (float(positions[i]), float(positions[i + 1]), float(values[i]))
+            for i in range(len(positions) - 1)
+        ]
+
+    if len(positions) < 2:
+        return None
+    widths = np.diff(positions)
+    if not np.all(np.abs(widths - widths[0]) <= abs(widths[0]) * _WIDTH_TOLERANCE):
+        return None
+
+    half = widths[0] / 2.0
+    return [
+        (float(centre - half), float(centre + half), float(value))
+        for centre, value in zip(positions, values)
+    ]

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -17,7 +17,7 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.histogram import DRAWN_BARS
 from maidr.core.plot.maidr_plot import GROUP_NAME
-from maidr.core.plot.outlined_histogram import OUTLINE_LINE
+from maidr.core.plot.outlined_histogram import OUTLINE_HORIZONTAL, OUTLINE_LINE
 from maidr.core.plot.outlined_histogram import reads as outline_reads
 from maidr.core.plot.scatterplot import _rgba
 from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, STEP_ORIENTATION
@@ -492,7 +492,40 @@ def _lines_of(ax: Axes | None) -> list:
     return list(getattr(ax, "lines", ()) or ())
 
 
-def _drew_outline_lines(ax: Axes | None, before: list, kde: bool) -> list:
+def _asked_for_horizontal(kwargs: dict) -> bool:
+    """
+    Whether the caller asked ``histplot`` for a distribution up the y axis.
+
+    ``x`` and ``y`` are keyword-only on ``seaborn.histplot``, so a named axis
+    is here whichever way it was spelled -- ``histplot(df, y="v")`` and
+    ``histplot(y=series)`` alike -- and a call naming neither is the
+    univariate default, which runs along x.
+
+    A ``y`` is therefore the whole question. Naming *both* makes a bivariate
+    histogram, and that never reaches here: measured, it draws no ``Line2D``
+    at all -- one ``QuadMesh``, read as a heatmap -- so there is no outline
+    for an orientation to be wanted for.
+
+    Asked because an outline's drawing cannot always answer it; see
+    :data:`~maidr.core.plot.outlined_histogram.OUTLINE_HORIZONTAL` for the
+    shape that made it necessary.
+
+    Parameters
+    ----------
+    kwargs : dict
+        The keyword arguments the caller passed.
+
+    Returns
+    -------
+    bool
+        True for a horizontal distribution.
+    """
+    return kwargs.get("y") is not None
+
+
+def _drew_outline_lines(
+    ax: Axes | None, before: list, kde: bool, horizontal: bool
+) -> list:
     """
     The unfilled outlines this call added, if it added any it can tell apart.
 
@@ -527,6 +560,9 @@ def _drew_outline_lines(ax: Axes | None, before: list, kde: bool) -> list:
         The lines present beforehand.
     kde : bool
         Whether the caller asked for a density overlay.
+    horizontal : bool
+        Whether the caller asked for a distribution up the y axis, which is
+        what decides an outline whose drawing reads either way.
 
     Returns
     -------
@@ -540,9 +576,10 @@ def _drew_outline_lines(ax: Axes | None, before: list, kde: bool) -> list:
     return [
         line
         for line in added
-        if outline_reads(line)
+        if outline_reads(line, horizontal)
         and (not kde or str(line.get_drawstyle()).startswith("steps"))
     ]
+
 
 def _drew_mesh(ax: Axes | None, before: list) -> bool:
     """
@@ -609,7 +646,10 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
             for outline in drew:
                 FigureManager.create_maidr(axes, PlotType.HIST, collection=outline)
             return drawn
-        outlined = _drew_outline_lines(axes, lines, bool(kwargs.get("kde", False)))
+        horizontal = _asked_for_horizontal(kwargs)
+        outlined = _drew_outline_lines(
+            axes, lines, bool(kwargs.get("kde", False)), horizontal
+        )
         if outlined:
             # The same two elements drawn `fill=False`: seaborn swaps the
             # collection for a bare `Line2D`, so the branch above finds
@@ -623,7 +663,11 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
                 FigureManager.create_maidr(
                     axes,
                     PlotType.HIST,
-                    **{OUTLINE_LINE: line, GROUP_NAME: name},
+                    **{
+                        OUTLINE_LINE: line,
+                        OUTLINE_HORIZONTAL: horizontal,
+                        GROUP_NAME: name,
+                    },
                 )
             return drawn
         if _drew_mesh(axes, meshes):

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -17,8 +17,10 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.histogram import DRAWN_BARS
 from maidr.core.plot.maidr_plot import GROUP_NAME
-from maidr.patch.kdeplot import _curve_names, _names_for, deferred_names
+from maidr.core.plot.outlined_histogram import OUTLINE_LINE
+from maidr.core.plot.outlined_histogram import reads as outline_reads
 from maidr.core.plot.scatterplot import _rgba
+from maidr.patch.kdeplot import _curve_names, _names_for, deferred_names
 from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, STEP_ORIENTATION
 from maidr.core.plot.stepped_histogram import reads as _reads_outline
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
@@ -470,6 +472,78 @@ def _drew_outlines(ax: Axes | None, before: list) -> list:
     ]
 
 
+
+def _lines_of(ax: Axes | None) -> list:
+    """
+    The lines already on an axes, for a before-and-after comparison.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes about to be drawn on, where the caller named one.
+
+    Returns
+    -------
+    list
+        The `Line2D` artists present, or empty.
+    """
+    if ax is None:
+        return []
+    return list(getattr(ax, "lines", ()) or ())
+
+
+def _drew_outline_lines(ax: Axes | None, before: list, kde: bool) -> list:
+    """
+    The unfilled outlines this call added, if it added any it can tell apart.
+
+    ``fill=False`` makes ``element="step"`` and ``element="poly"`` draw a
+    ``Line2D`` where the filled spelling draws a ``PolyCollection``, and a
+    ``hue`` draws one per group. Compared against a snapshot rather than swept
+    for, so a line already on the axes is not claimed.
+
+    The care here is telling an outline from a ``kde=True`` overlay, which is
+    also a ``Line2D`` this call added. Measured on seaborn 0.13.2, the two
+    interleave -- ``[outline, kde, outline, kde]`` for two groups -- so
+    neither "the first half" nor "the last one" separates them.
+
+    What does separate them is the drawstyle, for one of the two elements. A
+    stepped outline is ``steps-post`` (or ``steps-pre`` drawn sideways) and a
+    density is never stepped, so ``element="step"`` is decided outright. A
+    ``poly`` outline and a density are both ``"default"`` and differ only in
+    how many vertices they happen to have -- 4 against 200 here, but
+    ``gridsize=`` moves the second and the bin count moves the first, so a
+    threshold between them would be a guess.
+
+    So a ``poly`` outline is read only when the call asked for no density.
+    That leaves ``element="poly", fill=False, kde=True`` unread, which is
+    narrower than the silence it replaces and is a decline rather than a
+    density announced as a distribution.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The axes drawn on.
+    before : list
+        The lines present beforehand.
+    kde : bool
+        Whether the caller asked for a density overlay.
+
+    Returns
+    -------
+    list
+        The outlines this call drew, in draw order.
+    """
+    if ax is None:
+        return []
+    seen = {id(line) for line in before}
+    added = [line for line in (getattr(ax, "lines", ()) or ()) if id(line) not in seen]
+    return [
+        line
+        for line in added
+        if outline_reads(line)
+        and (not kde or str(line.get_drawstyle()).startswith("steps"))
+    ]
+
 def _drew_mesh(ax: Axes | None, before: list) -> bool:
     """
     Whether *this call* drew a mesh of joint counts.
@@ -509,6 +583,7 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     before = _containers_of(prospective)
     meshes = _meshes_of(prospective)
     outlines = _outlines_of(prospective)
+    lines = _lines_of(prospective)
 
     with ContextManager.set_internal_context():
         drawn = _draw_quietly(wrapped, args, kwargs)
@@ -533,6 +608,23 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
             # closed outline per series instead of a row of bars.
             for outline in drew:
                 FigureManager.create_maidr(axes, PlotType.HIST, collection=outline)
+            return drawn
+        outlined = _drew_outline_lines(axes, lines, bool(kwargs.get("kde", False)))
+        if outlined:
+            # The same two elements drawn `fill=False`: seaborn swaps the
+            # collection for a bare `Line2D`, so the branch above finds
+            # nothing and the chart was silent (#583). Named from the legend
+            # by colour, as the filled spelling and the density already are.
+            names = deferred_names(
+                lambda: _names_for(axes, [_rgba(line.get_color()) for line in outlined]),
+                len(outlined),
+            )
+            for line, name in zip(outlined, names):
+                FigureManager.create_maidr(
+                    axes,
+                    PlotType.HIST,
+                    **{OUTLINE_LINE: line, GROUP_NAME: name},
+                )
             return drawn
         if _drew_mesh(axes, meshes):
             # Named from `stat` rather than hardcoded, because it is what the

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -20,10 +20,10 @@ from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.core.plot.outlined_histogram import OUTLINE_LINE
 from maidr.core.plot.outlined_histogram import reads as outline_reads
 from maidr.core.plot.scatterplot import _rgba
-from maidr.patch.kdeplot import _curve_names, _names_for, deferred_names
 from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, STEP_ORIENTATION
 from maidr.core.plot.stepped_histogram import reads as _reads_outline
 from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
+from maidr.patch.kdeplot import _curve_names, _names_for, deferred_names
 
 
 @wrapt.patch_function_wrapper(Axes, "hist")

--- a/tests/core/plot/test_unfilled_histogram.py
+++ b/tests/core/plot/test_unfilled_histogram.py
@@ -101,6 +101,75 @@ def test_each_hue_group_carries_the_name_its_colour_is_given(element: str) -> No
     assert [schema.get(MaidrKey.NAME) for schema in _schemas(fig)] == ["b", "a"]
 
 
+# Counts 2 and 5 over two bins, and 1/2/3/4 over four: both frames make the
+# *counts* column ascend, and the four-bin one makes it ascend by an even
+# step as well. A `poly` outline repeats no value, so on a `y=` chart both of
+# its columns then read as bins and the drawing cannot say which is which.
+CLIMBING_TWO = [0.1, 0.2, 0.6, 0.7, 0.8, 0.9, 0.95]
+CLIMBING_FOUR = [0.0, 0.3, 0.4, 0.55, 0.6, 0.65, 0.8, 0.85, 0.9, 1.0]
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+@pytest.mark.parametrize(
+    ("values", "bins"), [(CLIMBING_TWO, 2), (CLIMBING_FOUR, 4)], ids=["two", "four"]
+)
+def test_a_horizontal_outline_whose_counts_climb_is_not_read_transposed(
+    element: str, values: list, bins: int
+) -> None:
+    """The counts are not the axis, however much they look like one.
+
+    Measured on the first draft, which took whichever column ascended first::
+
+        sns.histplot(df, y="v", bins=2, element="poly", fill=False)
+        orientation 'vert', xMin 0.5, xMax 3.5, y 0.3125
+
+    The bin edges were built out of the counts 2 and 5, and the bin centre
+    0.3125 was announced as the count. Silently transposed, which is the one
+    outcome this reading is meant not to have.
+
+    Pinned against the filled twin, which reads the same chart from a
+    ``PolyCollection`` that carries a baseline and so was never ambiguous.
+    """
+    frame = pd.DataFrame({"v": values})
+
+    def draw(**kwargs):
+        fig, ax = plt.subplots()
+        sns.histplot(frame, y="v", bins=bins, ax=ax, element=element, **kwargs)
+        return fig
+
+    filled = _schemas(draw())
+    unfilled = _schemas(draw(fill=False))
+
+    assert [s.get(MaidrKey.ORIENTATION) for s in unfilled] == ["horz"]
+    assert [s[MaidrKey.DATA] for s in unfilled] == [s[MaidrKey.DATA] for s in filled]
+    # The bins run up y and the counts sit on x, not the other way about.
+    for point in unfilled[0][MaidrKey.DATA]:
+        assert point["yMin"] < point["yMax"]
+        assert point["yMax"] == pytest.approx(max(values), abs=1e-9) or point[
+            "yMax"
+        ] < max(values)
+        assert point["x"] == int(point["x"])
+
+
+def test_an_outline_that_reads_either_way_declines_when_nothing_says_which() -> None:
+    """Both columns are bins, so without the caller there is no answer.
+
+    The tie-break is the orientation the patch hands over; a reader that has
+    none is in the position the first draft was in, and the rule there is the
+    one an uneven ``poly`` already follows -- decline rather than pick.
+    """
+    from matplotlib.lines import Line2D
+
+    from maidr.core.plot.outlined_histogram import _read_line
+
+    # Counts 1..4 against centres 0.125..0.875: both ascend, both evenly.
+    line = Line2D([1.0, 2.0, 3.0, 4.0], [0.125, 0.375, 0.625, 0.875])
+
+    assert _read_line(line, None) is None
+    assert _read_line(line, True)[0] is True
+    assert _read_line(line, False)[0] is False
+
+
 def test_a_stepped_outline_reads_uneven_bins_exactly() -> None:
     """It carries the edges themselves, so nothing has to be reconstructed."""
     fig, ax = plt.subplots()

--- a/tests/core/plot/test_unfilled_histogram.py
+++ b/tests/core/plot/test_unfilled_histogram.py
@@ -80,6 +80,27 @@ def test_a_hue_split_gives_one_layer_per_group(element: str) -> None:
     assert len(FigureManager.get_maidr(fig).plots) == 2
 
 
+@pytest.mark.parametrize("element", ["step", "poly"])
+def test_each_hue_group_carries_the_name_its_colour_is_given(element: str) -> None:
+    """Two layers of a kind need telling apart, which is what #828 added.
+
+    Counting the layers is not enough on its own: the patch matches each
+    outline's colour against the legend swatch that names it, and a layer
+    that computed the name and dropped it on the way to the schema counts
+    the same as one that carries it. Measured on the first draft, which
+    called ``HistPlot.__init__`` with the axes alone: both layers came out
+    ``name=None`` while the patch had a name for each.
+
+    The names come out in seaborn's own draw order, which is the reverse of
+    the legend's for a hue-grouped histogram.
+    """
+    frame = pd.DataFrame({"v": [1, 2, 3, 8, 9, 10], "g": ["a"] * 3 + ["b"] * 3})
+    fig, ax = plt.subplots()
+    sns.histplot(frame, x="v", hue="g", bins=3, element=element, fill=False, ax=ax)
+
+    assert [schema.get(MaidrKey.NAME) for schema in _schemas(fig)] == ["b", "a"]
+
+
 def test_a_stepped_outline_reads_uneven_bins_exactly() -> None:
     """It carries the edges themselves, so nothing has to be reconstructed."""
     fig, ax = plt.subplots()

--- a/tests/core/plot/test_unfilled_histogram.py
+++ b/tests/core/plot/test_unfilled_histogram.py
@@ -1,0 +1,165 @@
+"""`histplot(fill=False)` reads as the histogram its filled twin does (#583).
+
+`fill` is a purely visual choice and changes no count, so the two spellings
+have to say the same thing. That equality is the main assertion here: it
+cannot be satisfied by inventing numbers, because the filled reading is
+already pinned by its own tests.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import seaborn as sns
+
+import maidr
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.exception import UnsupportedPlotError
+
+VALUES = [1, 2, 2, 3, 3, 3, 8, 9]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    return pd.DataFrame({"v": VALUES})
+
+
+def _schemas(fig) -> list:
+    return [plot.schema for plot in FigureManager.get_maidr(fig).plots]
+
+
+def _draw(**kwargs):
+    fig, ax = plt.subplots()
+    sns.histplot(_frame(), bins=4, ax=ax, **kwargs)
+    return fig
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_unfilled_says_what_its_filled_twin_says(element: str, axis: str) -> None:
+    filled = _schemas(_draw(**{axis: "v"}, element=element))
+    unfilled = _schemas(_draw(**{axis: "v"}, element=element, fill=False))
+
+    assert [s[MaidrKey.DATA] for s in filled] == [s[MaidrKey.DATA] for s in unfilled]
+    assert [s.get(MaidrKey.ORIENTATION) for s in filled] == [
+        s.get(MaidrKey.ORIENTATION) for s in unfilled
+    ]
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+def test_an_unfilled_outline_is_one_hist_layer(element: str) -> None:
+    fig = _draw(x="v", element=element, fill=False)
+
+    assert [plot.type for plot in FigureManager.get_maidr(fig).plots] == [PlotType.HIST]
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+def test_the_counts_are_the_ones_the_data_has(element: str) -> None:
+    """Bins 1-3, 3-5, 5-7, 7-9 over the sample hold 3, 3, 0 and 2."""
+    fig = _draw(x="v", element=element, fill=False)
+
+    data = _schemas(fig)[0][MaidrKey.DATA]
+    assert [point["y"] for point in data] == [3.0, 3.0, 0.0, 2.0]
+    assert [point["xMin"] for point in data] == [1.0, 3.0, 5.0, 7.0]
+    assert [point["xMax"] for point in data] == [3.0, 5.0, 7.0, 9.0]
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+def test_a_hue_split_gives_one_layer_per_group(element: str) -> None:
+    frame = pd.DataFrame({"v": [1, 2, 3, 8, 9, 10], "g": ["a"] * 3 + ["b"] * 3})
+    fig, ax = plt.subplots()
+    sns.histplot(frame, x="v", hue="g", bins=3, element=element, fill=False, ax=ax)
+
+    assert len(FigureManager.get_maidr(fig).plots) == 2
+
+
+def test_a_stepped_outline_reads_uneven_bins_exactly() -> None:
+    """It carries the edges themselves, so nothing has to be reconstructed."""
+    fig, ax = plt.subplots()
+    sns.histplot(_frame(), x="v", bins=[0, 1, 5, 10], element="step", fill=False, ax=ax)
+
+    data = _schemas(fig)[0][MaidrKey.DATA]
+    assert [point["xMin"] for point in data] == [0.0, 1.0, 5.0]
+    assert [point["xMax"] for point in data] == [1.0, 5.0, 10.0]
+    assert [point["y"] for point in data] == [0.0, 6.0, 2.0]
+
+
+def test_an_uneven_poly_outline_is_declined_rather_than_invented() -> None:
+    """It carries only the centres, and centres 0.5, 3.0, 7.5 do not say
+    where the boundaries were. The same rule the filled poly already uses."""
+    fig, ax = plt.subplots()
+    sns.histplot(_frame(), x="v", bins=[0, 1, 5, 10], element="poly", fill=False, ax=ax)
+
+    with pytest.raises(UnsupportedPlotError):
+        FigureManager.get_maidr(fig)
+
+
+def test_a_kde_overlay_is_not_read_as_a_histogram() -> None:
+    """`kde=True` puts another `Line2D` on the same axes, and it is a density
+    rather than a distribution of bins. A stepped outline is told from it by
+    the drawstyle, which a density never has."""
+    fig, ax = plt.subplots()
+    sns.histplot(_frame(), x="v", bins=4, element="step", fill=False, kde=True, ax=ax)
+
+    hist = [
+        plot for plot in FigureManager.get_maidr(fig).plots if plot.type == PlotType.HIST
+    ]
+    assert len(hist) == 1
+    assert [point["y"] for point in hist[0].schema[MaidrKey.DATA]] == [
+        3.0,
+        3.0,
+        0.0,
+        2.0,
+    ]
+
+
+def test_a_poly_outline_under_a_density_is_declined_rather_than_guessed() -> None:
+    """Both are `default` drawstyle and differ only in vertex count, which
+    `gridsize=` and the bin count both move -- so a threshold between them
+    would be a guess, and a density announced as a distribution is worse than
+    one left unread."""
+    fig, ax = plt.subplots()
+    sns.histplot(_frame(), x="v", bins=4, element="poly", fill=False, kde=True, ax=ax)
+
+    # Nothing at all, which is what this combination already did and is not
+    # made worse here: the outline is declined, and the density overlay is
+    # registered only on the path a bar chart takes. The other three unfilled
+    # combinations are read; this one stays as it was.
+    with pytest.raises(UnsupportedPlotError):
+        FigureManager.get_maidr(fig)
+
+
+def test_the_two_kinds_of_line_really_do_interleave() -> None:
+    """What rules out separating them by position. Pinned because the fix
+    above rests on it."""
+    frame = pd.DataFrame({"v": [1, 2, 3, 8, 9, 10], "g": ["a"] * 3 + ["b"] * 3})
+    fig, ax = plt.subplots()
+    sns.histplot(
+        frame, x="v", hue="g", bins=3, element="step", fill=False, kde=True, ax=ax
+    )
+
+    stepped = [str(line.get_drawstyle()).startswith("steps") for line in ax.lines]
+    assert stepped == [True, False, True, False]
+
+
+def test_a_line_already_on_the_axes_is_not_claimed() -> None:
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [1, 2, 3])
+    sns.histplot(_frame(), x="v", bins=4, element="step", fill=False, ax=ax)
+
+    kinds = sorted(plot.type.value for plot in FigureManager.get_maidr(fig).plots)
+    assert kinds == ["hist", "line"]
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+def test_the_chart_renders(element: str) -> None:
+    fig = _draw(x="v", element=element, fill=False)
+
+    assert len(maidr.render(fig)._repr_html_()) > 0


### PR DESCRIPTION
Closes #583.

## The defect

`sns.histplot(..., fill=False)` draws its distribution as a `Line2D` outline
rather than as patches, and nothing in `maidr/patch/histogram.py` looked at
lines. The chart registered **no layer at all** — not a wrong reading, silence.

Measured across the element × fill × hue matrix, before this change:

| call | layers |
|---|---|
| `element="bars"`, `fill=True` | `["hist"]` |
| `element="bars"`, `fill=False` | `[]` |
| `element="step"`, `fill=True` | `["hist"]` |
| `element="step"`, `fill=False` | `[]` |
| `element="poly"`, `fill=True` | `["hist"]` |
| `element="poly"`, `fill=False` | `[]` |
| `element="step"`, `fill=False`, `hue=` (2 levels) | `[]` |
| `element="poly"`, `fill=False`, `hue=` (2 levels) | `[]` |
| `element="step"`, `fill=False`, `kde=True` | `[]` |
| `element="poly"`, `fill=False`, `kde=True` | `[]` |

Four of the ten were silent for want of a reading; `element="bars", fill=False`
still draws unfilled patches and was already read.

## The reading

New `maidr/core/plot/outlined_histogram.py`:

- `_read_line(line)` decides which of the two coordinate columns is the binned
  axis by which one ascends, so a `y=`-oriented histogram reads without a
  separate code path.
- `_bins_from(positions, values, stepped)` turns the vertices back into bins. A
  **stepped** outline traces bin *edges*, so the last value is the closing zero
  and is dropped. A **poly** outline traces bin *centres*, so the edges are
  recovered from the spacing — and when that spacing is uneven the centres do
  not determine the edges, so it returns `None` and the layer declines rather
  than inventing them.
- `OutlinedHistPlot` subclasses `HistPlot` and reuses its bin payload, so the
  emitted schema is byte-identical to the filled equivalent. Highlighting is off
  (`_support_highlighting = False`): a single `<path>` cannot be selected per
  bin.

`maidr/patch/histogram.py` gains `_drew_outline_lines(ax, before, kde)`, which
takes the lines seaborn added during the call and keeps the outlines. Each is
registered as its own `PlotType.HIST` layer, named from the legend by colour via
the existing `_names_for`, so a `hue=` outline names its groups the way the
`element="bars"` spelling does.

## What this deliberately does not read

`element="poly", fill=False, kde=True` stays silent, and a test pins that.

A poly outline and a KDE curve are both `drawstyle="default"` and differ only in
vertex count — which both `gridsize=` and the bin count move, so no threshold
separates them. A positional split does not work either: an XML read of the axes
shows seaborn interleaves them per hue group, `[outline, kde, outline, kde]`,
not outlines-then-curves. Announcing a density as a distribution is worse than
announcing nothing, and the chart was already silent, so this is not a
regression. `element="step", fill=False, kde=True` **is** read — a stepped
outline is unambiguous by drawstyle, which is exactly the discriminator the
filter uses.

## Review round: a name computed and dropped

`OutlinedHistPlot.__init__` called `HistPlot.__init__(ax)` without its kwargs,
so the `GROUP_NAME` the patch matched from the legend never reached the layer —
a `hue=` chart came out with two anonymous `hist` layers. Fixed in `cafe1f8`,
and the hue test now asserts the names rather than the layer count.

Measuring that also showed the **filled** `element="step"`/`"poly"` path names
nothing either, and for a wider reason: its caller never computes a name at all.
That is older than this branch, so it is filed as #587 rather than folded in.

| call | layer names |
|---|---|
| `element="bars"`, `fill=True` | `["b", "a"]` |
| `element="step"`, `fill=True` | `[None, None]` (#587) |
| `element="step"`, `fill=False` | `["b", "a"]` |

## Verification

- Unfilled agrees with filled — same bin points, same `orientation` — for all
  four element × orientation combinations.
- `steps-post` and `steps-pre` produce the same array layout, so the edge-drop
  is not drawstyle-specific.
- Uneven bins, `element="step"`: edges `0/1/5/10` read back exactly as counts
  `0/6/2`. Uneven bins, `element="poly"`: declines.
- Six mutations applied one at a time against a restored baseline, all killed:
  dropping the last stepped value, the ascending-column choice, the even-spacing
  guard, the drawstyle filter, the horizontal swap, and the kwargs forward.
- `tests/core/plot/test_unfilled_histogram.py` — 20 tests.
- Full suite: **2795 passed, 18 skipped**. `ruff check` clean.