### PR TITLE
fix(box): name each catplot box layer for the level it holds

### DIFF
--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -7,6 +7,7 @@ from matplotlib.axes import Axes
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
+from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.core.plot.scatterplot import _rgba
 from maidr.exception import ExtractionError
 from maidr.util.legend_names import names_for
@@ -239,6 +240,16 @@ class BoxPlot(
     def __init__(self, ax: Axes, **kwargs) -> None:
         super().__init__(ax, PlotType.BOX)
 
+        # The hue level this layer's boxes belong to, when the patch could
+        # name it. `None` is every chart with no hue and every one whose
+        # boxes reach the layer together -- there the level is on each box's
+        # `z` instead. A callable names it at render, which is what a
+        # `catplot` needs: its legend is built at the figure after every
+        # panel is drawn, so at registration there is none to read (#595).
+        group_name = kwargs.pop(GROUP_NAME, None)
+        self._group_name = (
+            group_name if isinstance(group_name, str) or callable(group_name) else None
+        )
         self._bxp_stats = kwargs.pop("bxp_stats", None)
         self._orientation = kwargs.pop("orientation", "vert")
         self._bxp_extractor = BoxPlotExtractor(orientation=self._orientation)
@@ -309,8 +320,20 @@ class BoxPlot(
         return selector if self._orientation == "vert" else list(reversed(selector))
 
     def render(self) -> dict:
+        """
+        Add ``orientation`` to the base schema, and the layer's group name
+        where one call drew one hue level's boxes.
+
+        ``MaidrLayer.name`` is the field xability/maidr#828 added so two
+        layers of a kind can be told apart, which is exactly where a
+        ``catplot(kind="box", hue=...)`` leaves a reader: every box is
+        announced, across two layers carrying the same three categories.
+        """
         base_schema = super().render()
         box_orientation = {MaidrKey.ORIENTATION: self._orientation}
+        name = self._group_name() if callable(self._group_name) else self._group_name
+        if name:
+            box_orientation[MaidrKey.NAME] = name
         return DictMergerMixin.merge_dict(base_schema, box_orientation)
 
     def _named_boxes(self, boxes: list, labels: list[str], key: MaidrKey) -> list[str]:

--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -7,7 +7,7 @@ from matplotlib.axes import Axes
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
-from maidr.core.plot.maidr_plot import GROUP_NAME
+from maidr.core.plot.maidr_plot import group_name_of
 from maidr.core.plot.scatterplot import _rgba
 from maidr.exception import ExtractionError
 from maidr.util.legend_names import names_for
@@ -246,10 +246,7 @@ class BoxPlot(
         # `z` instead. A callable names it at render, which is what a
         # `catplot` needs: its legend is built at the figure after every
         # panel is drawn, so at registration there is none to read (#595).
-        group_name = kwargs.pop(GROUP_NAME, None)
-        self._group_name = (
-            group_name if isinstance(group_name, str) or callable(group_name) else None
-        )
+        self._group_name = group_name_of(kwargs)
         self._bxp_stats = kwargs.pop("bxp_stats", None)
         self._orientation = kwargs.pop("orientation", "vert")
         self._bxp_extractor = BoxPlotExtractor(orientation=self._orientation)

--- a/maidr/core/plot/histogram.py
+++ b/maidr/core/plot/histogram.py
@@ -5,7 +5,7 @@ from matplotlib.container import BarContainer
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
-from maidr.core.plot.maidr_plot import GROUP_NAME
+from maidr.core.plot.maidr_plot import group_name_of
 from maidr.exception import ExtractionError
 from maidr.util.mixin import ContainerExtractorMixin, DictMergerMixin
 
@@ -42,10 +42,7 @@ class HistPlot(MaidrPlot, ContainerExtractorMixin, DictMergerMixin):
         # A string names the group now; a callable names it at render, which
         # is what a `pairplot` needs -- its legend does not exist until every
         # panel has been drawn (#561).
-        group_name = kwargs.pop(GROUP_NAME, None)
-        self._group_name = (
-            group_name if isinstance(group_name, str) or callable(group_name) else None
-        )
+        self._group_name = group_name_of(kwargs)
         super().__init__(ax, PlotType.HIST)
         self._orientation = "vert"
 

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -24,8 +24,9 @@ import uuid
 #: ``super().__init__(ax, PlotType.X)`` without forwarding their keyword
 #: arguments, so a key read here would arrive for some layer types and be
 #: swallowed by the rest -- a promise kept by accident of how each
-#: constructor happens to be written. ``HistPlot`` and ``SmoothPlot`` opt in
-#: today, each in one visible line.
+#: constructor happens to be written. ``HistPlot``, ``SmoothPlot`` and
+#: ``BoxPlot`` opt in today, each in one visible line --
+#: :func:`group_name_of`.
 #:
 #: ``ScatterPlot`` and ``EventPlot`` name their layers by other means -- a hue
 #: split and row labels -- and are unaffected, being passed neither this key
@@ -39,6 +40,34 @@ import uuid
 #: every diagonal came out anonymous while the scatters beside it were named
 #: (#561). Each class that honours this key resolves the callable itself.
 GROUP_NAME = "_maidr_group_name"
+
+
+def group_name_of(kwargs: dict):
+    """
+    Read :data:`GROUP_NAME` out of a layer's keyword arguments.
+
+    One line in each opting-in constructor, and the same line. Three copies
+    of it drifted apart is a layer honouring the key in a way the others do
+    not, which is the failure this whole mechanism exists to prevent -- and
+    they had already begun to: ``SmoothPlot`` read the key with ``get`` where
+    the others used ``pop``. Harmless there, since nothing reads it again and
+    the base constructor is called without the keyword arguments, but it is
+    the shape divergence takes.
+
+    Parameters
+    ----------
+    kwargs : dict
+        The layer's keyword arguments. The key is **popped**, so it does not
+        travel on to a base class that would not know it.
+
+    Returns
+    -------
+    str or callable or None
+        What the patch handed over, or ``None`` when it handed over nothing
+        this can use.
+    """
+    name = kwargs.pop(GROUP_NAME, None)
+    return name if isinstance(name, str) or callable(name) else None
 
 
 class MaidrPlot(ABC, FormatExtractorMixin):

--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from matplotlib.axes import Axes
-from maidr.core.plot.maidr_plot import GROUP_NAME, MaidrPlot
+from maidr.core.plot.maidr_plot import MaidrPlot, group_name_of
 from maidr.exception.extraction_error import ExtractionError
 import numpy as np
 from maidr.core.enum.plot_type import PlotType
@@ -46,10 +46,10 @@ class SmoothPlot(MaidrPlot):
         # A string names the group now; a callable names it at render, which
         # is what a `pairplot` needs -- its legend does not exist until every
         # panel has been drawn (#561).
-        group_name = kwargs.get(GROUP_NAME, None)
-        self._group_name = (
-            group_name if isinstance(group_name, str) or callable(group_name) else None
-        )
+        # `pop` here where this read `get` before, which changes nothing:
+        # nothing reads the key again, and `super().__init__` is called
+        # without the keyword arguments.
+        self._group_name = group_name_of(kwargs)
         super().__init__(ax, PlotType.SMOOTH)
         self._smooth_gid = None
         self._regression_line = kwargs.get("regression_line", None)

--- a/maidr/patch/boxplot.py
+++ b/maidr/patch/boxplot.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Callable
+
 import wrapt
 from matplotlib.axes import Axes
 
@@ -12,7 +14,7 @@ from maidr.patch.common import _draw_quietly, resolve_orientation, wrap_seaborn
 from maidr.util.legend_names import name_for
 
 
-def _level_of(ax: Axes, boxes: list):
+def _level_of(ax: Axes, boxes: list) -> Callable[[], str | None] | None:
     """
     Name the hue level one ``bxp`` call's boxes belong to, at render.
 

--- a/maidr/patch/boxplot.py
+++ b/maidr/patch/boxplot.py
@@ -6,7 +6,55 @@ from matplotlib.axes import Axes
 from maidr.core.context_manager import BoxplotContextManager, ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.boxplot import _box_colour
+from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.patch.common import _draw_quietly, resolve_orientation, wrap_seaborn
+from maidr.util.legend_names import name_for
+
+
+def _level_of(ax: Axes, boxes: list):
+    """
+    Name the hue level one ``bxp`` call's boxes belong to, at render.
+
+    A call draws one level's boxes across every category, so they share one
+    colour and that colour is what says which level it is.
+
+    Only this path asks. ``sns.boxplot`` accumulates every call before
+    registering and reaches its layer through ``sns_box``, where the levels
+    belong per box -- on each one's ``z`` -- rather than to the layer; naming
+    the layer there would say the whole of it was one level.
+
+    A call whose boxes do *not* share a colour therefore declines rather than
+    picking one. Nothing measured produces one -- ``bxp`` colours a call's
+    boxes together, and the two callers that reach here are ``ax.boxplot``
+    and ``catplot``, each of which draws one colour per call -- so a mutation
+    naming a mixed call anyway passes the suite. It stays because the answer
+    to "which level is this layer" for a layer holding two of them is
+    "neither", and an arbitrary one of them is worse than none.
+
+    Deferred rather than resolved here, because the chart that needs it has
+    no legend yet: ``sns.catplot`` builds one at the *figure* after every
+    panel is drawn. Read at registration it would find nothing, which is how
+    both layers came out anonymous (#595).
+
+    Parameters
+    ----------
+    ax : Axes
+        The panel drawn on.
+    boxes : list
+        The box artists this call drew.
+
+    Returns
+    -------
+    callable or None
+        A zero-argument callable answering the name, or ``None`` when the
+        call's boxes do not share one colour.
+    """
+    colours = {_box_colour(box) for box in boxes}
+    if len(colours) != 1:
+        return None
+    colour = colours.pop()
+    return lambda: name_for(ax, colour)
 
 
 @wrapt.patch_function_wrapper(Axes, "bxp")
@@ -28,7 +76,11 @@ def mpl_box(wrapped, _, args, kwargs) -> dict:
     # Extract the boxplot data points for MAIDR from the plot.
     ax = FigureManager.get_axes(plot)
     FigureManager.create_maidr(
-        ax, PlotType.BOX, bxp_stats=plot, orientation=orientation
+        ax,
+        PlotType.BOX,
+        bxp_stats=plot,
+        orientation=orientation,
+        **{GROUP_NAME: _level_of(ax, plot["boxes"])},
     )
 
     # Return to the caller.

--- a/maidr/util/legend_names.py
+++ b/maidr/util/legend_names.py
@@ -120,6 +120,54 @@ def names_for(ax: Axes, colours: list) -> list:
     return [None] * len(colours)
 
 
+def name_for(ax: Axes, colour) -> str | None:
+    """
+    The legend's name for one drawn colour.
+
+    :func:`names_for` declines a lone artist -- "a lone artist needs nothing
+    to be told apart from" -- which is right where the artists of one layer
+    are named against each other, and wrong where a *layer* is the artist.
+    A ``catplot(kind="box", hue=...)`` panel draws one call per hue level, so
+    a layer holds one colour and that colour is exactly what says which level
+    it is; declining it leaves two layers a reader cannot tell apart (#595).
+
+    Both passes :func:`names_for` makes are made here too, in the same order
+    and for the same reason: the RGBA match first, and the three-channel one
+    after it for an artist drawn at a different opacity from its swatch. The
+    guard that pass needs there -- that the drawn colours are distinct without
+    their alpha -- is unnecessary with one colour, and
+    :func:`_match_swatches` still declines a colour two swatches claim.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    colour : tuple of float or None
+        One rounded RGBA.
+
+    Returns
+    -------
+    str or None
+        The name, or ``None`` when no legend names that colour.
+    """
+    if colour is None:
+        return None
+
+    legend = legend_of(ax)
+    if legend is None:
+        return None
+
+    swatches = [
+        (_handle_colour(handle), text.get_text())
+        for handle, text in zip(legend.legend_handles, legend.get_texts())
+    ]
+    for key in (lambda one: one, lambda one: one[:3]):
+        named = _match_swatches([colour], swatches, key)
+        if named:
+            return named.get(key(colour))
+    return None
+
+
 def _match_swatches(colours: list, swatches: list, key) -> dict | None:
     """
     Map each swatch that a drawn artist shares a colour with to its name.

--- a/tests/core/plot/test_grouped_boxplot.py
+++ b/tests/core/plot/test_grouped_boxplot.py
@@ -261,3 +261,30 @@ class TestTheFigureLevelSpelling:
         assert {str(point["z"]).split(", ")[1] for point in emitted["data"]} == set(
             LEVELS
         )
+
+    def test_a_call_whose_boxes_differ_in_colour_is_not_named(self):
+        """A layer holding two levels is neither of them.
+
+        Nothing measured draws one -- `bxp` colours a call's boxes together,
+        and the two callers that reach `_level_of` each draw one colour per
+        call -- so this is the guard rather than a live path, asserted
+        directly because no chart can assert it.
+        """
+        from matplotlib.patches import PathPatch
+        from matplotlib.path import Path as MplPath
+
+        from maidr.patch.boxplot import _level_of
+
+        figure, ax = plt.subplots()
+        sns.boxplot(frame(), x="cat", y="val", hue="grp", ax=ax)
+        square = MplPath([(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)])
+        mixed = [
+            PathPatch(square, facecolor="red"),
+            PathPatch(square, facecolor="blue"),
+        ]
+
+        assert _level_of(ax, mixed) is None
+        # And one colour, on the same axes and legend, does resolve -- so the
+        # decline above is the mixture and not the setup.
+        alone = [PathPatch(square, facecolor=mixed[0].get_facecolor())]
+        assert callable(_level_of(ax, alone))

--- a/tests/core/plot/test_grouped_boxplot.py
+++ b/tests/core/plot/test_grouped_boxplot.py
@@ -178,3 +178,86 @@ class TestWhatIsUnchanged:
 
         assert len(data) == 6
         assert sorted(point["z"] for point in data) == sorted(CATEGORIES * 2)
+
+
+class TestTheFigureLevelSpelling:
+    """`catplot` announces every box across two layers nothing tells apart.
+
+    It registers one layer per `bxp` call, so no box is lost the way the
+    axes-level spelling lost three -- but both layers carried the same three
+    categories on `z` and no name, so a reader moving between them heard
+    a, b, c twice with nothing saying which group either was (#595).
+
+    The name cannot be resolved when the layer registers: `catplot` builds one
+    legend at the **figure**, after every panel is drawn, so at registration
+    there is none on the axes and none on the figure either. It is deferred
+    the way `GROUP_NAME` already is for a `pairplot` (#561).
+
+    `z` keeps the category and `name` says which side of the split the layer
+    is -- the division `ScatterPlot.render` documents.
+    """
+
+    @staticmethod
+    def _medians(data: pd.DataFrame, grp: str) -> list[float]:
+        return [
+            round(float(np.median(data.val[(data.cat == cat) & (data.grp == grp)])), 9)
+            for cat in CATEGORIES
+        ]
+
+    def test_each_layer_is_named_for_its_level(self):
+        data = frame()
+        grid = sns.catplot(data, x="cat", y="val", hue="grp", kind="box")
+        layers = [
+            (
+                plot.schema.get("name"),
+                [round(float(point["q2"]), 9) for point in plot.schema["data"]],
+            )
+            for plot in FigureManager.get_maidr(grid.figure).plots
+        ]
+
+        # Checked against the medians rather than registration order, so a
+        # name attached to the wrong layer fails rather than passes.
+        assert layers == [
+            ("p", self._medians(data, "p")),
+            ("q", self._medians(data, "q")),
+        ]
+
+    def test_a_faceted_grid_names_its_layers_too(self):
+        # The legend is figure-level here as well, and the panels are more
+        # numerous, so a resolver that read the wrong one would show.
+        grid = sns.catplot(frame(), x="cat", y="val", hue="grp", col="grp", kind="box")
+        names = [
+            plot.schema.get("name")
+            for plot in FigureManager.get_maidr(grid.figure).plots
+        ]
+
+        assert sorted(name for name in names if name) == LEVELS
+
+    def test_a_grid_with_no_hue_stays_unnamed(self):
+        grid = sns.catplot(frame(), x="cat", y="val", kind="box")
+        names = [
+            plot.schema.get("name")
+            for plot in FigureManager.get_maidr(grid.figure).plots
+        ]
+
+        assert names == [None]
+
+    def test_a_matplotlib_boxplot_stays_unnamed(self):
+        rng = np.random.default_rng(0)
+        figure, ax = plt.subplots()
+        ax.boxplot([rng.normal(size=20) for _ in range(3)])
+
+        assert schema(figure).get("name") is None
+
+    def test_the_axes_level_spelling_keeps_its_levels_on_z(self):
+        # Its boxes reach one layer together, so the level belongs per box
+        # rather than to the layer. Naming the layer as well would say the
+        # whole of it was one level, which is the opposite of true.
+        figure, ax = plt.subplots()
+        sns.boxplot(frame(), x="cat", y="val", hue="grp", ax=ax)
+        emitted = schema(figure)
+
+        assert emitted.get("name") is None
+        assert {str(point["z"]).split(", ")[1] for point in emitted["data"]} == set(
+            LEVELS
+        )


### PR DESCRIPTION
Closes #595 — the milder half of #593, scoped out of #594 and now done.

## The defect

`sns.catplot(..., kind="box", hue=...)` announces **all** its boxes; it
registers one layer per `bxp` call, so nothing is lost the way the axes-level
spelling lost three. But the two layers were indistinguishable:

```
layer 0   n=3   name=None   z=['a','b','c']   q2=[ 0.2687, -0.54,   0.068 ]
layer 1   n=3   name=None   z=['a','b','c']   q2=[-0.1045,  0.2446, 0.3534]
```

Same three categories twice, no name on either, so nothing said one was group
`p` and the other `q`. Since #594 the axes-level spelling reads
`['a, p', 'b, p', 'c, p', 'a, q', …]`, so the two interfaces disagreed — the
#522 / #446 shape.

## Why the name had to be deferred

The colour is right there on the boxes, but the legend is not: `catplot` builds
one at the **figure**, after every panel is drawn. At registration there is
none on the axes and none on the figure either, so a match made then finds
nothing. That is exactly the timing `deferred_names` already solves for
`GROUP_NAME` on a `pairplot` (#561), and `BoxPlot` now honours the same key —
string or callable — resolving it in `render()`.

## `name_for`

`names_for` declines a lone artist: *"a lone artist needs nothing to be told
apart from."* That is right where the artists of one layer are named against
each other, and wrong where a **layer** is the artist. A `bxp` call draws one
level's boxes across every category, so the layer holds one colour and that
colour is precisely what says which level it is.

`name_for(ax, colour)` is that one-colour half, in the same module and making
the same two passes in the same order — RGBA first, three-channel after it for
an artist drawn at a different opacity from its swatch. `_match_swatches`
still declines a colour two swatches claim.

## Where the name goes, and where it does not

`z` keeps the category; `name` says which side of the split the layer is — the
division `ScatterPlot.render` documents.

The axes-level `sns.boxplot` is deliberately untouched. Its boxes reach one
layer together, so the level belongs **per box** (`"a, p"` on each `z`, from
#594); naming that layer as well would assert the whole of it was one level.
A test pins that.

| call | before | after |
|---|---|---|
| `catplot(kind="box", hue=)` | two layers, no name | `name='p'` / `name='q'` |
| `catplot(kind="box", hue=, col=)` | no name | named per panel |
| `catplot(kind="box")` | no name | unchanged |
| `ax.boxplot()` | no name | unchanged |
| `sns.boxplot(hue=)` | levels on `z` | unchanged |

## Verification

- Layer names checked against each layer's **medians**, not registration
  order, so a name attached to the wrong layer fails rather than passes.
- The faceted grid is covered separately, since it has more panels for a
  resolver reading the wrong one to go astray in.
- Five mutations applied one at a time against a restored baseline, **four
  killed**: handing over no name, resolving it eagerly instead of at render,
  dropping it in the layer, and inverting the one-colour lookup's guard.
- The survivor is the guard against naming a call whose boxes do not share a
  colour. Nothing measured produces one — `bxp` colours a call's boxes
  together, and the two callers reaching this code (`ax.boxplot`, `catplot`)
  each draw one colour per call. It stays because the answer to "which level
  is this layer" for a layer holding two is *neither*, and an arbitrary one is
  worse than none; that is now written in the docstring rather than left to be
  rediscovered.
- `tests/core/plot/test_grouped_boxplot.py` — 15 tests (5 new).
- Full suite: **2875 passed, 18 skipped**. `ruff check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_