### PR TITLE
feat(iframe): let the chart frame reach a tactile display

### DIFF
--- a/maidr/util/iframe_utils.py
+++ b/maidr/util/iframe_utils.py
@@ -21,20 +21,27 @@ _UNTITLED_NAME = "Accessible chart"
 
 # Permissions-Policy features the chart frame is allowed to use.
 #
-# ``bluetooth`` is what lets maidr.js reach a refreshable tactile display --
-# a Dot Pad -- over Web Bluetooth and draw the chart on its pins.  The feature
-# is policy-gated with a default allowlist of ``self``, so a same-origin frame
-# already has it and this attribute is redundant there; a cross-origin one --
-# Colab, and any host that serves notebook output from a separate origin --
-# does not, and without the attribute ``navigator.bluetooth`` is simply absent
+# Both are what let maidr.js reach a refreshable tactile display -- a Dot
+# Pad -- and draw the chart on its pins: ``bluetooth`` for the wireless path,
+# ``serial`` for a cabled one.  Each is policy-gated with a default allowlist
+# of ``self``, so a same-origin frame already has them and this attribute is
+# redundant there; a cross-origin one -- Colab, and any host that serves
+# notebook output from a separate origin -- does not, and without the
+# attribute ``navigator.bluetooth`` and ``navigator.serial`` are simply absent
 # inside the frame.
 #
-# This delegates a capability, it does not create one: a frame can never
+# Both are listed because maidr offers both and they are gated independently:
+# granting only one would leave a reader on a cable unable to connect for a
+# reason nothing on the page explains.  USB is the faster of the two by a wide
+# margin -- a full frame over Bluetooth costs a second or more against a reader
+# pressing arrow keys several times a second -- so it is not the marginal case.
+#
+# This delegates capabilities, it does not create them: a frame can never
 # receive a feature the embedding page itself lacks, and the browser still
 # requires a user gesture and shows its own device picker before anything is
 # paired.  Readers with no tactile display are unaffected -- maidr never
-# touches the API unless they ask it to in Settings.
-_ALLOWED_FEATURES = "bluetooth"
+# touches either API unless they ask it to in Settings.
+_ALLOWED_FEATURES = "bluetooth; serial"
 
 
 def _generate_unique_id() -> str:

--- a/maidr/util/iframe_utils.py
+++ b/maidr/util/iframe_utils.py
@@ -21,36 +21,28 @@ _UNTITLED_NAME = "Accessible chart"
 
 # Permissions-Policy features the chart frame is allowed to use.
 #
-# Both are what let maidr.js reach a refreshable tactile display -- a Dot
-# Pad -- and draw the chart on its pins: ``bluetooth`` for the wireless path,
-# ``serial`` for a cabled one.  Without them ``navigator.bluetooth`` and
-# ``navigator.serial`` are not merely refused inside the frame, they are
-# absent, so maidr cannot tell a policy problem from an unsupported browser.
+# These let maidr.js reach a refreshable tactile display -- a Dot Pad -- and
+# draw the chart on its pins, over Bluetooth or over USB.  Both are listed
+# because maidr offers both and they are gated independently; granting one
+# would leave the other path dead with nothing on the page to explain it.
 #
-# Two default allowlists are in play and they are not the same one.  A feature
-# the container policy does not name falls back to the *feature's* own default,
-# ``self`` for both of these -- which a same-origin frame satisfies, so this
-# attribute changes nothing for one.  A feature named here without an
-# allowlist of its own takes the *attribute's* default, ``'src'``: the origin
-# the frame was loaded from.  Both wrappers use ``srcdoc``, whose document
-# inherits the embedder's origin, so ``'src'`` resolves same-origin and the
-# delegation lands -- which is why ``test_the_frame_still_carries_its_own_document``
-# guards the ``srcdoc`` choice rather than treating it as incidental.  What the
-# attribute actually buys is the cross-origin case -- Colab, and any host that
-# serves notebook output from a separate origin -- where the fallback would
-# otherwise deny both.
+# Two different default allowlists meet here.  A feature the container policy
+# does not name falls back to the *feature's* default, ``self`` -- which a
+# same-origin frame satisfies, so this attribute changes nothing for one.  A
+# feature named here without its own allowlist takes the *attribute's*
+# default, ``'src'``: the origin the frame was loaded from.  They coincide
+# only because these wrappers use ``srcdoc``, whose document inherits the
+# embedder's origin, which is why ``test_the_frame_still_carries_its_own_document``
+# guards that choice.  What the attribute buys is the cross-origin case, where
+# the fallback would deny both.
 #
-# Both are listed because maidr offers both and they are gated independently:
-# granting only one would leave a reader on a cable unable to connect for a
-# reason nothing on the page explains.  USB is the faster of the two by a wide
-# margin -- a full frame over Bluetooth costs a second or more against a reader
-# pressing arrow keys several times a second -- so it is not the marginal case.
-#
-# This delegates capabilities, it does not create them: a frame can never
-# receive a feature the embedding page itself lacks, and the browser still
-# requires a user gesture and shows its own device picker before anything is
-# paired.  Readers with no tactile display are unaffected -- maidr never
-# touches either API unless they ask it to in Settings.
+# This delegates capabilities, it does not create them: a frame cannot receive
+# a feature the embedding page lacks, and the browser still requires a user
+# gesture and its own device picker.  It does widen what an injection into the
+# framed document would reach, so it leans on an assumption worth stating: the
+# chart content placed in ``srcdoc`` stays non-executable.  ``htmltools``
+# escapes it today -- a title of ``</iframe><script>`` arrives as text -- and
+# that has to keep being true.
 _ALLOWED_FEATURES = "bluetooth; serial"
 
 

--- a/maidr/util/iframe_utils.py
+++ b/maidr/util/iframe_utils.py
@@ -39,10 +39,12 @@ _UNTITLED_NAME = "Accessible chart"
 # This delegates capabilities, it does not create them: a frame cannot receive
 # a feature the embedding page lacks, and the browser still requires a user
 # gesture and its own device picker.  It does widen what an injection into the
-# framed document would reach, so it leans on an assumption worth stating: the
-# chart content placed in ``srcdoc`` stays non-executable.  ``htmltools``
-# escapes it today -- a title of ``</iframe><script>`` arrives as text -- and
-# that has to keep being true.
+# framed document would reach, so it leans on an assumption worth stating.  The
+# document is executable by design -- it carries the chart's own scripts -- so
+# what has to hold is that the strings a caller supplies, the title above all,
+# land in it as text and never as markup.  ``htmltools`` escapes them today --
+# a title of ``</iframe><script>`` stays inside its attribute -- and
+# ``test_a_hostile_title_arrives_as_text`` fails if that stops being true.
 _ALLOWED_FEATURES = "bluetooth; serial"
 
 

--- a/maidr/util/iframe_utils.py
+++ b/maidr/util/iframe_utils.py
@@ -23,12 +23,22 @@ _UNTITLED_NAME = "Accessible chart"
 #
 # Both are what let maidr.js reach a refreshable tactile display -- a Dot
 # Pad -- and draw the chart on its pins: ``bluetooth`` for the wireless path,
-# ``serial`` for a cabled one.  Each is policy-gated with a default allowlist
-# of ``self``, so a same-origin frame already has them and this attribute is
-# redundant there; a cross-origin one -- Colab, and any host that serves
-# notebook output from a separate origin -- does not, and without the
-# attribute ``navigator.bluetooth`` and ``navigator.serial`` are simply absent
-# inside the frame.
+# ``serial`` for a cabled one.  Without them ``navigator.bluetooth`` and
+# ``navigator.serial`` are not merely refused inside the frame, they are
+# absent, so maidr cannot tell a policy problem from an unsupported browser.
+#
+# Two default allowlists are in play and they are not the same one.  A feature
+# the container policy does not name falls back to the *feature's* own default,
+# ``self`` for both of these -- which a same-origin frame satisfies, so this
+# attribute changes nothing for one.  A feature named here without an
+# allowlist of its own takes the *attribute's* default, ``'src'``: the origin
+# the frame was loaded from.  Both wrappers use ``srcdoc``, whose document
+# inherits the embedder's origin, so ``'src'`` resolves same-origin and the
+# delegation lands -- which is why ``test_the_frame_still_carries_its_own_document``
+# guards the ``srcdoc`` choice rather than treating it as incidental.  What the
+# attribute actually buys is the cross-origin case -- Colab, and any host that
+# serves notebook output from a separate origin -- where the fallback would
+# otherwise deny both.
 #
 # Both are listed because maidr offers both and they are gated independently:
 # granting only one would leave a reader on a cable unable to connect for a

--- a/maidr/util/iframe_utils.py
+++ b/maidr/util/iframe_utils.py
@@ -19,6 +19,23 @@ from htmltools import Tag, tags
 # What the frame is called when the chart it holds has no title of its own.
 _UNTITLED_NAME = "Accessible chart"
 
+# Permissions-Policy features the chart frame is allowed to use.
+#
+# ``bluetooth`` is what lets maidr.js reach a refreshable tactile display --
+# a Dot Pad -- over Web Bluetooth and draw the chart on its pins.  The feature
+# is policy-gated with a default allowlist of ``self``, so a same-origin frame
+# already has it and this attribute is redundant there; a cross-origin one --
+# Colab, and any host that serves notebook output from a separate origin --
+# does not, and without the attribute ``navigator.bluetooth`` is simply absent
+# inside the frame.
+#
+# This delegates a capability, it does not create one: a frame can never
+# receive a feature the embedding page itself lacks, and the browser still
+# requires a user gesture and shows its own device picker before anything is
+# paired.  Readers with no tactile display are unaffected -- maidr never
+# touches the API unless they ask it to in Settings.
+_ALLOWED_FEATURES = "bluetooth"
+
 
 def _generate_unique_id() -> str:
     """Generate a unique iframe ID."""
@@ -252,6 +269,7 @@ def wrap_in_iframe_matplotlib(base_html: Tag, chart_title: str | None = None) ->
         # iframe is the chart" -- the Shiny focus restore does -- would
         # otherwise act on one of those. See `maidr/widget/_focus.py`.
         **{"data-maidr-chart": ""},
+        allow=_ALLOWED_FEATURES,
         srcdoc=str(base_html.get_html_string()),
         width="100%",
         height="100%",
@@ -393,6 +411,7 @@ def wrap_in_iframe_plotly(base_html: Tag, chart_title: str | None = None) -> Tag
         # iframe is the chart" -- the Shiny focus restore does -- would
         # otherwise act on one of those. See `maidr/widget/_focus.py`.
         **{"data-maidr-chart": ""},
+        allow=_ALLOWED_FEATURES,
         srcdoc=str(base_html.get_html_string()),
         width="100%",
         height="100%",

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -302,14 +302,14 @@ def render_maidr(
     html = maidr_html(plot, use_cdn=use_cdn, _stacklevel=4)
 
     # Streamlit builds this frame itself, so maidr cannot put an ``allow``
-    # attribute on it the way it does for notebook renders (see
-    # ``_ALLOWED_FEATURES`` in ``maidr/util/iframe_utils.py``).  Web Bluetooth
-    # and Web Serial are therefore both unreachable here, and a Dot Pad or
-    # other tactile graphics display cannot be driven from a Streamlit app
-    # until Streamlit exposes the frame's permissions policy.  Everything
-    # else -- sonification, text, braille through the screen reader -- is
-    # unaffected, and maidr detects the missing capability and says so rather
-    # than offering a control that cannot work.
+    # attribute on it the way the notebook wrappers do (see
+    # ``_ALLOWED_FEATURES`` in ``maidr/util/iframe_utils.py``).  It does not
+    # need to: Streamlit renders a ``srcdoc`` frame sandboxed *with*
+    # ``allow-same-origin``, so the frame shares the app's origin, and a
+    # feature its fixed ``allow`` list leaves unnamed -- Web Bluetooth and
+    # Web Serial both -- falls back to the feature's own default, ``self``,
+    # which a same-origin frame satisfies.  A tactile display is reachable
+    # from a Streamlit app wherever the app document itself may reach one.
     if hasattr(st, "iframe"):
         st.iframe(html, width=width, height=height, tab_index=tab_index)
         return

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -304,12 +304,12 @@ def render_maidr(
     # Streamlit builds this frame itself, so maidr cannot put an ``allow``
     # attribute on it the way it does for notebook renders (see
     # ``_ALLOWED_FEATURES`` in ``maidr/util/iframe_utils.py``).  Web Bluetooth
-    # is therefore unreachable here, and a Dot Pad or other tactile graphics
-    # display cannot be driven from a Streamlit app until Streamlit exposes
-    # the frame's permissions policy.  Everything else -- sonification, text,
-    # braille through the screen reader -- is unaffected, and maidr detects
-    # the missing capability and says so rather than offering a control that
-    # cannot work.
+    # and Web Serial are therefore both unreachable here, and a Dot Pad or
+    # other tactile graphics display cannot be driven from a Streamlit app
+    # until Streamlit exposes the frame's permissions policy.  Everything
+    # else -- sonification, text, braille through the screen reader -- is
+    # unaffected, and maidr detects the missing capability and says so rather
+    # than offering a control that cannot work.
     if hasattr(st, "iframe"):
         st.iframe(html, width=width, height=height, tab_index=tab_index)
         return

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -301,6 +301,15 @@ def render_maidr(
 
     html = maidr_html(plot, use_cdn=use_cdn, _stacklevel=4)
 
+    # Streamlit builds this frame itself, so maidr cannot put an ``allow``
+    # attribute on it the way it does for notebook renders (see
+    # ``_ALLOWED_FEATURES`` in ``maidr/util/iframe_utils.py``).  Web Bluetooth
+    # is therefore unreachable here, and a Dot Pad or other tactile graphics
+    # display cannot be driven from a Streamlit app until Streamlit exposes
+    # the frame's permissions policy.  Everything else -- sonification, text,
+    # braille through the screen reader -- is unaffected, and maidr detects
+    # the missing capability and says so rather than offering a control that
+    # cannot work.
     if hasattr(st, "iframe"):
         st.iframe(html, width=width, height=height, tab_index=tab_index)
         return

--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -310,6 +310,17 @@ def render_maidr(
     # Web Serial both -- falls back to the feature's own default, ``self``,
     # which a same-origin frame satisfies.  A tactile display is reachable
     # from a Streamlit app wherever the app document itself may reach one.
+    #
+    # Measured on Streamlit 1.61.1, not inferred: ``st.iframe`` and the
+    # ``components.v1.html`` fallback below both enqueue the same ``IFrame``
+    # element, and its frontend's sandbox list carries ``allow-same-origin``
+    # while its feature list names neither ``bluetooth`` nor ``serial``.
+    # Nothing in this repository's tests pins that -- it lives in
+    # Streamlit's frontend bundle, which only a browser can exercise -- and
+    # no older Streamlit has been measured, so on a release where the
+    # fallback is what runs this is a reasoned expectation rather than a
+    # checked one.  If a Streamlit release tightens that sandbox, tactile
+    # displays stop working under it with nothing here to say so.
     if hasattr(st, "iframe"):
         st.iframe(html, width=width, height=height, tab_index=tab_index)
         return

--- a/tests/util/test_iframe_bluetooth_permission.py
+++ b/tests/util/test_iframe_bluetooth_permission.py
@@ -1,0 +1,97 @@
+"""
+Every iframed render delegates Web Bluetooth to the chart frame.
+
+maidr.js can draw a chart onto a refreshable tactile display -- a Dot Pad --
+over Web Bluetooth, so a blind reader feels the plot rather than only hearing
+it. ``navigator.bluetooth`` is Permissions-Policy gated, and a frame that is
+not granted the feature does not merely fail the call: the API is absent
+entirely, so maidr reports "this browser cannot reach a DotPad" and the reader
+has no way to tell a policy problem from an unsupported browser.
+
+The default allowlist is ``self``, so a same-origin frame already has it and
+the attribute changes nothing there. It is the cross-origin embeddings that
+need it -- Colab, and any host serving notebook output from a separate origin.
+Since both wrappers produce frames that end up in both kinds of page, both
+carry the attribute.
+
+Asserted on the rendered HTML rather than on a constant, because the constant
+holding the right string is not the claim -- the claim is that the attribute
+reaches the tag, on both wrappers, for the whole range of titles a chart
+arrives with.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pytest
+from htmltools import tags
+
+from maidr.util.iframe_utils import (
+    wrap_in_iframe_matplotlib,
+    wrap_in_iframe_plotly,
+)
+
+WRAPPERS = (wrap_in_iframe_matplotlib, wrap_in_iframe_plotly)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _html(tag) -> str:
+    return str(tag.get_html_string())
+
+
+class TestTheFrameMayReachATactileDisplay:
+    """The attribute reaches the tag, by both wrappers."""
+
+    @pytest.mark.parametrize("wrap", WRAPPERS)
+    def test_the_chart_frame_is_allowed_bluetooth(self, wrap) -> None:
+        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+
+        assert 'allow="bluetooth"' in rendered
+
+    @pytest.mark.parametrize("wrap", WRAPPERS)
+    def test_an_untitled_chart_is_allowed_it_too(self, wrap) -> None:
+        # The delegation has nothing to do with the chart's title, and a
+        # reader with a tactile display should not lose it for want of one.
+        rendered = _html(wrap(tags.div("chart")))
+
+        assert 'allow="bluetooth"' in rendered
+
+    @pytest.mark.parametrize("wrap", WRAPPERS)
+    def test_the_frame_is_not_sandboxed_into_an_opaque_origin(self, wrap) -> None:
+        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+
+        # A `sandbox` without `allow-same-origin` gives the frame an opaque
+        # origin, and a policy-controlled feature is never delegated to one --
+        # the `allow` attribute above would be inert. Nothing sandboxes these
+        # frames today; this fails if that changes without the pairing being
+        # thought through.
+        assert "sandbox=" not in rendered
+
+    @pytest.mark.parametrize("wrap", WRAPPERS)
+    def test_the_frame_still_carries_its_own_document(self, wrap) -> None:
+        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+
+        # `srcdoc` is what keeps the frame same-origin with its host. Serving
+        # the same document from a `data:` URL instead would hand it an opaque
+        # origin, and no `allow` attribute can grant a feature to one.
+        assert "srcdoc=" in rendered
+
+
+class TestNothingElseIsDelegated:
+    """The frame gets what the tactile display needs, and no more."""
+
+    @pytest.mark.parametrize("wrap", WRAPPERS)
+    def test_no_other_feature_is_granted(self, wrap) -> None:
+        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+
+        # Delegating a feature cannot exceed what the embedding page already
+        # holds, but it should still be the shortest list that works. maidr
+        # only ever scans for a device over BLE, so `serial`, `usb`, `camera`
+        # and the rest have no business here.
+        for feature in ("serial", "usb", "camera", "microphone", "geolocation"):
+            assert feature not in rendered

--- a/tests/util/test_iframe_device_permissions.py
+++ b/tests/util/test_iframe_device_permissions.py
@@ -129,7 +129,9 @@ class TestTheFrameMayReachATactileDisplay:
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_neither_transport_is_granted_without_the_other(self, wrap) -> None:
-        features = _allowed_features(_html(wrap(tags.div("chart"), "Body mass by species")))
+        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+
+        features = _allowed_features(rendered)
 
         # Independently gated, so dropping one leaves that path dead for a
         # reason nothing on the page explains. Asserted per feature rather
@@ -173,7 +175,9 @@ class TestNothingElseIsDelegated:
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_no_other_feature_is_granted(self, wrap) -> None:
-        features = _allowed_features(_html(wrap(tags.div("chart"), "Body mass by species")))
+        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+
+        features = _allowed_features(rendered)
 
         # Delegating a feature cannot exceed what the embedding page already
         # holds, but it should still be the shortest list that works. maidr

--- a/tests/util/test_iframe_device_permissions.py
+++ b/tests/util/test_iframe_device_permissions.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 import re
 from html.parser import HTMLParser
 
-import matplotlib.pyplot as plt
 import pytest
 from htmltools import tags
 
@@ -48,12 +47,6 @@ from maidr.util.iframe_utils import (
 )
 
 WRAPPERS = (wrap_in_iframe_matplotlib, wrap_in_iframe_plotly)
-
-
-@pytest.fixture(autouse=True)
-def _close_figures():
-    yield
-    plt.close("all")
 
 
 def _html(tag) -> str:
@@ -112,9 +105,7 @@ def _allowed_features(rendered: str) -> set[str]:
     """
     allow = _iframe_attrs(rendered).get("allow", "")
     return {
-        re.split(r"\s+", item.strip())[0]
-        for item in allow.split(";")
-        if item.strip()
+        re.split(r"\s+", item.strip())[0] for item in allow.split(";") if item.strip()
     }
 
 
@@ -125,28 +116,25 @@ class TestTheFrameMayReachATactileDisplay:
     def test_the_chart_frame_is_allowed_bluetooth_and_serial(self, wrap) -> None:
         rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
 
-        assert 'allow="bluetooth; serial"' in rendered
-
-    @pytest.mark.parametrize("wrap", WRAPPERS)
-    def test_neither_transport_is_granted_without_the_other(self, wrap) -> None:
-        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
-
         features = _allowed_features(rendered)
 
-        # Independently gated, so dropping one leaves that path dead for a
-        # reason nothing on the page explains. Asserted per feature rather
-        # than against the exact string above, so a reformatting of the list
-        # cannot quietly lose one.
-        assert "bluetooth" in features
-        assert "serial" in features
+        # Both, and nothing else. They are independently gated, so dropping
+        # one leaves that path dead for a reason nothing on the page
+        # explains; and delegating a feature cannot exceed what the embedding
+        # page holds, but the list should still be the shortest that works --
+        # maidr scans for a display over Bluetooth and over serial only, so
+        # `usb`, `hid`, `camera` and the rest have no business here. Compared
+        # as parsed features rather than as the exact string, so reformatting
+        # the list cannot quietly lose one.
+        assert features == {"bluetooth", "serial"}
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_an_untitled_chart_is_allowed_them_too(self, wrap) -> None:
         # The delegation has nothing to do with the chart's title, and a
         # reader with a tactile display should not lose it for want of one.
-        rendered = _html(wrap(tags.div("chart")))
+        features = _allowed_features(_html(wrap(tags.div("chart"))))
 
-        assert 'allow="bluetooth; serial"' in rendered
+        assert features == {"bluetooth", "serial"}
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_the_frame_is_not_sandboxed_into_an_opaque_origin(self, wrap) -> None:
@@ -171,19 +159,7 @@ class TestTheFrameMayReachATactileDisplay:
 
 
 class TestNothingElseIsDelegated:
-    """The frame gets what the tactile display needs, and no more."""
-
-    @pytest.mark.parametrize("wrap", WRAPPERS)
-    def test_no_other_feature_is_granted(self, wrap) -> None:
-        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
-
-        features = _allowed_features(rendered)
-
-        # Delegating a feature cannot exceed what the embedding page already
-        # holds, but it should still be the shortest list that works. maidr
-        # scans for a display over Bluetooth and over serial and nothing else,
-        # so `usb`, `hid`, `camera` and the rest have no business here.
-        assert features == {"bluetooth", "serial"}
+    """What the chart says cannot pass for what the frame was granted."""
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_chart_content_cannot_look_like_a_granted_feature(self, wrap) -> None:

--- a/tests/util/test_iframe_device_permissions.py
+++ b/tests/util/test_iframe_device_permissions.py
@@ -23,9 +23,20 @@ Asserted on the rendered HTML rather than on a constant, because the constant
 holding the right string is not the claim -- the claim is that the attribute
 reaches the tag, on both wrappers, for the whole range of titles a chart
 arrives with.
+
+Read back through an HTML parser rather than by substring, because the frame
+carries the whole chart document in its ``srcdoc``.  Searching the rendered
+string would be searching that payload too: ``maidr.js`` contains ``hid`` 150
+times (``aria-hidden``, ``hidden`` -- unsurprising in an accessibility bundle)
+and ``usb`` once, so a "no other feature is granted" assertion written as a
+substring check passes only for as long as the fixture stays a stub, and then
+fails for a reason unrelated to any policy regression.
 """
 
 from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
 
 import matplotlib.pyplot as plt
 import pytest
@@ -49,6 +60,64 @@ def _html(tag) -> str:
     return str(tag.get_html_string())
 
 
+class _FirstIframe(HTMLParser):
+    """Captures the attributes of the first ``iframe`` start tag."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.attrs: dict[str, str] | None = None
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        if tag == "iframe" and self.attrs is None:
+            self.attrs = {name: value or "" for name, value in attrs}
+
+
+def _iframe_attrs(rendered: str) -> dict[str, str]:
+    """
+    Reads the chart frame's own attributes out of the rendered HTML.
+
+    Scoped to the tag rather than the document: the frame carries the entire
+    chart -- bundle included -- inside ``srcdoc``, so a substring search over
+    the rendered string is a search of that payload as well.
+
+    Parameters
+    ----------
+    rendered
+        The wrapper's rendered HTML.
+
+    Returns
+    -------
+    dict[str, str]
+        The ``iframe`` start tag's attributes.
+    """
+    parser = _FirstIframe()
+    parser.feed(rendered)
+    assert parser.attrs is not None, "the wrapper rendered no iframe"
+    return parser.attrs
+
+
+def _allowed_features(rendered: str) -> set[str]:
+    """
+    Splits the frame's ``allow`` attribute into the features it delegates.
+
+    Parameters
+    ----------
+    rendered
+        The wrapper's rendered HTML.
+
+    Returns
+    -------
+    set[str]
+        One entry per delegated feature, without any allowlist that follows it.
+    """
+    allow = _iframe_attrs(rendered).get("allow", "")
+    return {
+        re.split(r"\s+", item.strip())[0]
+        for item in allow.split(";")
+        if item.strip()
+    }
+
+
 class TestTheFrameMayReachATactileDisplay:
     """The attribute reaches the tag, by both wrappers."""
 
@@ -60,13 +129,14 @@ class TestTheFrameMayReachATactileDisplay:
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_neither_transport_is_granted_without_the_other(self, wrap) -> None:
-        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+        features = _allowed_features(_html(wrap(tags.div("chart"), "Body mass by species")))
 
         # Independently gated, so dropping one leaves that path dead for a
-        # reason nothing on the page explains. Named separately from the exact
-        # string above so a reformatting of the list cannot quietly lose one.
-        assert "bluetooth" in rendered
-        assert "serial" in rendered
+        # reason nothing on the page explains. Asserted per feature rather
+        # than against the exact string above, so a reformatting of the list
+        # cannot quietly lose one.
+        assert "bluetooth" in features
+        assert "serial" in features
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_an_untitled_chart_is_allowed_them_too(self, wrap) -> None:
@@ -78,23 +148,24 @@ class TestTheFrameMayReachATactileDisplay:
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_the_frame_is_not_sandboxed_into_an_opaque_origin(self, wrap) -> None:
-        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+        attrs = _iframe_attrs(_html(wrap(tags.div("chart"), "Body mass by species")))
 
         # A `sandbox` without `allow-same-origin` gives the frame an opaque
         # origin, and a policy-controlled feature is never delegated to one --
         # the `allow` attribute above would be inert. Nothing sandboxes these
         # frames today; this fails if that changes without the pairing being
         # thought through.
-        assert "sandbox=" not in rendered
+        assert "sandbox" not in attrs
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_the_frame_still_carries_its_own_document(self, wrap) -> None:
-        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+        attrs = _iframe_attrs(_html(wrap(tags.div("chart"), "Body mass by species")))
 
         # `srcdoc` is what keeps the frame same-origin with its host. Serving
         # the same document from a `data:` URL instead would hand it an opaque
         # origin, and no `allow` attribute can grant a feature to one.
-        assert "srcdoc=" in rendered
+        assert "srcdoc" in attrs
+        assert "src" not in attrs
 
 
 class TestNothingElseIsDelegated:
@@ -102,11 +173,28 @@ class TestNothingElseIsDelegated:
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_no_other_feature_is_granted(self, wrap) -> None:
-        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+        features = _allowed_features(_html(wrap(tags.div("chart"), "Body mass by species")))
 
         # Delegating a feature cannot exceed what the embedding page already
         # holds, but it should still be the shortest list that works. maidr
         # scans for a display over Bluetooth and over serial and nothing else,
         # so `usb`, `hid`, `camera` and the rest have no business here.
-        for feature in ("usb", "hid", "camera", "microphone", "geolocation"):
-            assert feature not in rendered
+        assert features == {"bluetooth", "serial"}
+
+    @pytest.mark.parametrize("wrap", WRAPPERS)
+    def test_chart_content_cannot_look_like_a_granted_feature(self, wrap) -> None:
+        # The frame carries the whole chart document, bundle included, inside
+        # `srcdoc`. `maidr.js` alone contains `hid` 150 times (`aria-hidden`,
+        # `hidden`) and `usb` once, so reading the delegated features by
+        # substring over the rendered string would report features nobody
+        # granted -- and would do it only once the fixture grew realistic,
+        # long after the test was written. Content that says these words is
+        # the case that pins the difference.
+        loaded = tags.div(
+            "chart",
+            tags.span("aria-hidden usb camera microphone geolocation"),
+        )
+
+        features = _allowed_features(_html(wrap(loaded, "Body mass by species")))
+
+        assert features == {"bluetooth", "serial"}

--- a/tests/util/test_iframe_device_permissions.py
+++ b/tests/util/test_iframe_device_permissions.py
@@ -1,18 +1,23 @@
 """
-Every iframed render delegates Web Bluetooth to the chart frame.
+Every iframed render delegates Web Bluetooth and Web Serial to the chart frame.
 
 maidr.js can draw a chart onto a refreshable tactile display -- a Dot Pad --
-over Web Bluetooth, so a blind reader feels the plot rather than only hearing
-it. ``navigator.bluetooth`` is Permissions-Policy gated, and a frame that is
-not granted the feature does not merely fail the call: the API is absent
-entirely, so maidr reports "this browser cannot reach a DotPad" and the reader
-has no way to tell a policy problem from an unsupported browser.
+so a blind reader feels the plot rather than only hearing it. It reaches the
+device over Bluetooth or over USB, and both APIs are Permissions-Policy gated.
+A frame that is not granted a feature does not merely fail the call: the API is
+absent entirely, so maidr reports "this browser cannot reach a DotPad" and the
+reader has no way to tell a policy problem from an unsupported browser.
 
-The default allowlist is ``self``, so a same-origin frame already has it and
+The default allowlist is ``self``, so a same-origin frame already has them and
 the attribute changes nothing there. It is the cross-origin embeddings that
 need it -- Colab, and any host serving notebook output from a separate origin.
 Since both wrappers produce frames that end up in both kinds of page, both
 carry the attribute.
+
+Both features are asserted, not just one. They are gated independently, so
+granting only Bluetooth would leave a reader on a cable unable to connect for
+a reason nothing on the page explains -- and USB is the faster path by a wide
+margin, so it is not the marginal case.
 
 Asserted on the rendered HTML rather than on a constant, because the constant
 holding the right string is not the claim -- the claim is that the attribute
@@ -48,18 +53,28 @@ class TestTheFrameMayReachATactileDisplay:
     """The attribute reaches the tag, by both wrappers."""
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
-    def test_the_chart_frame_is_allowed_bluetooth(self, wrap) -> None:
+    def test_the_chart_frame_is_allowed_bluetooth_and_serial(self, wrap) -> None:
         rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
 
-        assert 'allow="bluetooth"' in rendered
+        assert 'allow="bluetooth; serial"' in rendered
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
-    def test_an_untitled_chart_is_allowed_it_too(self, wrap) -> None:
+    def test_neither_transport_is_granted_without_the_other(self, wrap) -> None:
+        rendered = _html(wrap(tags.div("chart"), "Body mass by species"))
+
+        # Independently gated, so dropping one leaves that path dead for a
+        # reason nothing on the page explains. Named separately from the exact
+        # string above so a reformatting of the list cannot quietly lose one.
+        assert "bluetooth" in rendered
+        assert "serial" in rendered
+
+    @pytest.mark.parametrize("wrap", WRAPPERS)
+    def test_an_untitled_chart_is_allowed_them_too(self, wrap) -> None:
         # The delegation has nothing to do with the chart's title, and a
         # reader with a tactile display should not lose it for want of one.
         rendered = _html(wrap(tags.div("chart")))
 
-        assert 'allow="bluetooth"' in rendered
+        assert 'allow="bluetooth; serial"' in rendered
 
     @pytest.mark.parametrize("wrap", WRAPPERS)
     def test_the_frame_is_not_sandboxed_into_an_opaque_origin(self, wrap) -> None:
@@ -91,7 +106,7 @@ class TestNothingElseIsDelegated:
 
         # Delegating a feature cannot exceed what the embedding page already
         # holds, but it should still be the shortest list that works. maidr
-        # only ever scans for a device over BLE, so `serial`, `usb`, `camera`
-        # and the rest have no business here.
-        for feature in ("serial", "usb", "camera", "microphone", "geolocation"):
+        # scans for a display over Bluetooth and over serial and nothing else,
+        # so `usb`, `hid`, `camera` and the rest have no business here.
+        for feature in ("usb", "hid", "camera", "microphone", "geolocation"):
             assert feature not in rendered

--- a/tests/util/test_iframe_device_permissions.py
+++ b/tests/util/test_iframe_device_permissions.py
@@ -4,9 +4,12 @@ Every iframed render delegates Web Bluetooth and Web Serial to the chart frame.
 maidr.js can draw a chart onto a refreshable tactile display -- a Dot Pad --
 so a blind reader feels the plot rather than only hearing it. It reaches the
 device over Bluetooth or over USB, and both APIs are Permissions-Policy gated.
-A frame that is not granted a feature does not merely fail the call: the API is
-absent entirely, so maidr reports "this browser cannot reach a DotPad" and the
-reader has no way to tell a policy problem from an unsupported browser.
+A frame denied a feature is not told so at the call: the browser may keep the
+API object and refuse every request, or drop the object altogether -- Chromium
+does one to ``navigator.serial`` and the other to ``navigator.bluetooth`` --
+which is why maidr asks Permissions Policy rather than testing for the object.
+Either way the reader is told "this browser cannot reach a DotPad", with no way
+to tell a policy problem from an unsupported browser.
 
 The default allowlist is ``self``, so a same-origin frame already has them and
 the attribute changes nothing there. It is the cross-origin embeddings that
@@ -42,6 +45,7 @@ import pytest
 from htmltools import tags
 
 from maidr.util.iframe_utils import (
+    iframe_title,
     wrap_in_iframe_matplotlib,
     wrap_in_iframe_plotly,
 )
@@ -178,3 +182,25 @@ class TestNothingElseIsDelegated:
         features = _allowed_features(_html(wrap(loaded, "Body mass by species")))
 
         assert features == {"bluetooth", "serial"}
+
+
+class TestWhatTheGrantCannotBeTurnedAgainst:
+    """The strings a caller supplies land in the frame as text, not markup."""
+
+    @pytest.mark.parametrize("wrap", WRAPPERS)
+    def test_a_hostile_title_arrives_as_text(self, wrap) -> None:
+        # Delegating a device to the frame raises what an injection into it
+        # could reach, from the frame's own document to a paired display. The
+        # other assumptions the delegation rests on are pinned above; this is
+        # the one that turns a markup escape into a device escape. The title
+        # is the caller's string that reaches the tag, so it is the one tried.
+        hostile = "</iframe><script>alert(1)</script>"
+
+        rendered = _html(wrap(tags.div("chart"), hostile))
+
+        # Never as markup: the closing tag and the script must not surface in
+        # the rendered document as themselves, anywhere in it.
+        assert "</iframe><script>" not in rendered
+        # And as text, whole, where it was meant to go: read back through the
+        # parser, the frame's accessible name is the string the caller gave.
+        assert _iframe_attrs(rendered)["title"] == iframe_title(hostile)


### PR DESCRIPTION
## Description

maidr.js can now draw a chart onto a refreshable tactile display — a Dot Pad — so a blind reader feels the plot rather than only hearing it (xability/maidr#1131). It reaches the device over Web Bluetooth or Web Serial, and **both are Permissions-Policy gated**.

A frame that is not granted a feature cannot reach the device, and the two are gated independently. This adds `allow="bluetooth; serial"` to the two notebook iframe wrappers so the frame can reach the device at all.

> **Correction to an earlier version of this description.** It said that a denied frame loses the API *entirely*. That is not what browsers do, and I have since measured it in Chromium: a cross-origin frame with no `allow` keeps `navigator.serial` while losing `navigator.bluetooth`; `document.featurePolicy.allowsFeature()` reports `false` for both. Presence is not permission, so detection has to ask the policy rather than test for the object — maidr's own detection did the wrong thing here and is fixed in xability/maidr#1131. Nothing in this PR's diff changes as a result; only that paragraph was wrong.

What the attribute buys is the **cross-origin** case — Colab, and any host serving notebook output from a separate origin. Same-origin frames already had both features and are unchanged.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules — **depends on xability/maidr#1131; harmless before it lands, see below**

# Pull Request

## Description

See above.

## Related Issues

Companion to xability/maidr#1131, which is where the feature itself lives.

## Changes Made

- **`maidr/util/iframe_utils.py`** — a single `_ALLOWED_FEATURES` constant, applied to both `tags.iframe(...)` calls (matplotlib and Plotly). These two are the only places py-maidr emits an iframe.
- **`maidr/widget/streamlit.py`** — a comment recording that Streamlit builds its own frame, so the same fix cannot reach it. Left where the frame is emitted rather than for someone to rediscover after "fixing" the wrappers again.
- **`tests/util/test_iframe_device_permissions.py`** — 14 test cases (7 parametrized functions × 2 wrappers).

### What this covers

Every notebook, Shiny and Flask render goes through one of the two wrappers. Note that **Altair is covered too**: `AltairMaidr._wrap_in_iframe` (`maidr/altair/altair_maidr.py:288`) delegates to `wrap_in_iframe_plotly`, so it picks this up with no separate change.

### Why both features rather than one

They are gated independently, so granting only `bluetooth` would leave the cabled path dead for a reason nothing on the page explains. USB is also not the marginal case: a full frame over Bluetooth costs a second or more against a reader pressing arrow keys several times a second, so the cable is what makes navigation keep up.

Still the shortest list that works — a test asserts the delegated set is exactly `{bluetooth, serial}`, so growing it has to be a deliberate act with a test change attached.

### Why this is not a permission widening in the usual sense

`allow` **delegates** a capability, it cannot create one. A frame never receives a feature the embedding page itself lacks, and the browser still requires a user gesture and shows its own device picker before anything connects. Readers with no tactile display are unaffected: maidr never touches either API unless they ask it to in Settings.

## Screenshots (if applicable)

Not applicable — an iframe attribute.

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

### Verification

Full suite: **2,703 passed, 1 skipped**. `ruff check` clean on every file touched (the 6 pre-existing `F401` in `maidr/core/enum/__init__.py` and `maidr/core/plot/__init__.py` are unrelated and present on a clean tree). `uv lock --check` clean.

The tests read the frame's attributes back through an HTML parser rather than by substring, and assert on those. The distinction matters because the frame carries the entire chart document — bundle included — inside `srcdoc`: `maidr.js` alone contains `hid` 150 times (`aria-hidden`, `hidden`) and `usb` once, so a substring search over the rendered string is a search of that payload as well. One case feeds the wrapper content that says those words out loud, so the difference is pinned rather than described.

Three assertions guard the ways this can be silently undone: a `sandbox` without `allow-same-origin` gives the frame an opaque origin and a policy-controlled feature is never delegated to one; serving the document from a `data:` URL instead of `srcdoc` does the same; and dropping either transport from the list leaves that path dead.

That `srcdoc` test is load-bearing rather than incidental. Two different default allowlists are in play: a feature the container policy does not name falls back to the *feature's* default (`self`), while a feature named in `allow` without its own allowlist takes the *attribute's* default (`'src'` — the origin the frame was loaded from). They coincide here only because `srcdoc` inherits the embedder's origin, so the test is what keeps `'src'` meaning what the delegation assumes it means.

### Ordering

Independent of xability/maidr#1131 and safe to merge in either order. Before that lands, this delegates features the bundled `maidr.js` does not call — inert, not harmful. After it lands without this, the feature is unreachable in cross-origin notebook embeddings.

### Where this still does not reach

- **Streamlit** — builds its own frame; noted in the source.
- **VS Code notebook renderers** — a separate restricted webview that neither maidr nor py-maidr can add attributes to.

**Update — r-maidr is no longer on this list.** An earlier version of this section said its iframe uses `src="data:text/html;base64,…"`, that an `allow` attribute there would be inert against an opaque origin, and that moving the frame to `srcdoc` was "deliberately not attempted here." The diagnosis was right and the frame has since been moved: xability/r-maidr#275 does that work, and the quote-escaping that base64 was chosen to sidestep is handled byte-wise there. The R path is reachable on the same terms as this one.

In the remaining cases, maidr detects the missing capability and says so rather than offering a control that cannot work.