### PR TITLE
fix(line): decline a band shaded across the page rather than up it

### DIFF
--- a/maidr/patch/fillbetween.py
+++ b/maidr/patch/fillbetween.py
@@ -143,7 +143,7 @@ def _magnitudes(wrapped, args: tuple, kwargs: dict, position: str, value: str):
     return positions, values
 
 
-def _tagged(collection, transposed: bool):
+def _tagged(collection: Collection, transposed: bool) -> Collection:
     """
     Record which way a region was shaded, on the region itself.
 

--- a/maidr/patch/fillbetween.py
+++ b/maidr/patch/fillbetween.py
@@ -8,6 +8,7 @@ from matplotlib.collections import Collection
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.patch.common import _argument, _draw_quietly
+from maidr.util.confidence_band import DRAWN_ALONG_Y
 
 
 def _baseline_is_zero(wrapped, args: tuple, kwargs: dict, name: str) -> bool:
@@ -142,6 +143,48 @@ def _magnitudes(wrapped, args: tuple, kwargs: dict, position: str, value: str):
     return positions, values
 
 
+def _tagged(collection, transposed: bool):
+    """
+    Record which way a region was shaded, on the region itself.
+
+    Asked later by :func:`maidr.util.confidence_band.band_edges_at`, which
+    reads the lowest and highest vertex **at each x** and so answers for a
+    vertical interval only. A region shaded the other way about has no such
+    interval to read, and bracketing does not catch it: a horizontal band
+    around a horizontal line surrounds that line vertically too, because it
+    surrounds it. Measured, ``plot(val, pos)`` under
+    ``fill_betweenx(pos, lo, hi)`` came out announcing the polygon's vertical
+    extent as ``yMin``/``yMax`` -- on the axis carrying the *positions*, which
+    the chart states no uncertainty about at all (#601).
+
+    Recorded here rather than worked out there because ``fill_betweenx`` *is*
+    the horizontal spelling: no inference is involved, which is the argument
+    :data:`maidr.core.plot.outlined_histogram.OUTLINE_HORIZONTAL` makes for
+    the same class of question.
+
+    Set on **every** region either spelling draws, including the ones drawn
+    inside another patch and the ones the declines below leave unregistered.
+    A region carries no layer of its own and is still read as some line's
+    band, so the tag has to outlive the decision not to register it. Setting
+    it unconditionally is also what lets its absence mean one thing only:
+    that this patch did not draw the region.
+
+    Parameters
+    ----------
+    collection : matplotlib.collections.Collection
+        The region the wrapped call drew.
+    transposed : bool
+        True for ``fill_betweenx``.
+
+    Returns
+    -------
+    matplotlib.collections.Collection
+        The same object, tagged.
+    """
+    setattr(collection, DRAWN_ALONG_Y, transposed)
+    return collection
+
+
 def _fill(
     wrapped,
     instance,
@@ -197,10 +240,10 @@ def _fill(
     # is a property of matplotlib's `stackplot` rather than a rule about
     # nested draws.
     if ContextManager.is_internal_context():
-        return _draw_quietly(wrapped, args, kwargs)
+        return _tagged(_draw_quietly(wrapped, args, kwargs), transposed)
 
     with ContextManager.set_internal_context():
-        collection = _draw_quietly(wrapped, args, kwargs)
+        collection = _tagged(_draw_quietly(wrapped, args, kwargs), transposed)
 
     if not _baseline_is_zero(wrapped, args, kwargs, other):
         return collection

--- a/maidr/util/confidence_band.py
+++ b/maidr/util/confidence_band.py
@@ -23,6 +23,25 @@ validates itself: a region is a line's band only if it **brackets every one of
 that line's samples**, which is the property a band has by construction and an
 unrelated shaded region does not.
 
+One thing it *does* assume, and has to. Reading the lowest and highest vertex
+**at each x** is a reading of a vertical interval, so a region shaded the other
+way about is not one this can answer for. Bracketing does not catch it: a
+horizontal band around a horizontal line surrounds that line vertically too,
+because it surrounds it. Measured, ``plot(val, pos)`` under
+``fill_betweenx(pos, lo, hi)`` came out carrying the polygon's vertical extent
+as ``yMin``/``yMax`` -- an artefact of the band being sloped, on the axis that
+holds the *positions*, which the chart states no uncertainty about at all
+(#601).
+
+Which way a region was shaded is therefore asked of
+:data:`maidr.patch.fillbetween.DRAWN_ALONG_Y` rather than inferred, for the
+reason :data:`maidr.core.plot.outlined_histogram.OUTLINE_HORIZONTAL` gives:
+the drawing cannot always say and the caller always can. Counting distinct
+coordinates nearly works -- a band has one position per column and two edge
+values, so the value axis generally carries twice the distinct values -- and
+measurably ties on small frames whose values collide, where declining would
+drop bands that read correctly today.
+
 Lifted out of ``SmoothPlot``, which read a ``regplot``'s band this way (#451),
 so a plain line can carry one too (#562).
 
@@ -41,6 +60,46 @@ from matplotlib.collections import PolyCollection
 #: so a genuine band brackets its line to within rounding; anything looser
 #: would start accepting regions that merely overlap.
 _TOLERANCE = 1e-9
+
+#: Attribute :mod:`maidr.patch.fillbetween` sets on a region it drew, saying
+#: which way the fill runs: ``True`` for ``fill_betweenx``, ``False`` for
+#: ``fill_between``.
+#:
+#: Named here rather than in the patch because both sides have to agree on it
+#: and only one of them can be imported from the other -- the patch imports
+#: this module's reader, not the reverse.
+DRAWN_ALONG_Y = "_maidr_fill_along_y"
+
+
+def shaded_along_y(collection) -> bool:
+    """
+    Whether this region's interval runs across the page rather than up it.
+
+    Answered from the tag :mod:`maidr.patch.fillbetween` leaves on every
+    region it draws, rather than from the vertices. ``fill_betweenx`` *is*
+    the horizontal spelling, so the patch knows outright what the geometry
+    can only be argued about -- and the arguments lose, as this module's
+    docstring records.
+
+    An untagged region is treated as vertical, which is what every region was
+    treated as before the tag existed. That keeps a shaded region some other
+    library drew reading exactly as it did, and confines this to the call it
+    can answer for.
+
+    Parameters
+    ----------
+    collection : matplotlib.collections.PolyCollection
+        A shaded region on the axes.
+
+    Returns
+    -------
+    bool
+        True only for a region drawn by ``fill_betweenx``.
+    """
+    # `bool` rather than `is True`: the patch is the only writer and it writes
+    # a bool, so the two agree on every value that can reach here, and the
+    # stricter spelling would be a distinction no test could tell apart.
+    return bool(getattr(collection, DRAWN_ALONG_Y, False))
 
 
 def band_edges_at(
@@ -81,6 +140,10 @@ def band_edges_at(
         # resolves to -- no band exists by that name and every chart silently
         # lost its interval.
         if not isinstance(collection, PolyCollection):
+            continue
+        # Shaded along the other axis, so its interval is not one `edges_of`
+        # reads. See this module's docstring and #601.
+        if shaded_along_y(collection):
             continue
         if any(collection is claimed for claimed in taken):
             continue

--- a/tests/core/plot/test_line_confidence_band.py
+++ b/tests/core/plot/test_line_confidence_band.py
@@ -29,6 +29,7 @@ import pytest
 import seaborn as sns
 
 from maidr.core.figure_manager import FigureManager
+from maidr.util.confidence_band import DRAWN_ALONG_Y, shaded_along_y
 
 X = np.linspace(0, 10, 20)
 Y = np.sin(X) + 2.0
@@ -246,8 +247,6 @@ def test_the_patch_records_which_way_every_region_it_draws_was_shaded():
     == 5`` for both spellings -- and a tie would have to be declined, which
     would drop bands that read correctly today.
     """
-    from maidr.util.confidence_band import DRAWN_ALONG_Y, shaded_along_y
-
     fig, ax = plt.subplots()
     upright = ax.fill_between(POS, VAL - 0.5, VAL + 0.5)
     sideways = ax.fill_betweenx(POS, VAL - 0.5, VAL + 0.5)
@@ -268,8 +267,6 @@ def test_a_region_this_patch_did_not_draw_reads_as_it_always_did():
     """
     from matplotlib.collections import PolyCollection
 
-    from maidr.util.confidence_band import shaded_along_y
-
     assert shaded_along_y(PolyCollection([])) is False
 
 
@@ -278,8 +275,6 @@ def test_a_band_drawn_inside_another_patch_is_tagged_too():
     context, and a region that registers no layer of its own is still read as
     some line's band later. So the tag cannot be set only on the path that
     registers one."""
-    from maidr.util.confidence_band import DRAWN_ALONG_Y
-
     fig, ax = plt.subplots()
     ax.stackplot(POS, VAL, VAL + 1.0)
 

--- a/tests/core/plot/test_line_confidence_band.py
+++ b/tests/core/plot/test_line_confidence_band.py
@@ -188,3 +188,101 @@ def test_one_band_around_two_lines_belongs_to_one_of_them():
     first, second = _series(fig)
     assert _band(first[0]) == (round(Y[0] - 1.0, 3), round(Y[0] + 1.0, 3))
     assert _band(second[0]) is None
+
+
+# --- A band shaded the other way about (#601) ---------------------------------
+#
+# `edges_of` reads the lowest and highest vertex **at each x**, which is a
+# reading of a vertical interval. A `fill_betweenx` band has none to read, and
+# bracketing does not reject it: a horizontal band around a horizontal line
+# surrounds that line vertically too, because it surrounds it.
+#
+# Measured before the fix, on the chart below:
+#
+#     {'x': 1.0, 'y': 0.0, 'yMin': 0.0, 'yMax': 1.5}
+#     {'x': 2.0, 'y': 1.0, 'yMin': 0.5, 'yMax': 3.0}
+#     {'x': 3.0, 'y': 2.0, 'yMin': 1.5, 'yMax': 3.5}
+#     {'x': 2.0, 'y': 3.0, 'yMin': 0.5, 'yMax': 3.0}
+#     {'x': 4.0, 'y': 4.0, 'yMin': 3.0, 'yMax': 4.0}
+#
+# against a true interval, on x, of (0.5,1.5) (1.5,2.5) (2.5,3.5) (1.5,2.5)
+# (3.5,4.5). The polygon's *vertical extent* at each x -- an artefact of the
+# band being sloped -- announced on the axis that carries the positions, which
+# this chart states no uncertainty about at all. The last point's `yMax` is its
+# own `y`.
+
+POS = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+VAL = np.array([1.0, 2.0, 3.0, 2.0, 4.0])
+
+
+def _sideways(ax) -> None:
+    """A horizontal line chart with a horizontal interval around it."""
+    ax.plot(VAL, POS)
+    ax.fill_betweenx(POS, VAL - 0.5, VAL + 0.5, alpha=0.3)
+
+
+def test_a_horizontal_band_is_not_read_as_a_vertical_interval():
+    fig, ax = plt.subplots()
+    _sideways(ax)
+
+    assert [_band(point) for point in _series(fig)[0]] == [None] * len(POS)
+
+
+def test_the_line_itself_is_unaffected():
+    """Declining the band costs the chart nothing else."""
+    fig, ax = plt.subplots()
+    _sideways(ax)
+
+    points = _series(fig)[0]
+    assert [point["x"] for point in points] == list(VAL)
+    assert [point["y"] for point in points] == list(POS)
+
+
+def test_the_patch_records_which_way_every_region_it_draws_was_shaded():
+    """The tag is what decides, so its two values are asserted directly.
+
+    Read rather than inferred, because counting distinct coordinates ties on
+    a small frame -- measured, this very pair of calls gives ``uniqX == uniqY
+    == 5`` for both spellings -- and a tie would have to be declined, which
+    would drop bands that read correctly today.
+    """
+    from maidr.util.confidence_band import DRAWN_ALONG_Y, shaded_along_y
+
+    fig, ax = plt.subplots()
+    upright = ax.fill_between(POS, VAL - 0.5, VAL + 0.5)
+    sideways = ax.fill_betweenx(POS, VAL - 0.5, VAL + 0.5)
+
+    assert getattr(upright, DRAWN_ALONG_Y) is False
+    assert getattr(sideways, DRAWN_ALONG_Y) is True
+    assert shaded_along_y(upright) is False
+    assert shaded_along_y(sideways) is True
+
+
+def test_a_region_this_patch_did_not_draw_reads_as_it_always_did():
+    """An absent tag says only that, and must not mean "horizontal".
+
+    Nothing in the suite draws such a region -- both spellings go through the
+    patch -- so the fallback is asserted directly. Getting it the other way
+    round would silently drop the band from every chart whose region some
+    other library shaded.
+    """
+    from matplotlib.collections import PolyCollection
+
+    from maidr.util.confidence_band import shaded_along_y
+
+    assert shaded_along_y(PolyCollection([])) is False
+
+
+def test_a_band_drawn_inside_another_patch_is_tagged_too():
+    """`stackplot` draws its bands through `fill_between` under the internal
+    context, and a region that registers no layer of its own is still read as
+    some line's band later. So the tag cannot be set only on the path that
+    registers one."""
+    from maidr.util.confidence_band import DRAWN_ALONG_Y
+
+    fig, ax = plt.subplots()
+    ax.stackplot(POS, VAL, VAL + 1.0)
+
+    drawn = [c for c in ax.collections if hasattr(c, DRAWN_ALONG_Y)]
+    assert len(drawn) == 2
+    assert all(getattr(c, DRAWN_ALONG_Y) is False for c in drawn)


### PR DESCRIPTION
Closes #601.

## The defect

A horizontal line chart with a horizontal interval — position up `y`, the measured value along `x`:

```python
ax.plot(val, pos)
ax.fill_betweenx(pos, val - 0.5, val + 0.5, alpha=.3)
```

```
before                                     true interval, on x
{'x': 1.0, 'y': 0.0, 'yMin': 0.0, 'yMax': 1.5}    (0.5, 1.5)
{'x': 2.0, 'y': 1.0, 'yMin': 0.5, 'yMax': 3.0}    (1.5, 2.5)
{'x': 3.0, 'y': 2.0, 'yMin': 1.5, 'yMax': 3.5}    (2.5, 3.5)
{'x': 2.0, 'y': 3.0, 'yMin': 0.5, 'yMax': 3.0}    (1.5, 2.5)
{'x': 4.0, 'y': 4.0, 'yMin': 3.0, 'yMax': 4.0}    (3.5, 4.5)
```

Wrong three ways at once, and confidently:

- **Wrong axis.** The interval is about the *value*, which is on `x`. It is emitted on `y` — the positions, which the chart states no uncertainty about at all.
- **Wrong numbers.** Not the interval transposed either. They are the polygon's vertical extent at each x, an artefact of the band being sloped. The last point's announced interval does not contain the true one, and its `yMax` is its own `y`.
- **No warning.** A reader is told an estimate and a precision, and the precision is invented.

## Why bracketing did not catch it

`maidr/util/confidence_band.py` identifies a band by whether it brackets the line's samples, and its docstring says reading the lowest and highest vertex at each x "assumes nothing about orientation."

It does — that *is* the assumption that the interval runs vertically. The docstring anticipates the artist and draws the wrong conclusion from it:

> seaborn draws a violin body with `fill_betweenx`, so a violin is the same class as a band

Right, and bracketing does reject a violin — because a violin body does not surround some other series' line. It rejects it by luck of geometry rather than by knowing what the region is, and a horizontal band around a horizontal line is where that luck runs out: the band surrounds the line, so of course it brackets it vertically too.

## The fix

The patch knows the answer outright and was not passing it on. `fill_betweenx` **is** the horizontal spelling — no inference. Every region either spelling draws is tagged with which way the fill runs, and `band_edges_at` skips a horizontal one.

Handed over rather than searched for, which is what `OUTLINE_HORIZONTAL` already does for the same class of question.

Tagged on **every** region, including draws made inside another patch (`stackplot`'s bands) and the ones the existing declines leave unregistered — a region carries no layer of its own and is still read as some line's band later, so the tag has to outlive the decision not to register it. That also lets an absent tag mean one thing only: this patch did not draw the region, so it reads as it always did.

### Why not count the vertices

It nearly works — a band has one position per column and two edge values, so the value axis generally carries about twice the distinct values. Measured, it ties:

```
fill_between  band   uniqX=  5  uniqY=  5     <- both spellings tie
fill_betweenx band   uniqX=  5  uniqY=  5
regplot       band   uniqX=100  uniqY=200
lineplot      band   uniqX=  5  uniqY= 10
violin (y=)          uniqX=200  uniqY=100
```

Values colliding across positions is enough, and a tie would have to be declined — silently dropping bands that read correctly today. The tag has no such failure mode.

## Deliberately not fixed here

**Reading the horizontal band correctly.** `LinePoint` carries `yMin`/`yMax` and no `xMin`/`xMax`, so the grammar has no field for an interval running along `x`. Until it does, the band is dropped — which is what this chart got before #562, and honest where the current reading is not. An upstream change to make on evidence of demand, not pre-emptively.

## Results

| chart | before | after |
|---|---|---|
| `plot` + `fill_betweenx` band | invented `yMin`/`yMax` | no band |
| `plot` + `fill_between` band | correct band | unchanged |
| `sns.regplot` | correct band | unchanged |
| `sns.lineplot` | correct band | unchanged |
| violin body nearby | correctly rejected | unchanged, now by the tag |
| `fill_between` area under its own line | correctly rejected | unchanged |

## Verification

- Nine mutations applied one at a time against a restored baseline, **all killed** — guard disabled, predicate inverted, predicate forced constant either way, default flipped either way, tag inverted, tag forced constant, internal-context draw left untagged. Each of the three narrow ones is killed by exactly one test, so each has coverage of its own rather than riding on another's.
- One mutation initially survived: `bool(...)` in place of `is True`. Investigated rather than left — the patch is the only writer and writes a bool, so the two agree on every reachable value and no test could tell them apart. Resolved by taking the simpler spelling, not by adding a test for a value nothing produces.
- `tests/core/plot/test_line_confidence_band.py` — 16 tests (5 new), including the two guards asserted directly on `shaded_along_y` because no chart reaches them: an untagged region, and a region drawn under the internal context.
- Full suite: **2892 passed, 18 skipped**. `ruff check --diff` (what CI runs) clean, exit 0.

## Related, and closed as invalid

I first filed #600 claiming the *vertical* hand-drawn band was dropped entirely. It is not — #562 reads it, by bracketing, in either call order. I had filed that off the `fillbetween.py` docstring's "left unregistered" without measuring the emitted schema; that docstring describes only its own patch. Closed with the measurement that disproves it. This PR is the part of that sweep that survived contact with the numbers.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_