### PR TITLE
feat(rug): give a rug the axis bounds its braille is built from

### DIFF
--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -8,7 +8,7 @@ from matplotlib.collections import LineCollection
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
-from maidr.core.plot.scatterplot import ScatterPlot
+from maidr.util.grid_axes import tick_step
 from maidr.util.legend_names import title_of
 
 #: Key the patch hands this layer the ``LineCollection`` its own call drew
@@ -218,9 +218,9 @@ class RugPlot(MaidrPlot):
         frontend builds is of the *chart*, and a reader feeling it is feeling
         the plotting area they would see. Taken from the same three places
         :meth:`~maidr.core.plot.scatterplot.ScatterPlot._extract_axes_data`
-        takes them, and declined on the same grounds -- a log scale, ticks
-        that are not evenly spaced, or bounds that do not enclose at least one
-        cell. A grid built on any of those would be a surface whose cells do
+        takes them -- the step through the helper both share -- and declined
+        on the same grounds: a log scale, ticks that are not evenly spaced, or
+        bounds that do not enclose at least one cell. A grid built on any of those would be a surface whose cells do
         not correspond to the axis a reader is told about.
 
         Only this axis is asked. The one across the ticks is supplied whole by
@@ -249,7 +249,7 @@ class RugPlot(MaidrPlot):
 
         low, high = self.ax.get_xlim() if self._along_x else self.ax.get_ylim()
         ticks = self.ax.get_xticks() if self._along_x else self.ax.get_yticks()
-        step = ScatterPlot._compute_tick_step(ticks)
+        step = tick_step(ticks)
 
         if step is None or low >= high or step <= 0 or step > (high - low):
             return None
@@ -268,8 +268,6 @@ class RugPlot(MaidrPlot):
         axes_data = super()._extract_axes_data()
         along = MaidrKey.X if self._along_x else MaidrKey.Y
         across = MaidrKey.Y if self._along_x else MaidrKey.X
-        axes_data[across] = self._axis_config(label=RUG_AXIS_LABEL)
-
         # Bounds on both axes, which is what makes the layer reachable in
         # grid mode -- and grid mode is the only mode where a point layer
         # renders braille at all. Measured against maidr's `ScatterTrace`:
@@ -301,6 +299,8 @@ class RugPlot(MaidrPlot):
             axes_data[across] = self._axis_config(
                 label=RUG_AXIS_LABEL, min=0, max=1, tick_step=1
             )
+        else:
+            axes_data[across] = self._axis_config(label=RUG_AXIS_LABEL)
 
         # A grouped layer names the grouping *variable* on z, the way the
         # scatter and line layers do: `z` says what the split is by, `name`

--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -8,6 +8,7 @@ from matplotlib.collections import LineCollection
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
+from maidr.core.plot.scatterplot import ScatterPlot
 from maidr.util.legend_names import title_of
 
 #: Key the patch hands this layer the ``LineCollection`` its own call drew
@@ -209,6 +210,51 @@ class RugPlot(MaidrPlot):
             ]
         return [{MaidrKey.X: 0, MaidrKey.Y: position} for position in self._positions]
 
+    def _observation_bounds(self) -> tuple[float, float, float] | None:
+        """
+        The axis the ticks stand on, as ``(min, max, tickStep)``.
+
+        Read off the axes rather than off the observations: the grid the
+        frontend builds is of the *chart*, and a reader feeling it is feeling
+        the plotting area they would see. Taken from the same three places
+        :meth:`~maidr.core.plot.scatterplot.ScatterPlot._extract_axes_data`
+        takes them, and declined on the same grounds -- a log scale, ticks
+        that are not evenly spaced, or bounds that do not enclose at least one
+        cell. A grid built on any of those would be a surface whose cells do
+        not correspond to the axis a reader is told about.
+
+        Only this axis is asked. The one across the ticks is supplied whole by
+        the caller, since a rug is one row deep by construction and no reading
+        of the panel could say so.
+
+        Returns
+        -------
+        tuple or None
+            ``(min, max, tickStep)``, or ``None`` when the axis cannot carry
+            a grid -- which leaves the layer exactly as it read before, minus
+            the braille it could not reach either way.
+        """
+        # A guard rather than a live branch, and kept as one deliberately. On a
+        # log axis the other check below already declines every chart measured,
+        # by an accident of units: `get_xlim` answers in **log space** while
+        # `get_xticks` answers in **data space**, so a log chart whose ticks sit
+        # at 1, 2 and 3 gives `step 1.0` against a span of 0.75 and fails the
+        # `step > (high - low)` clause. This is the check that states the
+        # intent -- the cells a non-linear axis draws are not the cells evenly
+        # spaced bounds describe -- and it holds if that accident ever stops.
+        # `test_rugplot.py` pins the two spaces, so the matplotlib release that
+        # ends it turns a test red rather than leaving this silently dead.
+        if self.ax.get_xscale() != "linear" or self.ax.get_yscale() != "linear":
+            return None
+
+        low, high = self.ax.get_xlim() if self._along_x else self.ax.get_ylim()
+        ticks = self.ax.get_xticks() if self._along_x else self.ax.get_yticks()
+        step = ScatterPlot._compute_tick_step(ticks)
+
+        if step is None or low >= high or step <= 0 or step > (high - low):
+            return None
+        return float(low), float(high), float(step)
+
     def _extract_axes_data(self) -> dict:
         """
         Name the axes, calling the strip the ticks sit in what it is.
@@ -220,8 +266,41 @@ class RugPlot(MaidrPlot):
         this layer emits sits at 0 rather than at any density.
         """
         axes_data = super()._extract_axes_data()
+        along = MaidrKey.X if self._along_x else MaidrKey.Y
         across = MaidrKey.Y if self._along_x else MaidrKey.X
         axes_data[across] = self._axis_config(label=RUG_AXIS_LABEL)
+
+        # Bounds on both axes, which is what makes the layer reachable in
+        # grid mode -- and grid mode is the only mode where a point layer
+        # renders braille at all. Measured against maidr's `ScatterTrace`:
+        # with the labels alone the braille state comes back `empty`, and a
+        # rug is then the one chart with no braille surface available by any
+        # keystroke. With them, four observations at 1, 2, 3 and 9 over a 0-10
+        # axis give `values [[2, 1, 0, 1]]` -- the observation count per cell,
+        # which is the clustering a rug is drawn to show and the one thing its
+        # audio cannot carry, since every tick sits at the same place on the
+        # axis pitch is mapped from (xability/maidr#1132).
+        #
+        # Additive only: grid mode is entered deliberately, and walking the
+        # ticks with and without these gives byte-identical audio, panning and
+        # text at every step.
+        bounds = self._observation_bounds()
+        if bounds is not None:
+            low, high, step = bounds
+            axes_data[along] = self._axis_config(
+                label=axes_data[along].get(MaidrKey.LABEL),
+                min=low,
+                max=high,
+                tick_step=step,
+            )
+            # One row deep, because that is what a rug is: every entry sits at
+            # the same place across the ticks. A finer step buys a second row
+            # of zeroes -- measured, `tickStep` 0.5 gives
+            # `[[2, 1, 0, 1], [0, 0, 0, 0]]` -- which is a row of the surface
+            # spent saying nothing.
+            axes_data[across] = self._axis_config(
+                label=RUG_AXIS_LABEL, min=0, max=1, tick_step=1
+            )
 
         # A grouped layer names the grouping *variable* on z, the way the
         # scatter and line layers do: `z` says what the split is by, `name`

--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -12,6 +12,7 @@ from matplotlib.colors import to_rgba
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
+from maidr.util.grid_axes import tick_step
 from maidr.util.hue_groups import grouped_by_name
 from maidr.util.mixin import CollectionExtractorMixin, LineExtractorMixin
 
@@ -424,15 +425,13 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
     def _compute_tick_step(ticks: np.ndarray) -> float | None:
         """Compute tick step from an array of tick positions.
 
-        Returns the tick interval if ticks are uniformly spaced,
-        otherwise returns ``None``.
+        Delegates to :func:`maidr.util.grid_axes.tick_step`, which is where
+        the reading now lives: ``RugPlot`` needs the same answer for the axis
+        its ticks stand on, and borrowing this private static across classes
+        would couple the two on something that is not a contract. Kept as a
+        method so this class's own callers are unchanged.
         """
-        if ticks is None or len(ticks) < 2:
-            return None
-        diffs = np.diff(ticks)
-        if np.allclose(diffs, diffs[0]):
-            return float(diffs[0])
-        return None
+        return tick_step(ticks)
 
     def _is_valid_grid_config(
         self,

--- a/maidr/util/grid_axes.py
+++ b/maidr/util/grid_axes.py
@@ -1,0 +1,55 @@
+"""The tick step a grid-navigable axis is walked in."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def tick_step(ticks: np.ndarray | None) -> float | None:
+    """
+    The interval between an axis' ticks, when they are evenly spaced.
+
+    Grid navigation walks an axis in equal increments, so an axis whose ticks
+    are not evenly spaced has no step to give and the grid is declined rather
+    than built on an invented one. Fewer than two ticks name no interval at
+    all.
+
+    Shared rather than reached for across classes. ``ScatterPlot`` computes it
+    for both its axes and ``RugPlot`` for the one its ticks stand on, and a
+    private static borrowed from the other would couple them on something that
+    is not a contract -- renamed or re-meant on one side, it breaks the other
+    with no import-time signal. The same argument #599 made for the hue split,
+    one caller later.
+
+    Only the step lives here. Whether the *rest* of a grid is valid stays with
+    each caller, because the two do not ask the same question: a scatter needs
+    both of its axes linear and declines both together, while a rug asks only
+    of the axis its observations lie along. Folding those into one helper would
+    change what a scatter emits for a chart with one transformed axis, which is
+    not this function's business.
+
+    Parameters
+    ----------
+    ticks : numpy.ndarray, optional
+        The axis' major tick positions.
+
+    Returns
+    -------
+    float or None
+        The interval, or ``None`` when the ticks do not name one.
+
+    Examples
+    --------
+    >>> tick_step(np.array([0.0, 2.0, 4.0, 6.0]))
+    2.0
+    >>> tick_step(np.array([0.0, 1.0, 5.0, 10.0])) is None
+    True
+    >>> tick_step(np.array([1.0])) is None
+    True
+    """
+    if ticks is None or len(ticks) < 2:
+        return None
+    diffs = np.diff(ticks)
+    if np.allclose(diffs, diffs[0]):
+        return float(diffs[0])
+    return None

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -532,3 +532,144 @@ def test_a_hue_on_one_level_is_read_as_one_ungrouped_layer():
     # The variable's own name, which is what an ungrouped rug announces.
     assert schemas[0].get("name") == "value"
     assert len(schemas[0]["data"]) == 4
+
+
+# --- The bounds that make the layer reachable in grid mode (maidr#1132) ------
+#
+# A point layer renders braille only in grid mode, and grid mode is built from
+# `axes.{x,y}.{min,max,tickStep}`. With the labels alone, maidr's `ScatterTrace`
+# returns an empty braille state, and a rug is then the one chart with no
+# braille surface reachable by any keystroke. Measured there, four observations
+# at 1, 2, 3 and 9 over a 0-10 axis give `values [[2, 1, 0, 1]]` -- the count
+# per cell, which is the clustering a rug is drawn to show and the one thing
+# its audio cannot carry, every tick sitting at the same place on the axis
+# pitch is mapped from.
+
+
+def _axis(schema, key) -> dict:
+    """One axis' config. `MaidrKey` is a str enum, so the emitted keys compare
+    equal to their plain-string spellings and need no conversion -- calling
+    `str()` on them gives `'MaidrKey.LABEL'` and breaks the comparison."""
+    return dict(schema["axes"][key])
+
+
+def test_the_observation_axis_carries_the_chart_s_own_bounds(frame):
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", ax=ax)
+
+    low, high = ax.get_xlim()
+    x = _axis(_schemas(fig)[0], "x")
+    assert x["min"] == pytest.approx(low)
+    assert x["max"] == pytest.approx(high)
+    assert x["tickStep"] > 0
+
+
+def test_the_strip_is_one_row_deep(frame):
+    """Which is what a rug is: every entry sits at the same place across the
+    ticks. A finer step buys a second row of zeroes -- measured against
+    `ScatterTrace`, `tickStep` 0.5 gives `[[2, 1, 0, 1], [0, 0, 0, 0]]`."""
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", ax=ax)
+
+    assert _axis(_schemas(fig)[0], "y") == {
+        "label": "Rug",
+        "min": 0,
+        "max": 1,
+        "tickStep": 1,
+    }
+
+
+def test_a_rug_up_the_y_axis_puts_the_bounds_on_y(frame):
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, y="value", ax=ax)
+
+    schema = _schemas(fig)[0]
+    assert _axis(schema, "x") == {"label": "Rug", "min": 0, "max": 1, "tickStep": 1}
+    assert _axis(schema, "y")["min"] == pytest.approx(ax.get_ylim()[0])
+
+
+def test_an_axis_whose_ticks_are_not_evenly_spaced_is_declined(frame):
+    """A grid built on uneven ticks is a surface whose cells do not
+    correspond to the axis the reader is told about, which is worse than no
+    surface.
+
+    The scale here is linear, so this is the chart that isolates the tick
+    check: measured, `set_xticks([0, 1, 5, 10])` gives `step=None` while the
+    log-scale guard passes it straight through.
+    """
+    fig, ax = plt.subplots()
+    ax.set_xticks([0.0, 1.0, 5.0, 10.0])
+    sns.rugplot(frame, x="value", ax=ax)
+
+    schema = _schemas(fig)[0]
+    assert _axis(schema, "x") == {"label": "value"}
+    assert _axis(schema, "y") == {"label": "Rug"}
+
+
+def test_a_log_axis_is_declined(frame):
+    fig, ax = plt.subplots()
+    ax.set_xscale("log")
+    sns.rugplot(frame, x="value", ax=ax)
+
+    schema = _schemas(fig)[0]
+    assert _axis(schema, "x") == {"label": "value"}
+    assert _axis(schema, "y") == {"label": "Rug"}
+
+
+def test_a_log_axis_answers_its_limits_and_its_ticks_in_different_spaces(frame):
+    """What makes the scale check a guard rather than a live branch.
+
+    Dropping it leaves the whole suite green, and the reason is worth
+    recording rather than rediscovering: matplotlib answers `get_xlim` in
+    **log space** and `get_xticks` in **data space**, so a log chart's tick
+    step is measured against a span it does not belong to and the
+    `step > (high - low)` clause declines it anyway.
+
+    Pinned here because it is a fact about matplotlib, not about this layer.
+    If a release ever makes the two agree, this goes red and the scale check
+    stops being redundant -- which is the moment it starts earning its keep.
+    """
+    fig, ax = plt.subplots()
+    ax.set_xscale("log")
+    ax.set_xticks([1.0, 2.0, 3.0])
+    sns.rugplot(frame, x="value", ax=ax)
+
+    low, high = ax.get_xlim()
+    ticks = list(ax.get_xticks())
+
+    # The ticks are the data-space values that were asked for.
+    assert ticks == [1.0, 2.0, 3.0]
+    # The limits are not: they are the logs of the data-space bounds, and the
+    # whole span is narrower than one tick step.
+    assert high - low < 1.0
+    assert high < min(ticks)
+
+
+def test_the_bounds_change_nothing_the_layer_already_said(frame):
+    """Additive only: grid mode is entered deliberately, so the ordinary
+    reading has to be untouched. Pinned against the values the layer emitted
+    before the bounds existed."""
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", ax=ax)
+
+    schema = _schemas(fig)[0]
+    assert schema.get("name") == "value"
+    assert [point["x"] for point in schema["data"]] == list(frame["value"])
+    assert all(point["y"] == 0 for point in schema["data"])
+    # One selector for the whole collection, as an ungrouped rug has always
+    # had -- a string rather than the per-segment list a grouped one gets.
+    assert isinstance(schema["selectors"], str)
+
+
+def test_each_hue_group_gets_the_bounds_too(frame):
+    """A grouped rug is several layers over one axis, and a reader feeling any
+    of them is feeling the same plotting area."""
+    frame = frame.assign(sex=["F", "F", "M", "M"])
+    fig, ax = plt.subplots()
+    sns.rugplot(frame, x="value", hue="sex", ax=ax)
+
+    schemas = _schemas(fig)
+    assert len(schemas) == 2
+    for schema in schemas:
+        assert _axis(schema, "x")["tickStep"] > 0
+        assert _axis(schema, "y") == {"label": "Rug", "min": 0, "max": 1, "tickStep": 1}

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -673,3 +673,7 @@ def test_each_hue_group_gets_the_bounds_too(frame):
     for schema in schemas:
         assert _axis(schema, "x")["tickStep"] > 0
         assert _axis(schema, "y") == {"label": "Rug", "min": 0, "max": 1, "tickStep": 1}
+        # And the grouping variable is still named. The bounds are added
+        # beside `z` rather than in place of it, and nothing else in the
+        # schema moves.
+        assert _axis(schema, "z") == {"label": "sex"}

--- a/tests/util/test_grid_axes.py
+++ b/tests/util/test_grid_axes.py
@@ -1,0 +1,31 @@
+"""`tick_step` is shared by the scatter and the rug (#605 review)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from maidr.util.grid_axes import tick_step
+
+
+def test_evenly_spaced_ticks_name_their_interval():
+    assert tick_step(np.array([0.0, 2.0, 4.0, 6.0])) == 2.0
+
+
+def test_uneven_ticks_name_none():
+    """Grid navigation walks in equal increments, so an axis whose ticks are
+    not evenly spaced has no step to give."""
+    assert tick_step(np.array([0.0, 1.0, 5.0, 10.0])) is None
+
+
+def test_fewer_than_two_ticks_name_no_interval():
+    assert tick_step(np.array([1.0])) is None
+    assert tick_step(np.array([])) is None
+    assert tick_step(None) is None
+
+
+def test_a_descending_axis_gives_a_negative_step():
+    """Reported rather than corrected: the callers' own validity checks
+    reject a step that is not positive, and which of them should is theirs to
+    decide -- a scatter declines both its axes together where a rug declines
+    only the one its observations lie along."""
+    assert tick_step(np.array([6.0, 4.0, 2.0])) == -2.0


### PR DESCRIPTION
Refs xability/maidr#1132, where this was measured. The r-maidr half follows separately.

## The gap

A point layer renders braille **only in grid mode**, and grid mode is built from `axes.{x,y}.{min,max,tickStep}`. A rug emitted labels alone. Measured against maidr's `ScatterTrace`:

```
axes as emitted before          braille { empty: true }
    x: { label: 'v' }, y: { label: 'Rug' }

with the bounds this adds       braille { values: [[2, 1, 0, 1]], min: 0, max: 2 }
    x: { label: 'v', min: 0, max: 10, tickStep: 2.5 }
    y: { label: 'Rug', min: 0, max: 1, tickStep: 1 }
```

So a rug was the one chart with **no braille surface reachable by any keystroke**. An ordinary scatter can enter grid mode and get one; a rug could not, because it never emitted what grid mode is built from.

## Why it matters more here than for a scatter

`values: [[2, 1, 0, 1]]` is the observation count per cell along the axis the rug marks — two observations in the first quarter, one in the second, none in the third, one in the fourth. That is the clustering a rug exists to show.

And it is the one thing a rug's **audio cannot carry**. Every tick sits at the same place on the axis pitch is mapped from, so `MathUtil.interpolate` hits its `fromMin === fromMax` guard and every tick plays at `minFrequency`. Position reaches the reader through stereo pan and text, one tick at a time; the shape of the distribution reached them nowhere. Braille is the modality that can hold a whole distribution at once.

## What is emitted

- **The observation axis** takes the chart's own limits and tick step — the grid the frontend builds is of the *chart*, so a reader feeling it is feeling the plotting area they would see. Declined on the same grounds `ScatterPlot._extract_axes_data` declines them: a non-linear scale, ticks that are not evenly spaced, or bounds enclosing no whole cell.
- **The axis across the ticks** is supplied whole as `{min: 0, max: 1, tickStep: 1}`. A rug is one row deep by construction and no reading of the panel could say so. One row is the right shape — measured, `tickStep` 0.5 gives `[[2, 1, 0, 1], [0, 0, 0, 0]]`, a row of the surface spent saying nothing.

## Additive only

Grid mode is entered deliberately, so the ordinary reading must not move. Verified rather than assumed: walking all four ticks with and without the bounds gives **byte-identical** `freq`, `panning` and `text` at every step, and the layer's name, data and selector shape are pinned unchanged.

Every case measured:

| chart | x | y |
|---|---|---|
| `rugplot(x=)` | `v`, 0.6–9.4, step 1 | `Rug`, 0–1, step 1 |
| `rugplot(y=)` | `Rug`, 0–1, step 1 | `v`, 0.6–9.4, step 1 |
| `rugplot(hue=)`, both layers | bounds | bounds, `z` preserved |
| rug over a `kdeplot` | bounds; the kde layer untouched | |
| log axis | label only | label only |

## Verification

- Five mutations, one at a time against a restored baseline: bounds never emitted, the wrong axis read, the strip two rows deep, and the two guards. **Four killed outright.**
- **Two survived and masked each other**, which took two rounds to untangle:
  - The grid-validity check and the log-scale check both declined the one log chart I had tested, so dropping either left the suite green. Fixed for the first by a chart that isolates it — a *linear* axis with `set_xticks([0, 1, 5, 10])`, where the scale guard passes and the tick step is `None`. That mutation now dies.
  - The log-scale check survives even so, and the reason is worth the note it now carries: matplotlib answers `get_xlim` in **log space** and `get_xticks` in **data space**, so a log chart's tick step is measured against a span it does not belong to and the `step > (high - low)` clause declines it anyway. Measured — ticks `[1, 2, 3]` against limits `(0.163, 0.914)`.

    Kept as a guard and **documented as currently unexercised**, with a test pinning the two spaces rather than the decline. It is a fact about matplotlib, not about this layer; if a release ever makes the two agree, that test goes red and the guard starts earning its keep. Same treatment as `_point_colours`'s count check.
- `tests/core/plot/test_rugplot.py` — 36 tests (9 new). `tests/core/test_axes_schema.py` passes, so the canonical `axes` contract still holds.
- Full suite: **2913 passed, 18 skipped**. `ruff check --diff` clean, exit 0.

## Not in scope

This does not make a rug's *audio* informative — pitch still carries nothing in the default mode, and xability/maidr#1132 lists four options for that, none of which I have taken. It means the information is not unavailable, only unavailable in one modality.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_