### PR TITLE
feat(seaborn): read the marks of seaborn.objects, which registered nothing

### DIFF
--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -38,5 +38,6 @@ from . import (  # noqa: E402, F401
     candlestick,
     mplfinance,
     violinplot,
+    seaborn_objects,
     seaborn_probe,
 )

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -245,7 +245,7 @@ def _wrap() -> None:
     except ImportError:  # pragma: no cover - seaborn without the objects API
         Plotter = None  # type: ignore[assignment]
 
-    if Plotter is None or not hasattr(Plotter, "_plot_layer"):  # pragma: no cover
+    if Plotter is None or not hasattr(Plotter, "_plot_layer"):
         warnings.warn(
             "maidr: seaborn._core.plot.Plotter._plot_layer is not there to "
             "wrap, so seaborn.objects charts are not read. Every mark -- "

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -1,0 +1,263 @@
+"""Read the marks of ``seaborn.objects``, seaborn's declarative interface."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, NamedTuple
+
+import wrapt
+from matplotlib.axes import Axes
+from matplotlib.collections import PathCollection
+from matplotlib.container import BarContainer
+from matplotlib.lines import Line2D
+
+from maidr.core.context_manager import ContextManager
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.barplot import DRAWN_BARS
+from maidr.core.plot.scatterplot import DRAWN_POINTS
+from maidr.patch.common import _draw_quietly
+
+
+class _Reading(NamedTuple):
+    """
+    How one mark is read: what it is, where it lands, and how it is handed on.
+
+    Attributes
+    ----------
+    plot_type : PlotType
+        What the layer is registered as.
+    holder : str
+        The ``Axes`` attribute the mark's artists arrive in -- ``collections``,
+        ``lines`` or ``containers``. Read by name because that is what makes
+        the before-and-after diff possible without knowing how many artists a
+        mark makes.
+    artist : type
+        The artist class to keep. The holder is filtered by it rather than
+        taken whole, so a layer that lands beside an unrelated artist of
+        another class in the same list describes only its own.
+    binding : str
+        The keyword the artists are handed over under, which is the existing
+        plot class' own: nothing new is extracted for any of these marks.
+    singular : bool
+        Whether that keyword names **one** artist rather than the list.
+        ``DRAWN_BARS`` does, because ``Axes.bar`` draws exactly one container
+        and ``BarPlot`` wraps what it is given in a list of one. So a reading
+        that finds several becomes several layers rather than one truncated
+        to the first -- which is also how a hue-grouped bar is already read
+        elsewhere (#593, #595), one layer per group. Measured, no ``so.Bar``
+        spelling reaches that branch: plain, horizontal, ``color=``,
+        ``Dodge()``, ``Stack()``, ``Hist()`` and faceted are each a single
+        container of n bars.
+    """
+
+    plot_type: PlotType
+    holder: str
+    artist: type
+    binding: str
+    singular: bool = False
+
+
+#: The marks read today, keyed by class name.
+#:
+#: By **name** rather than by ``isinstance``, and that is load-bearing here
+#: rather than a style choice. seaborn's mark hierarchy does not track what a
+#: mark draws::
+#:
+#:     Line  < Path  < Mark      Line2D
+#:     Dash  < Paths < Mark      LineCollection
+#:     Range < Paths < Mark      LineCollection
+#:
+#: ``Dash`` and ``Range`` are ``Paths`` subclasses that draw a
+#: ``LineCollection``, so dispatching on ancestry would claim two marks whose
+#: artists this cannot read -- the shape xability/r-maidr#225 hit from the
+#: other side, where ``class(geom)[1]`` declined a subclass that *was*
+#: readable. A name misses a mark seaborn renames; ancestry would claim one it
+#: cannot read, and a wrong reading is worse than a missing one.
+#:
+#: A caller's own ``Mark`` subclass is declined for the same reason: it is not
+#: in this table, and what it draws is not knowable from the class it came
+#: from.
+_READINGS: dict[str, _Reading] = {
+    "Dot": _Reading(PlotType.SCATTER, "collections", PathCollection, DRAWN_POINTS),
+    "Dots": _Reading(PlotType.SCATTER, "collections", PathCollection, DRAWN_POINTS),
+    "Line": _Reading(PlotType.LINE, "lines", Line2D, "lines"),
+    "Path": _Reading(PlotType.LINE, "lines", Line2D, "lines"),
+    "Bar": _Reading(PlotType.BAR, "containers", BarContainer, DRAWN_BARS, True),
+}
+
+
+def _reading_for(layer: Any) -> _Reading | None:
+    """
+    How to read one layer, or ``None`` when its mark is not one of these.
+
+    Parameters
+    ----------
+    layer : Any
+        The layer ``Plotter._plot_layer`` was handed. A ``TypedDict`` at type
+        level and a plain dict at runtime; anything else declines.
+
+    Returns
+    -------
+    _Reading or None
+        ``None`` leaves the layer exactly as it was, which is unregistered.
+    """
+    if not isinstance(layer, dict):
+        return None
+    return _READINGS.get(type(layer.get("mark")).__name__)
+
+
+def _held(ax: Axes, reading: _Reading) -> list:
+    """
+    The artists of this reading's kind currently on one axes.
+
+    Parameters
+    ----------
+    ax : Axes
+        The panel to look at.
+    reading : _Reading
+        Which holder to read and which class to keep.
+
+    Returns
+    -------
+    list
+        In the order the axes holds them, which is the order they were drawn.
+    """
+    return [
+        artist
+        for artist in getattr(ax, reading.holder, [])
+        if isinstance(artist, reading.artist)
+    ]
+
+
+def _panels(plotter: Any) -> list[Axes]:
+    """
+    Every axes the figure being drawn holds.
+
+    Read off the figure rather than off ``Plotter._subplots``, because the
+    diff below already decides which of them this layer drew on: a panel that
+    gained nothing registers nothing, whether it is one seaborn allocated and
+    left empty or one the caller drew on themselves before handing the figure
+    over. Asking the figure is one internal instead of two.
+
+    Parameters
+    ----------
+    plotter : Any
+        The ``Plotter`` the wrapped method is bound to.
+
+    Returns
+    -------
+    list of Axes
+        Possibly empty, which makes the caller a no-op rather than a guess.
+    """
+    figure = getattr(plotter, "_figure", None)
+    return [ax for ax in getattr(figure, "axes", [])]
+
+
+def _layer(wrapped, instance, args, kwargs) -> Any:
+    """
+    Draw one ``seaborn.objects`` layer and register what it drew.
+
+    ``Plotter._plot_layer`` runs once per ``.add()`` and draws that layer
+    across every panel, so this is the one place where "which artists belong
+    to which layer" is still answerable. Taking the axes' artists before and
+    after the call answers it exactly, and without predicting how many a mark
+    makes -- ``so.Line(color=...)`` draws one ``Line2D`` per level, and a
+    faceted layer draws on some panels and not others.
+
+    A mark that is not in :data:`_READINGS` is drawn and left alone entirely,
+    rather than drawn inside the internal context. That keeps the change
+    additive by construction: every unread mark registers exactly what it
+    registered before, which is nothing.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Plotter._plot_layer``.
+    instance : Any
+        The plotter it was called on.
+    args, kwargs : Any
+        As seaborn passed them: ``(p, layer)``.
+
+    Returns
+    -------
+    Any
+        Whatever ``_plot_layer`` returned, unchanged.
+    """
+    if ContextManager.is_internal_context():
+        return _draw_quietly(wrapped, args, kwargs)
+
+    layer = kwargs.get("layer", args[1] if len(args) > 1 else None)
+    reading = _reading_for(layer)
+    if reading is None:
+        return _draw_quietly(wrapped, args, kwargs)
+
+    panels = _panels(instance)
+    before = {id(ax): {id(artist) for artist in _held(ax, reading)} for ax in panels}
+
+    with ContextManager.set_internal_context():
+        drawn = _draw_quietly(wrapped, args, kwargs)
+
+    for ax in panels:
+        own = [
+            artist for artist in _held(ax, reading) if id(artist) not in before[id(ax)]
+        ]
+        # A panel this layer did not draw on registers nothing rather than an
+        # empty layer, which the reader would be offered and find nothing in
+        # (#421). A `col`/`row` grid allocates a panel per combination whether
+        # the data holds one or not, so this is the ordinary case and not an
+        # edge of it.
+        if not own:
+            continue
+        handovers = (
+            [{reading.binding: one} for one in own]
+            if reading.singular
+            else [{reading.binding: own}]
+        )
+        for handover in handovers:
+            FigureManager.create_maidr(ax, reading.plot_type, **handover)
+
+    return drawn
+
+
+def _wrap() -> None:
+    """
+    Wrap the per-layer draw, or say why it could not be.
+
+    ``seaborn._core.plot.Plotter._plot_layer`` is private twice over -- a
+    private method of a private module -- which is why this is guarded where
+    ``maidr/patch/histogram.py`` and its neighbours are not. Those wrap
+    ``_CategoricalPlotter`` and ``_DistributionPlotter`` methods that
+    ``maidr/patch/_seaborn_version.py`` states a floor for, and a seaborn
+    below it is turned into a readable ``ImportError``. There is no such floor
+    to state here: the name could move in a minor release, and letting that
+    take ``import maidr`` down with it would break every *classic* seaborn
+    chart over a mark nobody in that process drew.
+
+    Warns
+    -----
+    UserWarning
+        When the method cannot be found, naming what stops reading as a
+        consequence.
+    """
+    try:
+        from seaborn._core.plot import Plotter
+    except ImportError:  # pragma: no cover - seaborn without the objects API
+        Plotter = None  # type: ignore[assignment]
+
+    if Plotter is None or not hasattr(Plotter, "_plot_layer"):  # pragma: no cover
+        warnings.warn(
+            "maidr: seaborn._core.plot.Plotter._plot_layer is not there to "
+            "wrap, so seaborn.objects charts are not read. Every mark -- "
+            "so.Dot, so.Line, so.Bar -- draws through the artist API rather "
+            "than through Axes.scatter/plot/bar, so nothing else picks them "
+            "up and the chart registers no layers at all. Charts written "
+            "with the classic seaborn functions are unaffected.",
+            stacklevel=2,
+        )
+        return
+
+    wrapt.wrap_function_wrapper(Plotter, "_plot_layer", _layer)
+
+
+_wrap()

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -540,3 +540,61 @@ def test_a_colour_split_bar_draws_one_container_and_reads_as_one_layer(spelling,
 
     assert len(figure.axes[0].containers) == 1
     assert _kinds(figure) == ["bar"]
+
+
+@pytest.mark.parametrize(
+    "mark, expected",
+    [
+        pytest.param(so.Dot(), "point", id="Dot"),
+        pytest.param(so.Line(), "line", id="Line"),
+        pytest.param(so.Bar(), "bar", id="Bar"),
+    ],
+)
+def test_every_mark_reads_one_layer_per_panel_when_faceted(mark, expected):
+    """The panel diff is shared, but what each mark draws into it is not.
+
+    `Line` draws one `Line2D` per group and `Bar` one container per panel, so
+    a facet case for each is not a repeat of the `Dot` one: it is the only
+    place the three handovers meet the per-panel branch.
+    """
+    frame = _frame()
+    figure = _drawn(
+        lambda fig: so.Plot(frame, x="t", y="m").facet(col="g").add(mark).on(fig).plot()
+    )
+
+    assert _kinds(figure) == [expected, expected]
+
+
+def test_a_layer_that_drew_several_containers_becomes_several_bar_layers():
+    """The ``singular=True`` branch, which no ``so.Bar`` spelling reaches.
+
+    `DRAWN_BARS` names one container, so a layer that drew several has to
+    become several layers rather than one truncated to the first — which is
+    also how a hue-grouped bar is read elsewhere (#593, #595), one layer per
+    group. Every `so.Bar` measured draws exactly one container, so the branch
+    is forward-looking: it would be exercised for the first time, silently,
+    by a seaborn release that changed that.
+
+    Driven through `_layer` itself rather than through a chart, because a
+    chart cannot reach it today. The draw runs inside the internal context
+    `_layer` sets, so the two `Axes.bar` calls register nothing of their own
+    and what comes back is this layer's reading alone.
+    """
+    from maidr.patch.seaborn_objects import _layer
+
+    figure = plt.figure()
+    axes = figure.subplots()
+
+    class _Plotter:
+        """Only the attribute the panel lookup reads."""
+
+        _figure = figure
+
+    def draw(*args, **kwargs):
+        axes.bar(["a"], [4.0])
+        axes.bar(["b"], [9.0])
+
+    _layer(draw, _Plotter(), (None, {"mark": so.Bar()}), {})
+
+    assert len(axes.containers) == 2
+    assert _kinds(figure) == ["bar", "bar"]

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -458,3 +458,85 @@ def test_a_reading_takes_only_its_own_artist_class_from_a_holder():
 
     assert _held(axes, _READINGS["Dot"]) == [points]
     assert _held(axes, _READINGS["Bar"]) == [bars]
+
+
+def test_the_hook_still_takes_the_layer_as_its_second_argument():
+    """`_plot_layer(p, layer)` is a private method of a private module.
+
+    Nothing else in this file would notice a seaborn release that reordered
+    those two: the layer would read as `None`, `_reading_for` would decline
+    it, and every chart would go back to registering nothing -- silently,
+    because that is also what a mark outside the table does. Pinned so the
+    failure is one loud test rather than a whole interface quietly going dark
+    again.
+    """
+    import inspect
+
+    from seaborn._core.plot import Plotter
+
+    assert list(inspect.signature(Plotter._plot_layer).parameters) == [
+        "self",
+        "p",
+        "layer",
+    ]
+
+
+def test_a_seaborn_that_moved_the_hook_warns_rather_than_failing_the_import(
+    monkeypatch,
+):
+    """The branch the "guarded, unlike the other seaborn patches" argument
+    rests on, verified rather than reasoned about.
+
+    `maidr/patch/_seaborn_version.py` turns a missing
+    `_CategoricalPlotter.plot_bars` into a readable `ImportError`, because
+    there is a version floor to state. There is none to state for a
+    private-of-private method, so this path must leave `import maidr`
+    working -- a rename here would otherwise break every *classic* seaborn
+    chart over a mark nobody in that process drew.
+    """
+    import seaborn._core.plot as plot_module
+
+    from maidr.patch import seaborn_objects
+
+    class Moved:
+        """A Plotter that no longer has the method."""
+
+    monkeypatch.setattr(plot_module, "Plotter", Moved)
+
+    with pytest.warns(UserWarning, match=r"_plot_layer"):
+        seaborn_objects._wrap()
+
+    assert not hasattr(Moved, "_plot_layer")
+
+
+@pytest.mark.parametrize(
+    "spelling, build",
+    [
+        pytest.param("plain", lambda plot: plot.add(so.Bar()), id="plain"),
+        pytest.param(
+            "dodged", lambda plot: plot.add(so.Bar(), so.Dodge()), id="dodged"
+        ),
+        pytest.param(
+            "stacked", lambda plot: plot.add(so.Bar(), so.Stack()), id="stacked"
+        ),
+    ],
+)
+def test_a_colour_split_bar_draws_one_container_and_reads_as_one_layer(spelling, build):
+    """`DRAWN_BARS` names a single container, so a reading that found several
+    would become several layers.
+
+    Measured rather than claimed: every `so.Bar` spelling draws exactly one
+    `BarContainer` holding every bar, `color=` and `Dodge()` and `Stack()`
+    included -- unlike the classic `seaborn.barplot`, which draws one
+    container per hue level. So the branch is real but unreached, and this
+    says which of the two is true today.
+
+    What a stacked bar should be *read* as is a separate question and not
+    settled here: it reads as a plain `bar` of every segment, which is the
+    same shape #615 lists as follow-up work.
+    """
+    figure = plt.figure()
+    build(so.Plot(_frame(), x="cat", y="val", color="g")).on(figure).plot()
+
+    assert len(figure.axes[0].containers) == 1
+    assert _kinds(figure) == ["bar"]

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -1,0 +1,460 @@
+"""
+Every ``seaborn.objects`` mark registered nothing at all (#615).
+
+`seaborn.objects` is seaborn's declarative interface, and py-maidr read none
+of it. Not one plot type missing -- the whole front door. Measured before the
+fix, each row one `.add()`::
+
+    so.Plot(frame, x=, y=).add(so.Dot())    NOTHING REGISTERED
+                          .add(so.Line())   NOTHING REGISTERED
+                          .add(so.Bar())    NOTHING REGISTERED
+    sns.scatterplot(...)                    ['point']
+    sns.lineplot(...)                       ['line']
+    sns.barplot(...)                        ['bar']
+
+The same charts, written the way seaborn now teaches, going silent.
+
+`maidr/patch/` wraps the *user-facing* drawing calls -- `Axes.scatter`,
+`Axes.plot`, `Axes.bar`. A `Mark` calls none of them; it draws through the
+artist API (`ax.add_collection`, `ax.add_line`, `ax.add_patch`), so nothing
+was there to fire.
+
+`Plotter._plot_layer` runs once per `.add()` and draws that layer across
+every panel, which makes it the one place where "which artists belong to
+which layer" is still answerable. Taking each axes' artists before and after
+answers it without predicting how many a mark makes -- `so.Line(color=)`
+draws one `Line2D` per level, and a faceted layer draws on some panels and
+not others.
+
+Three marks needed no new extraction: `ScatterPlot` already takes a
+collection, `LinePlot` a list of lines, and `BarPlot` a container.
+"""
+
+from __future__ import annotations
+
+import re
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import seaborn.objects as so
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    # Values chosen so no two are equal and none is a position: a reading
+    # that paired a magnitude with the wrong category is then visible rather
+    # than hidden behind a coincidence.
+    return pd.DataFrame(
+        {
+            "cat": ["a", "b", "c"],
+            "val": [4.0, 9.0, 2.0],
+            "t": [1.0, 2.0, 3.0],
+            "m": [10.0, 30.0, 20.0],
+            "g": ["p", "p", "q"],
+        }
+    )
+
+
+def _drawn(build) -> plt.Figure:
+    """Draw a ``so.Plot`` onto a figure the caller can hand to maidr."""
+    figure = plt.figure()
+    build(figure)
+    return figure
+
+
+def _layers(figure) -> list[tuple[str, dict]]:
+    """Every layer as ``(type, schema)``, after a real render."""
+    maidr.render(figure)._repr_html_()
+    return [
+        (plot.type.value, plot.schema) for plot in FigureManager.get_maidr(figure).plots
+    ]
+
+
+def _kinds(figure) -> list[str]:
+    return [kind for kind, _ in _layers(figure)]
+
+
+def _registers_nothing(figure) -> bool:
+    """Whether the figure reaches maidr as no chart at all.
+
+    Asked of the ``FigureManager`` rather than of ``render``, because
+    ``render`` no longer raises for an unsupported figure -- it warns and
+    emits a static image instead (#443), which is a fallback rather than an
+    answer to this question.
+    """
+    from maidr.exception.unsupported_plot_error import UnsupportedPlotError
+
+    try:
+        return not FigureManager.get_maidr(figure).plots
+    except UnsupportedPlotError:
+        return True
+
+
+def test_a_dot_mark_reads_as_the_scatter_it_draws():
+    """The chart the seaborn tutorial opens with."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Dot()).on(fig).plot()
+    )
+    kind, schema = _layers(figure)[0]
+
+    assert kind == "point"
+    assert [(point["x"], point["y"]) for point in schema["data"]] == [
+        (1.0, 10.0),
+        (2.0, 30.0),
+        (3.0, 20.0),
+    ]
+
+
+def test_a_dots_mark_reads_the_same_way():
+    """`so.Dots` is the many-points spelling and draws the same artist."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Dots()).on(fig).plot()
+    )
+
+    assert _kinds(figure) == ["point"]
+
+
+def test_a_line_mark_reads_as_one_series():
+    """A `Line2D` per group, and one group here."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Line()).on(fig).plot()
+    )
+    kind, schema = _layers(figure)[0]
+
+    assert kind == "line"
+    assert [(point["x"], point["y"]) for point in schema["data"][0]] == [
+        (1.0, 10.0),
+        (2.0, 30.0),
+        (3.0, 20.0),
+    ]
+
+
+def test_a_path_mark_reads_as_a_line_too():
+    """`so.Path` is `so.Line` without the sort, and draws the same artist."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Path()).on(fig).plot()
+    )
+
+    assert _kinds(figure) == ["line"]
+
+
+def test_a_bar_mark_reads_its_categories_and_magnitudes():
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="cat", y="val").add(so.Bar()).on(fig).plot()
+    )
+    kind, schema = _layers(figure)[0]
+
+    assert kind == "bar"
+    assert schema["orientation"] == "vert"
+    assert [(bar["x"], bar["y"]) for bar in schema["data"]] == [
+        ("a", 4.0),
+        ("b", 9.0),
+        ("c", 2.0),
+    ]
+
+
+def test_a_bar_drawn_the_other_way_round_says_so():
+    """`x=` the magnitude and `y=` the category is a horizontal bar.
+
+    The orientation comes off the `BarContainer` seaborn builds, which is
+    also where `Axes.barh` leaves it -- so the two spellings of a horizontal
+    bar reach the reader identically, magnitude on x and label on y.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), y="cat", x="val").add(so.Bar()).on(fig).plot()
+    )
+    _, schema = _layers(figure)[0]
+
+    assert schema["orientation"] == "horz"
+    assert [(bar["x"], bar["y"]) for bar in schema["data"]] == [
+        (4.0, "a"),
+        (9.0, "b"),
+        (2.0, "c"),
+    ]
+
+
+def test_a_binned_bar_reads_the_bins_the_stat_made():
+    """`so.Hist()` bins before the mark draws, so what is read is the counts.
+
+    The point of asking: the layer's own `data` frame still holds the raw
+    rows at this stage, so a reading taken from seaborn's frame rather than
+    from the artists would announce three observations where three bins were
+    drawn.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="m")
+        .add(so.Bar(), so.Hist(bins=3))
+        .on(fig)
+        .plot()
+    )
+    _, schema = _layers(figure)[0]
+
+    assert [bar["y"] for bar in schema["data"]] == [1.0, 1.0, 1.0]
+
+
+def test_two_marks_read_as_two_layers_in_the_order_they_were_added():
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m")
+        .add(so.Dot())
+        .add(so.Line())
+        .on(fig)
+        .plot()
+    )
+
+    assert _kinds(figure) == ["point", "line"]
+
+
+def test_a_colour_split_line_is_one_layer_of_several_series():
+    """`color=` draws one `Line2D` per level.
+
+    All of them belong to the one `.add()`, so they are one layer with a
+    series each -- not a layer apiece, which would announce a single mark as
+    two charts.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m", color="g")
+        .add(so.Line())
+        .on(fig)
+        .plot()
+    )
+    kind, schema = _layers(figure)[0]
+
+    assert kind == "line"
+    assert [len(series) for series in schema["data"]] == [2, 1]
+
+
+def test_each_facet_panel_reads_its_own_rows():
+    """One layer per panel, holding that panel's data and no other's."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m")
+        .facet(col="g")
+        .add(so.Dot())
+        .on(fig)
+        .plot()
+    )
+    layers = _layers(figure)
+
+    assert [kind for kind, _ in layers] == ["point", "point"]
+    assert [[point["x"] for point in schema["data"]] for _, schema in layers] == [
+        [1.0, 2.0],
+        [3.0],
+    ]
+
+
+def test_a_panel_the_layer_never_drew_on_registers_nothing():
+    """A `col`/`row` grid allocates a panel per combination whether the data
+    holds one or not.
+
+    Registering the empty ones would offer the reader a layer to walk into
+    and find nothing in -- the phantom-layer shape of #421. Here `p` has no
+    `y` row and `q` no `x` row, so two of the four panels are empty.
+    """
+    frame = _frame().assign(row=["x", "x", "y"])
+    figure = _drawn(
+        lambda fig: so.Plot(frame, x="t", y="m")
+        .facet(col="g", row="row")
+        .add(so.Dot())
+        .on(fig)
+        .plot()
+    )
+
+    assert len(_layers(figure)) == 2
+
+
+@pytest.mark.parametrize(
+    "mark",
+    [
+        pytest.param(so.Area(), id="Area"),
+        pytest.param(so.Bars(), id="Bars"),
+        pytest.param(so.Lines(), id="Lines"),
+        pytest.param(so.Paths(), id="Paths"),
+        pytest.param(so.Dash(), id="Dash"),
+        pytest.param(so.Text(), id="Text"),
+    ],
+)
+def test_a_mark_this_does_not_read_still_registers_nothing(mark):
+    """The additive guarantee, asserted rather than assumed.
+
+    Each of these registered nothing before and must register nothing now: a
+    mark whose artists no existing plot class can read is left alone, not
+    guessed at. `Dash` and `Paths` matter most -- see the test below.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(mark).on(fig).plot()
+    )
+
+    assert _registers_nothing(figure)
+
+
+def test_the_marks_are_matched_by_name_and_not_by_ancestry():
+    """seaborn's mark hierarchy does not track what a mark draws::
+
+        Line  < Path  < Mark      Line2D
+        Dash  < Paths < Mark      LineCollection
+        Range < Paths < Mark      LineCollection
+
+    So dispatching on ancestry would claim `Dash` and `Range` as lines and
+    read a `LineCollection` through `LinePlot`, which cannot see it. This
+    pins the hierarchy itself, so the seaborn release that changes it fails
+    here rather than silently widening what gets claimed.
+    """
+    assert issubclass(so.Line, so.Path)
+    assert issubclass(so.Dash, so.Paths)
+    assert issubclass(so.Range, so.Paths)
+
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", ymin="val", ymax="m")
+        .add(so.Range())
+        .on(fig)
+        .plot()
+    )
+
+    assert _registers_nothing(figure)
+
+
+def test_a_mark_that_is_read_still_reads_beside_one_that_is_not():
+    """An unclaimed layer must not take the chart down with it.
+
+    That is the whole-chart-to-a-picture failure of xability/r-maidr#225,
+    from the side where declining is the right answer: the `Area` is not
+    read, and the `Dot` beside it is unaffected.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m")
+        .add(so.Dot())
+        .add(so.Area())
+        .on(fig)
+        .plot()
+    )
+
+    assert _kinds(figure) == ["point"]
+
+
+def test_a_plot_drawn_onto_an_existing_chart_reads_only_its_own_marks():
+    """`so.Plot.on()` takes a figure that may already hold a chart.
+
+    The before-and-after diff is what keeps the two apart: the scatter drawn
+    by `Axes.scatter` registered itself, and the `so.Dot` layer must describe
+    the collection *it* drew rather than both.
+    """
+    figure = plt.figure()
+    axes = figure.subplots()
+    axes.scatter([0.0, 1.0], [5.0, 6.0])
+    so.Plot(_frame(), x="t", y="m").add(so.Dot()).on(axes).plot()
+
+    layers = _layers(figure)
+
+    assert [kind for kind, _ in layers] == ["point", "point"]
+    assert [len(schema["data"]) for _, schema in layers] == [2, 3]
+
+
+def test_the_axis_labels_are_the_ones_the_plot_was_given():
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m")
+        .label(x="Time", y="Mass")
+        .add(so.Dot())
+        .on(fig)
+        .plot()
+    )
+    _, schema = _layers(figure)[0]
+
+    assert schema["axes"]["x"]["label"] == "Time"
+    assert schema["axes"]["y"]["label"] == "Mass"
+
+
+@pytest.mark.parametrize(
+    "mark, x, y",
+    [
+        pytest.param(so.Dot(), "t", "m", id="Dot"),
+        pytest.param(so.Line(), "t", "m", id="Line"),
+        pytest.param(so.Bar(), "cat", "val", id="Bar"),
+    ],
+)
+def test_every_selector_resolves_in_the_page_it_was_built_from(mark, x, y):
+    """A layer that announces correctly and outlines nothing is the blind
+    spot xability/maidr#814 names.
+
+    Asserted against the emitted HTML rather than against a written-down
+    shape, because the ids are generated per render.
+    """
+    figure = _drawn(lambda fig: so.Plot(_frame(), x=x, y=y).add(mark).on(fig).plot())
+    html = maidr.render(figure)._repr_html_()
+    schema = FigureManager.get_maidr(figure).plots[0].schema
+
+    selectors = schema.get("selectors") or schema.get("selector")
+    flat = selectors if isinstance(selectors, list) else [selectors]
+    assert flat
+
+    for selector in flat:
+        found = re.findall(r"'([^']+)'", str(selector))
+        assert found, selector
+        for identifier in found:
+            assert identifier in html
+
+
+# --------------------------------------------------------------------------
+# The two guards below are each unobservable through a chart *while the other
+# holds*, and that is why they are asked of the helpers directly.
+#
+# `_reading_for` declines a mark that is not in the table; `_held` keeps only
+# the artist class that reading reads. Every unread mark measured draws into a
+# holder no reading reads, or draws a class the filter removes -- so dropping
+# either one alone changes nothing any chart can show. Dropping *both* reads a
+# `so.Dash`'s `LineCollection` through `ScatterPlot`, which cannot see it,
+# silently falls back to sweeping the whole axes, and announces a neighbouring
+# layer's points as this one's.
+#
+# Measured, mutating the live code one change at a time against the tests
+# above: claiming every mark, and removing the class filter, each left all 24
+# green. Both are pinned here so that removing either is a failing test rather
+# than a silent widening.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mark",
+    [
+        pytest.param(so.Area(), id="Area"),
+        pytest.param(so.Bars(), id="Bars"),
+        pytest.param(so.Dash(), id="Dash"),
+        pytest.param(so.Range(), id="Range"),
+        pytest.param(so.Text(), id="Text"),
+    ],
+)
+def test_a_mark_outside_the_table_is_declined_rather_than_defaulted(mark):
+    """The lookup returns nothing for a mark it does not name."""
+    from maidr.patch.seaborn_objects import _reading_for
+
+    assert _reading_for({"mark": mark}) is None
+
+
+def test_a_reading_takes_only_its_own_artist_class_from_a_holder():
+    """``Axes.collections`` and ``Axes.containers`` are heterogeneous.
+
+    A holder can carry several artist classes at once, and handing the wrong
+    one over is not an error anywhere downstream: ``ScatterPlot`` filters what
+    it is given to ``PathCollection`` and, finding none, sweeps the axes
+    instead -- so the layer would describe every point on the panel rather
+    than raise.
+    """
+    from matplotlib.collections import LineCollection
+
+    from maidr.patch.seaborn_objects import _READINGS, _held
+
+    _, axes = plt.subplots()
+    points = axes.scatter([0.0, 1.0], [0.0, 1.0])
+    axes.add_collection(LineCollection([[(0.0, 0.0), (1.0, 1.0)]]))
+    bars = axes.bar(["a"], [1.0])
+    axes.errorbar([0.0], [0.0], yerr=[0.5])
+
+    assert _held(axes, _READINGS["Dot"]) == [points]
+    assert _held(axes, _READINGS["Bar"]) == [bars]


### PR DESCRIPTION
Closes #615.

`seaborn.objects` is seaborn's declarative interface, and py-maidr read none of it — not one plot type missing, the whole front door. Measured before, each row one `.add()`:

```
so.Plot(frame, x=, y=).add(so.Dot())    NOTHING REGISTERED
                      .add(so.Line())   NOTHING REGISTERED
                      .add(so.Bar())    NOTHING REGISTERED
sns.scatterplot(...)                    ['point']
sns.lineplot(...)                       ['line']
sns.barplot(...)                        ['bar']
```

The same charts, written the way seaborn now teaches, going silent.

## Why nothing fired

`maidr/patch/` wraps the *user-facing* drawing calls — `Axes.scatter`, `Axes.plot`, `Axes.bar`, and seaborn's plotter methods. A `Mark` calls none of them. It draws through the **artist** API instead: `ax.add_collection`, `ax.add_line`, `ax.add_patch`. None of those is a patched name.

## Where the hook goes

`Plotter._plot_layer` runs once per `.add()` and draws that layer across every panel, which makes it the one place where "which artists belong to which layer" is still answerable. Taking each axes' artists **before and after** answers it exactly, without predicting how many a mark makes — `so.Line(color=)` draws one `Line2D` per level, and a faceted layer draws on some panels and not others.

A panel a layer never drew on registers nothing, so a `col`/`row` grid's empty combinations do not become layers a reader can walk into and find nothing in (#421). That falls straight out of the diff rather than needing its own rule.

## What is read

| mark | artist | as | handed over through |
|---|---|---|---|
| `Dot`, `Dots` | `PathCollection` | `point` | `DRAWN_POINTS` |
| `Line`, `Path` | `Line2D` | `line` | `lines=` |
| `Bar` | `BarContainer` | `bar` | `DRAWN_BARS` |

No new extraction: three existing plot classes already take their artists this way, so a `so.Bar` reaches the same `BarPlot` as `Axes.bar` and its orientation comes off the container seaborn built. Measured, horizontal reads magnitude-on-x / label-on-y exactly as `Axes.barh` does, and every emitted selector resolves in the page it was built from — same shapes the classic spelling produces.

`Bars`, `Lines`, `Paths`, `Area`, `Band`, `Range`, `Dash` and `Text` are left for the follow-ups #615 lists.

## Matched by name, not by ancestry

seaborn's mark hierarchy does not track what a mark draws:

```
Line  < Path  < Mark      Line2D
Dash  < Paths < Mark      LineCollection
Range < Paths < Mark      LineCollection
```

So dispatching on ancestry would claim `Dash` and `Range` as lines and hand a `LineCollection` to `LinePlot`, which cannot see it. A name misses a mark seaborn renames; ancestry would claim one that cannot be read — and a wrong reading is worse than a missing one. The test pins the hierarchy itself, so the release that changes it fails there.

## Additive by construction

A mark outside the table is drawn and left **entirely** alone — not drawn inside the internal context — so it registers exactly what it registered before: nothing. Pinned for `Area`, `Bars`, `Lines`, `Paths`, `Dash`, `Text` and `Range`, and a chart mixing a read layer with an unread one still reads the read one (the whole-chart-to-a-picture failure of xability/r-maidr#225, from the side where declining is right).

## The wrap is guarded, unlike the other seaborn patches

`seaborn._core.plot.Plotter._plot_layer` is a private method of a private module. `maidr/patch/_seaborn_version.py` states a floor for `_CategoricalPlotter` / `_DistributionPlotter`, and there is no such floor to state here — so a rename is turned into a warning naming what stops reading, rather than taking `import maidr` down and breaking every *classic* seaborn chart over a mark nobody in that process drew.

## Verification

`uv run pytest` — **3002 passed, 18 skipped**, up from 2996; `ruff check --diff` clean; `uv lock --check` clean.

30 new tests. Mutation sweep, each change applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| drop the empty-panel guard | killed (1) |
| `Bar` not `singular` | killed (4) |
| ignore the before-snapshot | killed (1) |
| claim every mark | killed (5) |
| read only the first panel | killed (2) |
| drop the artist-class filter | killed (1) |

Two of those — *claim every mark* and *drop the artist-class filter* — **survived the first sweep**, because each is masked by the other: every unread mark measured draws into a holder no reading reads, *or* draws a class the filter removes. Dropping both together would read a `so.Dash`'s `LineCollection` through `ScatterPlot`, which silently falls back to sweeping the whole axes and announces a neighbouring layer's points as this one's. They are now asked of `_reading_for` and `_held` directly, with the masking written down in the test file, so removing either is a failing test rather than a silent widening.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_