### PR TITLE
fix(hue): name a faceted panel's lone group from the legend that names it

### DIFF
--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -460,7 +460,7 @@ def _face_colour(outline: PolyCollection):
     Its **face**, which is what carries the hue. By default the edge carries
     it too -- measured, the two agree but for the translucency the face and
     the legend swatch share -- so either would name the groups, the edge
-    through `names_for`'s alpha-insensitive pass. `edgecolor=` is what
+    through `_names_for`'s alpha-insensitive pass. `edgecolor=` is what
     separates them: it is the caller's to set, and setting it once colours
     *every* group's edge alike::
 

--- a/maidr/patch/histogram.py
+++ b/maidr/patch/histogram.py
@@ -22,8 +22,18 @@ from maidr.core.plot.outlined_histogram import reads as outline_reads
 from maidr.core.plot.scatterplot import _rgba
 from maidr.core.plot.step_histogram import STEP_COUNTS, STEP_EDGES, STEP_ORIENTATION
 from maidr.core.plot.stepped_histogram import reads as _reads_outline
-from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
-from maidr.patch.kdeplot import _curve_names, _names_for, deferred_names
+from maidr.patch.common import (
+    _draw_quietly,
+    common,
+    plotter_axes,
+    prospective_axes,
+    wrap_seaborn,
+)
+from maidr.patch.kdeplot import (
+    _curve_names,
+    _names_for_panel,
+    deferred_names,
+)
 
 
 @wrapt.patch_function_wrapper(Axes, "hist")
@@ -209,7 +219,9 @@ def _new_bar_containers(ax: Axes | None, before: list) -> list[BarContainer]:
     ]
 
 
-def _group_names(ax: Axes | None, containers: list) -> list[str | None]:
+def _group_names(
+    ax: Axes | None, containers: list, faceted: bool = False
+) -> list[str | None]:
     """
     Name each container from the legend swatch drawn in its colour.
 
@@ -241,7 +253,14 @@ def _group_names(ax: Axes | None, containers: list) -> list[str | None]:
     distribution needs nothing to tell it apart from, and a name there would
     read as though the chart held more.
 
-    The match itself is ``kdeplot._names_for``, which is the same one this
+    Unless it is one panel of a grid, where those two stop being the same
+    thing -- the figure holds several distributions and this panel holds one
+    of them, so the name is worth having and the legend has it. `faceted`
+    says which case this is; see :func:`~maidr.util.legend_names.names_for_panel`
+    for why the panel count decides it rather than where the legend was hung
+    (#608).
+
+    The match itself is ``kdeplot._names_for_panel``, which is the same one this
     used to make inline against ``_named_colours`` plus a second pass this
     lacked. That pass is not a nicety here: a ``pairplot(hue=...)`` draws its
     bars translucent and builds its figure legend from **opaque** swatches --
@@ -256,6 +275,8 @@ def _group_names(ax: Axes | None, containers: list) -> list[str | None]:
         The axes drawn on, for its legend.
     containers : list
         The containers this call drew, in draw order.
+    faceted : bool
+        Whether this panel is one of several.
 
     Returns
     -------
@@ -265,7 +286,7 @@ def _group_names(ax: Axes | None, containers: list) -> list[str | None]:
     if ax is None:
         return [None] * len(containers)
 
-    return _names_for(ax, [_container_colour(c) for c in containers])
+    return _names_for_panel(ax, [_container_colour(c) for c in containers], faceted)
 
 
 def _container_colour(container) -> tuple[float, ...] | None:
@@ -439,7 +460,7 @@ def _face_colour(outline: PolyCollection):
     Its **face**, which is what carries the hue. By default the edge carries
     it too -- measured, the two agree but for the translucency the face and
     the legend swatch share -- so either would name the groups, the edge
-    through `_names_for`'s alpha-insensitive pass. `edgecolor=` is what
+    through `names_for`'s alpha-insensitive pass. `edgecolor=` is what
     separates them: it is the caller's to set, and setting it once colours
     *every* group's edge alike::
 
@@ -508,7 +529,6 @@ def _drew_outlines(ax: Axes | None, before: list) -> list:
         for outline in _outlines_of(ax)
         if id(outline) not in seen and _reads_outline(outline)
     ]
-
 
 
 def _lines_of(ax: Axes | None) -> list:
@@ -754,7 +774,12 @@ def sns_hist(wrapped, instance, args, kwargs) -> Axes:
 
 
 def _register_outlines(
-    ax: Axes | None, outlines: list, lines: list, kde: bool, horizontal: bool
+    ax: Axes | None,
+    outlines: list,
+    lines: list,
+    kde: bool,
+    horizontal: bool,
+    faceted: bool = False,
 ) -> bool:
     """
     Register the panel's distribution when it was drawn as an outline.
@@ -805,7 +830,8 @@ def _register_outlines(
     drew = _drew_outlines(ax, outlines)
     if drew:
         names = deferred_names(
-            lambda: _names_for(ax, [_face_colour(one) for one in drew]), len(drew)
+            lambda: _names_for_panel(ax, [_face_colour(one) for one in drew], faceted),
+            len(drew),
         )
         for outline, name in zip(drew, names):
             FigureManager.create_maidr(
@@ -820,7 +846,9 @@ def _register_outlines(
         return False
 
     names = deferred_names(
-        lambda: _names_for(ax, [_rgba(one.get_color()) for one in outlined]),
+        lambda: _names_for_panel(
+            ax, [_rgba(one.get_color()) for one in outlined], faceted
+        ),
         len(outlined),
     )
     for line, name in zip(outlined, names):
@@ -883,6 +911,12 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
     # passes the suite, which is recorded here rather than left to be
     # rediscovered.
     panels = plotter_axes(instance)
+    # Whether a lone artist on a panel is a lone artist in the *chart*. A
+    # `col=`/`row=` grid draws several panels and one legend for all of them,
+    # so a panel holding one group holds one of several -- and the name that
+    # says which is worth having (#608). Read once, before the draw, because
+    # it is a property of the grid rather than of what any panel drew.
+    faceted = len(panels) > 1
     before = {id(ax): _containers_of(ax) for ax in panels}
     # The other two shapes a panel can arrive in. Snapshotted the same way and
     # for the same reason: an axes that already held an outline is not this
@@ -909,6 +943,7 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
                 lines.get(id(ax), []),
                 kde,
                 horizontal,
+                faceted,
             )
             continue
         # One layer per group here too; `displot(hue=...)` reaches only this
@@ -923,12 +958,18 @@ def sns_distribution_hist(wrapped, instance, args, kwargs) -> Any:
         # Measured on `displot(hue=..., col=...)` over a grid whose panels
         # hold different groups: three layers, all `None`, because the last
         # panel held a single container and a lone artist is exactly what
-        # `names_for` declines. Asked panel by panel the same figure gives
-        # `['b', 'a']` and `[None]` (#591).
-        for container, name in zip(containers, deferred_names(
-            lambda ax=ax, containers=containers: _group_names(ax, containers),
-            len(containers),
-        )):
+        # `names_for` declined. Asked panel by panel the same figure gave
+        # `['b', 'a']` and `[None]` (#591) -- the `[None]` since lifted by
+        # #608, which is what `faceted` carries.
+        for container, name in zip(
+            containers,
+            deferred_names(
+                lambda ax=ax, containers=containers: _group_names(
+                    ax, containers, faceted
+                ),
+                len(containers),
+            ),
+        ):
             FigureManager.create_maidr(
                 ax, PlotType.HIST, **{DRAWN_BARS: container, GROUP_NAME: name}
             )

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -25,6 +25,12 @@ from maidr.patch.common import (
     wrap_seaborn,
 )
 from maidr.core.context_manager import ContextManager
+
+# `legend_of` and `_names_for` are re-exported rather than used here:
+# `tests/core/plot/test_hue_kde_naming.py` and
+# `tests/core/plot/test_pairplot_group_names.py` reach the colour match
+# through this module, which is where it lived before it moved to
+# `maidr/util/legend_names.py`. The blanket noqa is what lets them.
 from maidr.util.legend_names import (  # noqa: F401
     legend_of,
     names_for as _names_for,

--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -12,13 +12,24 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.contour import tag
 from maidr.core.plot.maidr_plot import GROUP_NAME
+
 # `_handle_colour` and `legend_of` are re-exported rather than used here:
 # both moved out when the colour matching became shared, and both are
 # imported from this module by name elsewhere.
 from maidr.core.plot.scatterplot import _handle_colour, _rgba  # noqa: F401
-from maidr.patch.common import _draw_quietly, common, plotter_axes, prospective_axes, wrap_seaborn
+from maidr.patch.common import (
+    _draw_quietly,
+    common,
+    plotter_axes,
+    prospective_axes,
+    wrap_seaborn,
+)
 from maidr.core.context_manager import ContextManager
-from maidr.util.legend_names import legend_of, names_for as _names_for  # noqa: F401
+from maidr.util.legend_names import (  # noqa: F401
+    legend_of,
+    names_for as _names_for,
+    names_for_panel as _names_for_panel,
+)
 from maidr.util.svg_utils import unique_lines_by_xy
 
 
@@ -90,7 +101,7 @@ def _register_field(ax: Axes | None, before: list) -> None:
         FigureManager.create_maidr(ax, PlotType.CONTOUR, contour_set=drawn)
 
 
-def _curve_names(ax: Axes, curves: list) -> list:
+def _curve_names(ax: Axes, curves: list, faceted: bool = False) -> list:
     """
     Name each KDE curve from the legend swatch drawn in its colour.
 
@@ -110,7 +121,8 @@ def _curve_names(ax: Axes, curves: list) -> list:
     wrongly: no legend, a curve no swatch claims, or a swatch that names two
     things. A lone curve is left unnamed whatever the legend says, because a
     name on the only layer of a chart reads as though there were another to
-    tell it from.
+    tell it from -- unless the chart is a grid and this is one panel of it,
+    where the other layers exist and are drawn next door (#608).
 
     Parameters
     ----------
@@ -118,16 +130,18 @@ def _curve_names(ax: Axes, curves: list) -> list:
         The axes drawn on, for its legend.
     curves : list
         The KDE lines, in draw order.
+    faceted : bool
+        Whether this panel is one of several.
 
     Returns
     -------
     list
         One entry per curve, naming it or ``None``.
     """
-    return _names_for(ax, [_rgba(curve.get_color()) for curve in curves])
+    return _names_for_panel(ax, [_rgba(curve.get_color()) for curve in curves], faceted)
 
 
-def _fill_names(ax: Axes, fills: list) -> list:
+def _fill_names(ax: Axes, fills: list, faceted: bool = False) -> list:
     """
     Name each filled KDE band from the legend swatch drawn in its colour.
 
@@ -142,13 +156,15 @@ def _fill_names(ax: Axes, fills: list) -> list:
         The axes drawn on, for its legend.
     fills : list
         The bands, in draw order.
+    faceted : bool
+        Whether this panel is one of several.
 
     Returns
     -------
     list
         One entry per band, naming it or ``None``.
     """
-    return _names_for(ax, [_collection_colour(fill) for fill in fills])
+    return _names_for_panel(ax, [_collection_colour(fill) for fill in fills], faceted)
 
 
 def _collection_colour(collection) -> tuple | None:
@@ -214,7 +230,9 @@ def deferred_names(resolve, count: int) -> list:
     return [at(index) for index in range(count)]
 
 
-def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
+def _register_smooth(
+    ax: Axes | None, instance, args, kwargs, faceted: bool = False
+) -> None:
     """
     Register every KDE curve on one axes as a SMOOTH layer.
 
@@ -233,14 +251,18 @@ def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
         resolve one does nothing rather than guessing.
     instance, args, kwargs
         Forwarded to :func:`maidr.patch.common.common` unchanged.
+    faceted : bool
+        Whether this panel is one of several, which is what lets a panel
+        holding a single curve still be named (#608).
     """
     if ax is not None:
         # Register all unique Line2D objects
         lines = [line for line in ax.get_lines() if isinstance(line, Line2D)]
         curves = list(unique_lines_by_xy(lines))
-        for kde_line, name in zip(curves, deferred_names(
-            lambda: _curve_names(ax, curves), len(curves)
-        )):
+        for kde_line, name in zip(
+            curves,
+            deferred_names(lambda: _curve_names(ax, curves, faceted), len(curves)),
+        ):
             if kde_line.get_gid() is None:
                 gid = f"maidr-{uuid.uuid4()}"
                 kde_line.set_gid(gid)
@@ -253,9 +275,9 @@ def _register_smooth(ax: Axes | None, instance, args, kwargs) -> None:
             )
         # Register all PolyCollection boundaries as SMOOTH
         fills = [c for c in ax.collections if isinstance(c, PolyCollection)]
-        for poly, fill_name in zip(fills, deferred_names(
-            lambda: _fill_names(ax, fills), len(fills)
-        )):
+        for poly, fill_name in zip(
+            fills, deferred_names(lambda: _fill_names(ax, fills, faceted), len(fills))
+        ):
             if poly.get_paths():
                 path = poly.get_paths()[0]
                 boundary = path.vertices
@@ -323,8 +345,12 @@ def sns_distribution_density(wrapped, instance, args, kwargs):
     with ContextManager.set_internal_context():
         drawn = _draw_quietly(wrapped, args, kwargs)
 
-    for ax in plotter_axes(instance):
-        _register_smooth(ax, instance, args, kwargs)
+    # One legend for the whole grid, so a panel holding one curve holds one
+    # of several and the name that says which is worth having (#608).
+    panels = plotter_axes(instance)
+    faceted = len(panels) > 1
+    for ax in panels:
+        _register_smooth(ax, instance, args, kwargs, faceted)
 
     return drawn
 

--- a/maidr/util/legend_names.py
+++ b/maidr/util/legend_names.py
@@ -272,6 +272,21 @@ def names_for_panel(ax: Axes, colours: list, faceted: bool) -> list:
     asymmetry #522, #446 and #590 were each about. Both emit ``None`` today
     and both keep doing so.
 
+    The panel count is a **proxy** for "the figure holds more than this
+    panel does", and the two can come apart: a `col=` grid whose `hue=`
+    happens to have a single level across the whole frame draws one artist
+    per panel, all of them the same group, and every one is now named.
+    Measured, `displot(x=, hue=, col=)` with one hue level gives
+    `['only', 'only']` where it gave `[None, None]`.
+
+    Kept rather than guarded against, because the name is **true**: the
+    legend says which group these are, a sighted reader sees it, and the
+    panels are told apart by their `col` level rather than by hue, so
+    nothing is lost to the redundancy. The case the floor is right about is
+    the other one -- a single-panel chart, where a name implies a companion
+    layer that does not exist. Pinned in
+    `tests/core/test_displot_distribution.py`.
+
     Only the floor moves. Every other decline is :func:`name_for`'s and
     unchanged: no legend, a colour no swatch claims, a colour two swatches
     claim.

--- a/maidr/util/legend_names.py
+++ b/maidr/util/legend_names.py
@@ -114,8 +114,7 @@ def names_for(ax: Axes, colours: list) -> list:
         named = _match_swatches(colours, swatches, key)
         if named:
             return [
-                None if colour is None else named.get(key(colour))
-                for colour in colours
+                None if colour is None else named.get(key(colour)) for colour in colours
             ]
     return [None] * len(colours)
 
@@ -250,3 +249,48 @@ def title_of(ax: Axes) -> str:
     if title is None:
         return ""
     return title.get_text().strip()
+
+
+def names_for_panel(ax: Axes, colours: list, faceted: bool) -> list:
+    """
+    :func:`names_for`, plus the lone artist a faceted grid can still name.
+
+    The single-artist floor asks whether an artist is alone **on its axes**:
+    "a lone artist needs nothing to be told apart from". That is right about
+    one chart and wrong about one panel of a grid, because the two questions
+    come apart there -- the figure holds several distributions and the panel
+    holds one of them. A reader walking the layers of
+    ``displot(hue=..., col=...)`` heard two named ones and then one that would
+    not say which group it was, on a chart whose legend names it plainly
+    (#608).
+
+    So the panel count decides it, not where the legend was hung. A figure
+    legend is not the signal: seaborn's ``FacetGrid`` builds one for a single
+    panel too, and reading that as licence to name would leave
+    ``displot(one_level, hue=...)`` named and ``histplot(one_level, hue=...)``
+    unnamed -- the same chart, two spellings, two answers, which is the
+    asymmetry #522, #446 and #590 were each about. Both emit ``None`` today
+    and both keep doing so.
+
+    Only the floor moves. Every other decline is :func:`name_for`'s and
+    unchanged: no legend, a colour no swatch claims, a colour two swatches
+    claim.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    colours : list
+        One rounded RGBA per artist, or ``None`` where it has no single one.
+    faceted : bool
+        Whether this panel is one of several. False leaves
+        :func:`names_for` answering exactly as it did.
+
+    Returns
+    -------
+    list
+        One name per entry, or ``None``.
+    """
+    if faceted and len(colours) == 1:
+        return [name_for(ax, colours[0])]
+    return names_for(ax, colours)

--- a/tests/core/test_displot_distribution.py
+++ b/tests/core/test_displot_distribution.py
@@ -504,3 +504,36 @@ class TestAPanelHoldingOneGroupIsStillNamed:
         _, ax = plt.subplots()
         sns.histplot(self._one_level(), x="v", hue="g", bins=3, ax=ax)
         assert self._names(ax.get_figure()) == [None]
+
+    @staticmethod
+    def _one_level_faceted() -> pd.DataFrame:
+        # `g` has one level across the whole frame; `c` facets it into two
+        # panels. So every panel holds one artist, and all of them are the
+        # same group.
+        return pd.DataFrame(
+            {
+                "v": list(np.linspace(0, 1, 20)),
+                "g": ["only"] * 20,
+                "c": ["p"] * 10 + ["q"] * 10,
+            }
+        )
+
+    def test_a_grid_whose_hue_has_one_level_names_every_panel_alike(self):
+        """The panel count is a proxy for "the figure holds more than this
+        panel does", and this is where the two come apart.
+
+        Measured, `['only', 'only']` where it gave `[None, None]`. Kept
+        rather than guarded against, because the name is **true**: the legend
+        says which group these are, a sighted reader sees it, and the panels
+        are told apart by their `col` level rather than by hue -- so the
+        redundancy costs nothing. The case the floor is right about is the
+        other one, pinned above: a single-panel chart, where a name implies a
+        companion layer that does not exist.
+
+        Pinned so the approximation is visible rather than inferred, and so
+        that a later decision to decline it is a deliberate change to a test
+        rather than a silent one.
+        """
+        grid = sns.displot(self._one_level_faceted(), x="v", hue="g", col="c", bins=3)
+
+        assert self._names(grid.figure) == ["only", "only"]

--- a/tests/core/test_displot_distribution.py
+++ b/tests/core/test_displot_distribution.py
@@ -107,8 +107,7 @@ class TestADistributionReadsAsOne:
         # legible: nothing about `displot`'s reading looked wrong on its own.
         sns.displot(frame(), x="v", bins=3)
         figure_level = [
-            {str(key): value for key, value in sample.items()}
-            for sample in samples()
+            {str(key): value for key, value in sample.items()} for sample in samples()
         ]
 
         plt.close("all")
@@ -261,9 +260,7 @@ class TestEveryElementDisplotDraws:
     @pytest.mark.parametrize("element", ["step", "poly"])
     def test_a_hue_grouped_outline_names_its_groups(self, element):
         # The names come from the legend by colour, as the bars' do.
-        grid = sns.displot(
-            frame(), x="v", hue="g", bins=3, element=element, fill=False
-        )
+        grid = sns.displot(frame(), x="v", hue="g", bins=3, element=element, fill=False)
         names = [
             plot.schema.get("name")
             for plot in FigureManager.get_maidr(grid.figure)._plots
@@ -293,7 +290,15 @@ class TestAFacetedHistogramNamesEachPanelFromItself:
     Measured on a grid whose panels hold different groups: three layers, all
     ``None``, because the last panel held a single container and a lone
     artist is exactly what ``names_for`` declines. Asked panel by panel the
-    same figure gives ``['b', 'a']`` and ``[None]``.
+    same figure gave ``['b', 'a']`` and ``[None]``.
+
+    That last ``[None]`` is no longer what the panel answers -- #608 lifted
+    the lone-artist floor for a panel of a grid, so the third layer is now
+    named ``'c'``. This class still pins the binding: a resolver closing over
+    the loop variables would name **every** layer from the last panel, and
+    the last panel holds `c` alone, so the failure it guards against is now
+    three layers reading ``'c'``, ``'c'``, ``'c'`` rather than three
+    ``None``s. Either way the names would not be each panel's own.
     """
 
     @staticmethod
@@ -320,7 +325,7 @@ class TestAFacetedHistogramNamesEachPanelFromItself:
         assert named == [
             ("b", [0.0, 10.0, 0.0]),
             ("a", [10.0, 0.0, 0.0]),
-            (None, [0.0, 0.0, 10.0]),
+            ("c", [0.0, 0.0, 10.0]),
         ]
 
 
@@ -360,12 +365,8 @@ class TestTheShapesOnlyDisplotCanReach:
 
         assert sorted(name for name in names if name) == ["a", "b"]
 
-    @pytest.mark.parametrize(
-        ("element", "reads"), [("step", True), ("poly", False)]
-    )
-    def test_a_density_overlay_decides_which_outline_is_readable(
-        self, element, reads
-    ):
+    @pytest.mark.parametrize(("element", "reads"), [("step", True), ("poly", False)])
+    def test_a_density_overlay_decides_which_outline_is_readable(self, element, reads):
         """`kde=` has to be observed here, and it is not a `displot` keyword.
 
         The plotter method takes it under its own name, so this reads the
@@ -392,6 +393,114 @@ class TestTheShapesOnlyDisplotCanReach:
         # The asymmetry this whole class is about, asserted in the one place
         # the two interfaces are meant to agree on a *decline*.
         _, ax = plt.subplots()
-        sns.histplot(frame(), x="v", bins=4, element="poly", fill=False, kde=True, ax=ax)
+        sns.histplot(
+            frame(), x="v", bins=4, element="poly", fill=False, kde=True, ax=ax
+        )
 
         assert layers(ax.get_figure()) == []
+
+
+class TestAPanelHoldingOneGroupIsStillNamed:
+    """`names_for` declines a lone artist, and a facet panel is not one (#608).
+
+    The floor asks whether an artist is alone **on its axes**: "a lone
+    container needs nothing to tell it apart from". That is right about one
+    chart and wrong about one panel of a grid, where the two questions come
+    apart -- the figure holds several distributions and the panel holds one
+    of them.
+
+    Measured before the fix, on a grid whose panels hold different numbers of
+    groups, all three shapes a `displot` panel can arrive in:
+
+        displot(hue=, col=, bins=3)                  ['b', 'a', None]
+        displot(hue=, col=, bins=3, element="step")  ['b', 'a', None]
+        displot(hue=, col=, kind="kde")              ['b', 'a', None]
+        displot(hue=, bins=3)   # unfaceted control  ['c', 'b', 'a']
+
+    A reader walking the layers heard two named distributions and then one
+    that would not say which group it was, on a chart whose legend names it
+    plainly -- and the same data drawn unfaceted named all three.
+    """
+
+    @staticmethod
+    def _split_frame() -> pd.DataFrame:
+        # Panel "p" holds groups a and b; panel "q" holds only c. The panels
+        # must differ in *shape* or the lone-container case never arises.
+        return pd.DataFrame(
+            {
+                "v": list(np.linspace(0, 1, 30)),
+                "g": ["a"] * 10 + ["b"] * 10 + ["c"] * 10,
+                "c": ["p"] * 20 + ["q"] * 10,
+            }
+        )
+
+    @staticmethod
+    def _names(fig) -> list:
+        return [plot.schema.get("name") for plot in FigureManager.get_maidr(fig)._plots]
+
+    def test_a_lone_container_in_a_panel_is_named(self):
+        """Bars, the default `element`."""
+        grid = sns.displot(self._split_frame(), x="v", hue="g", col="c", bins=3)
+
+        assert sorted(self._names(grid.figure)) == ["a", "b", "c"]
+
+    def test_a_lone_outline_in_a_panel_is_named(self):
+        """`element="step"` draws a `PolyCollection`, not a `BarContainer`, so
+        it reaches the floor through `_register_outlines` rather than through
+        `_group_names`. Same rule, a different resolver -- and a fix applied
+        to one and not the other would leave a reader's experience depending
+        on which `element=` the author picked."""
+        grid = sns.displot(
+            self._split_frame(), x="v", hue="g", col="c", bins=3, element="step"
+        )
+
+        assert sorted(self._names(grid.figure)) == ["a", "b", "c"]
+
+    def test_a_lone_kde_curve_in_a_panel_is_named(self):
+        """`kind="kde"` reaches it through `_curve_names`, one module over."""
+        grid = sns.displot(self._split_frame(), x="v", hue="g", col="c", kind="kde")
+
+        assert sorted(self._names(grid.figure)) == ["a", "b", "c"]
+
+    def test_the_panels_holding_two_groups_are_unchanged(self):
+        """Additive: the fix moves the floor for a lone artist and nothing
+        else. Asserted in order here rather than sorted, because what must
+        hold is that each name is still on the layer whose counts it belongs
+        to -- the thing #591 was about."""
+        grid = sns.displot(self._split_frame(), x="v", hue="g", col="c", bins=3)
+        named = [
+            (plot.schema.get("name"), [point["y"] for point in plot.schema["data"]])
+            for plot in FigureManager.get_maidr(grid.figure)._plots
+        ]
+
+        assert named == [
+            ("b", [0.0, 10.0, 0.0]),
+            ("a", [10.0, 0.0, 0.0]),
+            ("c", [0.0, 0.0, 10.0]),
+        ]
+
+    @staticmethod
+    def _one_level() -> pd.DataFrame:
+        return pd.DataFrame({"v": list(np.linspace(0, 1, 10)), "g": ["a"] * 10})
+
+    def test_a_single_panel_holding_one_group_is_still_unnamed(self):
+        """The floor is right about one chart and has to stay right there.
+
+        A chart drawing one distribution has nothing to tell it apart from,
+        and a name would read as though it held more. Both spellings emit
+        `None` today and both must keep doing so -- naming only the `displot`
+        one would put the axes-level and figure-level spellings of one chart
+        out of step, which is the asymmetry #522, #446 and #590 were each
+        about.
+
+        This is also why the predicate is the panel count and not where the
+        legend was hung: seaborn's `FacetGrid` builds a *figure* legend for a
+        single panel too, so "the legend is figure-level" would name this one.
+        """
+        grid = sns.displot(self._one_level(), x="v", hue="g", bins=3)
+        assert self._names(grid.figure) == [None]
+
+        plt.close("all")
+        _, ax = plt.subplots()
+        sns.histplot(self._one_level(), x="v", hue="g", bins=3, ax=ax)
+        assert self._names(ax.get_figure()) == [None]


### PR DESCRIPTION
Closes #608. Follow-up to #591, whose binding half landed in #592 and whose remaining `[None]` is this.

## What was wrong

`names_for` declines a lone artist, and says so:

> A single container is left unnamed whatever the legend says: one distribution needs nothing to tell it apart from, and a name there would read as though the chart held more.

That asks whether an artist is alone **on its axes**. It is right about one chart and wrong about one panel of a grid, where the two questions come apart: the figure holds several distributions and the panel holds one of them.

Measured on seaborn 0.13.2, three groups with `col` putting `a` and `b` in one panel and `c` alone in the other:

| chart | before | after |
|---|---|---|
| `displot(x=, hue=, col=, bins=3)` | `['b', 'a', None]` | `['b', 'a', 'c']` |
| `displot(…, element="step")` | `['b', 'a', None]` | `['b', 'a', 'c']` |
| `displot(…, kind="kde")` | `['b', 'a', None]` | `['b', 'a', 'c']` |
| `displot(x=, hue=, bins=3)` — unfaceted control | `['c', 'b', 'a']` | unchanged |

A reader walking the layers heard two named distributions and then one that would not say which group it was — on a chart whose legend names it plainly, and whose unfaceted spelling names all three. The name was there for the asking:

```
panel 1 colours   [(0.173, 0.627, 0.173, 0.5)]
names_for   -> [None]
name_for    -> ['c']
```

`name_for` is the helper #595 added for exactly this shape: "wrong where a *layer* is the artist."

## The rule, stated once

`maidr/util/legend_names.names_for_panel(ax, colours, faceted)` sits beside the two helpers it chooses between. The five resolvers that reach the floor route through it:

| path | resolver |
|---|---|
| bars | `_group_names` |
| `element="step"`/`"poly"`, filled | `_names_for_panel(ax, [_face_colour(...)])` |
| `element="step"`/`"poly"`, `fill=False` | `_names_for_panel(ax, [_rgba(...)])` |
| `kind="kde"` curves | `_curve_names` |
| `kind="kde"` fills | `_fill_names` |

`faceted` is `len(plotter_axes(instance)) > 1`, read once per draw in each of the two per-panel loops (`histogram.py`, `kdeplot.py`) — a property of the grid, not of what any panel drew. Both axes-level entry points keep the default `False`, so `histplot` and `kdeplot` are untouched.

## Why the panel count and not the legend's placement

The tempting shortcut is "a *figure* legend names more than this panel, so a lone artist under one can be named." It is wrong: seaborn's `FacetGrid` builds a figure legend for a single panel too. Taking it would leave

```
displot(one_level, x="v", hue="g")   'a'     # figure legend, one panel
histplot(one_level, x="v", hue="g")  None    # axes legend
```

— the same chart, two spellings, two answers, which is the asymmetry #522, #446 and #590 were each about. Both emit `None` today and `test_a_single_panel_holding_one_group_is_still_unnamed` pins that they still do.

## Only the floor moves

Every other decline is unchanged: no legend, a colour no swatch claims, a colour two swatches claim. `test_the_panels_holding_two_groups_are_unchanged` asserts the two-group panel in order rather than sorted, so a name landing on the wrong layer — the thing #591 was about — still fails.

`TestAFacetedHistogramNamesEachPanelFromItself` (the #591 test) changes one expected value from `None` to `"c"`, and its docstring records that the failure it guards against is now three layers reading `'c', 'c', 'c'` rather than three `None`s. Either way the names would not be each panel's own, so it still pins the binding.

## Verification

- `tests/core/test_displot_distribution.py` → 41 passed (5 new)
- Full suite: **2930 passed, 18 skipped**
- `ruff check` clean on every touched file

Mutations, each applied alone against a restored baseline — all six killed:

| mutation | result |
|---|---|
| `names_for_panel` ignores `faceted` (floor always stands) | 5 failed |
| floor never stands (name any lone artist) | 1 failed |
| `faceted = len(panels) >= 1` | 1 failed |
| bars resolver drops `faceted` | 3 failed |
| outline registrar drops `faceted` | 1 failed |
| KDE registrar drops `faceted` | 1 failed |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_