### PR TITLE
refactor(hue): give the shared hue-group tail one home

### DIFF
--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -12,6 +12,7 @@ from matplotlib.colors import to_rgba
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
+from maidr.util.hue_groups import grouped_by_name
 from maidr.util.mixin import CollectionExtractorMixin, LineExtractorMixin
 
 
@@ -203,12 +204,11 @@ def hue_groups(ax: Axes, collection: PathCollection) -> list[tuple[str, list[int
       read as one layer, even though the same axes would split if asked a
       line later. seaborn builds its legend inside the call, so its charts
       are unaffected.
-    - **A point no swatch claims.** A *continuous* hue is the case: measured,
-      ``hue='v'`` on a numeric column gives ten distinct colours for ten
-      points against five legend levels sampled at round numbers, so most
-      points match nothing. That is a colour *scale*, not a grouping, and
-      splitting it into one layer per point would be nonsense.
-    - **Fewer than two groups.** Nothing to tell apart.
+    Two more declines are :func:`~maidr.util.hue_groups.grouped_by_name`'s
+    rather than this function's, and its docstring carries the charts behind
+    them: a point no swatch claims, and fewer than two groups. They live
+    there because the rug split reaches the same two from a different artist,
+    and three implementations of one rule had begun to drift (#599).
 
     Parameters
     ----------
@@ -236,15 +236,13 @@ def hue_groups(ax: Axes, collection: PathCollection) -> list[tuple[str, list[int
     if named is None or len(named) < 2:
         return None
 
-    members: dict[str, list[int]] = {name: [] for name in named.values()}
-    for index, colour in enumerate(colours):
-        name = named.get(colour)
-        if name is None:
-            return None
-        members[name].append(index)
-
-    groups = [(name, found) for name, found in members.items() if found]
-    return groups if len(groups) > 1 else None
+    # `named` was built in legend order, so its values are the order #502
+    # settled a grouped layer's layers on. The grouping itself, and the two
+    # declines that go with it, are `grouped_by_name`'s -- shared with the rug
+    # split, which reaches the same three decisions from a different artist.
+    return grouped_by_name(
+        [named.get(colour) for colour in colours], list(named.values())
+    )
 
 
 class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):

--- a/maidr/patch/rugplot.py
+++ b/maidr/patch/rugplot.py
@@ -19,6 +19,7 @@ from maidr.core.plot.rugplot import (
 )
 from maidr.core.plot.scatterplot import _rgba
 from maidr.patch.common import _draw_quietly, prospective_axes, wrap_seaborn
+from maidr.util.hue_groups import grouped_by_name
 from maidr.util.legend_names import legend_of, names_for
 
 
@@ -122,24 +123,12 @@ def _hue_groups(ax: Axes, collection: LineCollection, ticks: int) -> list | None
     if len(colours) != ticks or ticks < 2:
         return None
 
-    names = names_for(ax, colours)
-    if any(name is None for name in names):
-        return None
-
-    members: dict = {}
-    for index, name in enumerate(names):
-        members.setdefault(name, []).append(index)
-    if len(members) < 2:
-        return None
-
     # Legend order, which is the order #502 settled a grouped layer's layers
-    # on -- seaborn's draw order is not it.
+    # on -- seaborn's draw order is not it. The grouping and the two declines
+    # that go with it are `grouped_by_name`'s, shared with the scatter split.
     legend = legend_of(ax)
     order = [text.get_text() for text in legend.get_texts()] if legend else []
-    return sorted(
-        members.items(),
-        key=lambda group: order.index(group[0]) if group[0] in order else len(order),
-    )
+    return grouped_by_name(names_for(ax, colours), order)
 
 
 def _collections_of(ax: Axes | None) -> list:

--- a/maidr/util/hue_groups.py
+++ b/maidr/util/hue_groups.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 def grouped_by_name(
-    names: list, order: list | None = None
+    names: list[str | None], order: list[str] | None = None
 ) -> list[tuple[str, list[int]]] | None:
     """
     Turn one name per drawn thing into one group per distinct name.
@@ -38,10 +38,10 @@ def grouped_by_name(
 
     Parameters
     ----------
-    names : list
+    names : list of (str or None)
         One name per drawn thing, in drawing order. ``None`` anywhere
         declines.
-    order : list, optional
+    order : list of str, optional
         The names in the order the groups should come out in. Omitted, the
         groups keep the order their names first appear in.
 
@@ -72,7 +72,11 @@ def grouped_by_name(
     if not order:
         return list(members.items())
 
-    return sorted(
-        members.items(),
-        key=lambda group: order.index(group[0]) if group[0] in order else len(order),
-    )
+    # First occurrence wins, matching what `list.index` answered before this
+    # was a lookup -- a repeated name in the order would otherwise move its
+    # group to the later position.
+    places: dict[str, int] = {}
+    for place, name in enumerate(order):
+        places.setdefault(name, place)
+
+    return sorted(members.items(), key=lambda group: places.get(group[0], len(order)))

--- a/maidr/util/hue_groups.py
+++ b/maidr/util/hue_groups.py
@@ -1,0 +1,78 @@
+"""Group a layer's drawn things by the name each one was given."""
+
+from __future__ import annotations
+
+
+def grouped_by_name(
+    names: list, order: list | None = None
+) -> list[tuple[str, list[int]]] | None:
+    """
+    Turn one name per drawn thing into one group per distinct name.
+
+    The tail every hue split ends in. What a chart is read *from* differs by
+    artist -- a scatter has a face colour per point, a rug a colour per
+    segment, a strip plot a plotter to consult outright -- but what happens
+    after is the same three decisions every time, and they were made three
+    times in three ways before this existed:
+
+    - **A thing no name claims declines the whole split.** A partly-named
+      chart announces a group called "None" holding the rest -- maidr's own
+      word for "unmatched", read aloud as a level -- and is worse than an
+      unnamed one. The case behind it is a continuous ``hue=``: measured on a
+      scatter, ten points took ten distinct colours against five legend
+      levels sampled at round numbers, so most points matched nothing. That
+      is a colour *scale*, and one layer per point is not a reading of it.
+    - **Fewer than two groups is not a grouping.** Nothing to tell apart.
+    - **The groups come out in the order given**, which for every caller so
+      far is the legend's rather than the draw order -- the convention #502
+      settled. Stated as a parameter rather than assumed, because it is the
+      half most likely to drift: the two callers reached it by different
+      mechanisms before, one relying on a dict built in legend order and the
+      other sorting against the legend's texts.
+
+    A name the order does not mention sorts last, keeping its position
+    among its fellows. That case is not reachable through either caller --
+    both draw their names from the same legend they order by -- and is
+    defined rather than left to chance so that a caller reading names from
+    somewhere else gets a stated answer instead of an exception.
+
+    Parameters
+    ----------
+    names : list
+        One name per drawn thing, in drawing order. ``None`` anywhere
+        declines.
+    order : list, optional
+        The names in the order the groups should come out in. Omitted, the
+        groups keep the order their names first appear in.
+
+    Returns
+    -------
+    list of (str, list of int) or None
+        One entry per group, naming it and listing the positions that belong
+        to it, or ``None`` when the names are not a grouping.
+
+    Examples
+    --------
+    >>> grouped_by_name(["b", "a", "b"], ["a", "b"])
+    [('a', [1]), ('b', [0, 2])]
+    >>> grouped_by_name(["a", None, "b"]) is None
+    True
+    >>> grouped_by_name(["a", "a"]) is None
+    True
+    """
+    if not names or any(name is None for name in names):
+        return None
+
+    members: dict[str, list[int]] = {}
+    for index, name in enumerate(names):
+        members.setdefault(name, []).append(index)
+    if len(members) < 2:
+        return None
+
+    if not order:
+        return list(members.items())
+
+    return sorted(
+        members.items(),
+        key=lambda group: order.index(group[0]) if group[0] in order else len(order),
+    )

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -512,3 +512,23 @@ def test_a_split_named_by_a_figure_legend_still_says_what_it_split_by():
         {"label": "g"},
         {"label": "g"},
     ]
+
+
+def test_a_hue_on_one_level_is_read_as_one_ungrouped_layer():
+    """One group is not a grouping.
+
+    Reachable here and not from the scatter split, which declines a one-level
+    hue earlier on its own legend count. So this is where
+    `grouped_by_name`'s fewer-than-two rule is exercised through a chart --
+    measured, removing it leaves the scatter's own file green and only this
+    one red (#599).
+    """
+    frame = pd.DataFrame({"value": [0.1, 0.2, 0.3, 0.4], "grp": ["p"] * 4})
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="grp", ax=ax)
+
+    schemas = _schemas(fig)
+    assert len(schemas) == 1
+    # The variable's own name, which is what an ungrouped rug announces.
+    assert schemas[0].get("name") == "value"
+    assert len(schemas[0]["data"]) == 4

--- a/tests/core/plot/test_scatter_hue_groups.py
+++ b/tests/core/plot/test_scatter_hue_groups.py
@@ -460,3 +460,42 @@ def test_seaborn_drops_a_non_finite_row_before_drawing():
     offsets = _collection(ax).get_offsets()
     assert len(offsets) == len(frame) - 1
     assert np.isfinite(np.asarray(offsets)).all()
+
+
+def test_the_layers_come_out_in_the_legend_s_order_not_the_drawing_s():
+    """#502's convention, asserted on a chart where the two disagree.
+
+    The frame's first two rows are level "b" and `hue_order` puts "a" first,
+    so the legend reads ``a, b`` while the first point drawn belongs to "b".
+    A reading that grouped by first appearance would come out ``b, a``.
+
+    Pinned here as well as on the rug split, because the ordering now lives in
+    `grouped_by_name` and a shared rule that only one of its callers exercises
+    is a rule the other has stopped testing. Measured: dropping the sort from
+    the helper leaves this file green without it (#599).
+    """
+    frame = pd.DataFrame(
+        {"x": [1.0, 2.0, 3.0, 4.0], "y": [1.0, 2.0, 3.0, 4.0], "g": list("bbaa")}
+    )
+    ax = sns.scatterplot(data=frame, x="x", y="y", hue="g", hue_order=["a", "b"])
+
+    assert [text.get_text() for text in ax.get_legend().get_texts()] == ["a", "b"]
+    assert [layer.get("name") for layer in _points(ax.figure)] == ["a", "b"]
+
+
+def test_a_hue_on_one_level_is_read_as_one_layer():
+    """One group is not a grouping, and the scatter declines it before the
+    shared helper is reached.
+
+    Its own ``len(named) < 2`` catches it: measured, a one-level ``hue=``
+    gives two face-colour rows in one colour and one legend swatch. So
+    `grouped_by_name`'s own fewer-than-two decline is **not** reachable from
+    this caller, and no test here can exercise it -- which is why the rug
+    split, where it is reachable, carries that half.
+    """
+    frame = pd.DataFrame({"x": [1.0, 2.0], "y": [1.0, 2.0], "g": ["a", "a"]})
+    ax = sns.scatterplot(data=frame, x="x", y="y", hue="g")
+
+    layers = _points(ax.figure)
+    assert len(layers) == 1
+    assert layers[0].get("name") is None

--- a/tests/util/test_hue_groups.py
+++ b/tests/util/test_hue_groups.py
@@ -1,0 +1,87 @@
+"""`grouped_by_name` is the tail every hue split ends in (#599).
+
+Scatter and rug reached the same three decisions -- decline on an unnamed
+thing, decline on fewer than two groups, come out in the legend's order -- by
+two different routes, one relying on a dict built in legend order and the
+other sorting against the legend's texts. Two implementations of one rule is
+where drift starts, and the ordering is #502's convention rather than an
+incidental.
+
+Asserted directly here as well as through the two callers, because two of the
+helper's behaviours are not reachable from either: neither passes an empty
+order, and neither can pass a name its order does not mention -- both draw
+their names from the same legend they order by.
+"""
+
+from __future__ import annotations
+
+
+from maidr.util.hue_groups import grouped_by_name
+
+
+def test_it_groups_the_positions_each_name_claims():
+    assert grouped_by_name(["b", "a", "b", "a"], ["a", "b"]) == [
+        ("a", [1, 3]),
+        ("b", [0, 2]),
+    ]
+
+
+def test_the_groups_come_out_in_the_order_given():
+    """Not the draw order, which is what #502 settled."""
+    drawn = ["z", "y", "x"]
+
+    assert [name for name, _ in grouped_by_name(drawn, ["x", "y", "z"])] == [
+        "x",
+        "y",
+        "z",
+    ]
+    assert [name for name, _ in grouped_by_name(drawn, ["z", "y", "x"])] == [
+        "z",
+        "y",
+        "x",
+    ]
+
+
+def test_positions_keep_their_drawing_order_within_a_group():
+    """The order a group's own members come out in is the order they were
+    drawn in, whatever the groups themselves are ordered by."""
+    groups = dict(grouped_by_name(["a", "b", "a", "b", "a"], ["b", "a"]))
+
+    assert groups["a"] == [0, 2, 4]
+    assert groups["b"] == [1, 3]
+
+
+def test_a_thing_no_name_claims_declines_the_whole_split():
+    """A partly-named chart announces a group called "None" holding the rest.
+    Worse than an unnamed one, so the split is declined outright."""
+    assert grouped_by_name(["a", None, "b"], ["a", "b"]) is None
+
+
+def test_one_group_is_not_a_grouping():
+    assert grouped_by_name(["a", "a", "a"], ["a"]) is None
+
+
+def test_nothing_drawn_is_not_a_grouping():
+    assert grouped_by_name([], ["a", "b"]) is None
+
+
+def test_with_no_order_the_groups_keep_the_order_they_first_appear_in():
+    """Not reachable from either caller -- both pass their legend's order --
+    so the fallback is defined here rather than left to chance."""
+    assert grouped_by_name(["b", "a", "b"]) == [("b", [0, 2]), ("a", [1])]
+
+
+def test_a_name_the_order_does_not_mention_sorts_last():
+    """Also unreachable from either caller, for the same reason: each draws
+    its names from the legend it orders by. Defined so that a caller reading
+    names from somewhere else gets a stated answer rather than an exception --
+    which is what `order.index` on a missing name would raise."""
+    groups = grouped_by_name(["late", "first", "late"], ["first"])
+
+    assert [name for name, _ in groups] == ["first", "late"]
+
+
+def test_two_unmentioned_names_keep_their_order_among_themselves():
+    groups = grouped_by_name(["b", "a", "known"], ["known"])
+
+    assert [name for name, _ in groups] == ["known", "b", "a"]

--- a/tests/util/test_hue_groups.py
+++ b/tests/util/test_hue_groups.py
@@ -85,3 +85,16 @@ def test_two_unmentioned_names_keep_their_order_among_themselves():
     groups = grouped_by_name(["b", "a", "known"], ["known"])
 
     assert [name for name, _ in groups] == ["known", "b", "a"]
+
+
+def test_a_repeated_name_in_the_order_places_its_group_by_the_first():
+    """The order is looked up rather than scanned twice, and a lookup built
+    the obvious way would take the *last* place a repeated name holds.
+
+    Not reachable from either caller -- a legend does not list one name
+    twice -- but the two spellings differ only here, so it is the one case
+    that says the lookup replaced `list.index` rather than merely resembling
+    it."""
+    groups = grouped_by_name(["b", "a"], ["a", "b", "a"])
+
+    assert [name for name, _ in groups] == ["a", "b"]


### PR DESCRIPTION
Closes #599.

## What moved

`scatterplot.hue_groups` and `patch/rugplot._hue_groups` ended in the same three decisions and made them two different ways:

| | scatter, before | rug, before |
|---|---|---|
| decline on an unnamed thing | per-point `if name is None` | `any(name is None …)` |
| decline on fewer than two groups | `len(groups) > 1` on non-empty groups | `len(members) < 2` |
| legend order | a dict built in legend order | `sorted` against the legend's texts |

`maidr/util/hue_groups.grouped_by_name(names, order)` now takes that tail. Order is a **parameter** rather than an assumption, because it is the half most likely to drift — the two callers reached the same convention by two mechanisms, and neither said so where the other could see it.

## What did not move, and why

**What a chart is read *from* stays per artist**, because it genuinely is: a face colour per point, a colour per segment, a plotter's `lookup_table` consulted outright. Only the tail is common.

**Strip and swarm keep their own**, and this is a correction to what #599 assumed. Two differences, both by design:

- Their members are a **list per collection**, not flat positions — seaborn draws a categorical scatter as one collection per category, so a hue level spans several. Routing that through a flat helper and re-splitting adds work rather than removing it.
- A panel holding **one** level is deliberately *kept* and named — the opposite of the rule extracted here. A faceted `catplot` puts each level in whichever panels its rows fall in, and knowing which one a panel holds is the whole of what #586 was missing.

So this is an extraction across two callers, not three. Two is the threshold, and the ordering drift is the reason to reach it.

**Scatter still reads `ax.get_legend()`, not `legend_of`.** The figure-level fallback is rug's alone today; giving it to scatter would be a behaviour change and does not belong in a refactor.

## The mutation sweep found what it is for

#599 asked that each rule be killed by tests belonging to *each* call site, "otherwise the extraction has quietly made two of them untested." It had:

```
                            direct      scatter     rug
m1 unnamed decline removed   killed      killed      killed
m2 one-group decline removed killed      SURVIVED    SURVIVED
m3 ordering dropped          killed      SURVIVED    killed
```

Both survivors were real. Neither rule was tested at the scatter call site before this PR either — the extraction revealed the hole rather than opening it.

- **Legend ordering, scatter.** Added a chart where legend order and draw order disagree: the frame's first two rows are level `b`, `hue_order` puts `a` first, and the layers come out `a, b`. Before, no scatter test could tell the two orders apart.
- **Fewer than two groups, rug.** A `hue=` on a one-level column: measured, it reads as one layer named `value` — the variable, which is what an ungrouped rug announces.
- **Fewer than two groups, scatter — genuinely unreachable.** Measured: a one-level `hue=` gives two face-colour rows in one colour and one legend swatch, so scatter's own `len(named) < 2` declines it first and `grouped_by_name` is never reached. Recorded in a test that says so, rather than left as an unexplained hole or papered over with a test of something else.

After: m1, m2 and m3 are each killed at every call site where they are reachable.

One mutation is deliberately left to the direct tests: reversing the positions **within** a group. Both callers consume members as a `set` (`scatterplot.py`'s `[set(members) …]`, `rugplot.py`'s `set(self._group_members)`), so that order is unobservable through either chart. Pinned directly because a future caller could observe it.

## Tests

- `tests/util/test_hue_groups.py` — 9 direct tests, including the two behaviours no caller can reach: an omitted `order` (both callers always pass their legend's), and a name the order does not mention (both draw their names from the legend they order by). The latter is what `order.index` would raise on, so it is defined rather than left to chance.
- Two call-site tests as above.

## Verification

- Full suite: **2904 passed, 18 skipped** — 2892 before, plus the 12 added here. No existing test needed editing, which is the signal a no-behaviour-change extraction wants.
- `ruff check --diff` (what CI runs) clean, exit 0.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_