### PR TITLE
feat(hist): read every element displot draws, not only bars

### DIFF
--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -677,47 +677,13 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
         # context -- which is what made the same figure readable through one
         # spelling and silent through the other (#522).
         axes = FigureManager.get_axes(drawn)
-        drew = _drew_outlines(axes, outlines)
-        if drew:
-            # `element="step"` / `"poly"`: the same distribution drawn as one
-            # closed outline per series instead of a row of bars.
-            #
-            # Named from the legend by colour, the way the bars and the
-            # unfilled outlines are. Deferred for the reason `_curve_names`
-            # gives: a `pairplot`'s legend does not exist until every panel
-            # has been drawn (#561).
-            names = deferred_names(
-                lambda: _names_for(axes, [_face_colour(one) for one in drew]),
-                len(drew),
-            )
-            for outline, name in zip(drew, names):
-                FigureManager.create_maidr(
-                    axes, PlotType.HIST, collection=outline, **{GROUP_NAME: name}
-                )
-            return drawn
-        horizontal = _asked_for_horizontal(kwargs)
-        outlined = _drew_outline_lines(
-            axes, lines, bool(kwargs.get("kde", False)), horizontal
-        )
-        if outlined:
-            # The same two elements drawn `fill=False`: seaborn swaps the
-            # collection for a bare `Line2D`, so the branch above finds
-            # nothing and the chart was silent (#583). Named from the legend
-            # by colour, as the filled spelling and the density already are.
-            names = deferred_names(
-                lambda: _names_for(axes, [_rgba(line.get_color()) for line in outlined]),
-                len(outlined),
-            )
-            for line, name in zip(outlined, names):
-                FigureManager.create_maidr(
-                    axes,
-                    PlotType.HIST,
-                    **{
-                        OUTLINE_LINE: line,
-                        OUTLINE_HORIZONTAL: horizontal,
-                        GROUP_NAME: name,
-                    },
-                )
+        if _register_outlines(
+            axes,
+            outlines,
+            lines,
+            bool(kwargs.get("kde", False)),
+            _asked_for_horizontal(kwargs),
+        ):
             return drawn
         if _drew_mesh(axes, meshes):
             # Named from `stat` rather than hardcoded, because it is what the
@@ -788,8 +754,8 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
 
 
 def _register_outlines(
-    ax: Axes, outlines: list, lines: list, kde: bool, horizontal: bool
-) -> None:
+    ax: Axes | None, outlines: list, lines: list, kde: bool, horizontal: bool
+) -> bool:
     """
     Register the panel's distribution when it was drawn as an outline.
 
@@ -824,27 +790,40 @@ def _register_outlines(
         ``poly`` outline unreadable -- see :func:`_drew_outline_lines`.
     horizontal : bool
         Whether the distribution runs up the y axis.
+
+    Returns
+    -------
+    bool
+        Whether it registered anything, which is the caller's signal to stop
+        looking for another shape on this panel.
     """
+    # `element="step"` / `"poly"`: the same distribution drawn as one closed
+    # outline per series instead of a row of bars. Named from the legend by
+    # colour, the way the bars are, and deferred for the reason
+    # `_curve_names` gives: a `pairplot`'s legend does not exist until every
+    # panel has been drawn (#561).
     drew = _drew_outlines(ax, outlines)
     if drew:
-        for outline, name in zip(drew, deferred_names(
-            lambda ax=ax, drew=drew: _names_for(
-                ax, [_face_colour(one) for one in drew]
-            ),
-            len(drew),
-        )):
+        names = deferred_names(
+            lambda: _names_for(ax, [_face_colour(one) for one in drew]), len(drew)
+        )
+        for outline, name in zip(drew, names):
             FigureManager.create_maidr(
                 ax, PlotType.HIST, collection=outline, **{GROUP_NAME: name}
             )
-        return
+        return True
 
+    # The same two elements drawn `fill=False`: seaborn swaps the collection
+    # for a bare `Line2D`, so the branch above finds nothing (#583).
     outlined = _drew_outline_lines(ax, lines, kde, horizontal)
-    for line, name in zip(outlined, deferred_names(
-        lambda ax=ax, outlined=outlined: _names_for(
-            ax, [_rgba(one.get_color()) for one in outlined]
-        ),
+    if not outlined:
+        return False
+
+    names = deferred_names(
+        lambda: _names_for(ax, [_rgba(one.get_color()) for one in outlined]),
         len(outlined),
-    )):
+    )
+    for line, name in zip(outlined, names):
         FigureManager.create_maidr(
             ax,
             PlotType.HIST,
@@ -854,6 +833,7 @@ def _register_outlines(
                 GROUP_NAME: name,
             },
         )
+    return True
 
 
 def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
@@ -898,7 +878,10 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
     # since `displot` builds its own grid. Kept anyway, and mirrored below for
     # the other two shapes: one ownership rule for every artist a panel can
     # arrive with beats three, and the day a plotter is handed a used axes it
-    # is the only thing standing between declining and lying.
+    # is the only thing standing between declining and lying. No test covers
+    # it and none can while that holds -- a mutation emptying the snapshot
+    # passes the suite, which is recorded here rather than left to be
+    # rediscovered.
     panels = plotter_axes(instance)
     before = {id(ax): _containers_of(ax) for ax in panels}
     # The other two shapes a panel can arrive in. Snapshotted the same way and
@@ -920,8 +903,13 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
     for ax in plotter_axes(instance):
         seen = before.get(id(ax), [])
         if not _drew_bars(ax, seen):
-            _register_outlines(ax, outlines.get(id(ax), []), lines.get(id(ax), []),
-                               kde, horizontal)
+            _register_outlines(
+                ax,
+                outlines.get(id(ax), []),
+                lines.get(id(ax), []),
+                kde,
+                horizontal,
+            )
             continue
         # One layer per group here too; `displot(hue=...)` reaches only this
         # site, so leaving it reading the first container would fix the defect

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -787,6 +787,75 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
     return ax
 
 
+def _register_outlines(
+    ax: Axes, outlines: list, lines: list, kde: bool, horizontal: bool
+) -> None:
+    """
+    Register the panel's distribution when it was drawn as an outline.
+
+    ``element="step"`` and ``element="poly"`` draw a ``PolyCollection`` when
+    filled and a bare ``Line2D`` when not, so a panel with either holds no
+    ``BarContainer`` and the bar registrar above passes over it. Through
+    ``histplot`` both are read; through ``displot`` neither was, and the
+    figure produced no HTML at all -- measured on seaborn 0.13.2::
+
+        histplot(x="v", element="step")               hist
+        histplot(x="v", element="step", fill=False)   hist
+        displot(x="v", element="step")                nothing
+        displot(x="v", element="step", fill=False)    nothing
+
+    ``element="bars"`` was the only spelling ``displot`` read (#590). The
+    readings themselves already existed -- this is the branch that reaches
+    them, the same two ``sns_hist`` has.
+
+    Named from the legend by colour, as everything else here is: the filled
+    outline from its face, the unfilled one from the line's colour.
+
+    Parameters
+    ----------
+    ax : Axes
+        One panel.
+    outlines : list
+        The filled outlines the panel held beforehand.
+    lines : list
+        The lines the panel held beforehand.
+    kde : bool
+        Whether the caller asked for a density overlay, which is what makes a
+        ``poly`` outline unreadable -- see :func:`_drew_outline_lines`.
+    horizontal : bool
+        Whether the distribution runs up the y axis.
+    """
+    drew = _drew_outlines(ax, outlines)
+    if drew:
+        for outline, name in zip(drew, deferred_names(
+            lambda ax=ax, drew=drew: _names_for(
+                ax, [_face_colour(one) for one in drew]
+            ),
+            len(drew),
+        )):
+            FigureManager.create_maidr(
+                ax, PlotType.HIST, collection=outline, **{GROUP_NAME: name}
+            )
+        return
+
+    outlined = _drew_outline_lines(ax, lines, kde, horizontal)
+    for line, name in zip(outlined, deferred_names(
+        lambda ax=ax, outlined=outlined: _names_for(
+            ax, [_rgba(one.get_color()) for one in outlined]
+        ),
+        len(outlined),
+    )):
+        FigureManager.create_maidr(
+            ax,
+            PlotType.HIST,
+            **{
+                OUTLINE_LINE: line,
+                OUTLINE_HORIZONTAL: horizontal,
+                GROUP_NAME: name,
+            },
+        )
+
+
 def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
     """
     Register the panels ``seaborn.displot`` draws, which reach no other patch.
@@ -824,15 +893,35 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
 
     # Snapshot per axes before the call, so a panel that already held bars --
     # someone else's `barplot` on the same axes -- is not claimed as this
-    # histogram's. Empty for a faceted call, whose panels do not exist yet.
-    before = {id(ax): _containers_of(ax) for ax in plotter_axes(instance)}
+    # histogram's. The panels themselves exist by now, faceted or not
+    # (measured: one for a plain `displot`, two for `col=`), and hold nothing,
+    # since `displot` builds its own grid. Kept anyway, and mirrored below for
+    # the other two shapes: one ownership rule for every artist a panel can
+    # arrive with beats three, and the day a plotter is handed a used axes it
+    # is the only thing standing between declining and lying.
+    panels = plotter_axes(instance)
+    before = {id(ax): _containers_of(ax) for ax in panels}
+    # The other two shapes a panel can arrive in. Snapshotted the same way and
+    # for the same reason: an axes that already held an outline is not this
+    # call's to claim.
+    outlines = {id(ax): _outlines_of(ax) for ax in panels}
+    lines = {id(ax): _lines_of(ax) for ax in panels}
 
     with ContextManager.set_internal_context():
         drawn = _draw_quietly(wrapped, args, kwargs)
 
+    # Which axis the distribution runs along, off the plotter rather than off
+    # the caller's keywords -- `displot` forwards neither `x` nor `y` to this
+    # method. Measured, `data_variable` is 'x' or 'y' for every spelling.
+    # Only the unfilled outline needs it; see `OUTLINE_HORIZONTAL`.
+    horizontal = getattr(instance, "data_variable", "x") == "y"
+    kde = bool(kwargs.get("kde", False))
+
     for ax in plotter_axes(instance):
         seen = before.get(id(ax), [])
         if not _drew_bars(ax, seen):
+            _register_outlines(ax, outlines.get(id(ax), []), lines.get(id(ax), []),
+                               kde, horizontal)
             continue
         # One layer per group here too; `displot(hue=...)` reaches only this
         # site, so leaving it reading the first container would fix the defect

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -839,8 +839,18 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
         # for `histplot` and not for the figure-level spelling of the same
         # chart -- the asymmetry #522 and #446 were both about.
         containers = _new_bar_containers(ax, seen)
+        # `ax` and `containers` bound here rather than closed over. The
+        # resolver runs at *render* -- that is what `deferred_names` is for --
+        # by which time this loop has finished and both names hold the last
+        # panel's values, so every panel resolved against that one panel.
+        # Measured on `displot(hue=..., col=...)` over a grid whose panels
+        # hold different groups: three layers, all `None`, because the last
+        # panel held a single container and a lone artist is exactly what
+        # `names_for` declines. Asked panel by panel the same figure gives
+        # `['b', 'a']` and `[None]` (#591).
         for container, name in zip(containers, deferred_names(
-            lambda: _group_names(ax, containers), len(containers)
+            lambda ax=ax, containers=containers: _group_names(ax, containers),
+            len(containers),
         )):
             FigureManager.create_maidr(
                 ax, PlotType.HIST, **{DRAWN_BARS: container, GROUP_NAME: name}

--- a/tests/core/test_displot_distribution.py
+++ b/tests/core/test_displot_distribution.py
@@ -215,3 +215,47 @@ class TestWhatMustNotChange:
         grid = sns.jointplot(data=frame(), x="v", y="w")
 
         assert layers(grid.figure) == ["point", "hist", "hist"]
+
+
+class TestAFacetedHistogramNamesEachPanelFromItself:
+    """Every panel's names used to resolve from the last panel's (#591).
+
+    ``deferred_names`` stores its resolver and runs it at *render*, which is
+    what makes a ``pairplot``'s legend readable (#561). Built inside the
+    per-panel loop it closed over the loop variables, so by the time it ran
+    they held the final panel's axes and containers and every panel was named
+    from that one.
+
+    Measured on a grid whose panels hold different groups: three layers, all
+    ``None``, because the last panel held a single container and a lone
+    artist is exactly what ``names_for`` declines. Asked panel by panel the
+    same figure gives ``['b', 'a']`` and ``[None]``.
+    """
+
+    @staticmethod
+    def _split_frame() -> pd.DataFrame:
+        # Panel "p" holds groups a and b; panel "q" holds only c. The panels
+        # must differ in *shape*, or the last one's answer happens to fit.
+        return pd.DataFrame(
+            {
+                "v": list(np.linspace(0, 1, 30)),
+                "g": ["a"] * 10 + ["b"] * 10 + ["c"] * 10,
+                "c": ["p"] * 20 + ["q"] * 10,
+            }
+        )
+
+    def test_each_panel_is_named_from_its_own_groups(self):
+        grid = sns.displot(self._split_frame(), x="v", hue="g", col="c", bins=3)
+        named = [
+            (plot.schema.get("name"), [point["y"] for point in plot.schema["data"]])
+            for plot in FigureManager.get_maidr(grid.figure)._plots
+        ]
+
+        # The counts say which group each layer holds, so the names can be
+        # checked against them rather than against registration order.
+        assert named == [
+            ("b", [0.0, 10.0, 0.0]),
+            ("a", [10.0, 0.0, 0.0]),
+            (None, [0.0, 0.0, 10.0]),
+        ]
+

--- a/tests/core/test_displot_distribution.py
+++ b/tests/core/test_displot_distribution.py
@@ -359,3 +359,39 @@ class TestTheShapesOnlyDisplotCanReach:
         ]
 
         assert sorted(name for name in names if name) == ["a", "b"]
+
+    @pytest.mark.parametrize(
+        ("element", "reads"), [("step", True), ("poly", False)]
+    )
+    def test_a_density_overlay_decides_which_outline_is_readable(
+        self, element, reads
+    ):
+        """`kde=` has to be observed here, and it is not a `displot` keyword.
+
+        The plotter method takes it under its own name, so this reads the
+        *inner* call's kwargs -- measured, ``kde=True`` arrives there as a
+        keyword for every spelling. Worth pinning rather than assuming, since
+        the neighbouring `x`/`y` arguments are **not** forwarded that way and
+        the orientation had to come off the plotter instead.
+
+        What it decides: an unfilled ``poly`` outline and a density curve are
+        both ``drawstyle="default"`` and differ only in vertex count, which
+        both ``gridsize=`` and the bin count move -- so a ``poly`` drawn
+        beside a density is declined rather than guessed at (#583). A
+        ``step`` outline is unambiguous by drawstyle and is read. A `kde` that
+        arrived silently `False` would announce that density as a
+        distribution.
+        """
+        grid = sns.displot(
+            frame(), x="v", bins=4, element=element, fill=False, kde=True
+        )
+
+        assert layers(grid.figure) == (["hist"] if reads else [])
+
+    def test_the_same_pair_reads_the_same_way_through_histplot(self):
+        # The asymmetry this whole class is about, asserted in the one place
+        # the two interfaces are meant to agree on a *decline*.
+        _, ax = plt.subplots()
+        sns.histplot(frame(), x="v", bins=4, element="poly", fill=False, kde=True, ax=ax)
+
+        assert layers(ax.get_figure()) == []

--- a/tests/core/test_displot_distribution.py
+++ b/tests/core/test_displot_distribution.py
@@ -217,6 +217,70 @@ class TestWhatMustNotChange:
         assert layers(grid.figure) == ["point", "hist", "hist"]
 
 
+class TestEveryElementDisplotDraws:
+    """`element=` is a visual choice, and `displot` read only one of them.
+
+    ``element="step"`` and ``"poly"`` draw a ``PolyCollection`` when filled
+    and a bare ``Line2D`` when not, so a panel with either holds no
+    ``BarContainer`` and the bar registrar passed over it. Both readings
+    already existed for ``histplot`` (#583, #587); what was missing was the
+    branch that reaches them from the plotter, and the figure came out with
+    no HTML at all rather than with a wrong announcement (#590)::
+
+        histplot(x="v", element="step")               hist
+        displot(x="v", element="step")                nothing
+        displot(x="v", element="step", fill=False)    nothing
+        displot(x="v", element="poly", fill=False)    nothing
+    """
+
+    @pytest.mark.parametrize("element", ["bars", "step", "poly"])
+    @pytest.mark.parametrize("fill", [True, False])
+    @pytest.mark.parametrize("axis", ["x", "y"])
+    def test_displot_says_what_histplot_says(self, element, fill, axis):
+        # The whole assertion in one: the two interfaces draw the same chart
+        # from the same data, so they have to describe it identically --
+        # orientation, bin bounds and counts alike. It cannot be satisfied by
+        # inventing numbers, because `histplot`'s reading is pinned already.
+        data = frame()
+        _, ax = plt.subplots()
+        sns.histplot(data, bins=4, ax=ax, element=element, fill=fill, **{axis: "v"})
+        axes_level = [
+            (plot.schema.get("orientation"), plot.schema["data"])
+            for plot in FigureManager.get_maidr(ax.get_figure())._plots
+        ]
+
+        plt.close("all")
+        grid = sns.displot(data, bins=4, element=element, fill=fill, **{axis: "v"})
+        figure_level = [
+            (plot.schema.get("orientation"), plot.schema["data"])
+            for plot in FigureManager.get_maidr(grid.figure)._plots
+        ]
+
+        assert figure_level == axes_level
+
+    @pytest.mark.parametrize("element", ["step", "poly"])
+    def test_a_hue_grouped_outline_names_its_groups(self, element):
+        # The names come from the legend by colour, as the bars' do.
+        grid = sns.displot(
+            frame(), x="v", hue="g", bins=3, element=element, fill=False
+        )
+        names = [
+            plot.schema.get("name")
+            for plot in FigureManager.get_maidr(grid.figure)._plots
+        ]
+
+        assert sorted(name for name in names if name) == ["a", "b"]
+
+    def test_an_outline_panel_does_not_claim_a_neighbour_s_outline(self):
+        # The per-axes snapshot, asked of collections and lines the way it is
+        # already asked of containers.
+        _, ax = plt.subplots()
+        sns.histplot(frame(), x="v", bins=3, element="step", ax=ax)
+        sns.histplot(frame(), x="w", bins=3, element="step", ax=ax)
+
+        assert layers(ax.get_figure()) == ["hist", "hist"]
+
+
 class TestAFacetedHistogramNamesEachPanelFromItself:
     """Every panel's names used to resolve from the last panel's (#591).
 
@@ -259,3 +323,39 @@ class TestAFacetedHistogramNamesEachPanelFromItself:
             (None, [0.0, 0.0, 10.0]),
         ]
 
+
+class TestTheShapesOnlyDisplotCanReach:
+    def test_a_horizontal_poly_outline_is_not_read_transposed(self):
+        """The tie-break #585 added, reached through the plotter this time.
+
+        A ``poly`` outline repeats no value, so on a ``y=`` chart whose counts
+        climb, both of its columns ascend and both read as bins. The
+        orientation settles it, and through ``displot`` it cannot come from a
+        ``y=`` keyword -- ``displot`` forwards neither ``x`` nor ``y`` to the
+        plotter method. It comes from ``data_variable`` instead.
+
+        Two bins is the everyday case: a single gap is evenly spaced whatever
+        it holds.
+        """
+        counts = pd.DataFrame({"v": [0.1, 0.2, 0.6, 0.7, 0.8, 0.9, 0.95]})
+        grid = sns.displot(counts, y="v", bins=2, element="poly", fill=False)
+        schema = FigureManager.get_maidr(grid.figure)._plots[0].schema
+
+        assert schema.get("orientation") == "horz"
+        # The bins run up y and the counts sit on x, not the other way about.
+        for point in schema["data"]:
+            assert point["yMin"] < point["yMax"]
+            assert point["x"] == int(point["x"])
+
+    @pytest.mark.parametrize("element", ["step", "poly"])
+    def test_a_hue_grouped_filled_outline_names_its_groups(self, element):
+        # The filled branch, which the unfilled test above does not reach:
+        # `fill=True` draws a `PolyCollection` per group and the name comes
+        # off its face colour (#587).
+        grid = sns.displot(frame(), x="v", hue="g", bins=3, element=element)
+        names = [
+            plot.schema.get("name")
+            for plot in FigureManager.get_maidr(grid.figure)._plots
+        ]
+
+        assert sorted(name for name in names if name) == ["a", "b"]


### PR DESCRIPTION
Closes #590 and #591 — two defects found in the same function, kept as two
commits.

## 1. `displot` read only one of its elements (#590)

`sns.displot(..., element="step")` and `element="poly"` registered **no layer
at all** and the figure fell back to a static image, filled or not. The same
chart through `sns.histplot` read fine — the asymmetry #522 and #446 were both
about.

| call | before |
|---|---|
| `histplot(x="v", element="step")` | `hist` |
| `histplot(x="v", element="step", fill=False)` | `hist` |
| `displot(x="v")` | `hist` |
| `displot(x="v", element="step")` | **nothing** |
| `displot(x="v", element="step", fill=False)` | **nothing** |
| `displot(x="v", element="poly", fill=False)` | **nothing** |

Those elements draw a `PolyCollection` when filled and a bare `Line2D` when
not, so the panel holds no `BarContainer` and the bar registrar passed over it.
Both readings already existed — `SteppedHistPlot` (#583) and `OutlinedHistPlot`
(#587). What was missing was the branch that reaches them, the same two
`sns_hist` has, factored into `_register_outlines`.

The unfilled reading needs an orientation, and `displot` forwards neither `x`
nor `y` to the plotter method. It comes from the plotter's own
`data_variable`, measured as `'x'` or `'y'` for every spelling.

## 2. A faceted panel's names came from the last panel (#591)

Found while measuring the above. `deferred_names` stores its resolver and runs
it at **render** — which is what makes a `pairplot`'s legend readable (#561) —
and the resolver was built inside the per-panel loop, closing over the loop
variables:

```python
for ax in plotter_axes(instance):
    containers = _new_bar_containers(ax, seen)
    for container, name in zip(containers, deferred_names(
        lambda: _group_names(ax, containers), len(containers)   # late
    )):
```

By the time it ran, `ax` and `containers` held the **last** panel's values.

```
displot(hue="g", col="c")  over a grid whose panels hold different groups

before:  [(None, [0,10,0]), (None, [10,0,0]), (None, [0,0,10])]
after:   [('b',  [0,10,0]), ('a',  [10,0,0]), (None, [0,0,10])]
asked panel by panel:  panel 0 -> ['b', 'a'],  panel 1 -> [None]
```

Every layer came back `None` because the last panel held a single container,
and a lone artist is exactly what `names_for` declines. With a differently
shaped grid it would have resolved to another panel's names instead — right
count, wrong distributions. Only the faceted path was affected; `histplot`
draws one panel.

## Verification

- **All twelve** element × fill × orientation combinations now emit a schema
  identical to `histplot`'s — orientation, bin bounds and counts alike. That is
  the parametrised test, and it cannot be satisfied by inventing numbers
  because `histplot`'s reading is pinned already.
- The ambiguous shape #585 fixed — a `y=` two-bin `poly` whose counts climb —
  reads `horz` through this path too, with the bins on `y` and the counts on
  `x`.
- `hue=` names its groups through both branches: the filled outline from its
  face colour, the unfilled one from the line's.
- Faceted panel names checked against each layer's **counts**, so the names are
  attached to the right distributions rather than merely present.
- Seven mutations applied one at a time against a restored baseline, **six
  killed**: restoring the late binding, never registering outlines, dropping
  the filled branch, dropping the unfilled branch, forcing the orientation
  vertical, and binding a name to the wrong panel. Two of those (orientation,
  wrong panel) survived a first pass and were what showed the test set had gaps
  — the `y=`-poly and filled-hue cases are there because of it.
- The survivor is the per-axes ownership snapshot, which mirrors the one the
  bar branch already keeps. `displot` builds its own grid, so a panel reaching
  here holds nothing and removing it changes no measurable behaviour today; it
  is kept so one ownership rule covers every artist a panel can arrive with,
  and the stale comment claiming those panels "do not exist yet" is corrected
  (measured: one panel for a plain `displot`, two for `col=`).
- Full suite: **2857 passed, 18 skipped**. `ruff check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_