### PR TITLE
feat(rug): read the hue a rug plot was grouped by

### DIFF
--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -8,6 +8,7 @@ from matplotlib.collections import LineCollection
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
+from maidr.util.legend_names import title_of
 
 #: Key the patch hands this layer the ``LineCollection`` its own call drew
 #: under. Named like ``eventplot.DRAWN_EVENTS`` and read the same way: the
@@ -225,8 +226,16 @@ class RugPlot(MaidrPlot):
         # A grouped layer names the grouping *variable* on z, the way the
         # scatter and line layers do: `z` says what the split is by, `name`
         # says which side of it this layer is.
+        #
+        # Read off whichever legend named the groups, which is not always
+        # this axes' own: the patch names them through `legend_of`, and that
+        # falls back to a lone figure-level legend for a panel carrying
+        # none. `_legend_title` asks `ax.get_legend()` only, so on that path
+        # the layers came out named `a` and `b` with no `z` -- each saying
+        # which side of a grouping it was without the chart ever saying what
+        # the grouping was.
         if self._group_members is not None:
-            z_label = self._legend_title()
+            z_label = title_of(self.ax)
             if z_label:
                 axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
 

--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -18,6 +18,17 @@ DRAWN_RUG = "_maidr_rug"
 #: Key carrying the name to announce the layer under, when there is one.
 RUG_LABEL = "_maidr_rug_label"
 
+#: Key the patch hands one hue group over under: a ``(name, members)`` pair
+#: naming the group and listing the segments of :data:`DRAWN_RUG` that belong
+#: to it. Absent for an ungrouped rug, which is the chart this layer has
+#: always read and still reads unchanged.
+#:
+#: The split is made in the patch rather than here for the reason
+#: :func:`maidr.patch.scatterplot.scatter` gives: a layer *is* one entry in
+#: the schema, and seaborn draws a hue-grouped rug as one ``LineCollection``
+#: carrying a colour per tick, so one artist has to become several layers.
+RUG_GROUP = "_maidr_rug_group"
+
 #: What the layer's constant axis is called when the chart does not say.
 #: A rug's ticks sit in a strip against the frame rather than at a measured
 #: height, so the coordinate across the tick names the strip, not a value.
@@ -126,6 +137,13 @@ class RugPlot(MaidrPlot):
         )
         self._label = kwargs.get(RUG_LABEL, None)
 
+        # The hue group this layer reads, when the patch found one. `None`
+        # means the layer reads every tick the collection holds, which is
+        # what an ungrouped rug has always done.
+        group = kwargs.get(RUG_GROUP, None)
+        self._group_name = group[0] if group else None
+        self._group_members = list(group[1]) if group else None
+
         # Read once, here, rather than again per render. Two reasons, and
         # the first is correctness: `MaidrPlot.render()` builds the *axes*
         # payload before the data, so an orientation settled in
@@ -137,6 +155,18 @@ class RugPlot(MaidrPlot):
         # revalidating every segment each time buys nothing.
         read = read_rug(self._collection)
         self._positions, self._along_x = read if read is not None else ([], True)
+
+        # Kept to the group's own ticks, and their places among the drawn
+        # ones kept with them: the selector numbers by segment, so a layer
+        # that filtered its positions without remembering where they came
+        # from would highlight the first N ticks of the rug rather than its
+        # own -- the failure nothing announced can see (xability/maidr#814).
+        self._drawn = list(range(len(self._positions)))
+        if self._group_members is not None:
+            members = set(self._group_members)
+            kept = [index for index in self._drawn if index in members]
+            self._positions = [self._positions[index] for index in kept]
+            self._drawn = kept
 
         # Assigned here rather than relied upon, for the reason `EventPlot`
         # and `HexbinPlot` give: matplotlib stamps a gid at *draw* time and
@@ -154,8 +184,9 @@ class RugPlot(MaidrPlot):
         a rug drawn beside a scatter of the same variable.
         """
         schema = super().render()
-        if self._label:
-            schema[MaidrKey.NAME] = self._label
+        name = self._group_name or self._label
+        if name:
+            schema[MaidrKey.NAME] = name
         return schema
 
     def _extract_plot_data(self) -> list[dict]:
@@ -190,6 +221,15 @@ class RugPlot(MaidrPlot):
         axes_data = super()._extract_axes_data()
         across = MaidrKey.Y if self._along_x else MaidrKey.X
         axes_data[across] = self._axis_config(label=RUG_AXIS_LABEL)
+
+        # A grouped layer names the grouping *variable* on z, the way the
+        # scatter and line layers do: `z` says what the split is by, `name`
+        # says which side of it this layer is.
+        if self._group_members is not None:
+            z_label = self._legend_title()
+            if z_label:
+                axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
+
         return axes_data
 
     def _get_selector(self) -> str | list[str]:
@@ -207,4 +247,15 @@ class RugPlot(MaidrPlot):
         """
         if self._collection is None or self._collection.get_gid() is None:
             return []
-        return f"g[id='{self._collection.get_gid()}'] > path"
+
+        gid = self._collection.get_gid()
+        if self._group_members is None:
+            return f"g[id='{gid}'] > path"
+
+        # A grouped layer cannot use the whole-collection selector: the
+        # collection holds every group's ticks, so it would light the whole
+        # rug up for a layer announcing half of it. Numbered by segment,
+        # which is what the `<path>` children are written in.
+        return [
+            f"g[id='{gid}'] > path:nth-of-type({index + 1})" for index in self._drawn
+        ]

--- a/maidr/patch/rugplot.py
+++ b/maidr/patch/rugplot.py
@@ -183,11 +183,7 @@ def _drawn_by_this_call(ax: Axes | None, before: list) -> list:
     if ax is None:
         return []
     seen = [id(collection) for collection in before]
-    return [
-        collection
-        for collection in ax.collections
-        if id(collection) not in seen
-    ]
+    return [collection for collection in ax.collections if id(collection) not in seen]
 
 
 def _name_for(ax: Axes, along_x: bool) -> str:
@@ -307,7 +303,6 @@ def _register(ax: Axes | None, drawn, before: list):
         ax = drawn if isinstance(drawn, Axes) else None
     if ax is None:
         return drawn
-
 
     for collection in _drawn_by_this_call(ax, before):
         if not isinstance(collection, LineCollection):

--- a/maidr/patch/rugplot.py
+++ b/maidr/patch/rugplot.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import contextvars
+
+import numpy as np
+import wrapt
 from matplotlib.axes import Axes
 from matplotlib.collections import LineCollection
 
@@ -9,10 +13,133 @@ from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.rugplot import (
     DRAWN_RUG,
     RUG_AXIS_LABEL,
+    RUG_GROUP,
     RUG_LABEL,
     read_rug,
 )
+from maidr.core.plot.scatterplot import _rgba
 from maidr.patch.common import _draw_quietly, prospective_axes, wrap_seaborn
+from maidr.util.legend_names import legend_of, names_for
+
+
+#: What kind of hue mapping the rug being drawn was given, recorded by
+#: :func:`_note_hue_map` while seaborn draws and read once the draw is done.
+#:
+#: A ``ContextVar`` rather than a module attribute, matching
+#: ``ContextManager``: the patched method is class-wide, so every draw in the
+#: process writes here, and ``asyncio.to_thread`` runs a render in a copy of
+#: the context so concurrent draws keep their own view.
+_HUE_MAP_TYPE: contextvars.ContextVar = contextvars.ContextVar(
+    "maidr_rug_hue_map_type", default=None
+)
+
+
+def _note_hue_map(wrapped, instance, args, kwargs):
+    """
+    Record what kind of hue the rug about to be drawn was given.
+
+    ``seaborn.rugplot`` does not pass its hue mapping to anything the
+    function-level patch can see, and the drawn colours cannot answer on
+    their own: a **numeric** hue is a colour *scale*, and on a small frame
+    seaborn's legend samples every value, so every tick matches a swatch and
+    the rug would split into one layer per observation -- which is not a
+    reading of a scale. Measured on four observations with ``hue=`` a numeric
+    column: four legend entries, four groups of one.
+
+    The plotter knows outright. Wrapped only to record it; the drawing is
+    left alone, and the registration is still made by :func:`rug` after the
+    call returns.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``_DistributionPlotter.plot_rug``.
+    instance : Any
+        The plotter, for its hue mapping.
+    args : tuple
+        Positional arguments seaborn passed.
+    kwargs : dict
+        Keyword arguments seaborn passed.
+
+    Returns
+    -------
+    Any
+        Whatever the wrapped method returned.
+    """
+    hue_map = getattr(instance, "_hue_map", None)
+    _HUE_MAP_TYPE.set(getattr(hue_map, "map_type", None))
+    return wrapped(*args, **kwargs)
+
+
+def _hue_groups(ax: Axes, collection: LineCollection, ticks: int) -> list | None:
+    """
+    The hue groups a rug was drawn with, or ``None`` when it has none.
+
+    ``seaborn`` draws a hue-grouped rug as **one** ``LineCollection`` carrying
+    a colour per tick, not one collection per group, so the grouping survives
+    only in those colours and in the legend that names them -- the shape
+    ``scatterplot.hue_groups`` reads point by point, one artist type over.
+    Measured on twelve observations over two levels::
+
+        rugplot(x="v")            colour rows=1,  unique=1, legend None
+        rugplot(x="v", hue="g")   colour rows=12, unique=2, legend ['p', 'q']
+
+    Every reason to decline has a chart behind it:
+
+    - **One colour for the whole rug.** ``get_colors()`` returns a single row
+      when every tick shares a colour, which is what an ungrouped rug gives.
+      A count that does not match the ticks is the same answer: nothing here
+      can say which tick wore which colour.
+    - **A tick no swatch names.** ``legend=False`` suppresses the legend, and
+      the colours alone name nothing -- groups called "1" and "2" are not an
+      improvement on one strip.
+    - **Fewer than two groups.** Nothing to tell apart.
+    - **A hue that is not a grouping.** A numeric ``hue=`` is a colour
+      *scale*; see :func:`_note_hue_map` for why the colours cannot say so
+      themselves and the plotter is asked instead.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    collection : LineCollection
+        The ticks.
+    ticks : int
+        How many ticks ``read_rug`` found, so the colours can be checked
+        against them rather than assumed to correspond.
+
+    Returns
+    -------
+    list of (str, list of int) or None
+        One entry per group in legend order, naming it and listing the
+        segments that belong to it, or ``None`` for a rug that is not
+        grouped.
+    """
+    if _HUE_MAP_TYPE.get() != "categorical":
+        return None
+
+    colours = [_rgba(row) for row in np.asarray(collection.get_colors())]
+    if len(colours) != ticks or ticks < 2:
+        return None
+
+    names = names_for(ax, colours)
+    if any(name is None for name in names):
+        return None
+
+    members: dict = {}
+    for index, name in enumerate(names):
+        members.setdefault(name, []).append(index)
+    if len(members) < 2:
+        return None
+
+    # Legend order, which is the order #502 settled a grouped layer's layers
+    # on -- seaborn's draw order is not it.
+    legend = legend_of(ax)
+    order = [text.get_text() for text in legend.get_texts()] if legend else []
+    return sorted(
+        members.items(),
+        key=lambda group: order.index(group[0]) if group[0] in order else len(order),
+    )
 
 
 def _collections_of(ax: Axes | None) -> list:
@@ -143,13 +270,44 @@ def rug(wrapped, instance, args, kwargs) -> Axes:
     ax = prospective_axes(kwargs)
     before = _collections_of(ax)
 
-    with ContextManager.set_internal_context():
-        drawn = _draw_quietly(wrapped, args, kwargs)
+    # Cleared before the draw and restored after it, so a rug drawn without a
+    # hue is never read against the mapping of one drawn earlier.
+    token = _HUE_MAP_TYPE.set(None)
+    try:
+        with ContextManager.set_internal_context():
+            drawn = _draw_quietly(wrapped, args, kwargs)
+        return _register(ax, drawn, before)
+    finally:
+        _HUE_MAP_TYPE.reset(token)
+
+
+def _register(ax: Axes | None, drawn, before: list):
+    """
+    Register a layer for each rug the call drew, split by hue where it has one.
+
+    Split out of :func:`rug` so the hue mapping it reads is reset on every
+    path out, including the early returns below.
+
+    Parameters
+    ----------
+    ax : Axes, optional
+        The axes resolved before the draw, when there was one.
+    drawn : Any
+        Whatever ``seaborn.rugplot`` returned.
+    before : list
+        The collections the axes held beforehand.
+
+    Returns
+    -------
+    Any
+        ``drawn``, unchanged.
+    """
 
     if ax is None:
         ax = drawn if isinstance(drawn, Axes) else None
     if ax is None:
         return drawn
+
 
     for collection in _drawn_by_this_call(ax, before):
         if not isinstance(collection, LineCollection):
@@ -162,16 +320,32 @@ def rug(wrapped, instance, args, kwargs) -> Axes:
             # refuses while the schema is built takes the whole figure with
             # it, which is the defect #564 was about.
             continue
-        FigureManager.create_maidr(
-            ax,
-            PlotType.SCATTER,
-            **{
-                DRAWN_RUG: collection,
-                RUG_LABEL: _name_for(ax, read[1]),
-            },
-        )
+        shared = {DRAWN_RUG: collection, RUG_LABEL: _name_for(ax, read[1])}
+        groups = _hue_groups(ax, collection, len(read[0]))
+        if groups is None:
+            FigureManager.create_maidr(ax, PlotType.SCATTER, **shared)
+            continue
+
+        # One layer per level, each reading its own ticks. Split here rather
+        # than in the layer because a layer *is* one entry in the schema, and
+        # this is one artist -- the same reason `scatterplot.scatter` splits
+        # a hue-grouped scatter in its patch (#544, #597).
+        for group in groups:
+            FigureManager.create_maidr(
+                ax, PlotType.SCATTER, **dict(shared, **{RUG_GROUP: group})
+            )
 
     return drawn
 
 
 wrap_seaborn("rugplot", rug)
+
+# And the plotter method beneath it, read for the one thing the drawn
+# colours cannot say; see `_note_hue_map`. Wrapped by module path rather than
+# by importing the private class, matching how `maidr/patch/boxplot.py`
+# reaches `_CategoricalPlotter`.
+wrapt.wrap_function_wrapper(
+    "seaborn.distributions",
+    "_DistributionPlotter.plot_rug",
+    _note_hue_map,
+)

--- a/maidr/util/legend_names.py
+++ b/maidr/util/legend_names.py
@@ -224,6 +224,14 @@ def title_of(ax: Axes) -> str:
     Reading the title off whichever legend :func:`legend_of` chose keeps the
     two halves of one decision on one source.
 
+    Read **live**, at render, while a layer's group *names* are captured once
+    as the plotting call is patched -- the same split
+    :meth:`~maidr.core.plot.maidr_plot.MaidrPlot._legend_title` documents,
+    kept deliberately rather than inherited. A caller who retitles the legend
+    between two renders makes the two disagree, and the alternative is worse:
+    freezing the title at registration would have a layer announce a title
+    the figure no longer carries, which cannot be corrected by redrawing.
+
     Parameters
     ----------
     ax : Axes

--- a/maidr/util/legend_names.py
+++ b/maidr/util/legend_names.py
@@ -201,3 +201,44 @@ def _match_swatches(colours: list, swatches: list, key) -> dict | None:
             return None
         named[matched] = name
     return named
+
+
+def title_of(ax: Axes) -> str:
+    """
+    The grouping variable's name, off the legend that named the groups.
+
+    :meth:`maidr.core.plot.maidr_plot.MaidrPlot._legend_title` answers the
+    same question from ``ax.get_legend()`` alone. That is the legend a
+    single chart carries, and for the layers that predate :func:`legend_of`
+    the two are the same object.
+
+    They come apart wherever a group was named through the figure-level
+    fallback: the panel has no legend of its own, so ``_legend_title``
+    returns ``""`` and the ``z`` label is dropped, while the *names* were
+    read off the figure's legend and are on the layers. Measured -- a rug
+    drawn ``legend=False`` beside one ``fig.legend(title="g")`` naming the
+    same palette split into ``a`` and ``b`` with no ``z`` at all, so the
+    chart said which side of a grouping each layer was without ever saying
+    what the grouping was.
+
+    Reading the title off whichever legend :func:`legend_of` chose keeps the
+    two halves of one decision on one source.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on.
+
+    Returns
+    -------
+    str
+        The title, or an empty string when there is no legend to read or no
+        title on it.
+    """
+    legend = legend_of(ax)
+    if legend is None:
+        return ""
+    title = legend.get_title()
+    if title is None:
+        return ""
+    return title.get_text().strip()

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -231,18 +231,17 @@ def test_a_second_rug_on_the_same_axes_reads_only_its_own_ticks(frame):
 
 
 def test_a_hue_split_rug_still_marks_every_observation(frame):
-    # Review asked whether a hue split produces several collections that
-    # could be merged or dropped, given the one-layer-per-collection design.
-    # Measured: seaborn draws one collection either way and only recolours
-    # it, so a hue rug is one layer holding every observation. Pinned rather
-    # than left as an ad-hoc measurement, since the answer is seaborn's to
-    # change.
+    # The question this has always answered -- does a hue split lose ticks --
+    # asked of the reading it has now. Seaborn draws one collection either
+    # way and only recolours it, so the split is made in the patch (#597);
+    # what must not change is that every observation is still marked, exactly
+    # once, across whatever layers it takes.
     frame = frame.assign(sex=["F", "F", "M", "M"])
     fig, ax = plt.subplots()
     sns.rugplot(frame, x="value", hue="sex", ax=ax)
 
-    (schema,) = _schemas(fig)
-    assert [point["x"] for point in schema["data"]] == [1.0, 2.5, 3.0, 7.25]
+    marked = [point["x"] for schema in _schemas(fig) for point in schema["data"]]
+    assert sorted(marked) == [1.0, 2.5, 3.0, 7.25]
 
 
 def test_a_rug_under_a_hue_split_density_reads_beside_it(frame):
@@ -254,8 +253,19 @@ def test_a_rug_under_a_hue_split_density_reads_beside_it(frame):
     sns.rugplot(frame, x="value", hue="sex", ax=ax)
 
     schemas = _schemas(fig)
-    assert [schema["type"] for schema in schemas] == ["smooth", "smooth", "point"]
-    assert [point["x"] for point in schemas[-1]["data"]] == [1.0, 2.5, 3.0, 7.25]
+    assert [schema["type"] for schema in schemas] == [
+        "smooth",
+        "smooth",
+        "point",
+        "point",
+    ]
+    marked = [
+        point["x"]
+        for schema in schemas
+        if schema["type"] == "point"
+        for point in schema["data"]
+    ]
+    assert sorted(marked) == [1.0, 2.5, 3.0, 7.25]
 
 
 def test_a_name_can_come_off_an_axis_another_plot_labelled(frame):
@@ -284,3 +294,192 @@ def test_a_rug_with_no_tick_length_is_declined():
 
     assert _layers(fig) == []
     assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def _named(fig) -> list:
+    return [(schema.get("name"), [point["x"] for point in schema["data"]])
+            for schema in _schemas(fig)]
+
+
+def test_a_hue_split_rug_reads_one_layer_per_level(frame):
+    """The groups are drawn and were folded together (#597).
+
+    `rugplot(hue=...)` emitted exactly the schema of the same call without
+    one: a single layer holding every tick, named after the *variable* rather
+    than a level, with no `z`. The grouping was not merely unnamed -- it was
+    absent, on a chart drawn to compare two distributions' raw observations.
+
+    Seaborn leaves it readable: one `LineCollection` with a colour per tick,
+    and the legend that names those colours built inside the call. Measured
+    on twelve observations over two levels, `colour rows=12, unique=2` and
+    `names_for` names every one of them.
+    """
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="sex", ax=ax)
+
+    # Each layer holds its own level's observations, checked by value rather
+    # than by count -- a split that got the membership backwards would have
+    # the right two layers of two.
+    assert _named(fig) == [("F", [1.0, 2.5]), ("M", [3.0, 7.25])]
+
+
+def test_each_layer_names_the_variable_it_is_split_by(frame):
+    # `z` says what the split is by and `name` says which side of it this
+    # layer is, the division `ScatterPlot` documents.
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="sex", ax=ax)
+
+    labels = [schema["axes"]["z"]["label"] for schema in _schemas(fig)]
+    assert labels == ["sex", "sex"]
+
+
+def test_a_rug_on_y_splits_the_same_way(frame):
+    # The observations move to the other axis and the grouping does not move
+    # at all; reading the colours off the wrong thing would show here.
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, y="value", hue="sex", ax=ax)
+
+    assert [
+        (schema.get("name"), [point["y"] for point in schema["data"]])
+        for schema in _schemas(fig)
+    ] == [("F", [1.0, 2.5]), ("M", [3.0, 7.25])]
+
+
+def test_each_group_addresses_only_its_own_ticks(frame):
+    """A group's selectors must not light the whole rug up.
+
+    One collection holds every level's ticks, so the whole-collection
+    selector the ungrouped layer uses would highlight all four for a layer
+    announcing two. Numbered by segment instead, which is the order the
+    `<path>` children are written in.
+    """
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="sex", ax=ax)
+
+    selectors = [schema["selectors"] for schema in _schemas(fig)]
+    assert [len(group) for group in selectors] == [2, 2]
+    # Four distinct ticks addressed, none of them twice.
+    assert len({selector for group in selectors for selector in group}) == 4
+
+
+def test_a_split_drawn_without_a_legend_is_declined(frame):
+    # The colours are still there and nothing names them. Groups called "1"
+    # and "2" are not an improvement on one strip, so the chart keeps the
+    # reading it had.
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="sex", legend=False, ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert schema.get("name") == "value"
+    assert [point["x"] for point in schema["data"]] == [1.0, 2.5, 3.0, 7.25]
+
+
+def test_an_ungrouped_rug_keeps_its_whole_collection_selector(frame):
+    # Nothing to split, so nothing changes: one layer, one selector matching
+    # every tick, named after the variable it marks.
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert schema.get("name") == "value"
+    assert isinstance(schema["selectors"], str)
+    assert len(schema["data"]) == 4
+
+
+def test_the_layers_follow_the_legend_order_not_the_drawing_order(frame):
+    # #502 settled that a grouped layer's layers come out in the order the
+    # chart names its levels. This frame draws F first, so a split that kept
+    # the drawing order would put F first under either `hue_order`.
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="sex", hue_order=["M", "F"], ax=ax)
+
+    assert _named(fig) == [("M", [3.0, 7.25]), ("F", [1.0, 2.5])]
+
+
+def test_a_continuous_hue_is_a_scale_and_is_not_split(frame):
+    """One layer per observation is not a reading of a colour scale.
+
+    The colours cannot say so themselves, and on a small frame they look
+    exactly like a grouping: seaborn's legend samples every value, so all
+    four ticks match a swatch and `names_for` names all four. Measured, the
+    first draft split this into four layers of one tick each.
+
+    So the plotter is asked instead -- it reports `map_type='numeric'` --
+    which is the same discriminator `patch/stripplot` uses and the same
+    decline `scatterplot.hue_groups` makes one artist type over.
+    """
+    frame = frame.assign(level=[0.0, 0.33, 0.66, 1.0])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="level", ax=ax)
+
+    (schema,) = _schemas(fig)
+    assert [point["x"] for point in schema["data"]] == [1.0, 2.5, 3.0, 7.25]
+
+
+def _grouped_axes(frame):
+    """An axes carrying a real hue-split rug, for its legend and colours."""
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    _, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="sex", ax=ax)
+    return ax, list(np.asarray(ax.collections[0].get_colors()))
+
+
+def test_a_colour_list_that_does_not_correspond_to_the_ticks_is_declined(frame):
+    """Fewer colours than ticks cannot say which tick wore which.
+
+    Splitting on them would hand the first ticks to groups and drop the
+    rest, which is silent data loss. Nothing measured draws such a
+    collection -- seaborn gives one colour per tick under a hue, and one for
+    the whole rug without -- so it is asserted directly.
+
+    Built on an axes whose legend *does* name these colours, so the decline
+    is the count and not the naming: given four of them the same call
+    splits.
+    """
+    from matplotlib.collections import LineCollection
+
+    from maidr.patch.rugplot import _HUE_MAP_TYPE, _hue_groups
+
+    ax, colours = _grouped_axes(frame)
+    segments = [[(0.0, 0.0), (0.0, 1.0)] for _ in range(4)]
+    short = LineCollection(segments, colors=[colours[0], colours[-1]])
+    full = LineCollection(segments, colors=colours)
+
+    token = _HUE_MAP_TYPE.set("categorical")
+    try:
+        assert _hue_groups(ax, short, 4) is None
+        assert _hue_groups(ax, full, 4) is not None
+    finally:
+        _HUE_MAP_TYPE.reset(token)
+
+
+def test_a_tick_no_swatch_names_declines_the_whole_split(frame):
+    """A partly named rug is worse than an unnamed one.
+
+    Splitting on the named ticks alone would announce a group called "None"
+    holding the rest -- maidr's own word for "unmatched" read aloud as a
+    level. The whole split is declined instead, which is the rule
+    `scatterplot.hue_groups` follows for a point no swatch claims.
+    """
+    from matplotlib.collections import LineCollection
+
+    from maidr.patch.rugplot import _HUE_MAP_TYPE, _hue_groups
+
+    ax, colours = _grouped_axes(frame)
+    segments = [[(0.0, 0.0), (0.0, 1.0)] for _ in range(4)]
+    # Two ticks in a colour the legend names, two in one it does not.
+    partly = LineCollection(
+        segments, colors=[colours[0], colours[0], "magenta", "magenta"]
+    )
+
+    token = _HUE_MAP_TYPE.set("categorical")
+    try:
+        assert _hue_groups(ax, partly, 4) is None
+    finally:
+        _HUE_MAP_TYPE.reset(token)

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -28,6 +28,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.collections import LineCollection
 
 import maidr
 from maidr.core.figure_manager import FigureManager
@@ -191,8 +192,6 @@ def test_a_collection_that_is_not_a_set_of_ticks_is_declined():
     # A segment sloping across both axes is held constant on neither, so it
     # marks no position. The whole layer is declined rather than part of it
     # read, so a chart is never announced as a subset of itself.
-    from matplotlib.collections import LineCollection
-
     sloped = LineCollection([[[0.0, 1.0], [5.0, 2.0]]])
     assert read_rug(sloped) is None
 
@@ -297,8 +296,10 @@ def test_a_rug_with_no_tick_length_is_declined():
 
 
 def _named(fig) -> list:
-    return [(schema.get("name"), [point["x"] for point in schema["data"]])
-            for schema in _schemas(fig)]
+    return [
+        (schema.get("name"), [point["x"] for point in schema["data"]])
+        for schema in _schemas(fig)
+    ]
 
 
 def test_a_hue_split_rug_reads_one_layer_per_level(frame):
@@ -442,8 +443,6 @@ def test_a_colour_list_that_does_not_correspond_to_the_ticks_is_declined(frame):
     is the count and not the naming: given four of them the same call
     splits.
     """
-    from matplotlib.collections import LineCollection
-
     from maidr.patch.rugplot import _HUE_MAP_TYPE, _hue_groups
 
     ax, colours = _grouped_axes(frame)
@@ -467,8 +466,6 @@ def test_a_tick_no_swatch_names_declines_the_whole_split(frame):
     level. The whole split is declined instead, which is the rule
     `scatterplot.hue_groups` follows for a point no swatch claims.
     """
-    from matplotlib.collections import LineCollection
-
     from maidr.patch.rugplot import _HUE_MAP_TYPE, _hue_groups
 
     ax, colours = _grouped_axes(frame)
@@ -483,3 +480,35 @@ def test_a_tick_no_swatch_names_declines_the_whole_split(frame):
         assert _hue_groups(ax, partly, 4) is None
     finally:
         _HUE_MAP_TYPE.reset(token)
+
+
+def test_a_split_named_by_a_figure_legend_still_says_what_it_split_by():
+    """The `z` label has to come off the legend that named the groups.
+
+    `legend_of` falls back to a lone figure-level legend for a panel with
+    none of its own -- that is how a `PairGrid`'s panels are named -- and
+    the layers then carry the levels it named them with. Reading the title
+    off `ax.get_legend()` alone leaves that chart saying which side of a
+    grouping each layer is on without ever saying what the grouping is.
+
+    Measured before the fix: two layers, `name='a'` and `name='b'`, and no
+    `z` at all.
+    """
+    frame = pd.DataFrame({"v": [1.0, 2.0, 3.0, 7.0, 8.0, 9.0], "g": list("aaabbb")})
+    fig, ax = plt.subplots()
+    palette = sns.color_palette(n_colors=2)
+    handles = [
+        plt.Line2D([], [], color=colour, label=name)
+        for name, colour in zip(["a", "b"], palette)
+    ]
+    fig.legend(handles=handles, title="g")
+
+    sns.rugplot(frame, x="v", hue="g", ax=ax, legend=False)
+
+    assert ax.get_legend() is None
+    schemas = _schemas(fig)
+    assert [schema.get("name") for schema in schemas] == ["a", "b"]
+    assert [schema["axes"].get("z") for schema in schemas] == [
+        {"label": "g"},
+        {"label": "g"},
+    ]


### PR DESCRIPTION
Closes #597.

## The defect

`sns.rugplot(..., hue=...)` emitted exactly the schema of the same call
**without** `hue=`:

```
rugplot(x="val")            -> point  name='val'  n=12
rugplot(x="val", hue="grp") -> point  name='val'  n=12
```

Identical. The `name` is the *variable* the rug marks, not a level, and there
is no `z` — so a chart drawn to compare two distributions' raw observations
read as one undifferentiated strip. The grouping was not unnamed; it was
absent.

## Why it was readable all along

Seaborn draws the whole rug as **one `LineCollection` with a colour per
tick**, and builds the legend that names those colours inside the call:

```
rugplot(x="v")           colour rows=1,  unique=1, legend None
rugplot(x="v", hue="g")  colour rows=12, unique=2, legend ['p','q']

names_for(ax, per-tick colours)
  -> ['p','p','p','p','p','p','q','q','q','q','q','q']
```

That is the shape `scatterplot.hue_groups` reads point by point (#544) and
`patch/stripplot` reads for a categorical scatter (#586). A rug was the last
member of the family folding its groups together.

The split is made in the **patch**, for the reason `scatterplot.scatter`
gives: a layer *is* one entry in the schema, and this is one artist.

## What a grouped layer does differently

- Keeps to **its own ticks** — and remembers where they sat among the drawn
  ones, because the selector numbers by segment. A layer that filtered its
  positions without that would highlight the first *N* ticks of the rug
  rather than its own.
- Addresses them **per segment** (`path:nth-of-type(n)`). The whole-collection
  selector an ungrouped rug uses would light the entire rug up for a layer
  announcing half of it.
- Names the grouping variable on `z` and the level on `name`.

An ungrouped rug is untouched: one layer, one whole-collection selector,
named after its variable.

## The one thing the colours cannot say

Whether the hue is a grouping at all. A **numeric** `hue=` is a colour scale,
and on a small frame seaborn's legend samples every value — so every tick
matches a swatch and `names_for` names all of them. Measured on four
observations, the first draft of this split them into **four layers of one
tick each**, which is not a reading of a scale.

`_DistributionPlotter.plot_rug` is wrapped to record the plotter's
`map_type` — the same discriminator `patch/stripplot` uses, and the same
decline `hue_groups` makes one artist type over. Wrapped only to record it;
the drawing is untouched and the registration is still made by `rug()`.

## Results

| call | before | after |
|---|---|---|
| `rugplot(x=, hue=)` | one layer, all ticks | `p`(6) / `q`(6), `z='grp'` |
| `rugplot(y=, hue=)` | one layer | split the same way |
| `hue_order=` reversed | — | layers in legend order, not draw order |
| `hue=` numeric | one layer | unchanged — declined |
| `legend=False` | one layer | unchanged — declined |
| `rugplot(x=)` | one layer | unchanged |

## Verification

- Each layer holds its own level's observations, checked **by value**: a
  split that got the membership backwards would still give two layers of two.
- 6 selectors resolved against the rendered SVG with `lxml.cssselect`, each
  matching exactly one element, 6 distinct — no overlap, no misses.
- Eight mutations applied one at a time against a restored baseline, **all
  killed**. Three needed tests that did not exist and now do: the
  legend-order tie, and the two guards — a colour list that does not
  correspond to the ticks, and a tick no swatch names. Both had to be
  asserted directly on `_hue_groups`, because no chart draws a rug they
  decline; the first version of those tests passed either way because the
  axes they built had no legend, which is exactly what the mutation pass
  caught.
- Two existing tests pinned the old shape. Their intent — that a hue split
  loses no observation — is kept and asked of the reading it has now, rather
  than deleted.
- `tests/core/plot/test_rugplot.py` — 26 tests (10 new).
- Full suite: **2886 passed, 18 skipped**. `ruff check` clean.

## Two neighbours measured and found correct

Checked in the same sweep and **not** defects, recorded so they are not
re-investigated:

- `pointplot(hue=)` emits only an `error_bar` layer, which looked like a
  missing estimates layer. The estimate rides on each entry's `y` with the
  interval on `yMin`/`yMax`, and `errorbar=None` gives a `line` layer.
- `clustermap` appeared to emit 3 rows for a 5×4 frame. Its `data` is a dict
  of `points`/`x`/`y` — the "3" was the key count. The points are the full
  5×4, reordered to the clustering with `y` reordered to match.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_