### PR TITLE
fix(seaborn): split a colour-grouped seaborn.objects bar, and get its categories back

### DIFF
--- a/maidr/core/plot/barplot.py
+++ b/maidr/core/plot/barplot.py
@@ -8,6 +8,7 @@ from matplotlib.patches import Rectangle
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
+from maidr.core.plot.maidr_plot import group_name_of
 from maidr.exception import ExtractionError
 from maidr.util.mixin import (
     BarPositionMixin,
@@ -69,6 +70,52 @@ def _magnitude(raw: float) -> float | None:
     return float(raw) if math.isfinite(raw) else None
 
 
+def bar_groups(ax: Axes, container: BarContainer) -> list[tuple[str, list[int]]] | None:
+    """
+    The groups a colour-split bar layer was drawn with, or ``None``.
+
+    The ``BarContainer`` counterpart of
+    :func:`maidr.core.plot.scatterplot.hue_groups`, and the same question:
+    one artist carries every level, so the grouping survives only in the
+    bars' colours and in the legend that names them.
+
+    ``seaborn.objects`` needs it where ``seaborn.barplot(hue=...)`` does not.
+    The classic function draws one container **per level**, so each layer
+    already holds one bar per category; ``so.Bar()`` draws every level into
+    one container, and what that costs is not only the group names. Measured
+    on two categories and two levels::
+
+        so.Plot(frame, x=, y=, color="g").add(so.Bar(), so.Dodge())
+          bars 4, ticks ['a', 'b'] -> announced x ['-0.2', '0.2', '0.8', '1.2']
+
+    Those are the dodge offsets. ``BarPlot._labels_for`` announces bar
+    *positions* whenever the tick labels do not number the bars, which is
+    right where #382 put it -- a numeric axis picks its own breaks -- and
+    which a colour split walks straight into. Splitting the layer per level
+    puts one bar against one tick again, so the category names come back
+    with the group names (xability/py-maidr#617).
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    container : BarContainer
+        The bars.
+
+    Returns
+    -------
+    list of (str, list of int) or None
+        One entry per group in legend order, naming it and listing the
+        container positions that belong to it, or ``None`` when the layer is
+        not grouped.
+    """
+    from maidr.core.plot.scatterplot import _rgba, groups_from_colours
+
+    return groups_from_colours(
+        ax, [_rgba(patch.get_facecolor()) for patch in container]
+    )
+
+
 class BarPlot(
     MaidrPlot,
     BarPositionMixin,
@@ -83,6 +130,10 @@ class BarPlot(
         # `None` falls back to sweeping the axes, which is what seaborn needs:
         # it draws one layer as several containers, one per hue group.
         self._own_bars = kwargs.get(DRAWN_BARS, None)
+        # The group this layer reads, when the patch found one. Opted into
+        # here rather than read by `MaidrPlot`; see `GROUP_NAME` for why that
+        # is per class, and `render` for the callable form.
+        self._group_name = group_name_of(kwargs)
 
     @property
     def _is_horizontal(self) -> bool:
@@ -121,12 +172,21 @@ class BarPlot(
         return "horz" if plot[0].orientation == "horizontal" else "vert"
 
     def render(self) -> dict:
-        """Add ``orientation`` to the base schema."""
+        """Add ``orientation``, and the name of the group this layer reads."""
         # Read after the super call, not before: `self._orientation` is
         # populated by `_extract_plot_data`, which that call runs.
         base_schema = super().render()
         bar_orientation = {MaidrKey.ORIENTATION: self._orientation}
-        return DictMergerMixin.merge_dict(base_schema, bar_orientation)
+        schema = DictMergerMixin.merge_dict(base_schema, bar_orientation)
+
+        # `MaidrLayer.name` is what xability/maidr#828 added so that two
+        # layers of a kind can be told apart, which is exactly the position a
+        # colour-split bar puts a reader in. A callable is resolved here
+        # rather than at registration, for the timing #612 describes.
+        name = self._group_name() if callable(self._group_name) else self._group_name
+        if name:
+            schema[MaidrKey.NAME] = name
+        return schema
 
     def _extract_plot_data(self) -> list:
         plot = self._own_containers()

--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -228,7 +228,35 @@ def hue_groups(
         collection offsets that belong to it, or ``None`` for a scatter that
         is not grouped.
     """
-    colours = [_rgba(row) for row in collection.get_facecolors()]
+    return groups_from_colours(ax, [_rgba(row) for row in collection.get_facecolors()])
+
+
+def groups_from_colours(ax: Axes, colours: list) -> list[tuple[str, list[int]]] | None:
+    """
+    The groups a legend names among one layer's drawn colours.
+
+    Everything :func:`hue_groups` does after reading a collection's face
+    colours, which is everything that is not about the artist. A bar layer
+    asks the same question of a ``BarContainer``'s patches
+    (:func:`maidr.core.plot.barplot.bar_groups`) and must get the same answer,
+    including the declines -- three implementations of one rule had begun to
+    drift once already (#599), and this is where the second caller arrived.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    colours : list
+        One rounded RGBA per drawn thing, in draw order, as :func:`_rgba`
+        gives them. A ``None`` among them declines the split.
+
+    Returns
+    -------
+    list of (str, list of int) or None
+        One entry per group in legend order, naming it and listing the
+        positions that belong to it, or ``None`` when the layer is not
+        grouped.
+    """
     if len(colours) < 2 or any(colour is None for colour in colours):
         return None
 

--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -192,27 +192,10 @@ def hue_groups(
     together they give it back exactly: every point's colour is one of the
     legend's swatches, and each swatch carries its group's name.
 
-    Everything here is a reason to decline, and each has a chart behind it:
-
-    - **One colour for the whole collection.** ``get_facecolors()`` returns a
-      single row when every point shares a colour, which is what an ungrouped
-      scatter and a ``style=``-only scatter both produce.
-    - **No legend.** ``legend=False`` suppresses it, and a manual
-      ``ax.scatter(c=[...])`` never had one. The colours are still there but
-      nothing names them, and groups called "1" and "2" are not an improvement
-      on one cloud.
-
-      Read at registration, which is to say the instant the drawing call
-      returns. A legend built afterwards -- ``ax.scatter(c=[...])`` followed
-      by ``ax.legend(handles=[...])`` -- does not exist yet and the chart is
-      read as one layer, even though the same axes would split if asked a
-      line later. seaborn builds its legend inside the call, so its charts
-      are unaffected.
-    Two more declines are :func:`~maidr.util.hue_groups.grouped_by_name`'s
-    rather than this function's, and its docstring carries the charts behind
-    them: a point no swatch claims, and fewer than two groups. They live
-    there because the rug split reaches the same two from a different artist,
-    and three implementations of one rule had begun to drift (#599).
+    Reading those colours off the collection is the whole of what is specific
+    to the artist. Every reason to decline is
+    :func:`groups_from_colours`', which a bar layer reaches from a
+    ``BarContainer`` and must be told the same (#599, #617).
 
     Parameters
     ----------
@@ -241,6 +224,29 @@ def groups_from_colours(ax: Axes, colours: list) -> list[tuple[str, list[int]]] 
     (:func:`maidr.core.plot.barplot.bar_groups`) and must get the same answer,
     including the declines -- three implementations of one rule had begun to
     drift once already (#599), and this is where the second caller arrived.
+
+    Everything here is a reason to decline, and each has a chart behind it:
+
+    - **One colour for the whole layer.** ``get_facecolors()`` returns a
+      single row when every point shares a colour, which is what an ungrouped
+      scatter and a ``style=``-only scatter both produce; a bar drawn without
+      ``color=`` arrives one-long the same way.
+    - **No legend.** ``legend=False`` suppresses it, and a manual
+      ``ax.scatter(c=[...])`` never had one. The colours are still there but
+      nothing names them, and groups called "1" and "2" are not an improvement
+      on one cloud.
+
+      Read at registration, which is to say the instant the drawing call
+      returns. A legend built afterwards -- ``ax.scatter(c=[...])`` followed
+      by ``ax.legend(handles=[...])`` -- does not exist yet and the chart is
+      read as one layer, even though the same axes would split if asked a
+      line later. seaborn builds its legend inside the call, so its charts
+      are unaffected.
+
+    Two more declines are :func:`~maidr.util.hue_groups.grouped_by_name`'s
+    rather than this function's, and its docstring carries the charts behind
+    them: a point no swatch claims, and fewer than two groups. They live
+    there because the rug split reaches the same two from a different artist.
 
     Parameters
     ----------

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -14,7 +14,8 @@ from matplotlib.lines import Line2D
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.core.plot.barplot import DRAWN_BARS
+from maidr.core.plot.barplot import DRAWN_BARS, bar_groups
+from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.core.plot.scatterplot import DRAWN_POINTS, HUE_GROUP, hue_groups
 from maidr.patch.common import _draw_quietly
 
@@ -206,6 +207,24 @@ def _handovers(reading: _Reading, ax: Axes, own: list) -> list[dict]:
             # several (#586). A mark draws one, so it is a list of one.
             return [
                 {reading.binding: own, HUE_GROUP: (name, [members])}
+                for name, members in groups
+            ]
+
+    if reading.plot_type is PlotType.BAR and len(own) == 1:
+        groups = bar_groups(ax, own[0])
+        if groups:
+            # A synthetic container per group rather than a filter inside
+            # `BarPlot`: the patches are the ones on the axes, so the
+            # selectors resolve unchanged, and every layer then holds one bar
+            # per tick -- which is what brings the category names back.
+            return [
+                {
+                    reading.binding: BarContainer(
+                        tuple(own[0][index] for index in members),
+                        orientation=own[0].orientation,
+                    ),
+                    GROUP_NAME: name,
+                }
                 for name, members in groups
             ]
 

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -521,25 +521,27 @@ def test_a_seaborn_that_moved_the_hook_warns_rather_than_failing_the_import(
         ),
     ],
 )
-def test_a_colour_split_bar_draws_one_container_and_reads_as_one_layer(spelling, build):
-    """`DRAWN_BARS` names a single container, so a reading that found several
-    would become several layers.
+def test_a_colour_split_bar_draws_one_container_and_splits_into_its_groups(
+    spelling, build
+):
+    """Every `so.Bar` spelling draws exactly **one** `BarContainer` holding
+    every bar -- `color=`, `Dodge()` and `Stack()` alike -- unlike the classic
+    `seaborn.barplot`, which draws one per hue level.
 
-    Measured rather than claimed: every `so.Bar` spelling draws exactly one
-    `BarContainer` holding every bar, `color=` and `Dodge()` and `Stack()`
-    included -- unlike the classic `seaborn.barplot`, which draws one
-    container per hue level. So the branch is real but unreached, and this
-    says which of the two is true today.
+    That is why `DRAWN_BARS`' singular branch is real but unreached, and why
+    the split has to come from the bars' colours rather than from the
+    containers: `bar_groups` does for a container what `hue_groups` does for
+    a collection (#617).
 
-    What a stacked bar should be *read* as is a separate question and not
-    settled here: it reads as a plain `bar` of every segment, which is the
-    same shape #615 lists as follow-up work.
+    What a colour-split bar should be *typed* as is still open -- all three
+    read as `bar` here, where the classic path answers `dodged_bar` -- and is
+    the remaining item on #617.
     """
     figure = plt.figure()
     build(so.Plot(_frame(), x="cat", y="val", color="g")).on(figure).plot()
 
     assert len(figure.axes[0].containers) == 1
-    assert _kinds(figure) == ["bar"]
+    assert _kinds(figure) == ["bar", "bar"]
 
 
 @pytest.mark.parametrize(

--- a/tests/core/plot/test_seaborn_objects_hue.py
+++ b/tests/core/plot/test_seaborn_objects_hue.py
@@ -336,3 +336,117 @@ def test_a_plotter_with_nowhere_to_record_declines_rather_than_raising():
 
     assert drawn == [True]
     assert not hasattr(figure, "_maidr_pending")
+
+
+def _bars(frame: pd.DataFrame) -> pd.DataFrame:
+    """Two categories over two levels, every magnitude distinct."""
+    return pd.DataFrame(
+        {"cat": ["a", "a", "b", "b"], "val": [1.0, 2.0, 3.0, 4.0], "g": list("pqpq")}
+    )
+
+
+def test_a_colour_split_bar_announces_its_categories_not_its_coordinates():
+    """The half of #617 that fixes a *wrong* reading rather than a missing one.
+
+    `BarPlot._labels_for` announces bar positions whenever the tick labels do
+    not number the bars -- right where #382 put it, since a numeric axis picks
+    its own breaks -- and a colour split walks straight into it: every level's
+    bars land on one axes against one tick per category. Measured before, two
+    categories and two levels::
+
+                            bars   ticks        announced x
+        color= (no move)      4    ['a','b']    ['0', '0', '1', '1']
+        color= + Dodge()      4    ['a','b']    ['-0.2', '0.2', '0.8', '1.2']
+
+    Those are the dodge offsets, announced as the categories. Splitting the
+    layer per level puts one bar against one tick again.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_bars(None), x="cat", y="val", color="g")
+        .add(so.Bar(), so.Dodge())
+        .on(fig)
+        .plot()
+    )
+    maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    assert [
+        (plot.schema.get("name"), [(bar["x"], bar["y"]) for bar in plot.schema["data"]])
+        for plot in plots
+    ] == [
+        ("p", [("a", 1.0), ("b", 3.0)]),
+        ("q", [("a", 2.0), ("b", 4.0)]),
+    ]
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        pytest.param(lambda plot: plot.add(so.Bar()), id="plain"),
+        pytest.param(lambda plot: plot.add(so.Bar(), so.Dodge()), id="dodged"),
+        pytest.param(lambda plot: plot.add(so.Bar(), so.Stack()), id="stacked"),
+    ],
+)
+def test_every_position_transform_splits_the_same_way(build):
+    """`Dodge()` and `Stack()` move the bars; neither changes which level a
+    bar belongs to, so all three spellings split alike."""
+    figure = plt.figure()
+    build(so.Plot(_bars(None), x="cat", y="val", color="g")).on(figure).plot()
+    maidr.render(figure)._repr_html_()
+
+    assert [
+        plot.schema.get("name") for plot in FigureManager.get_maidr(figure).plots
+    ] == ["p", "q"]
+
+
+def test_a_bar_with_no_colour_is_untouched():
+    """Additive. One group against no legend reads exactly as it did."""
+    frame = _bars(None).groupby("cat", as_index=False).sum(numeric_only=True)
+    figure = _drawn(
+        lambda fig: so.Plot(frame, x="cat", y="val").add(so.Bar()).on(fig).plot()
+    )
+    maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    assert len(plots) == 1
+    assert plots[0].schema.get("name") is None
+    assert [(bar["x"], bar["y"]) for bar in plots[0].schema["data"]] == [
+        ("a", 3.0),
+        ("b", 7.0),
+    ]
+
+
+def test_each_split_bar_layer_addresses_its_own_bars():
+    """Two layers built from one container must not share a selector -- the
+    shape review caught on xability/r-maidr#226, where two layers of a kind
+    resolved to the same element and the second highlighted the first's."""
+    figure = _drawn(
+        lambda fig: so.Plot(_bars(None), x="cat", y="val", color="g")
+        .add(so.Bar(), so.Dodge())
+        .on(fig)
+        .plot()
+    )
+    html = maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    selectors = []
+    for plot in plots:
+        found = plot.schema.get("selectors") or plot.schema.get("selector")
+        flat = found if isinstance(found, list) else [found]
+        for selector in flat:
+            for identifier in re.findall(r"'([^']+)'", str(selector)):
+                assert identifier in html
+        selectors.append(tuple(flat))
+
+    assert len(set(selectors)) == len(selectors)
+
+
+def test_an_ungrouped_container_names_no_groups():
+    """`bar_groups` declines exactly where `hue_groups` does, because both
+    end in the same shared tail."""
+    from maidr.core.plot.barplot import bar_groups
+
+    _, axes = plt.subplots()
+    one_colour = axes.bar(["a", "b"], [1.0, 2.0])
+
+    assert bar_groups(axes, one_colour) is None

--- a/tests/core/plot/test_seaborn_objects_hue.py
+++ b/tests/core/plot/test_seaborn_objects_hue.py
@@ -338,7 +338,7 @@ def test_a_plotter_with_nowhere_to_record_declines_rather_than_raising():
     assert not hasattr(figure, "_maidr_pending")
 
 
-def _bars(frame: pd.DataFrame) -> pd.DataFrame:
+def _bars() -> pd.DataFrame:
     """Two categories over two levels, every magnitude distinct."""
     return pd.DataFrame(
         {"cat": ["a", "a", "b", "b"], "val": [1.0, 2.0, 3.0, 4.0], "g": list("pqpq")}
@@ -362,7 +362,7 @@ def test_a_colour_split_bar_announces_its_categories_not_its_coordinates():
     layer per level puts one bar against one tick again.
     """
     figure = _drawn(
-        lambda fig: so.Plot(_bars(None), x="cat", y="val", color="g")
+        lambda fig: so.Plot(_bars(), x="cat", y="val", color="g")
         .add(so.Bar(), so.Dodge())
         .on(fig)
         .plot()
@@ -391,7 +391,7 @@ def test_every_position_transform_splits_the_same_way(build):
     """`Dodge()` and `Stack()` move the bars; neither changes which level a
     bar belongs to, so all three spellings split alike."""
     figure = plt.figure()
-    build(so.Plot(_bars(None), x="cat", y="val", color="g")).on(figure).plot()
+    build(so.Plot(_bars(), x="cat", y="val", color="g")).on(figure).plot()
     maidr.render(figure)._repr_html_()
 
     assert [
@@ -399,9 +399,65 @@ def test_every_position_transform_splits_the_same_way(build):
     ] == ["p", "q"]
 
 
+def test_three_groups_split_three_ways_in_legend_order():
+    """Two levels is the smallest split there is, so it cannot tell a rule
+    that holds from one that happens to pair up. Three does: `grouped_by_name`
+    builds each group's index list by ascending draw order, and the bars
+    interleave (`p q r p q r`), so a level's bars are non-contiguous."""
+    frame = pd.DataFrame(
+        {
+            "cat": ["a"] * 3 + ["b"] * 3,
+            "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "g": list("pqr") * 2,
+        }
+    )
+    figure = _drawn(
+        lambda fig: so.Plot(frame, x="cat", y="val", color="g")
+        .add(so.Bar(), so.Dodge())
+        .on(fig)
+        .plot()
+    )
+    maidr.render(figure)._repr_html_()
+
+    assert [
+        (plot.schema.get("name"), [(bar["x"], bar["y"]) for bar in plot.schema["data"]])
+        for plot in FigureManager.get_maidr(figure).plots
+    ] == [
+        ("p", [("a", 1.0), ("b", 4.0)]),
+        ("q", [("a", 2.0), ("b", 5.0)]),
+        ("r", [("a", 3.0), ("b", 6.0)]),
+    ]
+
+
+def test_a_horizontal_colour_split_bar_keeps_its_orientation():
+    """The synthetic container carries the original's `orientation`, which is
+    what `_extract_orientation` reads. Drop it and every split bar would
+    default to vertical, putting the category in the magnitude field --
+    exactly the reading #950 warns about."""
+    figure = _drawn(
+        lambda fig: so.Plot(_bars(), y="cat", x="val", color="g")
+        .add(so.Bar(), so.Dodge())
+        .on(fig)
+        .plot()
+    )
+    maidr.render(figure)._repr_html_()
+
+    assert [
+        (
+            plot.schema.get("name"),
+            plot.schema.get("orientation"),
+            [(bar["x"], bar["y"]) for bar in plot.schema["data"]],
+        )
+        for plot in FigureManager.get_maidr(figure).plots
+    ] == [
+        ("p", "horz", [(1.0, "a"), (3.0, "b")]),
+        ("q", "horz", [(2.0, "a"), (4.0, "b")]),
+    ]
+
+
 def test_a_bar_with_no_colour_is_untouched():
     """Additive. One group against no legend reads exactly as it did."""
-    frame = _bars(None).groupby("cat", as_index=False).sum(numeric_only=True)
+    frame = _bars().groupby("cat", as_index=False).sum(numeric_only=True)
     figure = _drawn(
         lambda fig: so.Plot(frame, x="cat", y="val").add(so.Bar()).on(fig).plot()
     )
@@ -421,7 +477,7 @@ def test_each_split_bar_layer_addresses_its_own_bars():
     shape review caught on xability/r-maidr#226, where two layers of a kind
     resolved to the same element and the second highlighted the first's."""
     figure = _drawn(
-        lambda fig: so.Plot(_bars(None), x="cat", y="val", color="g")
+        lambda fig: so.Plot(_bars(), x="cat", y="val", color="g")
         .add(so.Bar(), so.Dodge())
         .on(fig)
         .plot()


### PR DESCRIPTION
Part of #617, following #618 which did the scatter.

Measuring the bar half turned up something worse than the issue recorded. A colour-split `so.Bar` does not read as "a plain `bar`" — it reads as a bar chart **whose categories are coordinates**. Measured on two categories and two levels:

```
                    bars   ticks        announced x
color= (no move)      4    ['a','b']    ['0', '0', '1', '1']
color= + Stack()      4    ['a','b']    ['0', '0', '1', '1']
color= + Dodge()      4    ['a','b']    ['-0.2', '0.2', '0.8', '1.2']
```

The `Dodge()` row is the clearest: a reader is told the categories are `-0.2`, `0.2`, `0.8`, `1.2`. Those are the dodge offsets.

After:

```
color= + Dodge()      bar 'p'  [('a', 1.0), ('b', 3.0)]
                      bar 'q'  [('a', 2.0), ('b', 4.0)]
```

## Why it happened

`BarPlot._labels_for` announces bar **positions** whenever the tick labels do not number the bars. That rule is right, and #382 is why it exists — a numeric x has a locator that picks its own breaks, and pairing three bars with five ticks used to raise and take the whole figure's HTML with it.

A colour split walks straight into it, because every level's bars land on one axes against one tick per *category*. `seaborn.barplot(hue=)` never reaches it: it draws one container **per level**, so each layer already holds one bar per tick.

So the split is what fixes the labels, and the two bar items on #617 turn out to be one piece of work.

## What changed

**`bar_groups()`** does for a `BarContainer` what `hue_groups()` does for a `PathCollection` — one artist carries every level, so the grouping survives only in the bars' colours and the legend naming them.

**Both now end in one shared `groups_from_colours()`**, the part that is about the legend rather than about the artist. Three implementations of that rule had already drifted once (#599); this is where the second caller arrived, so it was extracted rather than copied.

**The handover is a synthetic `BarContainer` per group**, not a filter inside `BarPlot`. The patches are the ones on the axes, so the selectors resolve unchanged and the two layers address their own bars — the collision review caught on xability/r-maidr#226, asserted here.

**`BarPlot` opts into `GROUP_NAME`**, following `HistPlot`, `SmoothPlot`, `BoxPlot`, `ScatterPlot` and `ErrorBarPlot`.

## Still open, deliberately

What a colour-split bar should be **typed** as. All three spellings read as `bar`, where the classic path answers `dodged_bar`. `layer["move"]` states the transform explicitly — cleaner than anything the classic side gets — and that is the remaining item on #617.

## Verification

`uv run pytest` — **3031 passed, 18 skipped**, up from 3021. `ruff check --diff` clean.

8 new tests. One existing test changed its **premise** rather than its expectation: `test_a_colour_split_bar_draws_one_container_and_reads_as_one_layer` asserted the old single-layer reading, and now asserts the split while keeping the container-count claim that was its real content (that count is why `DRAWN_BARS`' singular branch stays unreached).

Mutation sweep, each applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| `_handovers` skips the bar split | killed (7) |
| `BarPlot` stops reading `GROUP_NAME` | killed (4) |
| `render` stops emitting the name | killed (4) |
| the synthetic container takes every patch, not the group's | killed (1) |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_