### PR TITLE
fix(patch): a drawing call that drew nothing registers nothing

### DIFF
--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -11,9 +11,68 @@ import wrapt
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 
+from matplotlib.collections import Collection
+from matplotlib.container import Container
+from matplotlib.lines import Line2D
+
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+
+
+def drew_nothing(plot: Any) -> bool:
+    """
+    Whether a drawing call put nothing on the page.
+
+    A call can be perfectly well formed and still draw no artist --
+    ``ax.bar([], [])``, ``ax.scatter([], [])``, a dataframe filtered to
+    nothing, a groupby that produced no rows, a loop over categories where
+    one is absent. Registering a layer for it hands a reader something to
+    walk into with nothing in it, and for a bar it does worse: an empty
+    ``BarContainer`` has no children, so ``FigureManager.get_axes()`` finds
+    no axes on it and ``create_maidr`` raises ``ValueError("No plot found.")``
+    **out of the caller's own** ``ax.bar()`` **line** (#623).
+
+    A decline is a reading decision; an exception is a broken call. That is
+    the argument xability/r-maidr#230 settled on the R side, and it is
+    sharper here, because this one fires while the user is drawing rather
+    than while they are saving.
+
+    Only the artists whose emptiness is unambiguous are read. Everything else
+    -- an ``Axes``, a ``dict``, anything unrecognised -- answers ``False`` and
+    registers as before, so this is additive by construction. That is also why
+    it does not close the seaborn half of #623: ``seaborn.scatterplot``
+    returns the *axes*, so what it drew cannot be read off its return value at
+    all, and the empty call goes on to sweep the axes and find an earlier
+    call's collection.
+
+    Parameters
+    ----------
+    plot : Any
+        Whatever the patched drawing function returned.
+
+    Returns
+    -------
+    bool
+        ``True`` only when the return value is an artist that is certainly
+        empty, or a non-empty list of such artists.
+    """
+    if isinstance(plot, Container):
+        # `BarContainer` and friends are sized, and a bar drawn from no data
+        # is a container of no patches.
+        return len(plot) == 0
+    if isinstance(plot, Collection):
+        # `PathCollection` from `ax.scatter`, and every other collection: the
+        # offsets are the points, so no offsets is no marks.
+        return len(plot.get_offsets()) == 0
+    if isinstance(plot, Line2D):
+        return len(plot.get_xdata()) == 0
+    if isinstance(plot, list):
+        # `ax.plot` returns a list of lines, `ax.hist` a list per dataset.
+        # An empty list drew nothing; a list drew nothing when every artist
+        # in it did.
+        return all(drew_nothing(one) for one in plot)
+    return False
 
 #: The most vertices one confidence-interval polyline can have.
 #:
@@ -236,6 +295,11 @@ def common(
     with ContextManager.set_internal_context():
         # Patch the plotting function.
         plot = _draw_quietly(wrapped, args, kwargs)
+
+    # A call that drew nothing registers nothing, rather than an empty layer
+    # -- or, for a bar, an exception out of the caller's own line (#623).
+    if drew_nothing(plot):
+        return plot
 
     # Extract the data points for MAIDR from the plot.
     ax = FigureManager.get_axes(plot)

--- a/maidr/patch/scatterplot.py
+++ b/maidr/patch/scatterplot.py
@@ -8,6 +8,7 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.scatterplot import DRAWN_POINTS, HUE_GROUP, hue_groups
+from maidr.patch.common import drew_nothing
 from maidr.patch.common import _draw_quietly, wrap_seaborn
 
 
@@ -75,6 +76,13 @@ def scatter(wrapped, instance, args, kwargs) -> Axes | PathCollection:
     # single collection even under `hue`.
     with ContextManager.set_internal_context():
         plot = _draw_quietly(wrapped, args, kwargs)
+
+    # A call that drew no points registers nothing. `seaborn.scatterplot`
+    # returns the axes rather than its collection, so this reads only the
+    # `ax.scatter` spelling -- the seaborn half of #623 needs a before-and-
+    # after diff of the axes, which is a different change.
+    if drew_nothing(plot):
+        return plot
 
     ax = FigureManager.get_axes(plot)
     kwargs.pop("ax", None)

--- a/tests/core/plot/test_empty_drawing_call.py
+++ b/tests/core/plot/test_empty_drawing_call.py
@@ -1,0 +1,128 @@
+"""A drawing call that produced no artist registers nothing (#623).
+
+Carried across from xability/r-maidr#232, which found the same defect on the R
+side. Measured here before the fix, four real observations plus a second call
+drawing nothing::
+
+    scatter + empty scatter          point(4) point(0)
+    bar     + empty bar              ValueError: No plot found.
+    only an empty scatter            point(0)
+
+The bar row is the one that matters most: the exception came out of the
+caller's own ``ax.bar()`` line, not out of ``maidr.render()``, so ``import
+maidr`` decided whether an existing script's plotting call returned at all.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pytest
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+from maidr.patch.common import drew_nothing
+
+
+def _layers(figure):
+    """The layers a figure registered, as ``type(n)`` strings in order."""
+    plots = FigureManager.get_maidr(figure).plots
+    sizes = []
+    for plot in plots:
+        data = plot.schema.get("data")
+        if isinstance(data, list) and data and isinstance(data[0], list):
+            sizes.append(f"{plot.schema['type'].value}({len(data)}x{len(data[0])})")
+        else:
+            sizes.append(f"{plot.schema['type'].value}({len(data or [])})")
+    return sizes
+
+
+@pytest.mark.parametrize(
+    "draw_empty, kind",
+    [
+        pytest.param(lambda ax: ax.scatter([], []), "scatter", id="scatter"),
+        pytest.param(lambda ax: ax.bar([], []), "bar", id="bar"),
+        pytest.param(lambda ax: ax.plot([], []), "line", id="line"),
+    ],
+)
+def test_a_call_that_drew_nothing_adds_no_layer(draw_empty, kind):
+    """The chart reads as though the empty call had not been written."""
+    figure, axes = plt.subplots()
+    axes.scatter([1.0, 2.0, 3.0, 4.0], [2.0, 4.0, 6.0, 8.0])
+    draw_empty(axes)
+    maidr.render(figure)._repr_html_()
+
+    assert _layers(figure) == ["point(4)"]
+
+
+def test_an_empty_bar_does_not_raise_out_of_the_caller_s_own_call():
+    """The sharp end of #623.
+
+    `ax.bar([], [])` returns a `BarContainer` holding nothing, so
+    `FigureManager.get_axes()` found no axes on it and `create_maidr` raised
+    `ValueError("No plot found.")` -- from `ax.bar()`, while the user was
+    drawing, rather than from `maidr.render()` while they were saving. The
+    chart was fine: rendering after catching the error succeeded.
+
+    A decline is a reading decision; an exception is a broken call. That is
+    the argument xability/r-maidr#230 settled on the R side.
+    """
+    figure, axes = plt.subplots()
+    axes.bar(["a", "b"], [1.0, 2.0])
+
+    # The assertion is that this line returns at all.
+    container = axes.bar([], [])
+    assert len(container) == 0
+
+    maidr.render(figure)._repr_html_()
+    assert _layers(figure) == ["bar(2)"]
+
+
+def test_a_chart_that_is_only_an_empty_call_falls_back_to_an_image():
+    """No layers is not an interactive chart with nothing in it.
+
+    r-maidr states the reason at its own guard: a chart announcing itself as
+    interactive with nothing in it is worse than an image, because an image at
+    least says what it is. Here it comes out of the fallback #443 established
+    rather than a guard of its own -- nothing registers, so there is no
+    supported plot, so the figure renders as a picture.
+    """
+    figure, axes = plt.subplots()
+    axes.scatter([], [])
+
+    html = maidr.render(figure)._repr_html_()
+    assert "maidr-data" not in html
+    assert "base64" in html
+
+
+@pytest.mark.parametrize(
+    "make, empty",
+    [
+        pytest.param(lambda ax: ax.bar([], []), True, id="empty-bar"),
+        pytest.param(lambda ax: ax.bar(["a"], [1.0]), False, id="drawn-bar"),
+        pytest.param(lambda ax: ax.scatter([], []), True, id="empty-scatter"),
+        pytest.param(lambda ax: ax.scatter([1.0], [1.0]), False, id="drawn-scatter"),
+        pytest.param(lambda ax: ax.plot([], []), True, id="empty-line"),
+        pytest.param(lambda ax: ax.plot([1.0], [1.0]), False, id="drawn-line"),
+    ],
+)
+def test_drew_nothing_reads_the_artists_whose_emptiness_is_unambiguous(make, empty):
+    """`ax.plot` returns a *list*, which is why the list branch is not
+    decoration: a list drew nothing when every artist in it did."""
+    _, axes = plt.subplots()
+    assert drew_nothing(make(axes)) is empty
+
+
+def test_drew_nothing_declines_to_guess():
+    """Everything it does not recognise registers as before, which is what
+    makes this additive rather than a new way to lose a layer.
+
+    An `Axes` is the case that matters: `seaborn.scatterplot` returns one
+    rather than its collection, so what it drew cannot be read off its return
+    value at all -- and the seaborn half of #623 stays open because of it.
+    """
+    _, axes = plt.subplots()
+
+    assert drew_nothing(axes) is False
+    assert drew_nothing(None) is False
+    assert drew_nothing({}) is False
+    assert drew_nothing("not an artist") is False


### PR DESCRIPTION
Closes the matplotlib half of #623, found by carrying xability/r-maidr#232's question across to this side.

## The sharp end

`ax.bar([], [])` raised `ValueError("No plot found.")` **out of the caller's own drawing call** — not out of `maidr.render()`:

```
  File ".../maidr/patch/barplot.py", line 99, in bar
  File ".../maidr/patch/common.py", line 247, in common
  File ".../maidr/core/figure_manager.py", line 259, in create_maidr
    raise ValueError("No plot found.")
```

An empty `BarContainer` has no children, so `FigureManager.get_axes()` found no axes on it and `create_maidr` raised — at the *plotting* line rather than at save time. So `import maidr` decided whether an existing script's `ax.bar()` returned at all. The chart itself was fine: rendering after catching the error succeeded, which is what makes this purely the patch declining badly.

A decline is a reading decision; an exception is a broken call. That is the argument xability/r-maidr#230 settled on the R side, and it is sharper here because of *when* it fires.

## Measured

Four real observations plus a second call drawing nothing:

| | before | after |
|---|---|---|
| `scatter` + empty `scatter` | `point(4) point(0)` | `point(4)` |
| `bar` + empty `bar` | **`ValueError`** | `bar(2)` |
| `plot` + empty `plot` | `line(1x4)` | `line(1x4)` |
| only an empty `scatter` | `point(0)` | a static image |

The line row already behaved — the line layer's own dedup folded it away — which is why the shape of the answer was already in the codebase for one artist type.

The empty layers are the same defect #421 fixed for plotly subplots. The last row is what r-maidr's #176 guard exists for: *a chart announcing itself as interactive with nothing in it is worse than an image, because an image at least says what it is.* Here it needs no guard of its own — nothing registers, so there is no supported plot, so #443's fallback takes it. Verified: the HTML carries no `maidr-data` and does carry `base64`, and `plt.show()` falls back cleanly.

## Scope of the reading

`drew_nothing()` reads only the artists whose emptiness is unambiguous — `Container`, `Collection`, `Line2D`, and a list of those (`ax.plot` returns a list; `ax.hist` one per dataset). Everything else answers `False` and registers as before, so the change is **additive by construction**.

That is also why the **seaborn half of #623 stays open**. `seaborn.scatterplot` returns the *axes* rather than its collection, so what it drew cannot be read off its return value at all — and an empty call still sweeps the axes and finds an earlier call's points, announcing the same four points twice under two layers. That needs a before-and-after diff of the axes' collections, which is the technique `maidr/patch/seaborn_objects.py` already uses and a different change from this one. Recorded at the function so the gap is not mistaken for an oversight.

## Verification

`uv run pytest` — **3063 passed, 18 skipped**, up from 3049. `ruff check --diff maidr/ tests/` clean.

12 new tests in `tests/core/plot/test_empty_drawing_call.py`: the three empty spellings adding no layer, the bar call returning at all, the all-empty chart falling back, and `drew_nothing` itself over drawn-and-empty pairs plus the four things it declines to guess about.

Mutation sweep, each applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| `common()` no longer declines | killed (6 failed) |
| `scatter()` no longer declines | killed (4 failed) |
| drop the list branch from `drew_nothing` | killed (2 failed) |
| `drew_nothing` returns `True` for everything | killed (140 failed) |

The third is the one worth noting: `ax.plot` returns a list, so without that branch an empty line call still registers — the branch is load-bearing, not defensive padding.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_