### PR TITLE
feat(seaborn): read a seaborn.objects 100% stacked bar as one

### DIFF
--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -155,7 +155,14 @@ class MaidrPlotFactory:
             if kwargs.get(DRAWN_RUG) is not None:
                 return RugPlot(single_ax, **kwargs)
             return ScatterPlot(single_ax, **kwargs)
-        elif PlotType.DODGED == plot_type or PlotType.STACKED == plot_type:
+        elif plot_type in (PlotType.DODGED, PlotType.STACKED, PlotType.NORMALIZED):
+            # One class, three types. They differ in how the groups relate --
+            # side by side, piled up, piled up to a whole -- not in where the
+            # numbers come from, which is one magnitude per bar either way.
+            # A `NORMALIZED` layer's bars are already shares, because the
+            # library drew them that way; the plotly path computes its own
+            # (`maidr/plotly/barnorm.py`) only because plotly draws the raw
+            # values and normalises them in the view (#338, #620).
             return GroupedBarPlot(single_ax, plot_type, **kwargs)
         elif PlotType.SMOOTH == plot_type:
             return SmoothPlot(single_ax, **kwargs)

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -172,18 +172,113 @@ def _panels(plotter: Any) -> list[Axes]:
 #: and then stacks within each dodged slot, so the segments a reader steps
 #: through are the stack's.
 #:
-#: ``Norm`` is deliberately absent. It looks like the 100% stack's transform
-#: and is not one: `so.Norm()` divides by a *per-group* maximum, so measured
-#: on two categories over two levels, `Norm()` after `Stack()` draws negative
-#: heights and `Norm()` before it leaves the categories summing to 0.833 and
-#: 2.0 rather than to 1. The spelling that is a 100% stack is
-#: `so.Norm(func="sum", by=["x"])` before `so.Stack()`, and reading it needs
-#: a `stacked_normalized_bar` emitter this side does not have -- `NORMALIZED`
-#: is plotly-only in this package. Reported separately (#617).
+#: ``Norm`` is not here, because whether it makes a 100% stack cannot be
+#: answered from its class name. See :func:`_normalises_to_a_whole`.
 _MOVES: tuple[tuple[str, PlotType], ...] = (
     ("Stack", PlotType.STACKED),
     ("Dodge", PlotType.DODGED),
 )
+
+
+#: What a 100% stack's segments sum to, per category. ``so.Norm`` writes
+#: shares as fractions by default and as percentages under ``percent=True``,
+#: and the schema carries whichever the chart drew -- the plotly side does
+#: the same, through ``barnorm_scale`` (#338).
+_WHOLES = (1.0, 100.0)
+
+#: How far a stack's total may sit from a whole and still be one. Segments
+#: come off the drawn rectangles, so they carry the rounding of every share
+#: seaborn computed; measured on the spellings below, the worst total was
+#: within 1e-9 of its whole, so this is loose by a wide margin and still far
+#: tighter than any total that is not a whole (the nearest measured miss is
+#: 2.0).
+_WHOLE_TOLERANCE = 1e-6
+
+
+def _normalises_to_a_whole(move: list[Any] | None, container: BarContainer) -> bool:
+    """
+    Whether a stacked layer's segments are *shares of a whole*.
+
+    Asked of the drawn bars rather than of the spelling, because the spelling
+    cannot answer it. ``so.Norm`` takes a ``func`` and a ``by``, and only some
+    combinations normalise within the category. Measured, two categories over
+    two levels, totalling each category's stack:
+
+    ======================================  =======
+    ``Norm(...)`` before ``Stack()``        total
+    ======================================  =======
+    ``func="sum", by=["x"]``                1.0
+    ``func="sum", by=["x", "color"]``       2.0
+    ``func="sum"`` (no ``by``)              0.583 / 1.417
+    ``func="max"`` (the default)            0.833 / 2.0
+    ======================================  =======
+
+    Only the first is a 100% stack. The second is the trap: it names the
+    category axis, looks right, and normalises *each level* to 1 so the
+    stacks reach 2. A rule reading ``by`` for the category axis would claim
+    it and announce shares that sum to twice the whole.
+
+    So this asks the two questions separately. **Did the author ask for a
+    sum-normalisation**, which no plain ``Stack()`` does, and **did the bars
+    land on a whole**, which is what the type claims. Requiring both leaves
+    an ordinary stack reading as ``stacked_bar`` even when its categories
+    happen to total alike, and refuses a normalisation that did not land.
+
+    Where the moves sit *relative to each other* is deliberately not asked,
+    though it plainly matters to what gets drawn -- ``Stack()`` then
+    ``Norm()`` normalises the already-stacked tops and can draw segments of
+    negative height. The totals turn every such chart away on their own.
+    After that order the drawn tops are each category's ``t_i / sum(t_i)``
+    over the *cumulative* tops, so they are all wholes only when one top
+    carries the whole sum, which needs every level but the last at zero --
+    and seaborn draws no rectangle for a zero, so those levels leave no
+    colour, the split finds one group and no grouped layer is made at all.
+    Measured: three levels with one at zero totals 0.8 and 0.667, turned
+    away on the totals; two levels with one at zero draws **two** patches of
+    one colour and reads as a plain ``bar``. An order check would refuse
+    charts that never reach here.
+
+    Parameters
+    ----------
+    move : list of Move, optional
+        ``layer["move"]``, in the order the moves were written.
+    container : BarContainer
+        Every bar the layer drew, which is where the totals come from.
+
+    Returns
+    -------
+    bool
+        ``True`` when the layer asked to be normalised by sum and its
+        categories each total a whole.
+    """
+    names = [type(one).__name__ for one in move or ()]
+    if "Stack" not in names:
+        return False
+    if not any(
+        name == "Norm" and getattr(one, "func", None) == "sum"
+        for name, one in zip(names, move or ())
+    ):
+        return False
+
+    horizontal = container.orientation == "horizontal"
+    totals: dict[float, float] = {}
+    for patch in container:
+        if horizontal:
+            position, top = patch.get_y(), patch.get_x() + patch.get_width()
+        else:
+            position, top = patch.get_x(), patch.get_y() + patch.get_height()
+        # The top of the tallest segment *is* the stack's total, which saves
+        # summing the sizes and matches what a reader sees at the top of the
+        # bar. Keyed on the drawn position, which every segment of one
+        # category shares -- `Stack()` moves them along the magnitude axis
+        # only.
+        key = float(position)
+        totals[key] = max(totals.get(key, float("-inf")), float(top))
+
+    return bool(totals) and all(
+        any(abs(total - whole) <= _WHOLE_TOLERANCE for whole in _WHOLES)
+        for total in totals.values()
+    )
 
 
 def _grouped_type(move: list[Any] | None) -> PlotType | None:
@@ -303,6 +398,8 @@ def _handovers(
                 for _, members in groups
             ]
             grouped = _grouped_type(move)
+            if grouped is PlotType.STACKED and _normalises_to_a_whole(move, own[0]):
+                grouped = PlotType.NORMALIZED
             if grouped is not None:
                 # One layer of every group, which is what `GroupedBarPlot`
                 # takes -- the same list-of-containers a classic

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -195,6 +195,36 @@ _WHOLES = (1.0, 100.0)
 _WHOLE_TOLERANCE = 1e-6
 
 
+def _sums(func: Any) -> bool:
+    """
+    Whether a ``Norm``'s ``func`` adds its group up.
+
+    ``so.Norm`` takes either the *name* of a numpy method -- the documented
+    spelling, and ``"max"`` by default -- or a callable. Both are read,
+    because ``Norm(func=numpy.sum)`` draws exactly what ``Norm(func="sum")``
+    does and a reader should not be told a different thing about it.
+
+    A callable is matched on ``__name__``, which is ``"sum"`` for both
+    ``numpy.sum`` and the builtin. Anything else declines, a lambda included:
+    it is the layer's *stated* intent this reads, and a lambda states none.
+    That direction is the safe one -- the chart keeps reading as the stack it
+    is, rather than being claimed as a whole on a guess.
+
+    Parameters
+    ----------
+    func : Any
+        ``Norm.func``: a string, or a callable.
+
+    Returns
+    -------
+    bool
+        ``True`` for ``"sum"`` and for a callable named ``sum``.
+    """
+    if isinstance(func, str):
+        return func == "sum"
+    return getattr(func, "__name__", None) == "sum"
+
+
 def _normalises_to_a_whole(move: list[Any] | None, container: BarContainer) -> bool:
     """
     Whether a stacked layer's segments are *shares of a whole*.
@@ -219,8 +249,8 @@ def _normalises_to_a_whole(move: list[Any] | None, container: BarContainer) -> b
     it and announce shares that sum to twice the whole.
 
     So this asks the two questions separately. **Did the author ask for a
-    sum-normalisation**, which no plain ``Stack()`` does, and **did the bars
-    land on a whole**, which is what the type claims. Requiring both leaves
+    sum-normalisation** (:func:`_sums`), which no plain ``Stack()`` does, and
+    **did the bars land on a whole**, which is what the type claims. Requiring both leaves
     an ordinary stack reading as ``stacked_bar`` even when its categories
     happen to total alike, and refuses a normalisation that did not land.
 
@@ -255,7 +285,7 @@ def _normalises_to_a_whole(move: list[Any] | None, container: BarContainer) -> b
     if "Stack" not in names:
         return False
     if not any(
-        name == "Norm" and getattr(one, "func", None) == "sum"
+        name == "Norm" and _sums(getattr(one, "func", None))
         for name, one in zip(names, move or ())
     ):
         return False
@@ -272,6 +302,14 @@ def _normalises_to_a_whole(move: list[Any] | None, container: BarContainer) -> b
         # bar. Keyed on the drawn position, which every segment of one
         # category shares -- `Stack()` moves them along the magnitude axis
         # only.
+        #
+        # A `Dodge()` alongside the stack does move them apart, and the keys
+        # then split with them, which is the answer rather than a hole in it:
+        # each drawn column is one dodge slot's share of its category, not
+        # the category, so none of them is a whole and the layer stays a
+        # `stacked_bar`. Measured, four levels dodged and stacked under
+        # `Norm(func="sum", by=["x"])`: eight columns topping out between
+        # 0.1 and 0.4, no whole among them.
         key = float(position)
         totals[key] = max(totals.get(key, float("-inf")), float(top))
 

--- a/tests/core/plot/test_seaborn_objects_hue.py
+++ b/tests/core/plot/test_seaborn_objects_hue.py
@@ -664,6 +664,84 @@ def test_a_stack_normalised_afterwards_is_claimed_only_when_it_landed():
     assert [plot.schema["type"].value for plot in plots] == ["bar"]
 
 
+def test_a_callable_sum_is_read_like_the_named_one():
+    """`so.Norm` takes either a numpy method's *name* or a callable, and
+    `Norm(func=numpy.sum)` draws exactly what `Norm(func="sum")` does -- so a
+    reader should not be told a different thing about it.
+
+    A lambda still declines. What this reads is the layer's stated intent,
+    and a lambda states none; declining keeps the chart reading as the stack
+    it is rather than claiming a whole on a guess.
+    """
+    import numpy as np
+
+    for func in ("sum", np.sum, sum):
+        figure = plt.figure()
+        (
+            so.Plot(_bars(), x="cat", y="val", color="g")
+            .add(so.Bar(), so.Norm(func=func, by=["x"]), so.Stack())
+            .on(figure)
+            .plot()
+        )
+        maidr.render(figure)._repr_html_()
+        assert [
+            plot.schema["type"].value for plot in FigureManager.get_maidr(figure).plots
+        ] == ["stacked_normalized_bar"], func
+        plt.close("all")
+
+    figure = plt.figure()
+    (
+        so.Plot(_bars(), x="cat", y="val", color="g")
+        .add(so.Bar(), so.Norm(func=lambda a, **kw: a.sum(**kw), by=["x"]), so.Stack())
+        .on(figure)
+        .plot()
+    )
+    maidr.render(figure)._repr_html_()
+    assert [
+        plot.schema["type"].value for plot in FigureManager.get_maidr(figure).plots
+    ] == ["stacked_bar"]
+
+
+def test_a_dodge_beside_the_stack_is_not_a_whole():
+    """Where the boundary of `_normalises_to_a_whole` sits, stated rather
+    than left implicit.
+
+    Totals are keyed on the drawn position, and a `Dodge()` moves the
+    segments apart, so the keys split with them. That is the answer rather
+    than a hole in it: each drawn column is one dodge slot's share of its
+    category, not the category's, so none of them is a whole. Measured, four
+    levels dodged and stacked under `Norm(func="sum", by=["x"])`: eight
+    columns topping out between 0.1 and 0.4.
+    """
+    frame = pd.DataFrame(
+        {
+            "cat": ["a"] * 4 + ["b"] * 4,
+            "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            "g": list("pqrs") * 2,
+        }
+    )
+    figure = _drawn(
+        lambda fig: (
+            so.Plot(frame, x="cat", y="val", color="g")
+            .add(so.Bar(), so.Norm(func="sum", by=["x"]), so.Dodge(), so.Stack())
+            .on(fig)
+            .plot()
+        )
+    )
+    maidr.render(figure)._repr_html_()
+
+    tops = {}
+    for patch in figure.axes[0].containers[0]:
+        key = round(float(patch.get_x()), 3)
+        tops[key] = max(tops.get(key, 0.0), patch.get_y() + patch.get_height())
+    assert len(tops) == 8
+    assert not any(abs(top - 1.0) < 1e-6 for top in tops.values())
+
+    assert [
+        plot.schema["type"].value for plot in FigureManager.get_maidr(figure).plots
+    ] == ["stacked_bar"]
+
+
 def test_only_a_sum_normalisation_counts_as_asking_for_a_whole():
     """The intent half of `_normalises_to_a_whole`, asked of the function
     directly because no `so.Bar` reaches it.

--- a/tests/core/plot/test_seaborn_objects_hue.py
+++ b/tests/core/plot/test_seaborn_objects_hue.py
@@ -530,6 +530,219 @@ def test_a_faceted_grouped_bar_reads_one_layer_per_panel():
     ]
 
 
+@pytest.mark.parametrize(
+    "build, expected",
+    [
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Norm(func="sum", by=["x"]), so.Stack()),
+            "stacked_normalized_bar",
+            id="shares",
+        ),
+        pytest.param(
+            lambda plot: plot.add(
+                so.Bar(),
+                so.Norm(func="sum", by=["x"], percent=True),
+                so.Stack(),
+            ),
+            "stacked_normalized_bar",
+            id="percent",
+        ),
+        pytest.param(
+            lambda plot: plot.add(
+                so.Bar(), so.Norm(func="sum", by=["x", "color"]), so.Stack()
+            ),
+            "stacked_bar",
+            id="normed-per-level",
+        ),
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Norm(), so.Stack()),
+            "stacked_bar",
+            id="normed-by-max",
+        ),
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Norm(func="sum"), so.Stack()),
+            "stacked_bar",
+            id="normed-without-by",
+        ),
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Stack(), so.Norm(func="sum", by=["x"])),
+            "stacked_bar",
+            id="normed-after-stacking",
+        ),
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Stack()),
+            "stacked_bar",
+            id="not-normed",
+        ),
+        pytest.param(
+            lambda plot: plot.add(so.Bar(), so.Norm(func="sum", by=["x"]), so.Dodge()),
+            "dodged_bar",
+            id="normed-but-not-stacked",
+        ),
+    ],
+)
+def test_only_a_stack_that_reaches_a_whole_is_a_hundred_percent_bar(build, expected):
+    """#620. `so.Norm` looks like the 100% stack's transform and is not one
+    on its own -- which combination of `func` and `by` was written decides,
+    and so does whether it ran before the stack. Measured, each category's
+    stack total::
+
+        Norm(func="sum", by=["x"])              1.0     <- a whole
+        Norm(func="sum", by=["x", "color"])     2.0     <- every level to 1
+        Norm(func="sum")                        0.583 / 1.417
+        Norm()                                  0.833 / 2.0
+        Stack() then Norm(...)                  0.429 / 1.0
+
+    `by=["x", "color"]` is the trap: it names the category axis, so a rule
+    reading `by` would claim it, and it announces shares summing to twice
+    the whole.
+
+    So the drawn bars are asked instead, and a plain `Stack()` is left alone
+    even when its categories happen to total alike -- the author has to have
+    asked for a sum-normalisation *and* the bars have to have landed on it.
+
+    `Stack()` before `Norm(...)` is turned away by the totals rather than by
+    a rule about the order; `test_a_stack_normalised_afterwards_is_claimed_
+    only_when_it_landed` covers where that lands and why the order is not
+    asked about separately.
+    """
+    figure = plt.figure()
+    build(so.Plot(_bars(), x="cat", y="val", color="g")).on(figure).plot()
+    maidr.render(figure)._repr_html_()
+
+    assert [
+        plot.schema["type"].value for plot in FigureManager.get_maidr(figure).plots
+    ] == [expected]
+
+
+def test_a_stack_normalised_afterwards_is_claimed_only_when_it_landed():
+    """Why `_normalises_to_a_whole` does not check where `Norm` sits relative
+    to `Stack`, even though the order plainly changes the drawing.
+
+    After `Stack()` then `Norm(func="sum")` the drawn tops are each
+    category's `t_i / sum(t_i)` over the *cumulative* tops, so they are all
+    wholes only when one top carries the whole sum -- every level but the
+    last at zero -- and the shares announced then (0, 1) are the true ones.
+
+    Three levels with one at zero: tops 0.8 and 0.667, turned away.
+    Two levels with one at zero: tops 1.0, claimed, and correctly.
+    """
+    three = pd.DataFrame(
+        {
+            "cat": ["a"] * 3 + ["b"] * 3,
+            "val": [0.0, 1.0, 3.0, 0.0, 2.0, 2.0],
+            "g": list("pqr") * 2,
+        }
+    )
+    figure = _drawn(
+        lambda fig: (
+            so.Plot(three, x="cat", y="val", color="g")
+            .add(so.Bar(), so.Stack(), so.Norm(func="sum", by=["x"]))
+            .on(fig)
+            .plot()
+        )
+    )
+    maidr.render(figure)._repr_html_()
+    assert [
+        plot.schema["type"].value for plot in FigureManager.get_maidr(figure).plots
+    ] == ["stacked_bar"]
+
+    two = pd.DataFrame(
+        {"cat": ["a", "a", "b", "b"], "val": [0.0, 2.0, 0.0, 4.0], "g": list("pqpq")}
+    )
+    figure = _drawn(
+        lambda fig: (
+            so.Plot(two, x="cat", y="val", color="g")
+            .add(so.Bar(), so.Stack(), so.Norm(func="sum", by=["x"]))
+            .on(fig)
+            .plot()
+        )
+    )
+    maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+    assert len(figure.axes[0].containers[0]) == 2
+    assert [plot.schema["type"].value for plot in plots] == ["bar"]
+
+
+def test_only_a_sum_normalisation_counts_as_asking_for_a_whole():
+    """The intent half of `_normalises_to_a_whole`, asked of the function
+    directly because no `so.Bar` reaches it.
+
+    `Norm(func="max", by=["x"])` divides each category by its own maximum,
+    so a stack of it totals `sum / max`. With two drawn levels that is
+    always more than 1 and less than 100, and a level at zero draws nothing
+    at all -- so no chart of a plausible size lands it on a whole. A hundred
+    equal levels would, at exactly 100.0, and would then announce each
+    segment as 1 *percent* when it is the whole of its level.
+
+    Stubbing the moves and the bars says that in three lines instead of a
+    hundred-level chart, and it is the only thing keeping `func == "sum"`
+    from being decoration.
+    """
+    from types import SimpleNamespace
+
+    from maidr.patch.seaborn_objects import _normalises_to_a_whole
+
+    _, axes = plt.subplots()
+    # Two categories, each a stack reaching exactly 1.0 -- what a sum
+    # normalisation draws, and what a max normalisation would draw if a
+    # chart could get there.
+    container = axes.bar([0, 1, 0, 1], [0.25, 0.5, 0.75, 0.5], bottom=[0, 0, 0.25, 0.5])
+
+    # `Stack` and `Norm` are matched by class name, so the stubs are named.
+    class Norm(SimpleNamespace):
+        pass
+
+    class Stack(SimpleNamespace):
+        pass
+
+    assert _normalises_to_a_whole([Norm(func="sum"), Stack()], container) is True
+    assert _normalises_to_a_whole([Norm(func="max"), Stack()], container) is False
+    # No stack at all is not a whole either, however the bars happen to land.
+    assert _normalises_to_a_whole([Norm(func="sum")], container) is False
+    assert _normalises_to_a_whole(None, container) is False
+
+
+def test_a_hundred_percent_bar_announces_the_shares_it_drew():
+    """The payload is the drawn heights, because seaborn has already turned
+    the numbers into shares -- unlike the plotly path, where `layout.barnorm`
+    leaves the raw values in the trace and `maidr/plotly/barnorm.py` has to
+    compute them (#338).
+
+    Horizontal too, where the shares run along x and the categories sit on y.
+    """
+    figure = _drawn(
+        lambda fig: (
+            so.Plot(_bars(), y="cat", x="val", color="g")
+            .add(so.Bar(), so.Norm(func="sum", by=["y"]), so.Stack())
+            .on(fig)
+            .plot()
+        )
+    )
+    maidr.render(figure)._repr_html_()
+    (plot,) = FigureManager.get_maidr(figure).plots
+
+    assert plot.schema["type"].value == "stacked_normalized_bar"
+    assert plot.schema["orientation"] == "horz"
+    shares = [
+        [(bar["z"], bar["y"], round(bar["x"], 3)) for bar in group]
+        for group in plot.schema["data"]
+    ]
+    assert shares == [
+        [("p", "a", 0.333), ("p", "b", 0.429)],
+        [("q", "a", 0.667), ("q", "b", 0.571)],
+    ]
+    # Each category's segments are a whole, which is the claim the type makes.
+    for category in ("a", "b"):
+        total = sum(
+            bar["x"]
+            for group in plot.schema["data"]
+            for bar in group
+            if bar["y"] == category
+        )
+        assert total == pytest.approx(1.0)
+
+
 def test_the_grouped_reading_names_its_z_axis_from_the_figure_legend():
     """`GroupedBarPlot` read both its `z` label and its group names from
     `ax.get_legend()`, which is right for `seaborn.barplot(hue=)` and `None`


### PR DESCRIPTION
Closes #620, which #621 filed rather than guessed at.

`so.Norm(func="sum", by=["x"])` before `so.Stack()` draws a 100% stacked bar — each category's segments sum to exactly 1 — and it read as `stacked_bar`. The segments were announced; that they are *shares of a whole* was not.

```
                                          before          after
Norm(func="sum", by=["x"]), Stack()       stacked_bar     stacked_normalized_bar
same, percent=True                        stacked_bar     stacked_normalized_bar
```

`PlotType.NORMALIZED` was **plotly-only** in this package, with no `MaidrPlotFactory` branch at all. `GroupedBarPlot` now serves all three grouped types: they differ in how the groups relate — side by side, piled up, piled up to a whole — not in where the numbers come from. Nothing is computed here, unlike the plotly path: `layout.barnorm` leaves the raw values in the trace so `barnorm.py` has to derive the shares (#338), while seaborn has already written them into the bars.

## Why the spelling cannot decide it

This is the part worth reading. `Norm` takes a `func` and a `by`, and only some combinations normalise *within the category*. Measured, two categories over two levels, totalling each category's stack:

| moves | stack total |
|---|---|
| `Norm(func="sum", by=["x"])` then `Stack()` | **1.0** |
| `Norm(func="sum", by=["x", "color"])` then `Stack()` | 2.0 |
| `Norm(func="sum")` then `Stack()` | 0.583 / 1.417 |
| `Norm()` (default `func="max"`) then `Stack()` | 0.833 / 2.0 |
| `Stack()` then `Norm(func="sum", by=["x"])` | 0.429 / 1.0 |

The second row is the trap. It names the category axis, so the obvious rule — "is the orientation axis in `by`?" — claims it, and it normalises **each level** to 1 so the stacks reach twice the whole. A reader would be told shares that sum to 200%.

So the **drawn bars** are asked instead, and both halves are required:

- a **sum-normalisation among the moves**, which no plain `Stack()` has, and
- **every category landing on a whole** (1 or 100, matching the two conventions `barnorm_scale` already emits).

An ordinary stack whose categories happen to total alike keeps reading as `stacked_bar`; a normalisation that did not land is refused.

## Order is not checked, and the totals are why

`Stack()` then `Norm()` normalises the already-stacked tops and can draw segments of negative height, so an order check looks obviously right. It earns nothing. After that order the tops are each category's `t_i / sum(t_i)` over the **cumulative** tops, which are all wholes only when one top carries the whole sum — every level but the last at zero — and **seaborn draws no rectangle for a zero**, so those levels leave no colour behind, the split finds one group, and no grouped layer is made at all.

Measured both ways: three levels with one at zero totals 0.8 and 0.667 and is turned away on the totals; two levels with one at zero draws **two** patches of one colour and reads as a plain `bar`. An order check would only refuse charts that never reach the function. It was written, survived its mutation, and was removed — the reasoning is at the code so it is not re-added.

## Verification

`uv run pytest` — **3049 passed, 18 skipped**, up from 3038. `ruff check --diff maidr/ tests/` clean.

11 new tests: an 8-way parametrization over the spellings above, the horizontal shares payload, the stack-normalised-afterwards pair, and one unit test on `_normalises_to_a_whole` directly.

That last one exists because of a surviving mutant. `func == "sum"` looked like decoration — dropping it passed everything — since a `func="max"` stack totals `sum / max`, which with two drawn levels is always above 1 and below 100, and a level at zero draws nothing. A hundred equal levels would land it on exactly 100.0 and announce each segment as 1 *percent* when it is the whole of its level. Stubbing the moves and the bars says that in three lines instead of a hundred-level chart.

Mutation sweep, each applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| never promotes to `NORMALIZED` | killed (3) |
| any `Norm` counts, not just `func="sum"` | killed (1) |
| skips the whole check entirely | killed (4) |
| forgets `100.0` as a whole | killed (1) |
| reads a horizontal stack as vertical | killed (1) |
| factory drops the `NORMALIZED` branch | killed (3) |

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_