### PR TITLE
feat(eventplot): give a raster the axis bounds its braille is built from

### DIFF
--- a/maidr/core/plot/eventplot.py
+++ b/maidr/core/plot/eventplot.py
@@ -9,6 +9,7 @@ from matplotlib.collections import EventCollection
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
+from maidr.util.grid_axes import bounds_along, one_row_around
 
 #: The keyword the event patch hands one row's collection to this layer under.
 #: A chart is one collection per row and one layer per collection, so the
@@ -190,9 +191,7 @@ class EventPlot(MaidrPlot):
         self._marks = [index for index, _ in drawn]
 
         if horizontal:
-            return [
-                {MaidrKey.X: position, MaidrKey.Y: offset} for _, position in drawn
-            ]
+            return [{MaidrKey.X: position, MaidrKey.Y: offset} for _, position in drawn]
         return [{MaidrKey.X: offset, MaidrKey.Y: position} for _, position in drawn]
 
     def _extract_axes_data(self) -> dict:
@@ -219,6 +218,45 @@ class EventPlot(MaidrPlot):
         if not named:
             axes_data[stacked] = self._axis_config(label="Row")
 
+        # Bounds on both axes, which is what makes the layer reachable in
+        # grid mode -- the only mode where a point layer renders braille at
+        # all. Measured against maidr's `ScatterTrace`, an event plot came
+        # back with an empty braille state, the same gap a rug had before
+        # #605 (#606).
+        #
+        # The grid a trace builds is of its **own** layer: `ScatterTrace`
+        # holds `gridCells` as instance state and never sees a sibling's
+        # points. So a whole-chart surface, one row against another, is not
+        # something a producer can ask for -- each row gets its own, and that
+        # settles the question #606 left open rather than choosing between
+        # the two.
+        along = MaidrKey.X if horizontal else MaidrKey.Y
+        bounds = bounds_along(self.ax, horizontal)
+        if bounds is not None:
+            low, high, step = bounds
+            axes_data[along] = self._axis_config(
+                label=axes_data[along].get(MaidrKey.LABEL),
+                min=low,
+                max=high,
+                tick_step=step,
+            )
+            # This row's own line offset, not zero: an event plot stacks its
+            # rows at 0, 1, 2 ... and each layer holds exactly one of them,
+            # so the cell has to be the one its events actually sit in. A rug
+            # is the same shape with the offset always zero.
+            row_low, row_high, row_step = one_row_around(
+                float(self._collection.get_lineoffset())
+            )
+            # Read back rather than recomputed, so the caller's label and the
+            # "Row" fallback above are the one answer to what this axis is
+            # called and a grid never renames it.
+            axes_data[stacked] = self._axis_config(
+                label=axes_data[stacked].get(MaidrKey.LABEL),
+                min=row_low,
+                max=row_high,
+                tick_step=row_step,
+            )
+
         return axes_data
 
     def _get_selector(self) -> str | list[str]:
@@ -239,6 +277,5 @@ class EventPlot(MaidrPlot):
             return []
 
         return [
-            f"g[id='{gid}'] > path:nth-of-type({index + 1})"
-            for index in self._marks
+            f"g[id='{gid}'] > path:nth-of-type({index + 1})" for index in self._marks
         ]

--- a/maidr/core/plot/eventplot.py
+++ b/maidr/core/plot/eventplot.py
@@ -191,7 +191,9 @@ class EventPlot(MaidrPlot):
         self._marks = [index for index, _ in drawn]
 
         if horizontal:
-            return [{MaidrKey.X: position, MaidrKey.Y: offset} for _, position in drawn]
+            return [
+                {MaidrKey.X: position, MaidrKey.Y: offset} for _, position in drawn
+            ]
         return [{MaidrKey.X: offset, MaidrKey.Y: position} for _, position in drawn]
 
     def _extract_axes_data(self) -> dict:
@@ -277,5 +279,6 @@ class EventPlot(MaidrPlot):
             return []
 
         return [
-            f"g[id='{gid}'] > path:nth-of-type({index + 1})" for index in self._marks
+            f"g[id='{gid}'] > path:nth-of-type({index + 1})"
+            for index in self._marks
         ]

--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -8,7 +8,7 @@ from matplotlib.collections import LineCollection
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
-from maidr.util.grid_axes import tick_step
+from maidr.util.grid_axes import bounds_along, one_row_around
 from maidr.util.legend_names import title_of
 
 #: Key the patch hands this layer the ``LineCollection`` its own call drew
@@ -210,51 +210,6 @@ class RugPlot(MaidrPlot):
             ]
         return [{MaidrKey.X: 0, MaidrKey.Y: position} for position in self._positions]
 
-    def _observation_bounds(self) -> tuple[float, float, float] | None:
-        """
-        The axis the ticks stand on, as ``(min, max, tickStep)``.
-
-        Read off the axes rather than off the observations: the grid the
-        frontend builds is of the *chart*, and a reader feeling it is feeling
-        the plotting area they would see. Taken from the same three places
-        :meth:`~maidr.core.plot.scatterplot.ScatterPlot._extract_axes_data`
-        takes them -- the step through the helper both share -- and declined
-        on the same grounds: a log scale, ticks that are not evenly spaced, or
-        bounds that do not enclose at least one cell. A grid built on any of those would be a surface whose cells do
-        not correspond to the axis a reader is told about.
-
-        Only this axis is asked. The one across the ticks is supplied whole by
-        the caller, since a rug is one row deep by construction and no reading
-        of the panel could say so.
-
-        Returns
-        -------
-        tuple or None
-            ``(min, max, tickStep)``, or ``None`` when the axis cannot carry
-            a grid -- which leaves the layer exactly as it read before, minus
-            the braille it could not reach either way.
-        """
-        # A guard rather than a live branch, and kept as one deliberately. On a
-        # log axis the other check below already declines every chart measured,
-        # by an accident of units: `get_xlim` answers in **log space** while
-        # `get_xticks` answers in **data space**, so a log chart whose ticks sit
-        # at 1, 2 and 3 gives `step 1.0` against a span of 0.75 and fails the
-        # `step > (high - low)` clause. This is the check that states the
-        # intent -- the cells a non-linear axis draws are not the cells evenly
-        # spaced bounds describe -- and it holds if that accident ever stops.
-        # `test_rugplot.py` pins the two spaces, so the matplotlib release that
-        # ends it turns a test red rather than leaving this silently dead.
-        if self.ax.get_xscale() != "linear" or self.ax.get_yscale() != "linear":
-            return None
-
-        low, high = self.ax.get_xlim() if self._along_x else self.ax.get_ylim()
-        ticks = self.ax.get_xticks() if self._along_x else self.ax.get_yticks()
-        step = tick_step(ticks)
-
-        if step is None or low >= high or step <= 0 or step > (high - low):
-            return None
-        return float(low), float(high), float(step)
-
     def _extract_axes_data(self) -> dict:
         """
         Name the axes, calling the strip the ticks sit in what it is.
@@ -282,7 +237,7 @@ class RugPlot(MaidrPlot):
         # Additive only: grid mode is entered deliberately, and walking the
         # ticks with and without these gives byte-identical audio, panning and
         # text at every step.
-        bounds = self._observation_bounds()
+        bounds = bounds_along(self.ax, self._along_x)
         if bounds is not None:
             low, high, step = bounds
             axes_data[along] = self._axis_config(
@@ -296,8 +251,12 @@ class RugPlot(MaidrPlot):
             # of zeroes -- measured, `tickStep` 0.5 gives
             # `[[2, 1, 0, 1], [0, 0, 0, 0]]` -- which is a row of the surface
             # spent saying nothing.
+            strip_low, strip_high, strip_step = one_row_around(0.0)
             axes_data[across] = self._axis_config(
-                label=RUG_AXIS_LABEL, min=0, max=1, tick_step=1
+                label=RUG_AXIS_LABEL,
+                min=strip_low,
+                max=strip_high,
+                tick_step=strip_step,
             )
         else:
             axes_data[across] = self._axis_config(label=RUG_AXIS_LABEL)

--- a/maidr/util/grid_axes.py
+++ b/maidr/util/grid_axes.py
@@ -121,6 +121,13 @@ def one_row_around(position: float) -> tuple[float, float, float]:
     ``[[2, 1, 0, 1], [0, 0, 0, 0]]``, a row of the surface spent saying
     nothing.
 
+    A unit cell whatever the rows are spaced at, and deliberately so: each
+    layer gets a grid of its **own** -- ``ScatterTrace`` builds ``gridCells``
+    from the points of the layer it holds and never sees a sibling's -- so
+    there is no neighbour for the width to be measured against.
+    ``eventplot(rows, lineoffsets=2)`` moves which cell a row sits in, not
+    how wide it is.
+
     Parameters
     ----------
     position : float

--- a/maidr/util/grid_axes.py
+++ b/maidr/util/grid_axes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+from matplotlib.axes import Axes
 
 
 def tick_step(ticks: np.ndarray | None) -> float | None:
@@ -53,3 +54,88 @@ def tick_step(ticks: np.ndarray | None) -> float | None:
     if np.allclose(diffs, diffs[0]):
         return float(diffs[0])
     return None
+
+
+def bounds_along(ax: Axes, along_x: bool) -> tuple[float, float, float] | None:
+    """
+    One axis' ``(min, max, tickStep)``, when it can carry a grid.
+
+    Read off the axes rather than off the data: the grid the frontend builds
+    is of the *chart*, and a reader feeling it is feeling the plotting area
+    they would see.
+
+    For the layers whose other axis is a strip rather than a measurement --
+    a rug's ticks, an event plot's rows -- so only the axis named is asked.
+    ``ScatterPlot`` keeps its own rule, deliberately: it needs **both** its
+    axes and declines them together, and folding that in here would change
+    what it emits for a chart with one transformed axis.
+
+    Declined on three grounds, each of which would make the cells a reader
+    feels not the cells the axis draws:
+
+    - **A non-linear scale.** Currently a guard rather than a live branch: on
+      a log axis the step check below already declines every chart measured,
+      by an accident of units -- ``get_xlim`` answers in **log space** while
+      ``get_xticks`` answers in **data space**, so ticks at 1, 2 and 3 give a
+      step of 1.0 against a span of 0.75. This is the check that states the
+      intent, and it holds if that accident ever stops.
+      ``tests/core/plot/test_rugplot.py`` pins the two spaces, so the
+      matplotlib release that ends it turns a test red rather than leaving
+      this silently dead.
+    - **Ticks that are not evenly spaced**, which name no step at all.
+    - **Bounds enclosing no whole cell**, which is a grid of nothing.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on.
+    along_x : bool
+        Whether the axis wanted is the x one.
+
+    Returns
+    -------
+    tuple or None
+        ``(min, max, tickStep)``, or ``None`` when the axis cannot carry a
+        grid -- which leaves the layer reading exactly as it did before,
+        minus the braille it could not reach either way.
+    """
+    if ax.get_xscale() != "linear" or ax.get_yscale() != "linear":
+        return None
+
+    low, high = ax.get_xlim() if along_x else ax.get_ylim()
+    step = tick_step(ax.get_xticks() if along_x else ax.get_yticks())
+
+    if step is None or low >= high or step <= 0 or step > (high - low):
+        return None
+    return float(low), float(high), float(step)
+
+
+def one_row_around(position: float) -> tuple[float, float, float]:
+    """
+    Bounds enclosing one row, for an axis that is a strip rather than a scale.
+
+    A rug is one row deep across its ticks and an event plot's layer is one
+    row deep at its own line offset, so the grid across them wants exactly one
+    cell -- and which cell is the only thing that differs. A finer step buys
+    rows of zeroes: measured on a rug, halving it gives
+    ``[[2, 1, 0, 1], [0, 0, 0, 0]]``, a row of the surface spent saying
+    nothing.
+
+    Parameters
+    ----------
+    position : float
+        Where on that axis the layer's entries sit.
+
+    Returns
+    -------
+    tuple
+        ``(min, max, tickStep)`` for a single cell centred on ``position``.
+
+    Examples
+    --------
+    >>> one_row_around(0.0)
+    (-0.5, 0.5, 1.0)
+    >>> one_row_around(3.0)
+    (2.5, 3.5, 1.0)
+    """
+    return (position - 0.5, position + 0.5, 1.0)

--- a/tests/core/plot/test_eventplot.py
+++ b/tests/core/plot/test_eventplot.py
@@ -273,9 +273,9 @@ def test_every_selector_names_an_element_of_its_own_row():
             groups.add(gid)
             wanted = int(re.search(r"nth-of-type\((\d+)\)", selector).group(1))
             available = _paths_in(html, gid)
-            assert (
-                available >= wanted
-            ), f"selector asks for path {wanted} of a group holding {available}"
+            assert available >= wanted, (
+                f"selector asks for path {wanted} of a group holding {available}"
+            )
 
     # Two rows, two groups: a single shared group would mean both layers were
     # addressing the same elements while announcing different events.

--- a/tests/core/plot/test_eventplot.py
+++ b/tests/core/plot/test_eventplot.py
@@ -273,9 +273,9 @@ def test_every_selector_names_an_element_of_its_own_row():
             groups.add(gid)
             wanted = int(re.search(r"nth-of-type\((\d+)\)", selector).group(1))
             available = _paths_in(html, gid)
-            assert available >= wanted, (
-                f"selector asks for path {wanted} of a group holding {available}"
-            )
+            assert (
+                available >= wanted
+            ), f"selector asks for path {wanted} of a group holding {available}"
 
     # Two rows, two groups: a single shared group would mean both layers were
     # addressing the same elements while announcing different events.
@@ -422,3 +422,207 @@ def test_a_raster_beside_another_chart_stays_in_its_own_panel():
         [(2.0, 1.0), (5.0, 1.0)],
     ]
     assert _points(other) == [(1.0, 3.0), (2.0, 4.0)]
+
+
+# --- The bounds that make the layer reachable in grid mode (#606) ------------
+#
+# A point layer renders braille only in grid mode, and grid mode is built from
+# `axes.{x,y}.{min,max,tickStep}`. With the labels alone, maidr's `ScatterTrace`
+# returns `{empty: true}`, so a raster was the second chart -- after a rug,
+# fixed in #605 -- with no braille surface reachable by any keystroke.
+# Measured there, the first row of `ROWS` over a 0.7-7.3 axis now gives
+# `values [[1, 0, 0, 1, 0, 0, 1]]`: the events at 1, 4 and 7, spaced as the
+# axis spaces them, which is the pattern a raster is drawn to show and the one
+# thing its audio cannot carry -- every event in a row is the same pitch.
+#
+# One grid per row, not one for the chart. `ScatterTrace` holds `gridCells` as
+# instance state and builds them from its own layer's points, so it never sees
+# a sibling row's events: a whole-chart surface, one row felt against another,
+# is not something a producer can ask for. That settles the question #606 left
+# open by architecture rather than by preference.
+
+
+def _axis(layer, key) -> dict:
+    """
+    One axis' config, as plain data.
+
+    ``MaidrKey`` is a str enum, so the emitted keys compare equal to their
+    plain-string spellings -- but the dict itself is keyed by the enum members,
+    and ``dict()`` is what lets it be compared against a literal.
+
+    Parameters
+    ----------
+    layer : dict
+        The emitted layer.
+    key : str
+        Which axis.
+
+    Returns
+    -------
+    dict
+        The axis config.
+    """
+    return dict(layer[MaidrKey.AXES][key])
+
+
+def test_the_event_axis_carries_the_chart_s_own_bounds():
+    """The plotting area, not the spread of one row's events.
+
+    A reader feeling the grid is feeling the axis they would see, and the two
+    rows here hold different events -- so bounds taken from the data would put
+    each row on a surface of its own width and make the same cell mean two
+    different spans.
+    """
+    fig, ax = plt.subplots()
+    ax.eventplot(ROWS)
+
+    low, high = ax.get_xlim()
+    for layer in _layers(fig):
+        x = _axis(layer, MaidrKey.X)
+        assert x[MaidrKey.MIN] == pytest.approx(low)
+        assert x[MaidrKey.MAX] == pytest.approx(high)
+        assert x[MaidrKey.TICK_STEP] > 0
+
+
+def test_each_row_is_one_cell_deep_at_the_offset_it_was_drawn_at():
+    """
+    Across the rows, the grid is exactly the one cell this layer occupies.
+
+    Its *own* cell, which is the whole difference between a raster and a rug:
+    a rug always sits at zero, while ``eventplot`` stacks its rows at 0, 1,
+    2 ... and each layer holds exactly one of them.
+
+    Measured against maidr's `ScatterTrace`, the two readings are the
+    difference between a surface and a blank one. With its own cell the
+    second row gives `values [[0, 1, 0, 0, 1, 0, 0]]` -- its two events,
+    where they fall. Handed the zero-centred cell instead, every one of its
+    points is outside the surface and it gives `[[0, 0, 0, 0, 0, 0, 0]]`: a
+    grid that renders, reports nothing wrong, and says the row is empty.
+
+    One cell deep rather than finer: there is nothing to resolve across a row
+    whose entries all sit at the same offset, and a smaller step buys rows of
+    zeroes.
+    """
+    fig, ax = plt.subplots()
+    ax.eventplot(ROWS)
+
+    first, second = _layers(fig)
+
+    assert _axis(first, MaidrKey.Y) == {
+        MaidrKey.LABEL: "Row",
+        MaidrKey.MIN: -0.5,
+        MaidrKey.MAX: 0.5,
+        MaidrKey.TICK_STEP: 1.0,
+    }
+    assert _axis(second, MaidrKey.Y) == {
+        MaidrKey.LABEL: "Row",
+        MaidrKey.MIN: 0.5,
+        MaidrKey.MAX: 1.5,
+        MaidrKey.TICK_STEP: 1.0,
+    }
+
+
+def test_a_row_at_a_non_default_offset_gets_the_cell_it_was_drawn_in():
+    """
+    The offset is read off the artist, not counted from the layer's place.
+
+    The two agree only at the default spacing.
+    ``ax.eventplot(rows, lineoffsets=2)`` draws the second row at 2.0, so a
+    cell numbered from the layer index would hand it -0.5 to 0.5 and 0.5 to
+    1.5 -- a surface its events sit outside of, while every coordinate in the
+    payload stays right. Same trap the row *names* fell into before
+    ``test_named_rows_survive_a_non_default_spacing``.
+    """
+    fig, ax = plt.subplots()
+    ax.eventplot(ROWS, lineoffsets=2)
+
+    first, second = _layers(fig)
+
+    assert (_axis(first, MaidrKey.Y)[MaidrKey.MIN], _points(first)[0][1]) == (-0.5, 0.0)
+    assert (_axis(second, MaidrKey.Y)[MaidrKey.MIN], _points(second)[0][1]) == (
+        1.5,
+        2.0,
+    )
+
+
+def test_a_vertical_raster_bounds_the_axis_its_events_run_along():
+    """The bounds follow the orientation, as the coordinates already do.
+
+    Reading the wrong axis would be silent: both are numeric and both have
+    ticks, so a grid built across the rows and one cell wide along the events
+    is a surface that resolves nothing and reports no error.
+    """
+    fig, ax = plt.subplots()
+    ax.eventplot(ROWS, orientation="vertical")
+
+    first, second = _layers(fig)
+
+    assert _axis(first, MaidrKey.Y)[MaidrKey.MIN] == pytest.approx(ax.get_ylim()[0])
+    assert _axis(first, MaidrKey.X) == {
+        MaidrKey.LABEL: "Row",
+        MaidrKey.MIN: -0.5,
+        MaidrKey.MAX: 0.5,
+        MaidrKey.TICK_STEP: 1.0,
+    }
+    assert _axis(second, MaidrKey.X)[MaidrKey.MIN] == 0.5
+
+
+def test_a_caller_s_own_name_for_the_rows_survives_the_bounds():
+    """A grid says where the cells are, never what the axis is called."""
+    fig, ax = plt.subplots()
+    ax.set_ylabel("neuron")
+    ax.eventplot(ROWS)
+
+    y = _axis(_layers(fig)[0], MaidrKey.Y)
+    assert y[MaidrKey.LABEL] == "neuron"
+    assert y[MaidrKey.MAX] == 0.5
+
+
+def test_unevenly_spaced_ticks_take_the_row_cells_with_them():
+    """
+    Half a grid is not a grid, so the decline has to reach both axes.
+
+    An axis whose ticks are not evenly spaced names no step, and a surface
+    built on an invented one has cells that do not correspond to the axis the
+    reader is told about. Emitting the row cell anyway would leave bounds on
+    one axis alone -- which builds nothing, and reads as a chart that meant to
+    offer a grid.
+    """
+    fig, ax = plt.subplots()
+    ax.set_xticks([0.0, 1.0, 5.0, 10.0])
+    ax.eventplot(ROWS)
+
+    layer = _layers(fig)[0]
+    assert _axis(layer, MaidrKey.X) == {MaidrKey.LABEL: "X"}
+    assert _axis(layer, MaidrKey.Y) == {MaidrKey.LABEL: "Row"}
+
+
+def test_a_log_event_axis_is_declined():
+    """Spikes on a log time axis are an ordinary chart, and the cells a linear
+    grid describes are not the cells that axis draws."""
+    fig, ax = plt.subplots()
+    ax.set_xscale("log")
+    ax.eventplot(ROWS)
+
+    layer = _layers(fig)[0]
+    assert _axis(layer, MaidrKey.X) == {MaidrKey.LABEL: "X"}
+    assert _axis(layer, MaidrKey.Y) == {MaidrKey.LABEL: "Row"}
+
+
+def test_the_bounds_change_nothing_the_layer_already_said():
+    """Additive only: grid mode is entered deliberately, so the reading a
+    reader gets without asking for it has to be untouched. Pinned against what
+    the layer emitted before the bounds existed."""
+    fig, ax = plt.subplots()
+    ax.set_yticks([0, 1], ["neuron A", "neuron B"])
+    ax.eventplot(ROWS)
+
+    first, second = _layers(fig)
+
+    assert [layer.get(MaidrKey.NAME) for layer in (first, second)] == [
+        "neuron A",
+        "neuron B",
+    ]
+    assert _points(first) == [(1.0, 0.0), (4.0, 0.0), (7.0, 0.0)]
+    assert _points(second) == [(2.0, 1.0), (5.0, 1.0)]
+    assert len(first[MaidrKey.SELECTOR]) == 3

--- a/tests/core/plot/test_rugplot.py
+++ b/tests/core/plot/test_rugplot.py
@@ -567,15 +567,23 @@ def test_the_observation_axis_carries_the_chart_s_own_bounds(frame):
 def test_the_strip_is_one_row_deep(frame):
     """Which is what a rug is: every entry sits at the same place across the
     ticks. A finer step buys a second row of zeroes -- measured against
-    `ScatterTrace`, `tickStep` 0.5 gives `[[2, 1, 0, 1], [0, 0, 0, 0]]`."""
+    `ScatterTrace`, `tickStep` 0.5 gives `[[2, 1, 0, 1], [0, 0, 0, 0]]`.
+
+    Centred on the entries rather than starting at them. `0` to `1` was the
+    first spelling and reads identically -- measured against `ScatterTrace`,
+    both give `values [[2, 1, 0, 1]]` -- but it puts the entries on a cell
+    *edge*, and which side of an edge a value falls on is the frontend's
+    tie-break rather than something this states. `one_row_around` centres
+    them, which also generalises to a layer whose row is not zero.
+    """
     fig, ax = plt.subplots()
     sns.rugplot(frame, x="value", ax=ax)
 
     assert _axis(_schemas(fig)[0], "y") == {
         "label": "Rug",
-        "min": 0,
-        "max": 1,
-        "tickStep": 1,
+        "min": -0.5,
+        "max": 0.5,
+        "tickStep": 1.0,
     }
 
 
@@ -584,7 +592,12 @@ def test_a_rug_up_the_y_axis_puts_the_bounds_on_y(frame):
     sns.rugplot(frame, y="value", ax=ax)
 
     schema = _schemas(fig)[0]
-    assert _axis(schema, "x") == {"label": "Rug", "min": 0, "max": 1, "tickStep": 1}
+    assert _axis(schema, "x") == {
+        "label": "Rug",
+        "min": -0.5,
+        "max": 0.5,
+        "tickStep": 1.0,
+    }
     assert _axis(schema, "y")["min"] == pytest.approx(ax.get_ylim()[0])
 
 
@@ -672,7 +685,12 @@ def test_each_hue_group_gets_the_bounds_too(frame):
     assert len(schemas) == 2
     for schema in schemas:
         assert _axis(schema, "x")["tickStep"] > 0
-        assert _axis(schema, "y") == {"label": "Rug", "min": 0, "max": 1, "tickStep": 1}
+        assert _axis(schema, "y") == {
+            "label": "Rug",
+            "min": -0.5,
+            "max": 0.5,
+            "tickStep": 1.0,
+        }
         # And the grouping variable is still named. The bounds are added
         # beside `z` rather than in place of it, and nothing else in the
         # schema moves.


### PR DESCRIPTION
Closes #606.

## What was wrong

A point layer renders braille only in grid mode, and grid mode is built from `axes.{x,y}.{min,max,tickStep}`. An event plot emitted labels alone, so `ScatterTrace` came back `{empty: true}` — a raster was the second chart, after a rug in #605, with no braille surface reachable by any keystroke.

Measured against `ScatterTrace` with the layer this branch emits:

| layer payload | `braille` |
|---|---|
| labels only (before) | `{empty: true}` |
| row 0, `x 0.7–7.3 step 1`, `y -0.5–0.5 step 1` | `values [[1, 0, 0, 1, 0, 0, 1]]` |
| row 1, `x 0.7–7.3 step 1`, `y 0.5–1.5 step 1` | `values [[0, 1, 0, 0, 1, 0, 0]]` |

That spacing is the one thing a raster's audio cannot carry. Every event in a row is the same pitch — they all sit at the same place on the axis pitch is mapped from — so the pattern the chart is drawn to show is exactly what the reader was missing.

## One grid per row

#606 left open whether the grid should be per-row or one surface for the whole chart. That is settled by the architecture rather than by preference: `ScatterTrace` holds `gridCells` as instance state and builds them from its own layer's `data`, so it never sees a sibling row's points. A whole-chart surface, one row felt against another, is not something a producer can ask for — each row gets its own.

## Each row gets the cell it was drawn in

`one_row_around(get_lineoffset())`, not one centred on zero. That is the whole difference between a raster and a rug, which always sits at zero: `eventplot` stacks its rows at 0, 1, 2 …, and `lineoffsets=` moves them further.

Handed the zero-centred cell instead, the second row's points all fall outside the surface and it comes back `[[0, 0, 0, 0, 0, 0, 0]]` — a grid that renders, reports nothing wrong, and says the row is empty. Every coordinate in the payload stays right while that happens, which is the kind of gap no assertion about the data would catch.

## The extraction

`RugPlot._observation_bounds` becomes `maidr/util/grid_axes.bounds_along`, lifted whole — three declines and the note on why the log-scale guard is currently redundant included — beside the `tick_step` #605 already extracted. Second caller, so it moves; the same threshold #599 set for the hue split.

`ScatterPlot` deliberately keeps its own rule and this PR does not touch it: a scatter needs **both** axes linear and declines them together, while a rug and a raster ask only of the axis their entries lie along. Folding those into one helper would change what a scatter emits for a chart with one transformed axis, which is not this change's business.

`one_row_around(position)` centres the single cell on the entries rather than starting at them. A rug's strip moves from `0..1` to `-0.5..0.5` as a result. Measured against `ScatterTrace` before the pinned test values were touched, both spellings give `values [[2, 1, 0, 1]]` — but `0..1` puts the entries on a cell *edge*, and which side of an edge a value falls on is the frontend's tie-break rather than something the producer states. Centring also generalises to a layer whose row is not zero, which is what the raster needs.

## Declined together

An axis that cannot carry a grid — non-linear, unevenly spaced ticks, or bounds enclosing no whole cell — takes the row cell with it. Bounds on one axis alone build nothing, and emitting half a grid reads as a chart that meant to offer one.

## Additive

Points, layer names, selectors and axis labels are unchanged; `test_the_bounds_change_nothing_the_layer_already_said` pins that against the values the layer emitted before this branch.

## Verification

- `tests/core/plot/test_eventplot.py` → 22 passed (8 new)
- `tests/core/plot/test_rugplot.py` → 36 passed
- Full suite: **2925 passed, 18 skipped**
- `ruff check` / `ruff format --check` clean on every touched file

Each new test was checked by mutation, applied alone against a restored baseline — all six killed:

| mutation | result |
|---|---|
| row cell always at zero | 3 failed |
| no bounds on the row axis | 4 failed |
| no bounds on the event axis | 2 failed |
| bounds read off the wrong axis | 3 failed |
| row label recomputed as `"Row"` | 2 failed |
| `along` key swapped | 2 failed |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_