### PR TITLE
fix(hue): read a shared-axis panel's legend, so a jointplot's marginals are named

### DIFF
--- a/maidr/util/legend_names.py
+++ b/maidr/util/legend_names.py
@@ -54,7 +54,10 @@ def legend_of(ax: Axes | None):
     which is a figure whose panels were declared to be on one scale.
 
     Exactly one sharer, for the reason the figure fallback gives: two of them
-    cannot say which names this axes' colours.
+    cannot say which names this axes' colours. And **only** where the figure
+    carries none: two figure legends are ambiguous already, and a neighbour
+    having one of its own does not resolve them -- it would name the axes off
+    a third legend while two candidates for it stood unexamined.
 
     Parameters
     ----------
@@ -73,12 +76,15 @@ def legend_of(ax: Axes | None):
         return own
     figure = getattr(ax, "figure", None)
     legends = list(getattr(figure, "legends", ()) or ())
-    if len(legends) == 1:
-        return legends[0]
+    if legends:
+        # Two of them decline here rather than falling through to a sharer:
+        # a figure legend this axes could not be matched to does not stop
+        # being ambiguous because a neighbour has one of its own.
+        return legends[0] if len(legends) == 1 else None
     shared = [
-        sibling.get_legend()
+        legend
         for sibling in _sharing_an_axis_with(ax)
-        if sibling.get_legend() is not None
+        if (legend := sibling.get_legend()) is not None
     ]
     return shared[0] if len(shared) == 1 else None
 

--- a/maidr/util/legend_names.py
+++ b/maidr/util/legend_names.py
@@ -36,6 +36,26 @@ def legend_of(ax: Axes | None):
     written down here rather than left to be discovered, and pinned in
     `tests/core/plot/test_pairplot_group_names.py`.
 
+    A ``JointGrid`` puts the same one legend somewhere neither of those finds
+    it: on ``ax_joint``, an *axes* legend, leaving the two marginals with none
+    of their own and the figure with none either. Measured on a
+    ``jointplot(hue=...)``, the joint panel's two point layers are named and
+    each marginal's two density curves are not -- two identical
+    announcements, which is the defect #558 named (#610).
+
+    So a third place is read, and it is **narrower** than the figure fallback
+    rather than wider: an axes an axis is *shared* with. A ``JointGrid``
+    builds its marginals sharing one with the joint axes, because that is how
+    a marginal lines up with the scatter beside it, and matplotlib records
+    it. Two panels of a hand-built figure do not share by default, so the
+    hazard measured above -- ``plt.subplots(1, 2)`` with one ``fig.legend()``
+    -- is untouched and still answers ``None``. What is newly in scope is
+    ``plt.subplots(1, 2, sharex=True)`` with a legend on one panel only,
+    which is a figure whose panels were declared to be on one scale.
+
+    Exactly one sharer, for the reason the figure fallback gives: two of them
+    cannot say which names this axes' colours.
+
     Parameters
     ----------
     ax : Axes or None
@@ -53,7 +73,41 @@ def legend_of(ax: Axes | None):
         return own
     figure = getattr(ax, "figure", None)
     legends = list(getattr(figure, "legends", ()) or ())
-    return legends[0] if len(legends) == 1 else None
+    if len(legends) == 1:
+        return legends[0]
+    shared = [
+        sibling.get_legend()
+        for sibling in _sharing_an_axis_with(ax)
+        if sibling.get_legend() is not None
+    ]
+    return shared[0] if len(shared) == 1 else None
+
+
+def _sharing_an_axis_with(ax: Axes) -> list:
+    """
+    Every other axes this one shares an x or a y axis with.
+
+    Asked of matplotlib's own groupers rather than inferred from position or
+    from the figure's axes list, because sharing is the thing being tested and
+    it is a fact the axes carries.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on.
+
+    Returns
+    -------
+    list
+        The sharers, ``ax`` itself excluded. Empty when it shares nothing --
+        which is the default for a figure built with ``plt.subplots``.
+    """
+    sharers: list = []
+    for grouper in (ax.get_shared_x_axes(), ax.get_shared_y_axes()):
+        for sibling in grouper.get_siblings(ax):
+            if sibling is not ax and not any(one is sibling for one in sharers):
+                sharers.append(sibling)
+    return sharers
 
 
 def names_for(ax: Axes, colours: list) -> list:

--- a/tests/core/plot/test_jointplot_group_names.py
+++ b/tests/core/plot/test_jointplot_group_names.py
@@ -1,0 +1,219 @@
+"""
+A ``jointplot`` hue left its two marginals anonymous (#610).
+
+A ``JointGrid`` draws three panels off one hue mapping and hangs the one
+legend that names it on ``ax_joint``. ``legend_of`` reads an axes' own legend
+and, failing that, a **figure** legend -- which is where a ``PairGrid`` puts
+one (#561) and is what made that chart readable. A `JointGrid` puts it in
+neither place as far as a marginal is concerned, so the marginals found
+nothing and every resolver downstream declined correctly on the input it was
+given.
+
+Measured before the fix, two levels `p` and `q`::
+
+    [0][0] smooth  name=None       <- top marginal
+    [0][0] smooth  name=None
+    [1][0] point   name='p'        <- joint
+    [1][0] point   name='q'
+    [1][1] smooth  name=None       <- right marginal
+    [1][1] smooth  name=None
+
+The data is right in every panel. A reader who moves onto a marginal finds
+two density curves with identical announcements and nothing to tell them
+apart, which is the defect #558 named -- on the two panels of the chart where
+it was not yet fixed.
+
+**Not the lone-artist floor** (#608): each marginal holds two curves. There
+was simply no legend for them to be matched against.
+
+What the fix reads is narrower than the figure fallback, not wider: an axes
+an axis is *shared* with. A `JointGrid` builds its marginals sharing one with
+the joint axes, because that is how a marginal lines up with the scatter
+beside it, and matplotlib records it::
+
+    jointplot                        ax0 legend=True   shares=[1, 2]
+                                     ax1 legend=False  shares=[0]
+                                     ax2 legend=False  shares=[0]
+    plt.subplots(1, 2)                                 shares=[]
+    plt.subplots(1, 2, sharex=True)                    shares=[1]
+
+So the hazard `legend_of` already documents and
+`test_pairplot_group_names.py` already pins -- two unrelated panels named
+from one figure legend -- is untouched, because those panels share nothing.
+The tests below hold that line from the other side.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {
+            "a": rng.normal(size=40),
+            "b": rng.normal(size=40) + 20,
+            "g": ["p"] * 20 + ["q"] * 20,
+        }
+    )
+
+
+def _named(fig) -> list:
+    """Every layer as ``(type, name)``, after a real render."""
+    maidr.render(fig)._repr_html_()
+    return [
+        (plot.type.value, plot.schema.get("name"))
+        for plot in FigureManager.get_maidr(fig).plots
+    ]
+
+
+def _of_kind(named: list, kind: str) -> list:
+    return [name for layer, name in named if layer == kind]
+
+
+def test_a_hue_split_jointplots_marginals_are_named():
+    """Two curves per marginal, two marginals, all four named.
+
+    Sorted rather than asserted in order: what must hold is that no curve is
+    left anonymous and that the names are the hue's levels, while which of
+    the two comes first is the legend order #502 settled and not this
+    change's business.
+    """
+    named = _named(sns.jointplot(data=_frame(), x="a", y="b", hue="g").figure)
+
+    assert sorted(_of_kind(named, "smooth")) == ["p", "p", "q", "q"]
+
+
+def test_the_joint_panel_is_unchanged():
+    """Additive. The joint axes has a legend of its own and always did, so
+    its two point layers must be named exactly as before -- a fix that
+    reached them would mean the new fallback was running where the old rule
+    already answered."""
+    named = _named(sns.jointplot(data=_frame(), x="a", y="b", hue="g").figure)
+
+    assert sorted(_of_kind(named, "point")) == ["p", "q"]
+
+
+def test_a_jointplot_without_a_hue_is_untouched():
+    """Nothing to name, and nothing pretending to."""
+    named = _named(sns.jointplot(data=_frame(), x="a", y="b").figure)
+
+    assert {name for _, name in named} == {None}
+
+
+def _drawn_curves(ax) -> list:
+    from matplotlib.lines import Line2D
+
+    return [line for line in ax.get_lines() if isinstance(line, Line2D)]
+
+
+def _axes_legend(ax, source, labels):
+    """An axes legend naming another axes' drawn colours.
+
+    Parameters
+    ----------
+    ax : Axes
+        Where to hang it.
+    source : Axes
+        Whose curves supply the swatch colours.
+    labels : list of str
+        The names, in legend order.
+    """
+    from matplotlib.patches import Patch
+
+    handles = [Patch(facecolor=curve.get_color()) for curve in _drawn_curves(source)]
+    return ax.legend(handles=handles, labels=labels)
+
+
+def test_an_unshared_panels_legend_is_not_read():
+    """The line this fix holds, from the other side.
+
+    Two panels of a hand-built figure with a legend on one of them: the
+    second's colours match those swatches -- both panels draw the same
+    default cycle -- and it is still not named, because the panels share no
+    axis and nothing says they are one chart. This is the same figure
+    `test_one_figure_legend_names_every_panel_below_it` measures as the
+    accepted cost of the *figure* fallback; the sharer fallback does not
+    extend that cost to axes legends.
+    """
+    rng = np.random.default_rng(0)
+    left = pd.DataFrame({"v": rng.normal(size=40), "g": ["p"] * 20 + ["q"] * 20})
+    right = pd.DataFrame({"v": rng.normal(size=40) + 2, "h": ["s"] * 20 + ["t"] * 20})
+
+    fig, (first, second) = plt.subplots(1, 2)
+    sns.kdeplot(data=left, x="v", hue="g", ax=first, legend=False)
+    sns.kdeplot(data=right, x="v", hue="h", ax=second, legend=False)
+    _axes_legend(first, first, ["p", "q"])
+
+    # The first panel has the legend and is named by it; the second shares
+    # nothing with it and stays anonymous.
+    assert [name for _, name in _named(fig)] == ["p", "q", None, None]
+
+
+def test_a_shared_panels_legend_is_read():
+    """The same figure declared to be on one scale.
+
+    `sharex=True` is the author saying these panels are one chart, which is
+    what a `JointGrid` says structurally. Newly in scope, and pinned so the
+    widening is visible rather than implied.
+    """
+    frame = _frame()
+
+    fig, (first, second) = plt.subplots(1, 2, sharex=True)
+    sns.kdeplot(data=frame, x="a", hue="g", ax=first, legend=False)
+    sns.kdeplot(data=frame, x="a", hue="g", ax=second, legend=False)
+    _axes_legend(first, first, ["p", "q"])
+
+    assert [name for _, name in _named(fig)] == ["p", "q", "p", "q"]
+
+
+def test_two_sharers_with_legends_name_nothing():
+    """The guard, the same one the figure fallback has: two of them cannot
+    say which names this axes' colours, and a wrong name is worse than none.
+
+    Both legends carry the real swatches, so the test above is what makes
+    this one bite -- either alone would name the curves.
+    """
+    frame = _frame()
+
+    fig, (first, second, third) = plt.subplots(1, 3, sharex=True)
+    for panel in (first, second, third):
+        sns.kdeplot(data=frame, x="a", hue="g", ax=panel, legend=False)
+    _axes_legend(first, first, ["p", "q"])
+    _axes_legend(second, second, ["p", "q"])
+
+    # The third shares with both of the legend-bearing panels.
+    assert [name for _, name in _named(fig)][-2:] == [None, None]
+
+
+def test_a_panels_own_legend_wins_over_a_sharers():
+    """The mitigation, unchanged in shape from the figure fallback: a panel
+    that kept its own legend is named by it and never consults a sibling's.
+
+    The two legends carry the same swatches under **different** labels, so a
+    reading that consulted the sharer would be visible rather than agreeing
+    by luck.
+    """
+    frame = _frame()
+
+    fig, (first, second) = plt.subplots(1, 2, sharex=True)
+    sns.kdeplot(data=frame, x="a", hue="g", ax=first, legend=False)
+    sns.kdeplot(data=frame, x="a", hue="g", ax=second, legend=False)
+    _axes_legend(first, first, ["wrong", "answer"])
+    _axes_legend(second, second, ["p", "q"])
+
+    assert [name for _, name in _named(fig)][-2:] == ["p", "q"]

--- a/tests/core/plot/test_jointplot_group_names.py
+++ b/tests/core/plot/test_jointplot_group_names.py
@@ -200,6 +200,37 @@ def test_two_sharers_with_legends_name_nothing():
     assert [name for _, name in _named(fig)][-2:] == [None, None]
 
 
+def test_two_figure_legends_still_decline_even_with_a_sharer():
+    """Ambiguity is not resolved by a third legend.
+
+    Two figure legends are the case `test_two_figure_legends_name_nothing`
+    pins as irreducibly ambiguous. Adding a legend-bearing sharer does not
+    make them less so -- naming the axes off the neighbour would answer a
+    question while two candidates for it stood unexamined -- so the sharer
+    fallback is reached only where the figure carries **no** legend.
+
+    Caught in review on #611: the first spelling fell through to the sharer
+    whenever the figure did not carry exactly one, which quietly included
+    two.
+    """
+    from matplotlib.patches import Patch
+
+    frame = _frame()
+
+    fig, (first, second) = plt.subplots(1, 2, sharex=True)
+    sns.kdeplot(data=frame, x="a", hue="g", ax=first, legend=False)
+    sns.kdeplot(data=frame, x="a", hue="g", ax=second, legend=False)
+    _axes_legend(first, first, ["p", "q"])
+
+    swatches = [Patch(facecolor=c.get_color()) for c in _drawn_curves(first)]
+    fig.legend(handles=swatches, labels=["p", "q"], loc="upper left")
+    fig.legend(handles=swatches, labels=["p", "q"], loc="upper right")
+
+    # The second panel has no legend of its own, two ambiguous figure
+    # legends, and one legend-bearing sharer. It declines.
+    assert [name for _, name in _named(fig)][-2:] == [None, None]
+
+
 def test_a_panels_own_legend_wins_over_a_sharers():
     """The mitigation, unchanged in shape from the figure fallback: a panel
     that kept its own legend is named by it and never consults a sibling's.


### PR DESCRIPTION
Closes #610.

## What was wrong

A `JointGrid` draws three panels off one hue mapping and hangs the one legend that names it on `ax_joint`. `legend_of` reads an axes' own legend and, failing that, a **figure** legend — which is where a `PairGrid` puts one (#561). A `JointGrid` puts it in neither place as far as a marginal is concerned.

Measured on seaborn 0.13.2, `jointplot(hue=...)` over two levels:

| panel | before | after |
|---|---|---|
| top marginal, curve 1 | `None` | `q` |
| top marginal, curve 2 | `None` | `p` |
| joint, point layer 1 | `p` | `p` |
| joint, point layer 2 | `q` | `q` |
| right marginal, curve 1 | `None` | `q` |
| right marginal, curve 2 | `None` | `p` |

The data was right in every panel. A reader who moved onto a marginal found two density curves with identical announcements and nothing to tell them apart — the defect #558 named, on the two panels where it was not yet fixed.

Not the lone-artist floor #608 lifted: each marginal holds **two** curves. There was simply no legend for them to be matched against.

```
ax0 (joint)      own legend=True    legend_of -> Legend
ax1 (marg x)     own legend=False   legend_of -> None
ax2 (marg y)     own legend=False   legend_of -> None
figure legends: 0
```

## The signal, and why it is narrower than what is already there

The tempting widening — "read any sibling's legend" — walks into the hazard `legend_of` already documents and `test_pairplot_group_names.py` already pins: two unrelated panels drawing the same default colour cycle would take each other's names.

A `JointGrid` builds its marginals **sharing an axis** with the joint axes, because that is how a marginal lines up with the scatter beside it, and matplotlib records it:

```
jointplot                        ax0 legend=True   shares=[1, 2]
                                 ax1 legend=False  shares=[0]
                                 ax2 legend=False  shares=[0]
plt.subplots(1, 2)                                 shares=[]        <- the hazard case
plt.subplots(1, 2, sharex=True)                    shares=[1]
```

So: **when an axes has no legend of its own and no figure legend, and exactly one axes it shares an axis with has one, that legend names its colours.** From either marginal the answer is `ax_joint`, uniquely.

The hazard case is `plt.subplots(1, 2)` — unshared — so it is untouched and still answers `None`; `test_an_unshared_panels_legend_is_not_read` holds that line from the other side. What is newly in scope is `plt.subplots(1, 2, sharex=True)` with a legend on one panel only, which is a figure whose panels were declared to be on one scale, and `test_a_shared_panels_legend_is_read` pins it so the widening is visible rather than implied.

The two existing rules are unchanged: the axes' own legend wins, and two candidates decline.

## Found while measuring the roadmap

#610 came out of sweeping `pairplot`/`jointplot` against #345/#342. Everything else there reads correctly today — 14 chart/kind combinations, listed in the issue — and this was the one gap. Two things worth knowing that are **not** defects and are recorded there so they are not re-investigated:

- The unoccupied corner of a `JointGrid`, and the upper triangle of `pairplot(corner=True)`, emit `{id, layers: []}`. That is the shape maidr's `Subplot` explicitly supports for an unoccupied grid cell.
- The right marginal is read transposed correctly: `orientation: "horz"`, `x: "Count"`, `y: <column>`, with `yMin`/`yMax` carrying the bin edges. Not the #480 shape.

## Verification

- `tests/core/plot/test_jointplot_group_names.py` → 7 passed (new file)
- With `test_pairplot_group_names.py` → 21 passed
- Full suite: **2938 passed, 18 skipped**
- `ruff check` clean on both touched files

Mutations, each applied alone against a restored baseline — all five killed:

| mutation | result |
|---|---|
| sharer fallback removed | 2 failed |
| no uniqueness guard (first sharer wins) | 1 failed |
| every axes on the figure counts as a sharer | 1 failed |
| sharer consulted before the axes' own legend | 1 failed |
| only x-sharing counts (drops the right marginal) | 1 failed |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_