### PR TITLE
fix(box): announce every box a hue-grouped box plot draws

### DIFF
--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -2,16 +2,90 @@ from __future__ import annotations
 
 import uuid
 
+import numpy as np
 from matplotlib.axes import Axes
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
+from maidr.core.plot.scatterplot import _rgba
 from maidr.exception import ExtractionError
+from maidr.util.legend_names import names_for
 from maidr.util.mixin import (
     ContainerExtractorMixin,
     DictMergerMixin,
     LevelExtractorMixin,
 )
+
+
+def _box_centre(box, horizontal: bool) -> float | None:
+    """
+    Where on the category axis a box sits.
+
+    Read off the artist rather than counted, because a hue splits a category's
+    slot into one box per level and only the position says which slot a box
+    landed in. Both spellings of a box answer: ``patch_artist=True`` -- which
+    is what seaborn draws -- gives a ``PathPatch``, and the plain
+    ``ax.boxplot`` gives a ``Line2D`` outline.
+
+    Parameters
+    ----------
+    box : Any
+        One box artist.
+    horizontal : bool
+        Whether the categories run up the y axis.
+
+    Returns
+    -------
+    float or None
+        The midpoint of the box's extent along the category axis, or ``None``
+        for an artist neither spelling reads.
+    """
+    path = getattr(box, "get_path", None)
+    if path is not None:
+        vertices = np.asarray(path().vertices, dtype=float)
+    elif hasattr(box, "get_xdata"):
+        vertices = np.column_stack(
+            [np.asarray(box.get_xdata(), dtype=float),
+             np.asarray(box.get_ydata(), dtype=float)]
+        )
+    else:
+        return None
+
+    if vertices.ndim != 2 or not len(vertices):
+        return None
+    along = vertices[:, 1 if horizontal else 0]
+    if not np.all(np.isfinite(along)):
+        return None
+    return float((along.min() + along.max()) / 2)
+
+
+def _box_colour(box):
+    """
+    The one colour a box was drawn in, if it has one.
+
+    Its face where it is filled and its edge otherwise, which is the same
+    order :func:`maidr.core.plot.scatterplot._handle_colour` asks a legend
+    handle in -- a filled box carries the hue on its face, and an unfilled
+    one has only its outline to carry it.
+
+    Parameters
+    ----------
+    box : Any
+        One box artist.
+
+    Returns
+    -------
+    tuple of float or None
+        The rounded RGBA, or ``None`` when the artist names no single colour.
+    """
+    for getter in ("get_facecolor", "get_edgecolor", "get_color"):
+        read = getattr(box, getter, None)
+        if read is None:
+            continue
+        colour = _rgba(read())
+        if colour is not None:
+            return colour
+    return None
 
 
 class BoxPlotContainer(DictMergerMixin):
@@ -238,6 +312,60 @@ class BoxPlot(
         box_orientation = {MaidrKey.ORIENTATION: self._orientation}
         return DictMergerMixin.merge_dict(base_schema, box_orientation)
 
+    def _named_boxes(self, boxes: list, labels: list[str], key: MaidrKey) -> list[str]:
+        """
+        One name per box, for a chart that drew more than one per category.
+
+        Two questions per box, each answered by the drawing:
+
+        - **Which category.** The tick its slot belongs to, by position. Safe
+          by construction rather than by luck: seaborn dodges a category's
+          levels inside a slot narrower than the unit its ticks are spaced by,
+          so a box never lands nearer another category's tick. Measured on
+          three categories and two levels, against a half-spacing of 0.5, the
+          outermost box sits 0.267 from its own tick.
+        - **Which level.** The colour it was drawn in, matched against the
+          legend swatch that names it -- the same match the histogram and the
+          strip plot make, and the reason it is not the dodge lattice
+          :meth:`BoxenPlot._category_of` reads: a box carries its level on its
+          face, and a ladder of boxen boxes does not.
+
+        Answering only the first is still an improvement on answering neither:
+        a chart drawn ``legend=False``, or one whose hue repeats the category
+        variable, gets its boxes back with the category alone rather than
+        losing half of them.
+
+        Parameters
+        ----------
+        boxes : list
+            The box artists, in drawing order.
+        labels : list of str
+            The category tick labels.
+        key : MaidrKey
+            Which axis the categories run along.
+
+        Returns
+        -------
+        list of str
+            Exactly ``len(boxes)`` names, so the caller's ``zip`` cannot
+            truncate. ``"category, level"`` where both are known, the category
+            alone where the level is not, and ``""`` for a box that has
+            neither.
+        """
+        positions = self.extract_level_positions(self.ax, key) or []
+        ticks = list(zip(positions, labels)) if len(positions) == len(labels) else []
+        levels = names_for(self.ax, [_box_colour(box) for box in boxes])
+        horizontal = self._orientation != "vert"
+
+        named = []
+        for box, level in zip(boxes, levels):
+            centre = _box_centre(box, horizontal)
+            label = ""
+            if ticks and centre is not None:
+                label = min(ticks, key=lambda tick: abs(tick[0] - centre))[1]
+            named.append(f"{label}, {level}" if label and level else label or level or "")
+        return named
+
     def _extract_plot_data(self) -> list:
         data = self._extract_bxp_maidr(self._bxp_stats)
 
@@ -272,13 +400,19 @@ class BoxPlot(
         caps_elements = self._bxp_elements_extractor.extract_caps(bxp_stats["caps"])
         bxp_maidr = []
 
-        levels = (
-            self.extract_level(self.ax, MaidrKey.X)
-            if self._orientation == "vert"
-            else self.extract_level(self.ax, MaidrKey.Y)
-        )
-        if levels is None:
-            levels = []
+        key = MaidrKey.X if self._orientation == "vert" else MaidrKey.Y
+        levels = self.extract_level(self.ax, key) or []
+
+        # A `hue` draws one box per category *per level*, and the axis still
+        # carries one tick per category -- so the `zip` below, which ends at
+        # the shortest of what it is given, stopped at the ticks and dropped
+        # every box past them. Measured on three categories and two levels:
+        # six boxes drawn, three announced, and the three that survived were
+        # the first level's paired with the tick labels in order (#593). The
+        # selector list is built from the artists rather than from this, so
+        # the same chart also emitted six selectors against three rows.
+        if len(medians) > len(levels):
+            levels = self._named_boxes(bxp_stats["boxes"], levels, key)
 
         _pairs = [(e["min"], e["max"]) for e in caps_elements if e]
 

--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -23,9 +23,16 @@ def _box_centre(box, horizontal: bool) -> float | None:
 
     Read off the artist rather than counted, because a hue splits a category's
     slot into one box per level and only the position says which slot a box
-    landed in. Both spellings of a box answer: ``patch_artist=True`` -- which
-    is what seaborn draws -- gives a ``PathPatch``, and the plain
-    ``ax.boxplot`` gives a ``Line2D`` outline.
+    landed in.
+
+    ``get_path`` answers for both spellings of a box, which is why there is no
+    second branch: ``patch_artist=True`` -- what seaborn draws -- gives a
+    ``PathPatch``, and the plain ``ax.boxplot`` gives a ``Line2D``, whose
+    path carries the same data-space vertices its ``get_xdata`` does.
+    Measured on a box at position 5.0, both answer
+    ``[4.925, 5.075, 5.075, 4.925, 4.925]``. Neither is a placeholder unit
+    square: ``Axes.bxp`` builds the outline from explicit vertices because a
+    notched box is not a rectangle.
 
     Parameters
     ----------
@@ -41,16 +48,10 @@ def _box_centre(box, horizontal: bool) -> float | None:
         for an artist neither spelling reads.
     """
     path = getattr(box, "get_path", None)
-    if path is not None:
-        vertices = np.asarray(path().vertices, dtype=float)
-    elif hasattr(box, "get_xdata"):
-        vertices = np.column_stack(
-            [np.asarray(box.get_xdata(), dtype=float),
-             np.asarray(box.get_ydata(), dtype=float)]
-        )
-    else:
+    if path is None:
         return None
 
+    vertices = np.asarray(path().vertices, dtype=float)
     if vertices.ndim != 2 or not len(vertices):
         return None
     along = vertices[:, 1 if horizontal else 0]
@@ -363,7 +364,10 @@ class BoxPlot(
             label = ""
             if ticks and centre is not None:
                 label = min(ticks, key=lambda tick: abs(tick[0] - centre))[1]
-            named.append(f"{label}, {level}" if label and level else label or level or "")
+            if label and level:
+                named.append(f"{label}, {level}")
+            else:
+                named.append(label or level or "")
         return named
 
     def _extract_plot_data(self) -> list:

--- a/tests/core/plot/test_grouped_boxplot.py
+++ b/tests/core/plot/test_grouped_boxplot.py
@@ -1,0 +1,180 @@
+"""A hue-grouped box plot announces every box it draws (#593).
+
+`sns.boxplot(hue=...)` draws one box per category *per level* and announced
+only the first level's. Not a wrong reading of six boxes -- three of them
+absent from the schema entirely, with nothing raising, on a chart that reads
+as a complete single-grouped box plot.
+
+The cause is one `zip`. `_extract_bxp_maidr` paired the per-box lists against
+`levels`, which is the axis's **tick labels** -- one per category, three where
+there are six boxes -- and `zip` ends at the shortest of what it is given.
+Measured on three categories and two levels::
+
+    medians drawn   grp=p: [-0.54,   0.068, 0.2687]
+                    grp=q: [-0.1045, 0.2446, 0.3534]
+    emitted         n=3  z=['a','b','c']  q2=[0.2687, -0.54, 0.068]
+
+The three that survived are exactly group p's. The plumbing above was never
+at fault: the container accumulates both `bxp` calls and hands the layer six
+boxes, twelve whiskers and six medians.
+
+The siblings all read the same chart correctly -- `boxenplot` and
+`violinplot` both emit six -- which is what made this legible rather than
+plausible.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+sns = pytest.importorskip("seaborn")
+
+import matplotlib  # noqa: E402
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+CATEGORIES = ["a", "b", "c"]
+LEVELS = ["p", "q"]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def frame() -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {
+            "cat": CATEGORIES * 20,
+            "grp": LEVELS * 30,
+            "val": rng.normal(size=60),
+        }
+    )
+
+
+def schema(figure) -> dict:
+    return FigureManager.get_maidr(figure).plots[0].schema
+
+
+def drawn_medians(data: pd.DataFrame) -> set[float]:
+    """Every median the chart draws, computed without touching maidr."""
+    return {
+        round(float(np.median(data.val[(data.cat == cat) & (data.grp == grp)])), 9)
+        for cat in CATEGORIES
+        for grp in LEVELS
+    }
+
+
+class TestEveryBoxIsAnnounced:
+    def test_a_hue_split_emits_one_row_per_box(self):
+        figure, ax = plt.subplots()
+        sns.boxplot(frame(), x="cat", y="val", hue="grp", ax=ax)
+
+        assert len(schema(figure)["data"]) == len(CATEGORIES) * len(LEVELS)
+
+    def test_no_drawn_median_is_missing(self):
+        # Stronger than the count: a reading that emitted six rows by
+        # repeating one level's three would satisfy the case above.
+        data = frame()
+        figure, ax = plt.subplots()
+        sns.boxplot(data, x="cat", y="val", hue="grp", ax=ax)
+        announced = {
+            round(float(point["q2"]), 9) for point in schema(figure)["data"]
+        }
+
+        assert announced == drawn_medians(data)
+
+    def test_each_row_names_its_category_and_its_level(self):
+        figure, ax = plt.subplots()
+        sns.boxplot(frame(), x="cat", y="val", hue="grp", ax=ax)
+        names = [point["z"] for point in schema(figure)["data"]]
+
+        assert sorted(names) == [
+            f"{cat}, {grp}" for cat in CATEGORIES for grp in LEVELS
+        ]
+
+    def test_the_name_matches_the_box_it_is_on(self):
+        # The category comes from the box's position and the level from its
+        # colour, so a chart that got either wrong would still pass the case
+        # above. This pins the pairing.
+        data = frame()
+        figure, ax = plt.subplots()
+        sns.boxplot(data, x="cat", y="val", hue="grp", ax=ax)
+
+        for point in schema(figure)["data"]:
+            cat, grp = str(point["z"]).split(", ")
+            rows = data.val[(data.cat == cat) & (data.grp == grp)]
+            assert round(float(point["q2"]), 9) == round(float(np.median(rows)), 9)
+
+    def test_there_is_one_selector_per_announced_box(self):
+        # The selectors are built from the artists and the data was not, so
+        # the same chart emitted six selectors against three rows -- every
+        # highlight past the third addressing a box nothing announces.
+        figure, ax = plt.subplots()
+        sns.boxplot(frame(), x="cat", y="val", hue="grp", ax=ax)
+        emitted = schema(figure)
+
+        assert len(emitted["selectors"]) == len(emitted["data"])
+
+    def test_an_undodged_split_is_read_too(self):
+        # `dodge=False` overlays the levels in one slot instead of splitting
+        # it. Same six boxes, same loss before this.
+        figure, ax = plt.subplots()
+        sns.boxplot(frame(), x="cat", y="val", hue="grp", dodge=False, ax=ax)
+
+        assert len(schema(figure)["data"]) == 6
+
+    def test_a_chart_on_its_side_is_read_too(self):
+        # The categories move to y, so the box's position has to be read
+        # there. Reading x would name every box after whichever tick the
+        # *values* happened to fall nearest.
+        data = frame()
+        figure, ax = plt.subplots()
+        sns.boxplot(data, y="cat", x="val", hue="grp", ax=ax)
+        emitted = schema(figure)["data"]
+        announced = {round(float(point["q2"]), 9) for point in emitted}
+
+        assert announced == drawn_medians(data)
+        # And each row still names the box it is on. Reading the position off
+        # x here finds the *values*, which all fall near one category tick --
+        # so every box comes out named after that one category, with the
+        # medians above still all present and all mislabelled.
+        for point in emitted:
+            cat, grp = str(point["z"]).split(", ")
+            rows = data.val[(data.cat == cat) & (data.grp == grp)]
+            assert round(float(point["q2"]), 9) == round(float(np.median(rows)), 9)
+
+
+class TestWhatIsUnchanged:
+    def test_a_chart_with_no_hue_keeps_its_category_names(self):
+        figure, ax = plt.subplots()
+        sns.boxplot(frame(), x="cat", y="val", ax=ax)
+        data = schema(figure)["data"]
+
+        assert [point["z"] for point in data] == CATEGORIES
+
+    def test_a_matplotlib_boxplot_is_unchanged(self):
+        rng = np.random.default_rng(0)
+        figure, ax = plt.subplots()
+        ax.boxplot([rng.normal(size=20) for _ in range(3)])
+        data = schema(figure)["data"]
+
+        assert len(data) == 3
+
+    def test_a_split_drawn_without_a_legend_still_keeps_every_box(self):
+        # Nothing names the levels, so the boxes are named by category alone
+        # -- twice each. Half a reading, and better than half the boxes.
+        figure, ax = plt.subplots()
+        sns.boxplot(frame(), x="cat", y="val", hue="grp", legend=False, ax=ax)
+        data = schema(figure)["data"]
+
+        assert len(data) == 6
+        assert sorted(point["z"] for point in data) == sorted(CATEGORIES * 2)


### PR DESCRIPTION
Closes #593.

## The defect

`sns.boxplot(..., hue=...)` draws one box per category **per level** and
announced only the first level's. Not a wrong reading of six boxes — three of
them absent from the schema entirely, no warning, no error, on a chart that
reads as a complete single-grouped box plot.

Three categories, two levels, six boxes drawn:

```
medians actually drawn   grp=p: [-0.54,   0.068, 0.2687]
                         grp=q: [-0.1045, 0.2446, 0.3534]

emitted                  n=3   z=['a','b','c']   q2=[0.2687, -0.54, 0.068]
```

Exactly group p's. Group q is on screen and never spoken — the #558 shape, one
level over. `dodge=False` loses the same three.

There is a length mismatch alongside it: the selector list is built from the
artists rather than from the data, so the same chart emitted **6 selectors
against 3 rows** — every highlight past the third addressing a box nothing
announces.

## Why

One `zip`:

```python
for whisker, cap, median, outlier, level in zip(
    whiskers, caps, medians, outliers, levels
):
```

`levels` is `extract_level(...)` — the axis's **tick labels**, one per
category. The other four hold one entry per box. `zip` ends at the shortest.

The plumbing above it was never at fault, and that is worth saying because it
narrows the fix to one function:

```
add_bxp_context: +3 boxes, container now 3
add_bxp_context: +3 boxes, container now 6
create_maidr BOX with 6 boxes, 12 whiskers, 6 medians
```

Six boxes arrive. Three came out.

## The reading

`_named_boxes` answers per box, from the drawing:

- **Which category** — the nearest tick to the box's own position. Safe by
  construction rather than by luck: seaborn dodges a category's levels inside
  a slot narrower than the unit its ticks are spaced by, so a box never lands
  nearer another category's tick. Measured against a half-spacing of 0.5, the
  outermost box of a two-level split sits 0.267 from its own tick.
- **Which level** — the colour it was drawn in, matched against the legend
  swatch that names it. That is the match `patch/histogram` and
  `patch/stripplot` already make, and it works here where the dodge lattice
  `BoxenPlot._category_of` reads would be overkill: a box carries its level on
  its face, and a boxen *ladder* does not.

It returns exactly one name per box, so the `zip` cannot truncate again.

Engaged only where there are **more boxes than ticks**, so every chart that
was already right keeps the reading it had — `ax.boxplot`, the ungrouped
seaborn box, and any chart with custom `positions=` all take the path they
took before.

## Results

| call | before | after |
|---|---|---|
| `boxplot(hue=)` | 3 rows, `['a','b','c']` | 6 rows, `['a, p','b, p','c, p','a, q','b, q','c, q']` |
| `boxplot(hue=, dodge=False)` | 3 rows | 6 rows |
| `boxplot(y=cat, hue=)` | 3 rows | 6 rows, categories read off y |
| `boxplot(hue=, legend=False)` | 3 rows | 6 rows, category-only names |
| `boxplot()` | 3 rows, `['a','b','c']` | unchanged |
| `ax.boxplot()` | 3 rows | unchanged |

`z` reads `"a, p"`, matching what `boxenplot` already emits. (`violinplot`
spells the same thing `"a_p"` — an inconsistency worth settling separately
rather than adding a third spelling here.)

## Verification

- Each announced median checked against `np.median` over that
  (category, level)'s own rows — so the names are attached to the right
  distributions rather than merely present, in both orientations.
- Selector count now equals data count.
- Six mutations applied one at a time against a restored baseline, **all
  killed**: restoring the truncating zip, never naming the levels, reading the
  category off the wrong axis, taking the first tick instead of the nearest,
  reading the box centre from the other column, and preferring the edge colour
  to the face. The wrong-axis one survived a first pass — the horizontal test
  checked the values but not the names, which is now closed.
- `tests/core/plot/test_grouped_boxplot.py` — 10 tests.
- Full suite: **2870 passed, 18 skipped**. `ruff check` clean.

## Still open

`catplot(kind="box", hue=)` is the milder half and is **not** fixed here. It
registers one layer per `bxp` call, so all six boxes survive — but both layers
carry `z = ['a','b','c']` and no name, so nothing says which group either is.
Its legend is figure-level and does not exist when the layers register, so the
colour match returns nothing at that moment; naming it needs the deferral
`GROUP_NAME` has and `z` does not. Worth its own issue rather than folding in.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_