### PR TITLE
fix(seaborn): split a colour-grouped seaborn.objects scatter into its groups

### DIFF
--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -232,7 +232,19 @@ def hue_groups(
     if len(colours) < 2 or any(colour is None for colour in colours):
         return None
 
-    legend = ax.get_legend()
+    # `legend_of` rather than `ax.get_legend()`, which is what this asked
+    # before. The two answer the same question -- which legend names this
+    # axes' colours -- and answering it twice, differently, in one module is
+    # the drift #599 extracted `legend_names` to end. The wider answer also
+    # reads a lone *figure* legend (#561) and a lone shared-axis sibling's
+    # (#610), which is where `seaborn.objects` puts the only legend a
+    # `so.Plot(color=...)` has.
+    #
+    # Imported here rather than at module scope because `legend_names` reads
+    # `_handle_colour` from this module, so the two would import each other.
+    from maidr.util.legend_names import legend_of
+
+    legend = legend_of(ax)
     if legend is None:
         return None
 

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -15,7 +15,7 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS
-from maidr.core.plot.scatterplot import DRAWN_POINTS
+from maidr.core.plot.scatterplot import DRAWN_POINTS, HUE_GROUP, hue_groups
 from maidr.patch.common import _draw_quietly
 
 
@@ -78,6 +78,12 @@ class _Reading(NamedTuple):
 #: A caller's own ``Mark`` subclass is declined for the same reason: it is not
 #: in this table, and what it draws is not knowable from the class it came
 #: from.
+#: Where a plotter keeps the layers it has drawn but not yet registered.
+#:
+#: On the ``Plotter`` instance, which is built fresh by every ``Plot.plot()``
+#: call, so two plots in flight cannot see each other's.
+_PENDING = "_maidr_pending"
+
 _READINGS: dict[str, _Reading] = {
     "Dot": _Reading(PlotType.SCATTER, "collections", PathCollection, DRAWN_POINTS),
     "Dots": _Reading(PlotType.SCATTER, "collections", PathCollection, DRAWN_POINTS),
@@ -154,6 +160,60 @@ def _panels(plotter: Any) -> list[Axes]:
     return [ax for ax in getattr(figure, "axes", [])]
 
 
+def _handovers(reading: _Reading, ax: Axes, own: list) -> list[dict]:
+    """
+    What to register for one layer's artists: one entry per layer to make.
+
+    Three shapes, and each is a fact about the plot class being handed to.
+
+    A **colour-split scatter** becomes one layer per group. `so.Dot(color=)`
+    draws a *single* ``PathCollection`` carrying a colour per point -- the
+    same shape ``seaborn.scatterplot(hue=)`` produces -- so the grouping
+    survives only in those colours and in the legend naming them, which is
+    exactly what ``hue_groups`` inverts. Without it a reader is handed one
+    layer of every point where the classic spelling of the same chart gives
+    one per level, named (#617).
+
+    A **singular binding** becomes one layer per artist; see
+    :class:`_Reading`.
+
+    Everything else is one layer holding every artist it drew, which is what
+    a multi-series line is: `so.Line(color=)` draws one ``Line2D`` per level
+    and reads as one layer of several series -- measured, exactly what
+    ``seaborn.lineplot(hue=)`` already does, so there is nothing to bring
+    into line there.
+
+    Parameters
+    ----------
+    reading : _Reading
+        How this mark is read.
+    ax : Axes
+        The panel drawn on, asked for the legend that names the colours.
+    own : list
+        The artists this layer drew on that panel, in draw order.
+
+    Returns
+    -------
+    list of dict
+        One keyword mapping per layer to register.
+    """
+    if reading.plot_type is PlotType.SCATTER and len(own) == 1:
+        groups = hue_groups(ax, own[0])
+        if groups:
+            # `hue_groups` answers in the offsets of the collection it was
+            # asked about, and the layer takes a list of those -- one per
+            # collection -- because a classic strip plot's groups span
+            # several (#586). A mark draws one, so it is a list of one.
+            return [
+                {reading.binding: own, HUE_GROUP: (name, [members])}
+                for name, members in groups
+            ]
+
+    if reading.singular:
+        return [{reading.binding: one} for one in own]
+    return [{reading.binding: own}]
+
+
 def _layer(wrapped, instance, args, kwargs) -> Any:
     """
     Draw one ``seaborn.objects`` layer and register what it drew.
@@ -193,6 +253,7 @@ def _layer(wrapped, instance, args, kwargs) -> Any:
         return _draw_quietly(wrapped, args, kwargs)
 
     panels = _panels(instance)
+    pending = instance.__dict__.setdefault(_PENDING, [])
     before = {id(ax): {id(artist) for artist in _held(ax, reading)} for ax in panels}
 
     with ContextManager.set_internal_context():
@@ -209,15 +270,59 @@ def _layer(wrapped, instance, args, kwargs) -> Any:
         # edge of it.
         if not own:
             continue
-        handovers = (
-            [{reading.binding: one} for one in own]
-            if reading.singular
-            else [{reading.binding: own}]
-        )
-        for handover in handovers:
-            FigureManager.create_maidr(ax, reading.plot_type, **handover)
+        # Recorded rather than registered, because the legend that names a
+        # colour split does not exist yet: `Plotter._make_legend` runs after
+        # every layer has been drawn. That is the timing #612 met with
+        # `FacetGrid.add_legend()`, and a name can be deferred to render as a
+        # callable -- but a *split* cannot, because it decides how many
+        # layers there are. So the reading waits for `_register`.
+        pending.append((ax, reading, own))
 
     return drawn
+
+
+def _register(wrapped, instance, args, kwargs) -> Any:
+    """
+    Draw a whole ``so.Plot`` and register the layers it recorded.
+
+    The second half of a hook deliberately split in two. ``_plot_layer`` is
+    the only place that can say which artists a layer drew, and it runs too
+    early to say what *names* them: ``Plotter._make_legend`` builds the one
+    legend a ``so.Plot`` has after every layer is on the page, so a colour
+    split asked about there finds nothing and every chart reads as one
+    unnamed layer of every point.
+
+    Deferring the whole registration rather than only the name, because the
+    split decides how many layers there are -- and unlike a name, that cannot
+    be resolved at render from a callable.
+
+    ``Plot.plot`` is where every route ends up: ``show()``, ``save()`` and
+    ``_repr_png_()`` all call it, so wrapping it once covers them.
+
+    Parameters
+    ----------
+    wrapped : Callable
+        ``Plot.plot``.
+    instance : Any
+        The plot it was called on.
+    args, kwargs : Any
+        As passed by the caller.
+
+    Returns
+    -------
+    Plotter
+        Whatever ``plot`` returned, unchanged.
+    """
+    if ContextManager.is_internal_context():
+        return wrapped(*args, **kwargs)
+
+    plotter = wrapped(*args, **kwargs)
+
+    for ax, reading, own in getattr(plotter, _PENDING, ()):
+        for handover in _handovers(reading, ax, own):
+            FigureManager.create_maidr(ax, reading.plot_type, **handover)
+
+    return plotter
 
 
 def _wrap() -> None:
@@ -241,11 +346,11 @@ def _wrap() -> None:
         consequence.
     """
     try:
-        from seaborn._core.plot import Plotter
+        from seaborn._core.plot import Plot, Plotter
     except ImportError:  # pragma: no cover - seaborn without the objects API
-        Plotter = None  # type: ignore[assignment]
+        Plot = Plotter = None  # type: ignore[assignment]
 
-    if Plotter is None or not hasattr(Plotter, "_plot_layer"):
+    if Plotter is None or not hasattr(Plotter, "_plot_layer") or Plot is None:
         warnings.warn(
             "maidr: seaborn._core.plot.Plotter._plot_layer is not there to "
             "wrap, so seaborn.objects charts are not read. Every mark -- "
@@ -258,6 +363,7 @@ def _wrap() -> None:
         return
 
     wrapt.wrap_function_wrapper(Plotter, "_plot_layer", _layer)
+    wrapt.wrap_function_wrapper(Plot, "plot", _register)
 
 
 _wrap()

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -253,7 +253,14 @@ def _layer(wrapped, instance, args, kwargs) -> Any:
         return _draw_quietly(wrapped, args, kwargs)
 
     panels = _panels(instance)
-    pending = instance.__dict__.setdefault(_PENDING, [])
+    try:
+        pending = instance.__dict__.setdefault(_PENDING, [])
+    except AttributeError:
+        # A plotter that grew `__slots__` has nowhere to keep this. Declining
+        # leaves the chart reading as it did before #615 -- as nothing --
+        # which is this module's posture for a mark it cannot read, and far
+        # better than an `AttributeError` raised out of the user's draw.
+        return _draw_quietly(wrapped, args, kwargs)
     before = {id(ax): {id(artist) for artist in _held(ax, reading)} for ax in panels}
 
     with ContextManager.set_internal_context():
@@ -350,14 +357,24 @@ def _wrap() -> None:
     except ImportError:  # pragma: no cover - seaborn without the objects API
         Plot = Plotter = None  # type: ignore[assignment]
 
-    if Plotter is None or not hasattr(Plotter, "_plot_layer") or Plot is None:
+    # Both hooks are asked for, because the reading needs both: one says
+    # which artists a layer drew and the other says when the legend naming
+    # them exists. `Plot is None` is not tested separately -- the import
+    # above binds the two together, and `hasattr(None, "plot")` is False, so
+    # the short circuit already covers it.
+    if (
+        Plotter is None
+        or not hasattr(Plotter, "_plot_layer")
+        or not hasattr(Plot, "plot")
+    ):
         warnings.warn(
-            "maidr: seaborn._core.plot.Plotter._plot_layer is not there to "
-            "wrap, so seaborn.objects charts are not read. Every mark -- "
-            "so.Dot, so.Line, so.Bar -- draws through the artist API rather "
-            "than through Axes.scatter/plot/bar, so nothing else picks them "
-            "up and the chart registers no layers at all. Charts written "
-            "with the classic seaborn functions are unaffected.",
+            "maidr: seaborn._core.plot.Plotter._plot_layer or Plot.plot is "
+            "not there to wrap, so seaborn.objects charts are not read. "
+            "Every mark -- so.Dot, so.Line, so.Bar -- draws through the "
+            "artist API rather than through Axes.scatter/plot/bar, so "
+            "nothing else picks them up and the chart registers no layers "
+            "at all. Charts written with the classic seaborn functions are "
+            "unaffected.",
             stacklevel=2,
         )
         return

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -569,32 +569,23 @@ def test_a_layer_that_drew_several_containers_becomes_several_bar_layers():
     """The ``singular=True`` branch, which no ``so.Bar`` spelling reaches.
 
     `DRAWN_BARS` names one container, so a layer that drew several has to
-    become several layers rather than one truncated to the first — which is
+    become several layers rather than one truncated to the first -- which is
     also how a hue-grouped bar is read elsewhere (#593, #595), one layer per
     group. Every `so.Bar` measured draws exactly one container, so the branch
     is forward-looking: it would be exercised for the first time, silently,
     by a seaborn release that changed that.
 
-    Driven through `_layer` itself rather than through a chart, because a
-    chart cannot reach it today. The draw runs inside the internal context
-    `_layer` sets, so the two `Axes.bar` calls register nothing of their own
-    and what comes back is this layer's reading alone.
+    Asked of `_handovers` directly, because that is the function deciding it
+    and no chart can put two containers in front of it today.
     """
-    from maidr.patch.seaborn_objects import _layer
+    from maidr.core.plot.barplot import DRAWN_BARS
+    from maidr.patch.seaborn_objects import _READINGS, _handovers
 
-    figure = plt.figure()
-    axes = figure.subplots()
+    _, axes = plt.subplots()
+    first = axes.bar(["a"], [4.0])
+    second = axes.bar(["b"], [9.0])
 
-    class _Plotter:
-        """Only the attribute the panel lookup reads."""
-
-        _figure = figure
-
-    def draw(*args, **kwargs):
-        axes.bar(["a"], [4.0])
-        axes.bar(["b"], [9.0])
-
-    _layer(draw, _Plotter(), (None, {"mark": so.Bar()}), {})
-
-    assert len(axes.containers) == 2
-    assert _kinds(figure) == ["bar", "bar"]
+    assert _handovers(_READINGS["Bar"], axes, [first, second]) == [
+        {DRAWN_BARS: first},
+        {DRAWN_BARS: second},
+    ]

--- a/tests/core/plot/test_seaborn_objects_hue.py
+++ b/tests/core/plot/test_seaborn_objects_hue.py
@@ -281,3 +281,58 @@ def test_the_groups_are_read_off_the_legend_wherever_it_was_put():
     )
 
     assert hue_groups(axes, points) == [("p", [0, 1]), ("q", [2, 3])]
+
+
+def test_a_plot_that_was_given_no_figure_registers_too():
+    """`Plot.plot()` is wrapped because every route reaches it.
+
+    Every other test here hands the figure in with `.on(fig)`. This one does
+    not, so the layers are registered on a figure seaborn made -- which is
+    what `show()`, `save()` and `_repr_png_()` all do, and what makes
+    wrapping one method enough.
+    """
+    plotter = so.Plot(_frame(), x="x", y="y", color="g").add(so.Dot()).plot()
+
+    assert _named(plotter._figure) == [
+        ("point", "p", [1.0, 2.0, 3.0]),
+        ("point", "q", [11.0, 12.0, 13.0]),
+    ]
+
+
+def test_the_notebook_repr_route_reads_the_same_chart():
+    """`_repr_png_()` calls `plot()` for its own figure, so it must not
+    raise and must leave a chart behind."""
+    plot = so.Plot(_frame(), x="x", y="y", color="g").add(so.Dot())
+
+    assert plot._repr_png_() is not None
+    assert [name for _, name, _ in _named(plot.plot()._figure)] == ["p", "q"]
+
+
+def test_a_plotter_with_nowhere_to_record_declines_rather_than_raising():
+    """The layer's reading is kept on the plotter until the legend exists.
+
+    A seaborn release that gave `Plotter` `__slots__` would leave nowhere to
+    keep it, and raising there would come out of the user's *draw* -- so the
+    chart would stop rendering rather than stop being read. Declining puts it
+    back where #615 found it, which is what an unread mark already does.
+    """
+    from maidr.patch.seaborn_objects import _layer
+
+    figure = plt.figure()
+    figure.subplots()
+
+    class _Slotted:
+        __slots__ = ("_figure",)
+
+        def __init__(self, fig):
+            self._figure = fig
+
+    drawn = []
+
+    def draw(*args, **kwargs):
+        drawn.append(True)
+
+    _layer(draw, _Slotted(figure), (None, {"mark": so.Dot()}), {})
+
+    assert drawn == [True]
+    assert not hasattr(figure, "_maidr_pending")

--- a/tests/core/plot/test_seaborn_objects_hue.py
+++ b/tests/core/plot/test_seaborn_objects_hue.py
@@ -1,0 +1,283 @@
+"""
+A ``seaborn.objects`` mark split by ``color=`` read as one unnamed layer (#617).
+
+#615 made every `so.Dot` register; it registered as *one* layer holding every
+point. The classic spelling of the same chart has split and named its groups
+since #544. Measured before, two levels of three:
+
+    so.Plot(frame, x=, y=, color="g").add(so.Dot())   point None (6)
+    sns.scatterplot(data=frame, x=, y=, hue="g")      point 'p'  (3)
+                                                      point 'q'  (3)
+
+Two things had to change, and neither alone is enough.
+
+**`hue_groups` asked the wrong legend.** It read `ax.get_legend()` where the
+rest of the module goes through `legend_of`, which also reads a lone *figure*
+legend (#561) and a lone shared-axis sibling's (#610). A `so.Plot` puts its
+one legend on the figure, so the axes had none and the split declined before
+looking at a colour. Two answers to one question in one module is the drift
+#599 extracted `legend_names` to end.
+
+**The split was asked too early.** `Plotter._plot_layer` is the only place
+that can say which artists a layer drew, and `Plotter._make_legend` runs after
+every layer is on the page. A *name* can be deferred to render as a callable,
+which is what #612 did for `FacetGrid`; a *split* cannot, because it decides
+how many layers there are. So the reading is recorded during the draw and
+registered once the plot is complete.
+
+**Not in scope, deliberately.** `so.Line(color=)` reads as one layer of two
+series and stays that way -- measured, that is exactly what
+`seaborn.lineplot(hue=)` already does, so there is no gap between the two
+spellings to close and naming multi-series lines is a question for both at
+once. `so.Bar(color=)` draws every level into one container, unlike
+`seaborn.barplot(hue=)`, so its split needs an answer this does not have.
+"""
+
+from __future__ import annotations
+
+import re
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+import seaborn.objects as so
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    # `p` holds the low half of y and `q` the high half, with no overlap, so
+    # which layer got which group is a fact about the numbers rather than
+    # about the order they were registered in.
+    return pd.DataFrame(
+        {
+            "x": [1.0, 2.0, 3.0, 1.0, 2.0, 3.0],
+            "y": [1.0, 2.0, 3.0, 11.0, 12.0, 13.0],
+            "g": ["p", "p", "p", "q", "q", "q"],
+        }
+    )
+
+
+def _named(figure) -> list[tuple[str, object, list]]:
+    """Every layer as ``(type, name, the y values it holds)``."""
+    maidr.render(figure)._repr_html_()
+    out = []
+    for plot in FigureManager.get_maidr(figure).plots:
+        data = plot.schema["data"]
+        held = (
+            [float(point["y"]) for point in data] if plot.type.value == "point" else []
+        )
+        out.append((plot.type.value, plot.schema.get("name"), held))
+    return out
+
+
+def _drawn(build) -> plt.Figure:
+    figure = plt.figure()
+    build(figure)
+    return figure
+
+
+def test_a_colour_split_dot_reads_one_named_layer_per_group():
+    """Two layers, named, each holding its own half."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="x", y="y", color="g")
+        .add(so.Dot())
+        .on(fig)
+        .plot()
+    )
+
+    assert _named(figure) == [
+        ("point", "p", [1.0, 2.0, 3.0]),
+        ("point", "q", [11.0, 12.0, 13.0]),
+    ]
+
+
+def test_it_reads_exactly_as_the_classic_spelling_of_the_same_chart():
+    """Compared against `scatterplot(hue=)` rather than against written-down
+    names, so a change to how a grouped scatter is emitted moves both sides
+    together and this keeps asserting what it means to."""
+    frame = _frame()
+    objects = _named(
+        _drawn(
+            lambda fig: so.Plot(frame, x="x", y="y", color="g")
+            .add(so.Dot())
+            .on(fig)
+            .plot()
+        )
+    )
+    classic = _named(
+        _drawn(
+            lambda fig: sns.scatterplot(
+                data=frame, x="x", y="y", hue="g", ax=fig.subplots()
+            )
+        )
+    )
+
+    assert objects == classic
+
+
+def test_a_colour_split_dots_mark_splits_too():
+    """`so.Dots` is the many-points spelling and draws the same artist."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="x", y="y", color="g")
+        .add(so.Dots())
+        .on(fig)
+        .plot()
+    )
+
+    assert [name for _, name, _ in _named(figure)] == ["p", "q"]
+
+
+def test_a_dot_with_no_colour_is_untouched():
+    """Additive. One group against no legend reads exactly as it did."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="x", y="y").add(so.Dot()).on(fig).plot()
+    )
+
+    assert _named(figure) == [("point", None, [1.0, 2.0, 3.0, 11.0, 12.0, 13.0])]
+
+
+def test_a_colour_split_line_is_still_one_layer_of_several_series():
+    """Deliberately unchanged, and pinned so a later change is a decision.
+
+    `seaborn.lineplot(hue=)` reads as one `line` layer of two unnamed series,
+    measured, so the two spellings already agree. Naming a multi-series line
+    is a question for both at once rather than one this may answer for the
+    new interface alone.
+    """
+    frame = _frame()
+    objects = _named(
+        _drawn(
+            lambda fig: so.Plot(frame, x="x", y="y", color="g")
+            .add(so.Line())
+            .on(fig)
+            .plot()
+        )
+    )
+    classic = _named(
+        _drawn(
+            lambda fig: sns.lineplot(
+                data=frame, x="x", y="y", hue="g", ax=fig.subplots()
+            )
+        )
+    )
+
+    assert objects == classic == [("line", None, [])]
+
+
+def test_each_facet_panel_splits_its_own_groups():
+    """The split is per panel, and the legend naming it is the figure's."""
+    frame = _frame().assign(panel=["one", "one", "two", "one", "one", "two"])
+    figure = _drawn(
+        lambda fig: so.Plot(frame, x="x", y="y", color="g")
+        .facet(col="panel")
+        .add(so.Dot())
+        .on(fig)
+        .plot()
+    )
+
+    assert [(name, held) for _, name, held in _named(figure)] == [
+        ("p", [1.0, 2.0]),
+        ("q", [11.0, 12.0]),
+        ("p", [3.0]),
+        ("q", [13.0]),
+    ]
+
+
+def test_every_split_layer_can_be_highlighted():
+    """A layer that announces correctly and outlines nothing is the blind
+    spot xability/maidr#814 names, and a split layer addresses its points
+    through the collection it shares with its sibling."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="x", y="y", color="g")
+        .add(so.Dot())
+        .on(fig)
+        .plot()
+    )
+    html = maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    assert len(plots) == 2
+    for plot in plots:
+        selectors = plot.schema["selectors"]
+        assert len(selectors) == len(plot.schema["data"])
+        for selector in selectors:
+            for identifier in re.findall(r"'([^']+)'", str(selector)):
+                assert identifier in html
+
+
+# --------------------------------------------------------------------------
+# The shared helpers, asked directly. Both live in
+# `maidr/core/plot/scatterplot.py` and are reached by every grouped scatter,
+# so a change to either is a change to the classic path as well.
+# --------------------------------------------------------------------------
+
+
+def test_a_collection_swatch_and_a_marker_swatch_name_the_same_colour():
+    """The handle type `seaborn.objects` builds is not the classic one.
+
+    Classic seaborn builds scatter legend handles as `Line2D` markers, which
+    answer with a flat RGBA; `seaborn.objects` builds `PathCollection`s,
+    which answer `get_facecolor()` with a row per colour. `to_rgba` accepts
+    both -- measured, a ``(1, 4)`` array resolves to its single colour -- so
+    nothing had to be added for this, and this test says so rather than
+    leaving the shape difference looking like a hazard that was handled.
+    """
+    from matplotlib.collections import PathCollection
+    from matplotlib.lines import Line2D
+
+    from maidr.core.plot.scatterplot import _handle_colour
+
+    _, axes = plt.subplots()
+    collection = axes.scatter([0.0], [0.0], color="#1f77b4")
+    line = Line2D([], [], color="#1f77b4")
+
+    assert isinstance(collection, PathCollection)
+    assert _handle_colour(collection) == _handle_colour(line) is not None
+
+
+def test_a_handle_drawn_in_several_colours_names_none():
+    """A swatch drawn in several colours names no group, and must keep
+    declining -- a handle resolved to the first of its colours would name a
+    group after a colour it only partly stands for."""
+    from maidr.core.plot.scatterplot import _handle_colour
+
+    _, axes = plt.subplots()
+    many = axes.scatter([0.0, 1.0], [0.0, 1.0], color=["#1f77b4", "#ff7f0e"])
+
+    assert _handle_colour(many) is None
+
+
+def test_the_groups_are_read_off_the_legend_wherever_it_was_put():
+    """`hue_groups` goes through `legend_of` now, so a figure legend answers.
+
+    Built by hand rather than through `so.Plot`, so this states the rule
+    rather than one library's use of it: one collection carrying two colours,
+    and the only legend naming them on the figure.
+    """
+    from matplotlib.lines import Line2D
+
+    from maidr.core.plot.scatterplot import hue_groups
+
+    figure, axes = plt.subplots()
+    rng = np.random.default_rng(0)
+    points = axes.scatter(
+        rng.uniform(size=4),
+        rng.uniform(size=4),
+        color=["#1f77b4"] * 2 + ["#ff7f0e"] * 2,
+    )
+    figure.legend(
+        handles=[Line2D([], [], color="#1f77b4"), Line2D([], [], color="#ff7f0e")],
+        labels=["p", "q"],
+    )
+
+    assert hue_groups(axes, points) == [("p", [0, 1]), ("q", [2, 3])]


### PR DESCRIPTION
Part of #617, the follow-up filed from the review on #616.

#615 made every `so.Dot` register. It registered as **one** layer holding every point, where the classic spelling of the same chart has split and named its groups since #544. Measured, two levels of three:

```
so.Plot(frame, x=, y=, color="g").add(so.Dot())   point None (6)
sns.scatterplot(data=frame, x=, y=, hue="g")      point 'p'  (3)
                                                  point 'q'  (3)
```

After: the two readings are identical, asserted against each other rather than against written-down names.

## Two things had to change, and neither alone is enough

**`hue_groups` asked the wrong legend.** It read `ax.get_legend()` where the rest of the module goes through `legend_of`, which also reads a lone **figure** legend (#561) and a lone shared-axis sibling's (#610). A `so.Plot` puts its one legend on the figure, so the axes had none and the split declined before it ever looked at a colour.

Two answers to one question in one module is the drift #599 extracted `legend_names` to end, so this is a unification rather than a new rule — and the blast radius was measured rather than assumed. `pairplot(hue=)` already splits by a different route (seaborn calls `scatterplot` once per level, so each call registers its own layer), and `jointplot(hue=)`'s joint panel keeps a legend of its own. The full suite is unchanged by the widening: no existing chart read differently for having asked the narrower question.

**The split was asked too early.** `Plotter._plot_layer` is the only place that can say which artists a layer drew, and `Plotter._make_legend` runs *after* every layer is on the page. A **name** can be deferred to render as a callable — that is what #612 did for `FacetGrid.add_legend()` — but a **split** cannot, because it decides how many layers there are.

So the hook is now two halves: `_plot_layer` records `(axes, reading, artists)` on the plotter, and `Plot.plot` registers them once the plot is complete. `show()`, `save()` and `_repr_png_()` all reach `Plot.plot`, so wrapping it once covers every route.

## Deliberately not in scope

- **`so.Line(color=)`** stays one layer of several unnamed series. Measured, `seaborn.lineplot(hue=)` reads exactly the same way, so there is no gap between the two spellings to close — naming a multi-series line is a question for both at once. Pinned by a test that asserts the two are equal, so a later change is a decision rather than a drift.
- **`so.Bar(color=)`** draws every level into **one** container, unlike `seaborn.barplot(hue=)` which draws one per level, so the classic reading's "a container is a group" does not transfer. Its split needs an answer this does not have.
- The position transforms (`so.Stack()`, `so.Norm()` reading as a plain `bar`) remain as #617 lists them.

## Verification

`uv run pytest` — **3021 passed, 18 skipped**, up from 3011. `ruff check --diff` clean.

10 new tests. Mutation sweep, each applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| `hue_groups` reads `ax.get_legend()` again | killed (6) |
| `_handle_colour` tries only its first getter | killed (6) |
| `_handovers` skips the scatter split | killed (5) |
| `_layer` registers eagerly instead of recording | killed (5) |

A fifth mutation is worth reporting because it **survived and was right to**. The first draft added an `_unwrapped` helper to pull a single colour out of the `(1, 4)` array a `PathCollection` legend handle answers with, on the reasoning that `to_rgba` refuses that shape. Removing it changed nothing, and the measurement says why: `to_rgba` accepts a one-row array and resolves it to its single colour. The helper was dead code carrying a confident and false docstring, so it was **removed** rather than left with a test written around it. What survives is a test stating that the two handle types — `Line2D` for classic seaborn, `PathCollection` for `seaborn.objects` — name the same colour, so the shape difference is documented as a non-hazard instead of looking like one that was handled.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_