### PR TITLE
feat(seaborn): type a colour-split seaborn.objects bar from its position transform

### DIFF
--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -6,12 +6,20 @@ from matplotlib.container import BarContainer
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.exception import ExtractionError
+from maidr.util.legend_names import legend_of
 from maidr.util.mixin import (
     BarPositionMixin,
     ContainerExtractorMixin,
     DictMergerMixin,
     LevelExtractorMixin,
 )
+
+#: Key a patch uses to hand this layer the containers it drew, one per group,
+#: instead of letting it sweep the axes. A `seaborn.objects` bar needs it for
+#: a reason the classic path never has: `so.Bar(color=)` draws every level
+#: into *one* container, so the groups are synthesised from the bars' colours
+#: and are not on the axes to be found (#617).
+DRAWN_GROUPS = "_maidr_bar_groups"
 
 
 class GroupedBarPlot(
@@ -24,6 +32,7 @@ class GroupedBarPlot(
     def __init__(self, ax: Axes, plot_type: PlotType, **kwargs) -> None:
         super().__init__(ax, plot_type)
         self._orientation = "vert"
+        self._own_groups = kwargs.get(DRAWN_GROUPS, None)
 
     @property
     def _is_horizontal(self) -> bool:
@@ -85,8 +94,16 @@ class GroupedBarPlot(
         return axes_data
 
     def _extract_z_label_from_legend(self) -> str:
-        """Return the legend title text (trimmed) or an empty string."""
-        legend = self.ax.get_legend()
+        """
+        Return the legend title text (trimmed) or an empty string.
+
+        Through :func:`~maidr.util.legend_names.legend_of` rather than
+        ``ax.get_legend()``, which is what this read before. The two answer
+        the same question -- which legend names this axes' groups -- and the
+        wider answer also reads a lone *figure* legend, which is where
+        ``so.Plot`` puts the only legend a colour-split bar has (#617).
+        """
+        legend = legend_of(self.ax)
         if legend is None:
             return ""
         title = legend.get_title()
@@ -94,8 +111,33 @@ class GroupedBarPlot(
             return ""
         return title.get_text().strip()
 
+    def _own_containers(self) -> list[BarContainer] | None:
+        """
+        The containers this layer holds: the ones handed to it, or the axes'.
+
+        Sweeping the axes is what every grouped bar read before, and it is
+        right for the classic spelling -- ``seaborn.barplot(hue=)`` draws one
+        container per level and nothing else onto that axes. It cannot serve
+        a ``seaborn.objects`` bar, whose levels arrive in a single container
+        and are split by colour after the fact (#617): the sweep would find
+        the one undivided container and read every level as one group.
+
+        The same shape :meth:`maidr.core.plot.barplot.BarPlot._own_containers`
+        already has, for the reason #527 gave it -- a layer reads the artists
+        its own call drew.
+
+        Returns
+        -------
+        list of BarContainer, optional
+            The handed-over containers when there are any, otherwise every
+            container on the axes.
+        """
+        if self._own_groups is not None:
+            return self._own_groups
+        return self.extract_container(self.ax, BarContainer, include_all=True)
+
     def _extract_plot_data(self) -> list[list[dict]]:
-        plot = self.extract_container(self.ax, BarContainer, include_all=True)
+        plot = self._own_containers()
         data = self._extract_grouped_bar_data(plot)
 
         if data is None:
@@ -230,8 +272,14 @@ class GroupedBarPlot(
         >>> categories = plot._extract_hue_categories_from_legend()
         >>> print(categories)
         []
+
+        Notes
+        -----
+        Read through :func:`~maidr.util.legend_names.legend_of`, so a lone
+        figure legend counts -- ``so.Plot`` puts the only legend a
+        colour-split bar has there, and ``ax.get_legend()`` is ``None`` (#617).
         """
-        legend = self.ax.get_legend()
+        legend = legend_of(self.ax)
         if legend is None:
             return []
 

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -15,6 +15,7 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS, bar_groups
+from maidr.core.plot.grouped_barplot import DRAWN_GROUPS
 from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.core.plot.scatterplot import DRAWN_POINTS, HUE_GROUP, hue_groups
 from maidr.patch.common import _draw_quietly
@@ -161,11 +162,65 @@ def _panels(plotter: Any) -> list[Axes]:
     return [ax for ax in getattr(figure, "axes", [])]
 
 
-def _handovers(reading: _Reading, ax: Axes, own: list) -> list[dict]:
+#: What a position transform makes a colour-split bar chart. Keyed on the
+#: ``Move``'s class name for the reason the mark table is: ancestry does not
+#: track what a move *does*, and matching the name states exactly what was
+#: asked for.
+#:
+#: ``Stack`` before ``Dodge`` because a layer may carry both, and stacking is
+#: the one a reader meets -- `so.Dodge(), so.Stack()` dodges the levels apart
+#: and then stacks within each dodged slot, so the segments a reader steps
+#: through are the stack's.
+#:
+#: ``Norm`` is deliberately absent. It looks like the 100% stack's transform
+#: and is not one: `so.Norm()` divides by a *per-group* maximum, so measured
+#: on two categories over two levels, `Norm()` after `Stack()` draws negative
+#: heights and `Norm()` before it leaves the categories summing to 0.833 and
+#: 2.0 rather than to 1. The spelling that is a 100% stack is
+#: `so.Norm(func="sum", by=["x"])` before `so.Stack()`, and reading it needs
+#: a `stacked_normalized_bar` emitter this side does not have -- `NORMALIZED`
+#: is plotly-only in this package. Reported separately (#617).
+_MOVES: tuple[tuple[str, PlotType], ...] = (
+    ("Stack", PlotType.STACKED),
+    ("Dodge", PlotType.DODGED),
+)
+
+
+def _grouped_type(move: Any) -> PlotType | None:
+    """
+    What a layer's position transform makes it, or ``None`` for no transform.
+
+    ``layer["move"]`` is ``None`` or a *list* of ``Move`` objects, applied in
+    the order written. It states the transform outright, which is more than
+    the classic path gets -- `seaborn.barplot(hue=)` is read as dodged by
+    counting containers, and a stacked bar has to be declared through
+    `maidr.stacked()`.
+
+    Parameters
+    ----------
+    move : Any
+        ``layer["move"]``: ``None``, or a list of ``Move`` instances.
+
+    Returns
+    -------
+    PlotType or None
+        ``STACKED`` or ``DODGED`` when the layer carries that transform,
+        ``None`` when it carries neither.
+    """
+    names = {type(one).__name__ for one in move or ()}
+    for name, plot_type in _MOVES:
+        if name in names:
+            return plot_type
+    return None
+
+
+def _handovers(
+    reading: _Reading, ax: Axes, own: list, move: Any = None
+) -> list[tuple[PlotType, dict]]:
     """
     What to register for one layer's artists: one entry per layer to make.
 
-    Three shapes, and each is a fact about the plot class being handed to.
+    Four shapes, and each is a fact about the plot class being handed to.
 
     A **colour-split scatter** becomes one layer per group. `so.Dot(color=)`
     draws a *single* ``PathCollection`` carrying a colour per point -- the
@@ -174,6 +229,19 @@ def _handovers(reading: _Reading, ax: Axes, own: list) -> list[dict]:
     exactly what ``hue_groups`` inverts. Without it a reader is handed one
     layer of every point where the classic spelling of the same chart gives
     one per level, named (#617).
+
+    A **colour-split bar carrying a position transform** becomes one
+    ``dodged_bar`` or ``stacked_bar`` layer holding every group, which is the
+    shape ``seaborn.barplot(hue=)`` already reads as: `data` a list per group,
+    each point carrying its group in `z`, and cross-group navigation between
+    levels at one category. That is strictly more than the split gives, and
+    it is available here because `so` states the transform outright.
+
+    A **colour-split bar with no transform** falls back to one layer per
+    group. `so.Bar(color=)` alone overplots the levels at the same position
+    -- measured, four bars at two x values -- which is neither a dodge nor a
+    stack, so a grouped reading would claim a structure the chart does not
+    have. Named layers are the honest reading of overplotted bars.
 
     A **singular binding** becomes one layer per artist; see
     :class:`_Reading`.
@@ -192,11 +260,15 @@ def _handovers(reading: _Reading, ax: Axes, own: list) -> list[dict]:
         The panel drawn on, asked for the legend that names the colours.
     own : list
         The artists this layer drew on that panel, in draw order.
+    move : Any, optional
+        ``layer["move"]``: the position transforms the layer was written
+        with, which is what types a colour-split bar.
 
     Returns
     -------
-    list of dict
-        One keyword mapping per layer to register.
+    list of (PlotType, dict)
+        One (type, keyword mapping) pair per layer to register. The type is
+        the mark's own except where a position transform names a richer one.
     """
     if reading.plot_type is PlotType.SCATTER and len(own) == 1:
         groups = hue_groups(ax, own[0])
@@ -206,31 +278,42 @@ def _handovers(reading: _Reading, ax: Axes, own: list) -> list[dict]:
             # collection -- because a classic strip plot's groups span
             # several (#586). A mark draws one, so it is a list of one.
             return [
-                {reading.binding: own, HUE_GROUP: (name, [members])}
+                (
+                    reading.plot_type,
+                    {reading.binding: own, HUE_GROUP: (name, [members])},
+                )
                 for name, members in groups
             ]
 
     if reading.plot_type is PlotType.BAR and len(own) == 1:
         groups = bar_groups(ax, own[0])
         if groups:
-            # A synthetic container per group rather than a filter inside
-            # `BarPlot`: the patches are the ones on the axes, so the
+            # A synthetic container per group rather than a filter inside the
+            # plot class: the patches are the ones on the axes, so the
             # selectors resolve unchanged, and every layer then holds one bar
             # per tick -- which is what brings the category names back.
+            containers = [
+                BarContainer(
+                    tuple(own[0][index] for index in members),
+                    orientation=own[0].orientation,
+                )
+                for _, members in groups
+            ]
+            grouped = _grouped_type(move)
+            if grouped is not None:
+                # One layer of every group, which is what `GroupedBarPlot`
+                # takes -- the same list-of-containers a classic
+                # `seaborn.barplot(hue=)` leaves on the axes. It names the
+                # groups from the legend itself, so no `GROUP_NAME` here.
+                return [(grouped, {DRAWN_GROUPS: containers})]
             return [
-                {
-                    reading.binding: BarContainer(
-                        tuple(own[0][index] for index in members),
-                        orientation=own[0].orientation,
-                    ),
-                    GROUP_NAME: name,
-                }
-                for name, members in groups
+                (reading.plot_type, {reading.binding: container, GROUP_NAME: name})
+                for container, (name, _) in zip(containers, groups)
             ]
 
     if reading.singular:
-        return [{reading.binding: one} for one in own]
-    return [{reading.binding: own}]
+        return [(reading.plot_type, {reading.binding: one}) for one in own]
+    return [(reading.plot_type, {reading.binding: own})]
 
 
 def _layer(wrapped, instance, args, kwargs) -> Any:
@@ -302,7 +385,7 @@ def _layer(wrapped, instance, args, kwargs) -> Any:
         # `FacetGrid.add_legend()`, and a name can be deferred to render as a
         # callable -- but a *split* cannot, because it decides how many
         # layers there are. So the reading waits for `_register`.
-        pending.append((ax, reading, own))
+        pending.append((ax, reading, own, layer.get("move")))
 
     return drawn
 
@@ -344,9 +427,9 @@ def _register(wrapped, instance, args, kwargs) -> Any:
 
     plotter = wrapped(*args, **kwargs)
 
-    for ax, reading, own in getattr(plotter, _PENDING, ()):
-        for handover in _handovers(reading, ax, own):
-            FigureManager.create_maidr(ax, reading.plot_type, **handover)
+    for ax, reading, own, move in getattr(plotter, _PENDING, ()):
+        for plot_type, handover in _handovers(reading, ax, own, move):
+            FigureManager.create_maidr(ax, plot_type, **handover)
 
     return plotter
 

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -186,7 +186,7 @@ _MOVES: tuple[tuple[str, PlotType], ...] = (
 )
 
 
-def _grouped_type(move: Any) -> PlotType | None:
+def _grouped_type(move: list[Any] | None) -> PlotType | None:
     """
     What a layer's position transform makes it, or ``None`` for no transform.
 
@@ -198,8 +198,11 @@ def _grouped_type(move: Any) -> PlotType | None:
 
     Parameters
     ----------
-    move : Any
-        ``layer["move"]``: ``None``, or a list of ``Move`` instances.
+    move : list of Move, optional
+        ``layer["move"]``: ``None``, or a list of ``Move`` instances. Typed
+        loosely because naming ``seaborn._core.moves.Move`` would import a
+        private class this module deliberately does not depend on -- it
+        matches on the class *name* for exactly that reason.
 
     Returns
     -------
@@ -215,7 +218,7 @@ def _grouped_type(move: Any) -> PlotType | None:
 
 
 def _handovers(
-    reading: _Reading, ax: Axes, own: list, move: Any = None
+    reading: _Reading, ax: Axes, own: list, move: list[Any] | None = None
 ) -> list[tuple[PlotType, dict]]:
     """
     What to register for one layer's artists: one entry per layer to make.
@@ -260,7 +263,7 @@ def _handovers(
         The panel drawn on, asked for the legend that names the colours.
     own : list
         The artists this layer drew on that panel, in draw order.
-    move : Any, optional
+    move : list of Move, optional
         ``layer["move"]``: the position transforms the layer was written
         with, which is what types a colour-split bar.
 

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -533,15 +533,15 @@ def test_a_colour_split_bar_draws_one_container_and_splits_into_its_groups(
     containers: `bar_groups` does for a container what `hue_groups` does for
     a collection (#617).
 
-    What a colour-split bar should be *typed* as is still open -- all three
-    read as `bar` here, where the classic path answers `dodged_bar` -- and is
-    the remaining item on #617.
+    The container count is what this asserts, and it holds for every
+    spelling. What the layers are *typed* as does not -- a position transform
+    names a richer type -- and that belongs to `test_seaborn_objects_hue.py`,
+    which reads the transform.
     """
     figure = plt.figure()
     build(so.Plot(_frame(), x="cat", y="val", color="g")).on(figure).plot()
 
     assert len(figure.axes[0].containers) == 1
-    assert _kinds(figure) == ["bar", "bar"]
 
 
 @pytest.mark.parametrize(
@@ -580,6 +580,7 @@ def test_a_layer_that_drew_several_containers_becomes_several_bar_layers():
     Asked of `_handovers` directly, because that is the function deciding it
     and no chart can put two containers in front of it today.
     """
+    from maidr.core.enum import PlotType
     from maidr.core.plot.barplot import DRAWN_BARS
     from maidr.patch.seaborn_objects import _READINGS, _handovers
 
@@ -588,6 +589,6 @@ def test_a_layer_that_drew_several_containers_becomes_several_bar_layers():
     second = axes.bar(["b"], [9.0])
 
     assert _handovers(_READINGS["Bar"], axes, [first, second]) == [
-        {DRAWN_BARS: first},
-        {DRAWN_BARS: second},
+        (PlotType.BAR, {DRAWN_BARS: first}),
+        (PlotType.BAR, {DRAWN_BARS: second}),
     ]

--- a/tests/core/plot/test_seaborn_objects_hue.py
+++ b/tests/core/plot/test_seaborn_objects_hue.py
@@ -486,6 +486,50 @@ def test_three_groups_reach_the_grouped_reading_in_legend_order():
     ]
 
 
+def test_a_faceted_grouped_bar_reads_one_layer_per_panel():
+    """The per-panel loop and the grouped handover meet here. Faceting is
+    exercised for the scatter split elsewhere; a bar carrying a transform
+    reaches the same loop by a different branch, and the one legend `so.Plot`
+    builds has to name the groups on *every* panel -- `legend_of` reads a
+    lone figure legend as doing exactly that (#561).
+    """
+    frame = pd.DataFrame(
+        {
+            "cat": ["a", "a", "b", "b"] * 2,
+            "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            "g": list("pqpq") * 2,
+            "panel": ["L"] * 4 + ["R"] * 4,
+        }
+    )
+    figure = _drawn(
+        lambda fig: (
+            so.Plot(frame, x="cat", y="val", color="g")
+            .facet(col="panel")
+            .add(so.Bar(), so.Dodge())
+            .on(fig)
+            .plot()
+        )
+    )
+    maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    assert [plot.schema["type"].value for plot in plots] == [
+        "dodged_bar",
+        "dodged_bar",
+    ]
+    assert [plot.schema["axes"]["z"] for plot in plots] == [{"label": "g"}] * 2
+    assert [
+        [
+            [(bar["z"], bar["x"], bar["y"]) for bar in group]
+            for group in plot.schema["data"]
+        ]
+        for plot in plots
+    ] == [
+        [[("p", "a", 1.0), ("p", "b", 3.0)], [("q", "a", 2.0), ("q", "b", 4.0)]],
+        [[("p", "a", 5.0), ("p", "b", 7.0)], [("q", "a", 6.0), ("q", "b", 8.0)]],
+    ]
+
+
 def test_the_grouped_reading_names_its_z_axis_from_the_figure_legend():
     """`GroupedBarPlot` read both its `z` label and its group names from
     `ax.get_legend()`, which is right for `seaborn.barplot(hue=)` and `None`
@@ -497,10 +541,12 @@ def test_the_grouped_reading_names_its_z_axis_from_the_figure_legend():
     nothing they can name.
     """
     figure = _drawn(
-        lambda fig: so.Plot(_bars(), x="cat", y="val", color="g")
-        .add(so.Bar(), so.Dodge())
-        .on(fig)
-        .plot()
+        lambda fig: (
+            so.Plot(_bars(), x="cat", y="val", color="g")
+            .add(so.Bar(), so.Dodge())
+            .on(fig)
+            .plot()
+        )
     )
     maidr.render(figure)._repr_html_()
     (plot,) = FigureManager.get_maidr(figure).plots

--- a/tests/core/plot/test_seaborn_objects_hue.py
+++ b/tests/core/plot/test_seaborn_objects_hue.py
@@ -89,10 +89,9 @@ def _drawn(build) -> plt.Figure:
 def test_a_colour_split_dot_reads_one_named_layer_per_group():
     """Two layers, named, each holding its own half."""
     figure = _drawn(
-        lambda fig: so.Plot(_frame(), x="x", y="y", color="g")
-        .add(so.Dot())
-        .on(fig)
-        .plot()
+        lambda fig: (
+            so.Plot(_frame(), x="x", y="y", color="g").add(so.Dot()).on(fig).plot()
+        )
     )
 
     assert _named(figure) == [
@@ -108,10 +107,9 @@ def test_it_reads_exactly_as_the_classic_spelling_of_the_same_chart():
     frame = _frame()
     objects = _named(
         _drawn(
-            lambda fig: so.Plot(frame, x="x", y="y", color="g")
-            .add(so.Dot())
-            .on(fig)
-            .plot()
+            lambda fig: (
+                so.Plot(frame, x="x", y="y", color="g").add(so.Dot()).on(fig).plot()
+            )
         )
     )
     classic = _named(
@@ -128,10 +126,9 @@ def test_it_reads_exactly_as_the_classic_spelling_of_the_same_chart():
 def test_a_colour_split_dots_mark_splits_too():
     """`so.Dots` is the many-points spelling and draws the same artist."""
     figure = _drawn(
-        lambda fig: so.Plot(_frame(), x="x", y="y", color="g")
-        .add(so.Dots())
-        .on(fig)
-        .plot()
+        lambda fig: (
+            so.Plot(_frame(), x="x", y="y", color="g").add(so.Dots()).on(fig).plot()
+        )
     )
 
     assert [name for _, name, _ in _named(figure)] == ["p", "q"]
@@ -157,10 +154,9 @@ def test_a_colour_split_line_is_still_one_layer_of_several_series():
     frame = _frame()
     objects = _named(
         _drawn(
-            lambda fig: so.Plot(frame, x="x", y="y", color="g")
-            .add(so.Line())
-            .on(fig)
-            .plot()
+            lambda fig: (
+                so.Plot(frame, x="x", y="y", color="g").add(so.Line()).on(fig).plot()
+            )
         )
     )
     classic = _named(
@@ -178,11 +174,13 @@ def test_each_facet_panel_splits_its_own_groups():
     """The split is per panel, and the legend naming it is the figure's."""
     frame = _frame().assign(panel=["one", "one", "two", "one", "one", "two"])
     figure = _drawn(
-        lambda fig: so.Plot(frame, x="x", y="y", color="g")
-        .facet(col="panel")
-        .add(so.Dot())
-        .on(fig)
-        .plot()
+        lambda fig: (
+            so.Plot(frame, x="x", y="y", color="g")
+            .facet(col="panel")
+            .add(so.Dot())
+            .on(fig)
+            .plot()
+        )
     )
 
     assert [(name, held) for _, name, held in _named(figure)] == [
@@ -198,10 +196,9 @@ def test_every_split_layer_can_be_highlighted():
     spot xability/maidr#814 names, and a split layer addresses its points
     through the collection it shares with its sibling."""
     figure = _drawn(
-        lambda fig: so.Plot(_frame(), x="x", y="y", color="g")
-        .add(so.Dot())
-        .on(fig)
-        .plot()
+        lambda fig: (
+            so.Plot(_frame(), x="x", y="y", color="g").add(so.Dot()).on(fig).plot()
+        )
     )
     html = maidr.render(figure)._repr_html_()
     plots = FigureManager.get_maidr(figure).plots
@@ -360,12 +357,15 @@ def test_a_colour_split_bar_announces_its_categories_not_its_coordinates():
 
     Those are the dodge offsets, announced as the categories. Splitting the
     layer per level puts one bar against one tick again.
+
+    Asked here of the plain `color=` spelling, which stays split: a bar
+    carrying `Dodge()` or `Stack()` is read as one grouped layer instead, and
+    the same claim about its categories is made below against that shape.
     """
     figure = _drawn(
-        lambda fig: so.Plot(_bars(), x="cat", y="val", color="g")
-        .add(so.Bar(), so.Dodge())
-        .on(fig)
-        .plot()
+        lambda fig: (
+            so.Plot(_bars(), x="cat", y="val", color="g").add(so.Bar()).on(fig).plot()
+        )
     )
     maidr.render(figure)._repr_html_()
     plots = FigureManager.get_maidr(figure).plots
@@ -380,23 +380,46 @@ def test_a_colour_split_bar_announces_its_categories_not_its_coordinates():
 
 
 @pytest.mark.parametrize(
-    "build",
+    "build, expected",
     [
-        pytest.param(lambda plot: plot.add(so.Bar()), id="plain"),
-        pytest.param(lambda plot: plot.add(so.Bar(), so.Dodge()), id="dodged"),
-        pytest.param(lambda plot: plot.add(so.Bar(), so.Stack()), id="stacked"),
+        pytest.param(lambda plot: plot.add(so.Bar()), "bar", id="plain"),
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Dodge()), "dodged_bar", id="dodged"
+        ),
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Stack()), "stacked_bar", id="stacked"
+        ),
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Dodge(), so.Stack()),
+            "stacked_bar",
+            id="dodged-then-stacked",
+        ),
     ],
 )
-def test_every_position_transform_splits_the_same_way(build):
-    """`Dodge()` and `Stack()` move the bars; neither changes which level a
-    bar belongs to, so all three spellings split alike."""
+def test_a_position_transform_types_the_layer(build, expected):
+    """The third item on #617. `so` states the transform as an explicit
+    `Move` on the layer, which is a cleaner signal than anything the classic
+    path gets -- `seaborn.barplot(hue=)` is read as dodged by *counting
+    containers*, and a stacked bar has to be declared through
+    `maidr.stacked()`.
+
+    A transform makes the chart a grouped bar chart of that kind, so it reads
+    as one layer of every group rather than a layer per group. Plain `color=`
+    has no transform and overplots the levels at the same position, which is
+    neither, so it keeps the split.
+
+    `Dodge()` *and* `Stack()` together resolves to the stack: seaborn dodges
+    the levels apart and then stacks within each dodged slot, so the segments
+    a reader steps through are the stack's.
+    """
     figure = plt.figure()
     build(so.Plot(_bars(), x="cat", y="val", color="g")).on(figure).plot()
     maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
 
-    assert [
-        plot.schema.get("name") for plot in FigureManager.get_maidr(figure).plots
-    ] == ["p", "q"]
+    assert [str(plot.schema["type"].value) for plot in plots] == (
+        [expected] if expected != "bar" else ["bar", "bar"]
+    )
 
 
 def test_three_groups_split_three_ways_in_legend_order():
@@ -412,10 +435,9 @@ def test_three_groups_split_three_ways_in_legend_order():
         }
     )
     figure = _drawn(
-        lambda fig: so.Plot(frame, x="cat", y="val", color="g")
-        .add(so.Bar(), so.Dodge())
-        .on(fig)
-        .plot()
+        lambda fig: (
+            so.Plot(frame, x="cat", y="val", color="g").add(so.Bar()).on(fig).plot()
+        )
     )
     maidr.render(figure)._repr_html_()
 
@@ -429,29 +451,103 @@ def test_three_groups_split_three_ways_in_legend_order():
     ]
 
 
-def test_a_horizontal_colour_split_bar_keeps_its_orientation():
-    """The synthetic container carries the original's `orientation`, which is
-    what `_extract_orientation` reads. Drop it and every split bar would
-    default to vertical, putting the category in the magnitude field --
-    exactly the reading #950 warns about."""
+def test_three_groups_reach_the_grouped_reading_in_legend_order():
+    """The same three levels through the transform branch, where they become
+    one layer of three groups rather than three layers. The interleaving is
+    what makes it worth asking twice: `grouped_by_name` returns each level's
+    indices in ascending draw order, and with `p q r p q r` no level's bars
+    are contiguous, so a container assembled from the wrong slice shows up.
+    """
+    frame = pd.DataFrame(
+        {
+            "cat": ["a"] * 3 + ["b"] * 3,
+            "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            "g": list("pqr") * 2,
+        }
+    )
     figure = _drawn(
-        lambda fig: so.Plot(_bars(), y="cat", x="val", color="g")
+        lambda fig: (
+            so.Plot(frame, x="cat", y="val", color="g")
+            .add(so.Bar(), so.Dodge())
+            .on(fig)
+            .plot()
+        )
+    )
+    maidr.render(figure)._repr_html_()
+    (plot,) = FigureManager.get_maidr(figure).plots
+
+    assert [
+        [(bar["z"], bar["x"], bar["y"]) for bar in group]
+        for group in plot.schema["data"]
+    ] == [
+        [("p", "a", 1.0), ("p", "b", 4.0)],
+        [("q", "a", 2.0), ("q", "b", 5.0)],
+        [("r", "a", 3.0), ("r", "b", 6.0)],
+    ]
+
+
+def test_the_grouped_reading_names_its_z_axis_from_the_figure_legend():
+    """`GroupedBarPlot` read both its `z` label and its group names from
+    `ax.get_legend()`, which is right for `seaborn.barplot(hue=)` and `None`
+    for an `so.Plot` -- seaborn hangs that legend on the **figure**. Reading
+    through `legend_of` finds it, the same tier #561 added for `PairGrid`.
+
+    Without it the `z` axis has no label and the groups fall back to the
+    containers' matplotlib labels, so a reader is told the levels apart by
+    nothing they can name.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_bars(), x="cat", y="val", color="g")
         .add(so.Bar(), so.Dodge())
         .on(fig)
         .plot()
     )
     maidr.render(figure)._repr_html_()
+    (plot,) = FigureManager.get_maidr(figure).plots
 
-    assert [
-        (
-            plot.schema.get("name"),
-            plot.schema.get("orientation"),
-            [(bar["x"], bar["y"]) for bar in plot.schema["data"]],
+    assert figure.axes[0].get_legend() is None
+    assert plot.schema["axes"]["z"] == {"label": "g"}
+    assert [group[0]["z"] for group in plot.schema["data"]] == ["p", "q"]
+
+
+@pytest.mark.parametrize(
+    "build",
+    [
+        pytest.param(lambda plot: plot.add(so.Bar()), id="split"),
+        pytest.param(lambda plot: plot.add(so.Bar(), so.Dodge()), id="grouped"),
+    ],
+)
+def test_a_horizontal_colour_split_bar_keeps_its_orientation(build):
+    """The synthetic container carries the original's `orientation`, and both
+    readings depend on it -- `BarPlot._extract_orientation` on the split path,
+    `GroupedBarPlot._extract_orientation` on the grouped one. Drop it and a
+    horizontal colour-split bar defaults to vertical, putting the category in
+    the magnitude field: exactly the reading #950 warns about.
+    """
+    figure = _drawn(
+        lambda fig: build(so.Plot(_bars(), y="cat", x="val", color="g")).on(fig).plot()
+    )
+    maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    assert {plot.schema["orientation"] for plot in plots} == {"horz"}
+    # The magnitude runs along x and the category sits on y, whichever
+    # reading was taken -- the layers just group the same points differently.
+    points = [
+        bar
+        for plot in plots
+        for group in (
+            plot.schema["data"]
+            if isinstance(plot.schema["data"][0], list)
+            else [plot.schema["data"]]
         )
-        for plot in FigureManager.get_maidr(figure).plots
-    ] == [
-        ("p", "horz", [(1.0, "a"), (3.0, "b")]),
-        ("q", "horz", [(2.0, "a"), (4.0, "b")]),
+        for bar in group
+    ]
+    assert sorted((bar["x"], bar["y"]) for bar in points) == [
+        (1.0, "a"),
+        (2.0, "a"),
+        (3.0, "b"),
+        (4.0, "b"),
     ]
 
 
@@ -477,10 +573,12 @@ def test_each_split_bar_layer_addresses_its_own_bars():
     shape review caught on xability/r-maidr#226, where two layers of a kind
     resolved to the same element and the second highlighted the first's."""
     figure = _drawn(
-        lambda fig: so.Plot(_bars(), x="cat", y="val", color="g")
-        .add(so.Bar(), so.Dodge())
-        .on(fig)
-        .plot()
+        lambda fig: (
+            so.Plot(_bars(), x="cat", y="val", color="g")
+            .add(so.Bar(), so.Dodge())
+            .on(fig)
+            .plot()
+        )
     )
     html = maidr.render(figure)._repr_html_()
     plots = FigureManager.get_maidr(figure).plots


### PR DESCRIPTION
The third and last item on #617, after #616 (registration), #618 (scatter split) and #619 (bar split).

A colour-split `so.Bar` with `so.Dodge()` or `so.Stack()` read as plain `bar` layers, where the same chart written `seaborn.barplot(hue=)` answers `dodged_bar`. A reader lost the grouping structure, the `z` axis naming it, and cross-group navigation between levels at one category.

`so` states the transform outright as a `Move` on the layer, which is a **cleaner signal than anything the classic path gets**: `seaborn.barplot(hue=)` is read as dodged by *counting containers*, and a stacked bar has to be declared through `maidr.stacked()`.

Measured, two categories over two levels:

| spelling | before | after |
|---|---|---|
| `color=` | `bar`, `bar` | `bar`, `bar` (unchanged) |
| `color=` + `Dodge()` | `bar`, `bar` | `dodged_bar` |
| `color=` + `Stack()` | `bar`, `bar` | `stacked_bar` |
| `color=` + `Dodge(), Stack()` | `bar`, `bar` | `stacked_bar` |

The grouped payload is the one the classic path already emits, so the two spellings of one chart now read alike:

```
dodged_bar   axes.z.label 'g'
             [[{'x':'a','z':'p','y':1.0}, {'x':'b','z':'p','y':3.0}],
              [{'x':'a','z':'q','y':2.0}, {'x':'b','z':'q','y':4.0}]]
```

## Plain `color=` keeps the split

It carries no transform and **overplots** the levels at the same position — measured, four bars at two x values. That is neither a dodge nor a stack, so a grouped reading would claim a structure the chart does not have. #619's named layers stay the honest reading of overplotted bars.

## Two supporting changes

**`GroupedBarPlot` can be handed its containers** instead of sweeping the axes. The sweep is right for the classic spelling, where the levels *are* separate containers, and cannot serve an `so.Bar(color=)`, whose levels arrive in one container and are split by colour after the fact — the sweep finds the one undivided container and reads every level as one group. Same shape `BarPlot._own_containers` has had since #527.

**Its two legend reads go through `legend_of`.** `so.Plot` hangs its legend on the **figure** (`ax.get_legend() is None`, `len(fig.legends) == 1`), so without this the `z` axis had no label and the groups fell back to the containers' matplotlib labels — a reader told the levels apart by nothing they can name. Same tier #561 added for `PairGrid`.

## `so.Norm()` is deliberately not read as a 100% stack

It looks like the missing symmetric case and is not one. `Norm()` defaults to `func="max"` with no `by`, which rescales within each *colour group*:

```
Stack(), Norm()    heights  0.333,  1.0,  -0.571,  -2.0     <- negative
Norm(), Stack()    categories sum to 0.833 and 2.0          <- not 1
```

The spelling that **is** a 100% stack is `Norm(func="sum", by=["x"])` before `Stack()`, which does sum to exactly 1 per category. Reading it needs a `stacked_normalized_bar` emitter this side does not have — `PlotType.NORMALIZED` is plotly-only in this package, with no `MaidrPlotFactory` branch. Filed as #620 with both measurements and the two pieces it needs, and documented at `_MOVES` so the next reader does not add it as the obvious omission.

## Verification

`uv run pytest` — **3037 passed, 18 skipped**, up from 3033. `ruff check --diff maidr/ tests/` clean.

Four tests changed their **premise** rather than their expectation, each because `Dodge()`/`Stack()` now group where they used to split; each was rewritten to keep the claim that was its real content:

- `test_a_colour_split_bar_announces_its_categories_not_its_coordinates` — moved to the plain `color=` spelling, which stays split; the same claim is made against the grouped shape below it.
- `test_every_position_transform_splits_the_same_way` → `test_a_position_transform_types_the_layer`, now covering `Dodge(), Stack()` together as well.
- `test_three_groups_split_three_ways_in_legend_order` — kept on the split path, joined by a grouped three-group twin. Three levels still matter for the same reason: with `p q r p q r` no level's bars are contiguous.
- `test_a_horizontal_colour_split_bar_keeps_its_orientation` — parametrized over both readings; the synthetic container's `orientation` now feeds `GroupedBarPlot._extract_orientation` too.
- `test_a_colour_split_bar_draws_one_container_and_splits_into_its_groups` — kept its container-count claim, which holds for every spelling, and dropped the type claim that now belongs elsewhere.
- `test_a_layer_that_drew_several_containers_becomes_several_bar_layers` — mechanical: `_handovers` now returns `(PlotType, kwargs)` pairs.

One new test, `test_the_grouped_reading_names_its_z_axis_from_the_figure_legend`, pins both legend reads.

Mutation sweep, each applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| `_grouped_type` never types from the move | killed (4) |
| `Dodge` ordered before `Stack` in `_MOVES` | killed (1) |
| `GroupedBarPlot` sweeps the axes instead of taking its containers | killed (2) |
| both legend reads back to `ax.get_legend()` | killed (2) |

The last one killed only 1 before the `z`-label test was added — that test is why it now kills 2.

Closes #617.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_