### PR TITLE
fix(hist): name the hue groups of a filled step or poly histogram

### DIFF
--- a/maidr/core/plot/stepped_histogram.py
+++ b/maidr/core/plot/stepped_histogram.py
@@ -62,7 +62,11 @@ class SteppedHistPlot(HistPlot):
 
     def __init__(self, ax: Axes, collection: PolyCollection, **kwargs) -> None:
         self._collection = collection
-        super().__init__(ax)
+        # Forwarded, not dropped. `HistPlot.__init__` is what reads
+        # `GROUP_NAME`, so calling it with the axes alone leaves a `hue=`
+        # chart with a layer per group and no name on any of them -- the
+        # defect #585 fixed on the unfilled twin of this class, and #587 here.
+        super().__init__(ax, **kwargs)
         # One `<path>` for the whole outline, as `Axes.stairs` has: there is no
         # per-bin element for a selector to name, and one naming the outline
         # would light the whole distribution up at every bin.

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -458,8 +458,13 @@ def _face_colour(outline: PolyCollection):
     Returns
     -------
     tuple of float or None
-        The rounded RGBA, or ``None`` when the collection names no single
-        colour.
+        The rounded RGBA of the collection's first row, or ``None`` when it
+        holds no rows or that row names no colour.
+
+        The first row *is* the colour here rather than a sample of several:
+        seaborn draws one outline per series and colours it in one call, so
+        the collection carries a single face. Said rather than checked, since
+        a uniformity test over one row could not fail.
     """
     rows = np.asarray(outline.get_facecolor())
     return _rgba(rows[0]) if len(rows) else None

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -432,6 +432,39 @@ def _outlines_of(ax: Axes | None) -> list:
     ]
 
 
+def _face_colour(outline: PolyCollection):
+    """
+    The one colour a filled outline was drawn in, if it has one.
+
+    Its **face**, which is what carries the hue. By default the edge carries
+    it too -- measured, the two agree but for the translucency the face and
+    the legend swatch share -- so either would name the groups, the edge
+    through `_names_for`'s alpha-insensitive pass. `edgecolor=` is what
+    separates them: it is the caller's to set, and setting it once colours
+    *every* group's edge alike::
+
+        histplot(hue="g", element="step")                    edges (1.0, .50, .05) / (.12, .47, .71)
+        histplot(hue="g", element="step", edgecolor="black") edges (0, 0, 0) / (0, 0, 0)
+
+    Two groups drawn one colour name nothing, and a chart outlined in black
+    is an ordinary chart rather than a strange one. The face is untouched by
+    it, so it is what this reads.
+
+    Parameters
+    ----------
+    outline : PolyCollection
+        The outline seaborn drew.
+
+    Returns
+    -------
+    tuple of float or None
+        The rounded RGBA, or ``None`` when the collection names no single
+        colour.
+    """
+    rows = np.asarray(outline.get_facecolor())
+    return _rgba(rows[0]) if len(rows) else None
+
+
 def _drew_outlines(ax: Axes | None, before: list) -> list:
     """
     The outlines *this call* added, if any.
@@ -643,8 +676,19 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
         if drew:
             # `element="step"` / `"poly"`: the same distribution drawn as one
             # closed outline per series instead of a row of bars.
-            for outline in drew:
-                FigureManager.create_maidr(axes, PlotType.HIST, collection=outline)
+            #
+            # Named from the legend by colour, the way the bars and the
+            # unfilled outlines are. Deferred for the reason `_curve_names`
+            # gives: a `pairplot`'s legend does not exist until every panel
+            # has been drawn (#561).
+            names = deferred_names(
+                lambda: _names_for(axes, [_face_colour(one) for one in drew]),
+                len(drew),
+            )
+            for outline, name in zip(drew, names):
+                FigureManager.create_maidr(
+                    axes, PlotType.HIST, collection=outline, **{GROUP_NAME: name}
+                )
             return drawn
         horizontal = _asked_for_horizontal(kwargs)
         outlined = _drew_outline_lines(

--- a/tests/core/plot/test_hue_histogram.py
+++ b/tests/core/plot/test_hue_histogram.py
@@ -101,6 +101,75 @@ def test_each_layer_is_named_from_the_legend():
     assert _names(fig) == ["x", "y"]
 
 
+@pytest.mark.parametrize("element", ["bars", "step", "poly"])
+def test_a_filled_outline_is_named_the_way_the_bars_are(element: str):
+    """`element=` is a visual choice, so it cannot cost the groups their names.
+
+    ``element="step"`` and ``"poly"`` draw one ``PolyCollection`` per group
+    instead of a row of bars, and that branch registered the collection and
+    nothing else -- measured, `[None, None]` against `["b", "a"]` for the
+    same frame drawn as bars (#587). Not wrong, but two `hist` layers over
+    one axis with no way to tell them apart, which is the position
+    ``MaidrLayer.name`` exists to fix.
+
+    Named from the outline's *face* colour: seaborn draws face and edge in
+    the same hue and the legend swatch carries the face's translucency, so
+    the face matches a swatch outright.
+    """
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", hue="g", bins=5, element=element, ax=ax)
+
+    assert _names(fig) == ["x", "y"]
+    assert _counts(fig) == [
+        [float(count) for count in _true_counts(frame, "x", 5)],
+        [float(count) for count in _true_counts(frame, "y", 5)],
+    ]
+
+
+def test_an_outline_drawn_with_one_edge_colour_is_still_named():
+    """`edgecolor=` colours every group's edge alike; the face is untouched.
+
+    The reason the name comes off the face. By default the edge carries the
+    hue as well and either would do, so nothing in the ordinary chart
+    distinguishes the two choices -- measured::
+
+        element="step"                     edges (1.0, .50, .05) / (.12, .47, .71)
+        element="step", edgecolor="black"  edges (0, 0, 0) / (0, 0, 0)
+
+    An edge-based match names the second chart `[None, None]`, because two
+    groups drawn one colour cannot be told apart by it.
+    """
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(
+        data=frame, x="a", hue="g", bins=5, element="step", edgecolor="black", ax=ax
+    )
+
+    assert _names(fig) == ["x", "y"]
+
+
+@pytest.mark.parametrize("element", ["step", "poly"])
+def test_a_filled_outline_with_no_hue_stays_unnamed(element: str):
+    # Nothing to tell apart, and the naming must not invent one.
+    frame = _frame(["x"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, x="a", bins=5, element=element, ax=ax)
+
+    assert _names(fig) == [None]
+
+
+def test_a_filled_outline_reads_the_same_on_its_side():
+    # The name comes from the colour and the orientation from the geometry,
+    # so turning the chart moves one and not the other.
+    frame = _frame(["x", "y"])
+    fig, ax = plt.subplots()
+    sns.histplot(data=frame, y="a", hue="g", bins=5, element="step", ax=ax)
+
+    assert _names(fig) == ["x", "y"]
+    assert {layer.get("orientation") for layer in _layers(fig)} == {"horz"}
+
+
 def test_a_third_group_is_read_and_named_too():
     # Not a restatement of the pair: the old reading dropped *every* group
     # after the first, so the loss grew with the chart.


### PR DESCRIPTION
Closes #587.

## The defect

`sns.histplot(hue=..., element="step"|"poly")` split into one layer per group
and named **none** of them. Not a wrong reading — two `hist` announcements over
one axis with nothing to tell them apart, which is exactly the position
`MaidrLayer.name` was added for (xability/maidr#828).

Measured, two groups of twenty rows over four bins:

| call | layer names |
|---|---|
| `element="bars"` | `["b", "a"]` |
| `element="step"` | `[None, None]` |
| `element="poly"` | `[None, None]` |
| `element="step"`, `fill=False` | `["b", "a"]` (since #585) |

`element=` is a purely visual choice, so the filled outline was the only
spelling of this chart that cost the reader the grouping.

## Why, and both halves of it

The patch registered each outline with its collection and nothing else — **no
name was ever computed**:

```python
for outline in drew:
    FigureManager.create_maidr(axes, PlotType.HIST, collection=outline)
```

And `SteppedHistPlot.__init__` called `HistPlot.__init__(ax)` without its
kwargs, so a name handed over would have been dropped on the way in — the same
defect #585 fixed on `OutlinedHistPlot`, which is why the review there flagged
this class as latent. It was not latent; it was silent for a second reason as
well, and fixing either alone changes nothing.

## Which colour names a group

The outline's **face**.

By default the edge carries the hue too, so either would name the groups — the
face matches the legend swatch outright (both `(0.12, 0.47, 0.71, 0.25)`,
translucency included) and the edge matches through `_names_for`'s
alpha-insensitive second pass. Nothing in the ordinary chart distinguishes the
two choices, which is how a mutation swapping them survived the first pass.

`edgecolor=` is what separates them, and it is an ordinary thing to pass:

```
element="step"                       edges (1.0, .50, .05) / (.12, .47, .71)
element="step", edgecolor="black"    edges (0, 0, 0)       / (0, 0, 0)
```

One edge colour for every group names nothing — an edge-based match returns
`[None, None]` for a chart that is merely outlined in black. The face is
untouched by it. `test_an_outline_drawn_with_one_edge_colour_is_still_named`
pins that, and it is what turns the mutation from surviving to killed.

Names are deferred like the bars' and the density curves', because a
`pairplot`'s legend does not exist until every panel has been drawn (#561).

## Verification

| call | after |
|---|---|
| `element="bars"` | `["x", "y"]` |
| `element="step"` | `["x", "y"]`, counts per group correct |
| `element="poly"` | `["x", "y"]`, counts per group correct |
| `element="step"`, `y=` | `["x", "y"]`, both `horz` |
| `element="step"`, `edgecolor="black"` | `["x", "y"]` |
| `element="step"`, no hue | `[None]` — unchanged |
| `pairplot(diag_kind="hist", element="step")` | `['y', 'x', 'y', 'x']` — the deferred path |

- Each layer's counts checked against `np.histogram` over that group's rows
  alone, so the names are attached to the right distributions rather than
  merely present.
- Four mutations applied one at a time against a restored baseline, all killed:
  dropping the kwargs again, computing no names, reading the edge colour, and
  pairing the names in reverse.
- Full suite: **2838 passed, 18 skipped**. `ruff check` clean.

## Still out of scope

`displot(kind="hist", fill=False)` registers nothing at all — `displot` drives
the plotter directly and that patch reads containers only, so the unfilled
spelling never reaches a reading there. Pre-existing and wider than this;
worth its own issue rather than folding in.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_