### PR TITLE
feat(scatter): read the hue a strip or swarm plot was grouped by

### DIFF
--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -15,8 +15,9 @@ from maidr.exception import ExtractionError
 from maidr.util.mixin import CollectionExtractorMixin, LineExtractorMixin
 
 
-#: The keyword ``Axes.scatter`` hands its own ``PathCollection`` to this layer
-#: under. Named once and imported at both ends rather than spelled twice:
+#: The keyword a patch hands this layer the collections its own call drew
+#: under -- one ``PathCollection``, or a list of them where a layer spans
+#: several. Named once and imported at both ends rather than spelled twice:
 #: ``kwargs.get`` falls back to sweeping the axes on a mismatch, so a typo
 #: would not raise -- it would quietly restore the behaviour #426 removed.
 #:
@@ -24,11 +25,26 @@ from maidr.util.mixin import CollectionExtractorMixin, LineExtractorMixin
 #: imports ``maidr.core`` and not the other way about.
 DRAWN_POINTS = "_maidr_points"
 
-#: The keyword the scatter patch hands one hue group to this layer under: a
-#: ``(name, members)`` pair naming the group and listing the collection
-#: offsets that belong to it. Absent for an ungrouped scatter, which is the
-#: chart this layer has always read and still reads unchanged.
+#: The keyword a patch hands one hue group to this layer under: a
+#: ``(name, members)`` pair naming the group and listing, **per collection of**
+#: ``DRAWN_POINTS`` **and in the same order**, the offsets that belong to it.
+#: One collection is one entry; the list is not flattened, because an offset
+#: means nothing without the collection it indexes. Absent for an ungrouped
+#: scatter, which is the chart this layer has always read and still reads
+#: unchanged.
 HUE_GROUP = "_maidr_hue_group"
+
+#: The keyword a patch hands the grouping *variable's* name under, for the
+#: charts whose legend cannot be asked for it. Only ever a fallback: the
+#: legend's title is read first and wins, because it is what the chart shows.
+#:
+#: Three charts need it, and all three are ones the legend cannot answer for.
+#: ``sns.catplot`` builds its legend at the *figure* after the panels are
+#: drawn; ``legend=False`` suppresses it outright; and a ``hue=`` that repeats
+#: the ``x`` variable makes seaborn draw one with no title at all. Each still
+#: has a grouping, and a group named "x" with nothing saying what "x" is a
+#: kind of is half a reading.
+GROUP_LABEL = "_maidr_group_label"
 
 #: How closely two colours must agree to be the same colour. Both sides come
 #: from the same palette object -- the legend handle is built from the swatch
@@ -129,6 +145,38 @@ def _named_colours(legend, drawn: set[tuple[float, ...]]) -> dict | None:
     return named
 
 
+def _collections(given) -> list[PathCollection]:
+    """
+    The collections a patch handed this layer, in the order it drew them.
+
+    Either spelling is read: ``Axes.scatter`` has one collection to give and
+    gives it, while a patch whose layer spans several -- a hue group over
+    ``seaborn``'s one-collection-per-category strip plot (#586) -- gives the
+    list. Everything below works in the list, so a single collection becomes
+    a list of one here rather than a second path through the layer.
+
+    Filtered by type rather than trusted, for the reason the one-collection
+    form was: ``seaborn.scatterplot`` is patched through the same wrapper and
+    returns an ``Axes``, not a collection. An empty answer falls back to
+    sweeping the axes, which is right for that call and for that call alone.
+
+    Parameters
+    ----------
+    given : Any
+        Whatever arrived under :data:`DRAWN_POINTS`.
+
+    Returns
+    -------
+    list of PathCollection
+        Possibly empty, which is the caller's signal to sweep instead.
+    """
+    if isinstance(given, PathCollection):
+        return [given]
+    if isinstance(given, (list, tuple)):
+        return [part for part in given if isinstance(part, PathCollection)]
+    return []
+
+
 def hue_groups(ax: Axes, collection: PathCollection) -> list[tuple[str, list[int]]] | None:
     """
     The hue groups a scatter was drawn with, or ``None`` when it has none.
@@ -202,48 +250,52 @@ def hue_groups(ax: Axes, collection: PathCollection) -> list[tuple[str, list[int
 class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
     def __init__(self, ax: Axes, **kwargs) -> None:
         super().__init__(ax, PlotType.SCATTER)
-        # The collection this layer's own call drew, when the patch could say.
-        # `None` falls back to the first collection on the axes, which is the
-        # right answer only while a layer *is* one collection.
+        # The collections this layer's own call drew, when the patch could
+        # say. Empty falls back to the first collection on the axes, which is
+        # the right answer only while a layer *is* one collection.
         #
-        # Guarded on the type rather than on presence: `seaborn.scatterplot`
-        # is patched through the same wrapper and returns an `Axes`, not the
-        # collection. Falling back is correct there -- measured, it draws a
-        # single `PathCollection` of every point even under `hue`, so the
-        # sweep finds exactly the right one.
-        own_points = kwargs.get(DRAWN_POINTS, None)
-        self._own_points = (
-            own_points if isinstance(own_points, PathCollection) else None
-        )
+        # A list rather than one, because a hue group is not always confined
+        # to a single collection: seaborn draws a categorical scatter as one
+        # collection per *category*, so a group that spans the categories --
+        # which is what a hue level is -- spans the collections with them
+        # (#586). `Axes.scatter` hands over the one collection it drew and
+        # takes the one-entry path through everything below.
+        self._own_points = _collections(kwargs.get(DRAWN_POINTS, None))
 
-        # The hue group this layer reads, when the patch found one. `None`
-        # means the layer reads every point the collection holds, which is
-        # what an ungrouped scatter has always done.
+        # The hue group this layer reads, when the patch found one: one set of
+        # offsets per collection, positionally paired with `_own_points`.
+        # `None` means the layer reads every point there is, which is what an
+        # ungrouped scatter has always done.
         group = kwargs.get(HUE_GROUP, None)
         self._group_name = group[0] if group else None
-        self._group_members = set(group[1]) if group else None
+        self._group_label = str(kwargs.get(GROUP_LABEL, "") or "")
+        self._group_members = (
+            [set(members) for members in group[1]] if group else None
+        )
 
-        # A grouped layer addresses its points through the collection's id, so
-        # the collection needs one before the SVG is written. Assigned here
-        # rather than relied upon, for the reason `HexbinPlot` and
-        # `contour.tag` give: matplotlib stamps a gid at *draw* time, and the
-        # schema is built first -- so reading it here would find `None` and
-        # the layer would ship with an empty selector list, announcing
-        # correctly and highlighting nothing.
+        # A grouped layer addresses its points through each collection's id,
+        # so they need one before the SVG is written. Assigned here rather
+        # than relied upon, for the reason `HexbinPlot` and `contour.tag`
+        # give: matplotlib stamps a gid at *draw* time, and the schema is
+        # built first -- so reading it here would find `None` and the layer
+        # would ship with an empty selector list, announcing correctly and
+        # highlighting nothing.
         #
-        # Every group shares the one collection, so the first layer built
-        # names it and the rest find the name already there.
-        if self._group_members is not None and self._own_points is not None:
-            if self._own_points.get_gid() is None:
-                self._own_points.set_gid(f"maidr-{uuid.uuid4()}")
+        # Every group shares the same collections, so the first layer built
+        # names them and the rest find the names already there.
+        if self._group_members is not None:
+            for collection in self._own_points:
+                if collection.get_gid() is None:
+                    collection.set_gid(f"maidr-{uuid.uuid4()}")
 
-        # Where each emitted point sits among the drawn ones, filled in by
-        # extraction and read by `_get_selector`. `render()` builds `data`
-        # before `selectors`, so the order is guaranteed rather than lucky --
-        # and a selector list built from a stale one would highlight the
-        # previous group's points, which is the failure nothing announced can
-        # see (xability/maidr#814).
-        self._drawn_positions: list[int] = []
+        # Where each emitted point sits among the drawn ones -- which
+        # collection, and which position within it -- filled in by extraction
+        # and read by `_get_selector`. `render()` builds `data` before
+        # `selectors`, so the order is guaranteed rather than lucky -- and a
+        # selector list built from a stale one would highlight the previous
+        # group's points, which is the failure nothing announced can see
+        # (xability/maidr#814).
+        self._drawn_positions: list[tuple[int, int]] = []
 
     def render(self) -> dict:
         """
@@ -271,12 +323,17 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
         ``<use>``, so one selector matching them all is both correct and in
         document order.
 
-        A hue-grouped one cannot use it: the collection holds every group's
+        A hue-grouped one cannot use it: the collections hold every group's
         points, so that selector would light up the whole chart for a layer
         that announces a third of it. Under per-point colours matplotlib
         writes **one ``<g>`` per point** instead -- measured, six points give
-        six groups of one ``<use>`` each -- so each point has an element of
-        its own to name, and the layer names only its own.
+        six groups of one ``<use>`` each, and a strip plot's uniformly
+        coloured dodged collection writes them too, because seaborn colours
+        it point by point either way -- so each point has an element of its
+        own to name, and the layer names only its own.
+
+        Each position carries the collection it belongs to, so a group that
+        spans several addresses each through that collection's own id.
 
         ``nth-of-type`` rather than ``nth-child``, for the reason
         :class:`~maidr.core.plot.hexbinplot.HexbinPlot` gives: the shared
@@ -286,17 +343,14 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
         if self._group_members is None:
             return ["g[maidr='true'] > g > use"]
 
-        collection = self._own_points
-        if collection is None:
-            collection = self.extract_collection(self.ax, PathCollection)
-        gid = collection.get_gid() if collection is not None else None
-        if gid is None:
-            return []
-
-        return [
-            f"g[id='{gid}'] > g:nth-of-type({position + 1}) > use"
-            for position in self._drawn_positions
-        ]
+        parts = self._own_points or self._swept()
+        selectors: list[str] = []
+        for part, position in self._drawn_positions:
+            gid = parts[part].get_gid() if part < len(parts) else None
+            if gid is None:
+                return []
+            selectors.append(f"g[id='{gid}'] > g:nth-of-type({position + 1}) > use")
+        return selectors
 
     def _extract_axes_data(self) -> dict:
         """Extract axes data as canonical per-axis ``AxisConfig`` objects.
@@ -357,8 +411,12 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
         # and point layers do. The group's own name goes on the layer rather
         # than here: `z` says what the split is by, `name` says which side of
         # it this layer is.
+        #
+        # The legend's title first, then whatever the patch could name the
+        # variable from -- see `GROUP_LABEL` for the three charts that have a
+        # grouping and no legend title to read it off.
         if self._group_members is not None:
-            z_label = self._legend_title()
+            z_label = self._legend_title() or self._group_label
             if z_label:
                 axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
 
@@ -418,18 +476,46 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
 
         return True
 
+    def _swept(self) -> list[PathCollection]:
+        """
+        The axes' first collection, for a layer whose patch named none.
+
+        A list of one, or an empty list where the axes holds no collection at
+        all -- so the callers below read it exactly as they read the ones the
+        patch did name.
+        """
+        found = self.extract_collection(self.ax, PathCollection)
+        return [found] if found is not None else []
+
     def _extract_plot_data(self) -> list[dict]:
-        plot = self._own_points
-        if plot is None:
-            plot = self.extract_collection(self.ax, PathCollection)
-        data = self._extract_point_data(plot)
+        # One pass per collection, in the order the patch drew them, so a
+        # group that spans several reads as one series in drawing order. A
+        # layer the patch named one collection for -- every scatter before
+        # #586 -- makes a single pass and comes out unchanged.
+        parts = self._own_points or self._swept()
+        if not parts:
+            raise ExtractionError(self.type, None)
 
-        if data is None:
-            raise ExtractionError(self.type, plot)
+        members = self._group_members
+        if members is None:
+            members = [None] * len(parts)
 
-        return data
+        samples: list[dict] = []
+        positions: list[tuple[int, int]] = []
+        for part, (plot, mine) in enumerate(zip(parts, members)):
+            read = self._extract_point_data(plot, mine)
+            if read is None:
+                raise ExtractionError(self.type, plot)
+            found, drawn = read
+            samples.extend(found)
+            positions.extend((part, at) for at in drawn)
 
-    def _extract_point_data(self, plot: PathCollection | None) -> list[dict] | None:
+        self._drawn_positions = positions
+        return samples
+
+    def _extract_point_data(
+        self, plot: PathCollection | None, members: set[int] | None
+    ) -> tuple[list[dict], list[int]] | None:
         if plot is None or plot.get_offsets() is None:
             return None
 
@@ -471,7 +557,6 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
         # diverge over. `test_seaborn_drops_a_non_finite_row_before_drawing`
         # pins that, and turns red on the release where this arithmetic
         # starts mattering.
-        members = self._group_members
         samples: list[dict] = []
         positions: list[int] = []
         position = 0
@@ -486,8 +571,7 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
             samples.append(self._sample(float(x), float(y), x_ticks, y_ticks))
             positions.append(drawn_at)
 
-        self._drawn_positions = positions
-        return samples
+        return samples, positions
 
     @classmethod
     def _sample(

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -25,6 +25,7 @@ from . import (  # noqa: E402, F401
     histogram,
     lineplot,
     stem,
+    stripplot,
     pieplot,
     pointplot,
     scatterplot,

--- a/maidr/patch/scatterplot.py
+++ b/maidr/patch/scatterplot.py
@@ -91,7 +91,11 @@ def scatter(wrapped, instance, args, kwargs) -> Axes | PathCollection:
         FigureManager.create_maidr(
             ax,
             PlotType.SCATTER,
-            **dict(kwargs, **{DRAWN_POINTS: points, HUE_GROUP: group}),
+            # One membership list, for the one collection this call drew.
+            # `hue_groups` answers in the offsets of the collection it was
+            # asked about; the layer takes a list of those, one per
+            # collection, because a strip plot's groups span several (#586).
+            **dict(kwargs, **{DRAWN_POINTS: points, HUE_GROUP: (group[0], [group[1]])}),
         )
 
     return plot

--- a/maidr/patch/stripplot.py
+++ b/maidr/patch/stripplot.py
@@ -1,0 +1,317 @@
+"""Read the hue a categorical scatter was grouped by."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Tuple
+
+import numpy as np
+import wrapt
+from matplotlib.axes import Axes
+from matplotlib.collections import PathCollection
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.scatterplot import (
+    DRAWN_POINTS,
+    GROUP_LABEL,
+    HUE_GROUP,
+    _rgba,
+)
+from maidr.patch.common import _draw_quietly, plotter_axes
+
+
+def _point_colours(collection: PathCollection) -> list:
+    """
+    One colour per point.
+
+    ``get_facecolor`` answers a row per point on every collection seaborn
+    colours by hue -- it assigns them in one ``set_facecolors`` call over the
+    panel's rows -- and no rows at all on the empty collections a faceted grid
+    leaves where a panel holds none of a category. Measured across strip,
+    swarm, dodged, faceted, translucent and unfilled-marker charts: the two
+    counts agree every time.
+
+    The mismatch below is therefore not a live path but where this stops if
+    that ever changes. Zipping a shorter list over the points would name each
+    point after whichever colour fell opposite it, which is a grouping made
+    up rather than read; answering ``None`` per point makes the caller decline
+    the panel instead.
+    ``test_seaborn_gives_every_point_its_own_colour`` pins the agreement, so
+    the seaborn release that ends it turns a test red rather than this branch
+    silently load-bearing.
+
+    Parameters
+    ----------
+    collection : PathCollection
+        The points.
+
+    Returns
+    -------
+    list
+        One rounded RGBA per drawn point, ``None`` where a row names no
+        colour or where the rows do not correspond to the points at all.
+    """
+    rows = np.asarray(collection.get_facecolor())
+    count = len(np.asarray(collection.get_offsets()))
+    if len(rows) != count:
+        return [None] * count
+    return [_rgba(row) for row in rows]
+
+
+def _hue_colours(plotter: Any) -> dict | None:
+    """
+    Each hue level's name against the colour seaborn drew it in.
+
+    Read off the plotter's own ``_hue_map`` rather than off the legend, and
+    that is the point of doing this here at all. The legend is the only
+    source the ``Axes.scatter`` patch has, and for these charts it has two
+    problems: a faceted ``catplot`` has no per-panel legend -- the grid's is
+    built afterwards, at the figure -- and a panel holding only one of the
+    levels could not be named from a legend anyway, since one colour matched
+    against a swatch is a guess. The plotter knows the mapping outright.
+
+    Keyed by the three colour channels, not by four. ``alpha=`` scales the
+    drawn points' opacity and leaves the mapping's alone -- measured,
+    ``stripplot(hue=..., alpha=.4)`` draws ``(0.12, 0.47, 0.71, 0.4)`` against
+    a lookup entry of ``(0.12, 0.47, 0.71, 1.0)`` -- and what identifies a
+    level is its hue rather than how transparently it was drawn. Two levels
+    that differ *only* in opacity would collide, so that is the one case this
+    declines on.
+
+    Declined too when the mapping is numeric. Seaborn builds a lookup entry
+    per distinct value there, so a continuous ``hue=`` on eighteen rows offers
+    eighteen "levels" -- a colour *scale*, not a grouping, and one layer per
+    point is not a reading of it. ``hue_groups`` declines the same chart for
+    the same reason, one step further down.
+
+    Parameters
+    ----------
+    plotter : Any
+        The seaborn plotter the wrapped method is bound to.
+
+    Returns
+    -------
+    dict or None
+        RGB to level name, or ``None`` for a chart with no hue grouping to
+        read.
+    """
+    hue_map = getattr(plotter, "_hue_map", None)
+    if getattr(hue_map, "map_type", None) != "categorical":
+        return None
+
+    lookup = getattr(hue_map, "lookup_table", None) or {}
+    if len(lookup) < 2:
+        return None
+
+    named: dict = {}
+    for level, colour in lookup.items():
+        rgba = _rgba(colour)
+        if rgba is None:
+            return None
+        named[rgba[:3]] = str(level)
+    return named if len(named) == len(lookup) else None
+
+
+def _hue_levels(plotter: Any, drawn: list) -> list | None:
+    """
+    One ``(name, members)`` group per hue level present among these points.
+
+    ``members`` holds a list of offsets per collection, positionally paired
+    with ``drawn``, which is the shape :data:`HUE_GROUP` takes: seaborn draws
+    a categorical scatter as one collection per category, so a level spans
+    every collection that holds a point of it.
+
+    A level the panel does not hold is absent rather than empty -- a faceted
+    ``catplot`` puts each level in whichever panels its rows fall in -- and a
+    panel holding one level still gets that level named, because knowing
+    which one it is is the whole of what was missing.
+
+    Returns ``None`` the moment a point cannot be placed, which leaves the
+    caller reading the chart the way it read it before there was a hue to
+    find. A point no level claims means the colours are not the grouping, and
+    a partly-named chart is worse than an unnamed one.
+
+    Parameters
+    ----------
+    plotter : Any
+        The seaborn plotter the wrapped method is bound to.
+    drawn : list of PathCollection
+        The collections this call added to one panel, in drawing order.
+
+    Returns
+    -------
+    list of (str, list of list of int) or None
+        The groups in the plotter's own level order, or ``None``.
+    """
+    named = _hue_colours(plotter)
+    if named is None:
+        return None
+
+    members: Dict[str, list] = {}
+    for part, collection in enumerate(drawn):
+        for index, colour in enumerate(_point_colours(collection)):
+            if colour is None:
+                return None
+            name = named.get(colour[:3])
+            if name is None:
+                return None
+            members.setdefault(name, [[] for _ in drawn])[part].append(index)
+
+    if not members:
+        return None
+
+    # The plotter's level order, which is the order seaborn's own legend is
+    # written in and the order #502 settled a grouped layer's layers on.
+    order = [str(level) for level in getattr(plotter._hue_map, "levels", None) or []]
+    return sorted(
+        members.items(),
+        key=lambda group: order.index(group[0]) if group[0] in order else len(order),
+    )
+
+
+def _added(ax: Axes, before: set) -> list:
+    """
+    The collections this call put on one panel, in drawing order.
+
+    Parameters
+    ----------
+    ax : Axes
+        One panel.
+    before : set
+        ``id`` of every collection the panel already held.
+
+    Returns
+    -------
+    list of PathCollection
+        Possibly empty, which makes the caller skip the panel.
+    """
+    return [
+        artist
+        for artist in ax.collections
+        if isinstance(artist, PathCollection) and id(artist) not in before
+    ]
+
+
+def sns_categorical_points(
+    wrapped: Callable, instance: Any, args: Tuple[Any, ...], kwargs: Dict[str, Any]
+) -> Any:
+    """
+    Register the strip and swarm panels seaborn draws, hue and all.
+
+    One registrar for both, and for ``sns.catplot`` with them: ``catplot``
+    drives ``_CategoricalPlotter`` directly and imports neither public
+    function, so a patch on the functions reaches two of the three ways in
+    and a patch here reaches all of them -- the same reason
+    ``maidr/patch/barplot.py`` wraps ``plot_bars``.
+
+    The reading has to happen *after* the method rather than under it, and
+    that is the defect this fixes (#586). ``plot_strips`` colours its points
+    by hue and builds its legend as its last two acts::
+
+        points = ax.scatter(...)
+        if "hue" in self.variables:
+            points.set_facecolors(self._hue_map(sub_data["hue"]))
+        ...
+        self._configure_legend(...)
+
+    so the ``Axes.scatter`` patch, which registered these charts until now,
+    was asked for the grouping before either existed -- measured, one uniform
+    colour and no legend at every one of the three calls. It declined both
+    times and the chart came out with its hue dropped: identical, point for
+    point, to the same call without one.
+
+    Drawing inside the internal context is what moves the decision here. The
+    ``Axes.scatter`` calls made under it draw and register nothing, and every
+    panel is registered below instead.
+
+    The layers a panel gets:
+
+    - **A hue level each**, spanning the categories, named by the level and
+      carrying the hue variable on ``z``. That is the decomposition
+      ``seaborn.scatterplot(hue=...)`` already emits for the same frame
+      (#544), and a dodged bar's before it.
+    - **A collection each, unnamed**, for a chart with no hue to read --
+      which is one layer per category, exactly what #426 settled these charts
+      on and what ``tests/core/plot/test_scatter_own_collection.py`` pins.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``_CategoricalPlotter.plot_strips`` or ``.plot_swarms``.
+    instance : Any
+        The plotter, for its axes and its hue mapping.
+    args : tuple
+        Positional arguments seaborn passed.
+    kwargs : dict
+        Keyword arguments seaborn passed.
+
+    Returns
+    -------
+    Any
+        Whatever the wrapped method returned.
+
+    Examples
+    --------
+    >>> # Two named layers, nine points each, categories on `xLabel`.
+    >>> sns.stripplot(data=df, x="cat", y="val", hue="hue")
+
+    >>> # Three unnamed layers, one per category, as before.
+    >>> sns.swarmplot(data=df, x="cat", y="val")
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    panels = plotter_axes(instance)
+    before = {id(artist) for ax in panels for artist in ax.collections}
+
+    with ContextManager.set_internal_context():
+        drawn = _draw_quietly(wrapped, args, kwargs)
+
+    for ax in plotter_axes(instance):
+        added = _added(ax, before)
+        if not added:
+            continue
+
+        levels = _hue_levels(instance, added)
+        if levels is None:
+            for collection in added:
+                FigureManager.create_maidr(
+                    ax, PlotType.SCATTER, **{DRAWN_POINTS: collection}
+                )
+            continue
+
+        # The plotter's own record of which column the hue came from. A
+        # `catplot` panel has no legend to read the variable's name off --
+        # the grid builds one at the figure, afterwards -- and neither has a
+        # chart drawn `legend=False`.
+        label = (getattr(instance, "variables", None) or {}).get("hue")
+
+        for name, members in levels:
+            FigureManager.create_maidr(
+                ax,
+                PlotType.SCATTER,
+                **{
+                    DRAWN_POINTS: added,
+                    HUE_GROUP: (name, members),
+                    GROUP_LABEL: label,
+                },
+            )
+
+    return drawn
+
+
+# The plotter methods `seaborn.stripplot`, `seaborn.swarmplot` and
+# `sns.catplot(kind="strip"/"swarm")` all drive. Wrapped by module path rather
+# than by importing the private class, matching how `maidr/patch/barplot.py`
+# reaches `_CategoricalPlotter`.
+wrapt.wrap_function_wrapper(
+    "seaborn.categorical",
+    "_CategoricalPlotter.plot_strips",
+    sns_categorical_points,
+)
+wrapt.wrap_function_wrapper(
+    "seaborn.categorical",
+    "_CategoricalPlotter.plot_swarms",
+    sns_categorical_points,
+)

--- a/maidr/patch/stripplot.py
+++ b/maidr/patch/stripplot.py
@@ -113,7 +113,9 @@ def _hue_colours(plotter: Any) -> dict | None:
     return named if len(named) == len(lookup) else None
 
 
-def _hue_levels(plotter: Any, drawn: list) -> list | None:
+def _hue_levels(
+    plotter: Any, drawn: list
+) -> list[tuple[str, list[list[int]]]] | None:
     """
     One ``(name, members)`` group per hue level present among these points.
 
@@ -262,13 +264,16 @@ def sns_categorical_points(
     if ContextManager.is_internal_context():
         return _draw_quietly(wrapped, args, kwargs)
 
+    # Asked once. The panels a plotter draws into are fixed before it draws
+    # -- `plotter.ax` for one axes, the grid's for a faceted call -- so the
+    # snapshot and the reading below are of the same list.
     panels = plotter_axes(instance)
     before = {id(artist) for ax in panels for artist in ax.collections}
 
     with ContextManager.set_internal_context():
         drawn = _draw_quietly(wrapped, args, kwargs)
 
-    for ax in plotter_axes(instance):
+    for ax in panels:
         added = _added(ax, before)
         if not added:
             continue

--- a/maidr/patch/stripplot.py
+++ b/maidr/patch/stripplot.py
@@ -165,7 +165,8 @@ def _hue_levels(
 
     # The plotter's level order, which is the order seaborn's own legend is
     # written in and the order #502 settled a grouped layer's layers on.
-    order = [str(level) for level in getattr(plotter._hue_map, "levels", None) or []]
+    hue_map = getattr(plotter, "_hue_map", None)
+    order = [str(level) for level in getattr(hue_map, "levels", None) or []]
     return sorted(
         members.items(),
         key=lambda group: order.index(group[0]) if group[0] in order else len(order),

--- a/tests/core/plot/test_categorical_scatter_hue.py
+++ b/tests/core/plot/test_categorical_scatter_hue.py
@@ -1,0 +1,381 @@
+"""A hue-grouped strip or swarm plot reads by hue level (#586).
+
+``sns.stripplot(..., hue=...)`` emitted exactly the schema of the same call
+without a ``hue=``: three layers, one per *category*, unnamed, with nothing
+anywhere saying which points belonged to which group. Not a wrong grouping --
+no grouping at all, on a chart whose whole subject is the comparison between
+the levels.
+
+The cause was where the reading happened rather than what it read. These
+charts registered at the inner ``Axes.scatter`` calls seaborn makes, one per
+category, and ``hue_groups`` needs the per-point colours and the legend, both
+of which ``plot_strips`` writes *after* those calls return::
+
+    points = ax.scatter(...)
+    if "hue" in self.variables:
+        points.set_facecolors(self._hue_map(sub_data["hue"]))
+    ...
+    self._configure_legend(...)
+
+Measured at each of the three returns: one uniform colour, no legend.
+
+``maidr/patch/stripplot.py`` moves the decision to the plotter method, which
+``sns.catplot`` drives as well, and reads the grouping off the plotter's own
+``_hue_map`` rather than off a legend that a faceted grid does not give a
+panel. The layers a grouped chart gets are one per hue level, spanning the
+categories -- the decomposition ``scatterplot(hue=)`` already emits (#544),
+with the category on each point's ``xLabel``.
+
+The ungrouped chart is untouched: one layer per category, which is what #426
+settled and what ``test_scatter_own_collection.py`` pins.
+"""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+import pytest
+
+sns = pytest.importorskip("seaborn")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+
+import maidr  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+CATEGORIES = ["a", "b", "c"]
+LEVELS = ["x", "y"]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def frame() -> pd.DataFrame:
+    """Three categories, two hue levels, three rows in each combination."""
+    return pd.DataFrame(
+        {
+            "cat": [category for category in CATEGORIES for _ in range(6)],
+            "val": list(range(18)),
+            "hue": (["x"] * 3 + ["y"] * 3) * 3,
+            # Two panels that hold different levels: "p" has every "a" row and
+            # the "b" rows that are level x, "q" has the rest.
+            "col": ["p"] * 9 + ["q"] * 9,
+        }
+    )
+
+
+def layers(figure) -> list[dict]:
+    return [plot.schema for plot in FigureManager.get_maidr(figure)._plots]
+
+
+def names(figure) -> list:
+    return [layer.get("name") for layer in layers(figure)]
+
+
+def points(layer: dict) -> list[tuple[float, float]]:
+    return [(float(point["x"]), float(point["y"])) for point in layer["data"]]
+
+
+def drawn(ax) -> set[tuple[float, float]]:
+    return {
+        (round(float(x), 9), round(float(y), 9))
+        for collection in ax.collections
+        for x, y in collection.get_offsets()
+    }
+
+
+def announced(figure) -> list[tuple[float, float]]:
+    return [
+        (round(x, 9), round(y, 9))
+        for layer in layers(figure)
+        for x, y in points(layer)
+    ]
+
+
+def z_label(layer: dict):
+    axis = (layer.get("axes") or {}).get("z")
+    return None if axis is None else axis.get("label")
+
+
+@pytest.mark.parametrize("plot", ["stripplot", "swarmplot"])
+class TestAHueGroupedCategoricalScatter:
+    def test_the_layers_are_the_hue_levels_not_the_categories(self, plot):
+        # The defect's signature: three layers for three categories, with the
+        # two levels nowhere in the schema.
+        figure, ax = plt.subplots()
+        getattr(sns, plot)(data=frame(), x="cat", y="val", hue="hue", ax=ax)
+
+        assert names(figure) == LEVELS
+
+    def test_each_level_spans_every_category(self, plot):
+        # The point of grouping by level rather than by category: a reader
+        # moving through one layer compares the same level across the chart,
+        # which is the comparison the hue was drawn for.
+        figure, ax = plt.subplots()
+        getattr(sns, plot)(data=frame(), x="cat", y="val", hue="hue", ax=ax)
+
+        for layer in layers(figure):
+            assert len(layer["data"]) == 9
+            assert {point["xLabel"] for point in layer["data"]} == set(CATEGORIES)
+
+    def test_every_drawn_point_is_announced_exactly_once(self, plot):
+        # Stronger than "the layers are named": splitting by colour could
+        # drop a point no swatch claims, or double one claimed by two.
+        figure, ax = plt.subplots()
+        getattr(sns, plot)(data=frame(), x="cat", y="val", hue="hue", ax=ax)
+        found = announced(figure)
+
+        assert len(found) == 18
+        assert len(set(found)) == 18
+        assert {y for _, y in found} == {y for _, y in drawn(ax)}
+
+    def test_the_hue_variable_is_named_on_z(self, plot):
+        # `z` says what the split is by and `name` says which side of it this
+        # layer is; a group called "x" with nothing saying what "x" is a kind
+        # of is half a reading.
+        figure, ax = plt.subplots()
+        getattr(sns, plot)(data=frame(), x="cat", y="val", hue="hue", ax=ax)
+
+        assert [z_label(layer) for layer in layers(figure)] == ["hue", "hue"]
+
+    def test_a_chart_with_no_hue_still_reads_one_layer_per_category(self, plot):
+        # #426's shape, unchanged. Registration moved to the plotter method
+        # for every one of these charts, not only the grouped ones, so the
+        # ungrouped path is as much a part of this as the grouped one.
+        figure, ax = plt.subplots()
+        getattr(sns, plot)(data=frame(), x="cat", y="val", ax=ax)
+
+        assert names(figure) == [None, None, None]
+        assert [len(layer["data"]) for layer in layers(figure)] == [6, 6, 6]
+        assert len(set(announced(figure))) == 18
+
+
+class TestTheShapesTheGroupingSurvives:
+    def test_a_dodged_chart_groups_by_level_too(self):
+        # `dodge=True` splits each category into one collection per level, so
+        # every collection is uniformly coloured and the legend-based split
+        # declines for a second reason. The hue map does not care.
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", dodge=True, ax=ax)
+
+        assert names(figure) == LEVELS
+        assert [len(layer["data"]) for layer in layers(figure)] == [9, 9]
+
+    def test_a_translucent_chart_is_still_named(self):
+        # `alpha=` scales the drawn points' opacity and leaves the hue map's
+        # alone -- measured, (0.12, 0.47, 0.71, 0.4) drawn against a lookup
+        # entry of (..., 1.0) -- so the match is on the three colour channels.
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", alpha=0.4, ax=ax)
+
+        assert names(figure) == LEVELS
+
+    def test_a_chart_drawn_without_a_legend_is_still_named(self):
+        # The names come from the plotter's mapping, so suppressing the
+        # legend hides the grouping from sighted readers and from nobody else.
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", legend=False, ax=ax)
+
+        assert names(figure) == LEVELS
+        assert [z_label(layer) for layer in layers(figure)] == ["hue", "hue"]
+
+    def test_a_chart_on_its_side_groups_the_same_way(self):
+        # The categories move to `y` and the levels do not move at all.
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), y="cat", x="val", hue="hue", ax=ax)
+
+        assert names(figure) == LEVELS
+        for layer in layers(figure):
+            assert {point["yLabel"] for point in layer["data"]} == set(CATEGORIES)
+
+    def test_a_hue_that_repeats_the_category_names_the_categories(self):
+        # seaborn draws this one with a titleless legend, so the variable's
+        # name has to come from the plotter as well. Nothing is lost: the
+        # layers were one per category before and still are, now named.
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="cat", ax=ax)
+
+        assert names(figure) == CATEGORIES
+        assert [z_label(layer) for layer in layers(figure)] == ["cat"] * 3
+
+
+class TestWhatIsDeclined:
+    def test_a_continuous_hue_is_not_a_grouping(self):
+        # seaborn gives a numeric `hue=` one "level" per distinct value --
+        # eighteen of them here -- which is a colour scale. One layer per
+        # point is not a reading of it, so the chart keeps the reading it had.
+        figure, ax = plt.subplots()
+        sns.stripplot(
+            data=frame().assign(num=np.linspace(0, 1, 18)),
+            x="cat",
+            y="val",
+            hue="num",
+            ax=ax,
+        )
+
+        assert names(figure) == [None, None, None]
+        assert [len(layer["data"]) for layer in layers(figure)] == [6, 6, 6]
+
+
+    def test_a_hue_with_one_level_is_not_a_grouping(self):
+        # Nothing to tell apart. A layer named "only" over every point says
+        # no more than the unnamed one it would replace.
+        figure, ax = plt.subplots()
+        sns.stripplot(
+            data=frame().assign(one=["only"] * 18), x="cat", y="val", hue="one", ax=ax
+        )
+
+        assert names(figure) == [None, None, None]
+
+
+class TestTheOrderAndTheNeighbours:
+    def test_the_layers_follow_the_hue_order_not_the_drawing_order(self):
+        # #502 settled that a grouped layer's layers come out in the order the
+        # chart names its levels, not the order the rows happen to arrive in.
+        # This frame's first row is level "x", so a reading that kept the
+        # drawing order would put "x" first under either `hue_order`.
+        figure, ax = plt.subplots()
+        sns.stripplot(
+            data=frame(), x="cat", y="val", hue="hue", hue_order=["y", "x"], ax=ax
+        )
+
+        assert names(figure) == ["y", "x"]
+
+    def test_a_scatter_already_on_the_axes_is_left_to_its_own_layer(self):
+        # The panel is read by what this call *added* to it. Reading every
+        # collection instead would fold a neighbouring scatter into the strip
+        # plot's groups, or -- worse -- decline the grouping because that
+        # scatter's colour matches no hue level.
+        figure, ax = plt.subplots()
+        ax.scatter([0.5], [30])
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", ax=ax)
+
+        assert names(figure) == [None, "x", "y"]
+        assert [len(layer["data"]) for layer in layers(figure)] == [1, 9, 9]
+
+
+class TestTheFacetedAndFigureLevelInterfaces:
+    @pytest.mark.parametrize("kind", ["strip", "swarm"])
+    def test_catplot_reads_the_same_as_the_function(self, kind):
+        # `catplot` drives the plotter directly and imports neither public
+        # function, so a patch on `seaborn.stripplot` would have reached two
+        # of the three ways in and left this one behind.
+        grid = sns.catplot(data=frame(), x="cat", y="val", hue="hue", kind=kind)
+
+        assert names(grid.figure) == LEVELS
+        assert [len(layer["data"]) for layer in layers(grid.figure)] == [9, 9]
+
+    def test_each_panel_names_only_the_levels_it_holds(self):
+        # A faceted grid has no per-panel legend at all -- it builds one at
+        # the figure, after the panels are drawn -- and a panel that holds
+        # one level would not be nameable from a legend anyway.
+        grid = sns.catplot(
+            data=frame(), x="cat", y="val", hue="hue", col="col", kind="strip"
+        )
+        found = [(layer.get("name"), len(layer["data"])) for layer in layers(grid.figure)]
+
+        # Panel "p": six x rows (a and b), three y rows (a).
+        # Panel "q": three x rows (c), six y rows (b and c).
+        assert found == [("x", 6), ("y", 3), ("x", 3), ("y", 6)]
+        assert {z_label(layer) for layer in layers(grid.figure)} == {"hue"}
+
+
+class TestTheAssumptionTheGroupingRestsOn:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            pytest.param(
+                lambda data: sns.stripplot(data=data, x="cat", y="val", hue="hue"),
+                id="strip",
+            ),
+            pytest.param(
+                lambda data: sns.swarmplot(data=data, x="cat", y="val", hue="hue"),
+                id="swarm",
+            ),
+            pytest.param(
+                lambda data: sns.stripplot(
+                    data=data, x="cat", y="val", hue="hue", dodge=True
+                ),
+                id="dodged",
+            ),
+            pytest.param(
+                lambda data: sns.stripplot(
+                    data=data, x="cat", y="val", hue="hue", alpha=0.4
+                ),
+                id="translucent",
+            ),
+            pytest.param(
+                lambda data: sns.stripplot(
+                    data=data, x="cat", y="val", hue="hue", marker="x"
+                ),
+                id="unfilled-marker",
+            ),
+            pytest.param(
+                lambda data: sns.catplot(
+                    data=data, x="cat", y="val", hue="hue", col="col", kind="strip"
+                ),
+                id="faceted",
+            ),
+        ],
+    )
+    def test_seaborn_gives_every_point_its_own_colour(self, call):
+        # The whole grouping rests on this: a point's colour is what says
+        # which level it belongs to, so `get_facecolor` has to answer a row
+        # per point rather than the one row a uniformly styled collection
+        # would give. Seaborn assigns them in a single `set_facecolors` call
+        # over each panel's rows, which is why it holds -- including for the
+        # empty collections a faceted grid leaves, which have neither rows
+        # nor points.
+        #
+        # `_point_colours` declines a collection where the counts disagree,
+        # and that branch is unreachable while this passes. It is pinned here
+        # rather than left implicit so the release that ends it fails loudly.
+        call(frame())
+
+        for axes in plt.gcf().axes:
+            for collection in axes.collections:
+                rows = len(np.asarray(collection.get_facecolor()))
+                assert rows == len(np.asarray(collection.get_offsets()))
+
+
+class TestHighlighting:
+    def test_each_point_is_addressed_by_an_element_of_its_own(self):
+        # A group spans several collections, so its selectors have to name
+        # each through that collection's own id. One selector resolving to
+        # two elements, or two resolving to one, is a highlight on a point
+        # whose value is not being announced -- the failure nothing said
+        # aloud can catch.
+        pytest.importorskip("lxml")
+        from lxml import etree
+        from lxml.cssselect import CSSSelector
+
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", ax=ax)
+        html = maidr.render(figure)._repr_html_()
+
+        svg = re.search(r"<svg.*?</svg>", html, re.S)
+        assert svg is not None
+        root = etree.fromstring(svg.group(0).encode(), etree.XMLParser(recover=True))
+        for element in root.iter():
+            if isinstance(element.tag, str) and "}" in element.tag:
+                element.tag = element.tag.split("}", 1)[1]
+
+        matched = []
+        for layer in layers(figure):
+            selectors = layer["selectors"]
+            assert len(selectors) == len(layer["data"])
+            for selector in selectors:
+                found = CSSSelector(selector)(root)
+                assert len(found) == 1
+                matched.append(found[0])
+
+        assert len({id(element) for element in matched}) == 18

--- a/tests/core/plot/test_categorical_scatter_hue.py
+++ b/tests/core/plot/test_categorical_scatter_hue.py
@@ -226,6 +226,26 @@ class TestWhatIsDeclined:
         assert [len(layer["data"]) for layer in layers(figure)] == [6, 6, 6]
 
 
+    @pytest.mark.parametrize(
+        "palette",
+        [
+            pytest.param({"x": (0.0, 0.0, 1.0, 0.3), "y": (0.0, 0.0, 1.0, 0.9)},
+                         id="same-hue-different-opacity"),
+            pytest.param({"x": "blue", "y": "blue"}, id="the-same-colour-twice"),
+        ],
+    )
+    def test_two_levels_drawn_the_same_colour_are_not_told_apart(self, palette):
+        # The levels are matched on their three colour channels, so opacity
+        # alone does not separate them -- and a palette that draws two levels
+        # the same colour does not separate them at all. Measured: both come
+        # out as the ungrouped reading, three unnamed layers, rather than
+        # every point of both levels handed to whichever name matched first.
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", palette=palette, ax=ax)
+
+        assert names(figure) == [None, None, None]
+        assert len(set(announced(figure))) == 18
+
     def test_a_hue_with_one_level_is_not_a_grouping(self):
         # Nothing to tell apart. A layer named "only" over every point says
         # no more than the unnamed one it would replace.


### PR DESCRIPTION
Closes #586.

## The defect

`sns.stripplot(..., hue=...)` emitted exactly the schema of the same call
**without** a `hue=`. Not a wrong grouping — no grouping at all, on a chart
whose subject is the comparison between the levels.

| call | layers | names | `z` |
|---|---|---|---|
| `stripplot(x, y)` | `point` ×3 | — | — |
| `stripplot(x, y, hue=)` | `point` ×3 | — | — |
| `swarmplot(x, y, hue=)` | `point` ×3 | — | — |
| `catplot(kind="strip", hue=)` | `point` ×3 | — | — |

The three layers were the three *categories*; the legend `['x', 'y']` seaborn
drew never reached the schema.

## Why

These charts registered at the inner `Axes.scatter` calls seaborn makes, one
per category. `hue_groups` needs two things from the collection at that
moment and **neither exists yet** — `plot_strips` writes both afterwards:

```python
points = ax.scatter(sub_data["x"], sub_data["y"], color=color, **plot_kws)
if "hue" in self.variables:
    points.set_facecolors(self._hue_map(sub_data["hue"]))
...
self._configure_legend(ax, _scatter_legend_artist, common_kws=plot_kws)
```

Measured by spying on `Axes.scatter`:

```
at each of the three returns:  legend present = False, facecolor rows = 1, unique = 1
after the call:                legend = ['x', 'y'], unique colours per collection = 2
```

`hue_groups` is not at fault — it was being asked before the answer existed.
`sns.scatterplot` escapes only because it is wrapped at the seaborn level and
read afterwards.

## The reading

New `maidr/patch/stripplot.py` wraps `_CategoricalPlotter.plot_strips` and
`plot_swarms`, the way `plot_bars` and `plot_boxens` already are — `catplot`
drives the plotter directly and imports neither public function, so a patch on
`seaborn.stripplot` would have reached three of the four rows above (verified:
`catplot(kind="strip")` does not call `seaborn.stripplot`). Both methods call
`_configure_legend` as their last statement, so drawing inside the internal
context and reading after it puts everything in place.

The grouping comes off the plotter's own `_hue_map`, not off a legend:

- a faceted `catplot` panel has **no legend** — the grid builds one at the
  figure, afterwards;
- a panel holding only one of the levels could not be named from a legend
  anyway, since one colour against a swatch is a guess.

Levels are keyed on the three colour channels rather than four, because
`alpha=` scales the drawn points and leaves the mapping alone — measured,
`(0.12, 0.47, 0.71, 0.4)` drawn against a lookup entry of `(..., 1.0)`.

A **numeric** `hue=` is declined: seaborn builds one lookup entry per distinct
value, so eighteen rows offer eighteen "levels". That is a colour scale, and
one layer per point is not a reading of it — the same chart `hue_groups`
declines one level down.

## What a panel gets

- **A hue level each**, spanning the categories, named by the level with the
  hue variable on `z`. That is the decomposition `scatterplot(hue=)` already
  emits for the same frame (#544), with the category on each point's `xLabel`
  — so the same data drawn two ways finally reads the same way.
- **A collection each, unnamed**, when there is no hue to read: one layer per
  category, exactly what #426 settled and `test_scatter_own_collection.py`
  pins. Untouched.

`ScatterPlot` now takes a **list** of collections, since a hue level spans
seaborn's one-collection-per-category drawing, and addresses each point
through its own collection's id. A layer handed a single collection — every
scatter before this — takes the one-entry path through all of it unchanged.

`GROUP_LABEL` is a new fallback for the `z` label, for the three charts that
have a grouping and no legend title to read it from: `catplot`, `legend=False`,
and a `hue=` that repeats `x` (seaborn draws that one titleless).

## Verification

| call | after |
|---|---|
| `stripplot(hue=)` | `x`(9), `y`(9), `z: hue` |
| `swarmplot(hue=)` | `x`(9), `y`(9), `z: hue` |
| `stripplot(hue=, dodge=True)` | `x`(9), `y`(9) |
| `stripplot(hue=, alpha=.4)` | `x`(9), `y`(9) |
| `stripplot(y=, x=, hue=)` | `x`(9), `y`(9), categories on `yLabel` |
| `catplot(kind="strip", col=, hue=)` | `x`(6), `y`(3) \| `x`(3), `y`(6) |
| `stripplot(hue="num")` | unchanged — 3 unnamed |
| `stripplot()` | unchanged — 3 unnamed, 6 points each |

- Every drawn point announced exactly once, no duplicates, values matching the
  offsets.
- Selectors resolved against the rendered SVG with `lxml.cssselect`: 18
  selectors, each matching exactly **one** element, 18 distinct across the
  chart — no overlap and no misses. The same check on `strip plain` and
  `scatterplot(hue=)` is unchanged.
- Eleven mutations applied one at a time against a restored baseline, ten
  killed: reading collection 0 for every selector, extracting only the first
  collection, dropping the categorical guard, matching on full RGBA, dropping
  the hue-order sort, drawing outside the internal context, reading every
  collection rather than the new ones, grouping a single-level hue, dropping
  the `z` fallback, and truncating the colour list.
- The eleventh — removing the decline when a collection's facecolor rows do not
  match its point count — **survives**, because that branch is unreachable
  today: seaborn writes one row per point on every shape measured (strip,
  swarm, dodged, faceted, translucent, unfilled marker, and the empty
  collections a faceted grid leaves, which have neither). Rather than leave
  that implicit, `test_seaborn_gives_every_point_its_own_colour` pins the
  assumption across all six, so the release that ends it turns a test red
  instead of making that branch quietly load-bearing.
- `tests/core/plot/test_categorical_scatter_hue.py` — 29 tests.
- Full suite: **2829 passed, 18 skipped**. `ruff check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_