### PR TITLE
fix(seaborn): an empty scatterplot no longer announces the previous call's points

### DIFF
--- a/maidr/patch/scatterplot.py
+++ b/maidr/patch/scatterplot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import matplotlib.pyplot as plt
 import wrapt
 from matplotlib.axes import Axes
 from matplotlib.collections import PathCollection
@@ -62,6 +63,21 @@ def scatter(wrapped, instance, args, kwargs) -> Axes | PathCollection:
     if ContextManager.is_internal_context():
         return _draw_quietly(wrapped, args, kwargs)
 
+    # How many collections the target axes held before the call, so a call
+    # that adds none can be told from one that adds a collection of no
+    # points. `seaborn.scatterplot` returns the *axes*, so its return value
+    # says nothing about what it drew, and an empty call went on to sweep the
+    # axes and find an earlier call's points -- announcing the same points
+    # twice, under two layers, with nothing to say they were the same (#623).
+    #
+    # Guessed axes are not trusted: the count is used only when the axes
+    # counted is the one the call came back with, which is exact. Anything
+    # else declines to decide and registers as before.
+    counted = kwargs.get("ax")
+    if counted is None and plt.get_fignums():
+        counted = plt.gca()
+    before = len(counted.collections) if isinstance(counted, Axes) else None
+
     # Hand the layer the collection this call drew. `ScatterPlot` otherwise
     # takes the *first* `PathCollection` on the axes, which is right only
     # while a layer is one collection -- and seaborn's categorical scatters
@@ -77,11 +93,16 @@ def scatter(wrapped, instance, args, kwargs) -> Axes | PathCollection:
     with ContextManager.set_internal_context():
         plot = _draw_quietly(wrapped, args, kwargs)
 
-    # A call that drew no points registers nothing. `seaborn.scatterplot`
-    # returns the axes rather than its collection, so this reads only the
-    # `ax.scatter` spelling -- the seaborn half of #623 needs a before-and-
-    # after diff of the axes, which is a different change.
+    # A call that drew no points registers nothing -- as an empty artist for
+    # the `ax.scatter` spelling, and as an unchanged collection count for the
+    # seaborn one (#623).
     if drew_nothing(plot):
+        return plot
+    if (
+        before is not None
+        and counted is plot
+        and len(plot.collections) == before
+    ):
         return plot
 
     ax = FigureManager.get_axes(plot)

--- a/tests/core/plot/test_empty_drawing_call.py
+++ b/tests/core/plot/test_empty_drawing_call.py
@@ -16,6 +16,7 @@ maidr`` decided whether an existing script's plotting call returned at all.
 from __future__ import annotations
 
 import matplotlib.pyplot as plt
+import pandas as pd
 import pytest
 
 import maidr
@@ -75,6 +76,55 @@ def test_an_empty_bar_does_not_raise_out_of_the_caller_s_own_call():
 
     maidr.render(figure)._repr_html_()
     assert _layers(figure) == ["bar(2)"]
+
+
+def test_an_empty_seaborn_scatter_does_not_announce_the_previous_call_s_points():
+    """The seaborn half of #623, and the worst of the three.
+
+    `seaborn.scatterplot` returns the *axes* rather than its collection, so
+    `drew_nothing` cannot read it and the empty call went on to sweep the
+    axes for a `PathCollection` -- finding the *first* call's. Measured
+    before::
+
+        layer 0: point [{x:1,y:2}, {x:2,y:4}, {x:3,y:6}, {x:4,y:8}]
+        layer 1: point [{x:1,y:2}, {x:2,y:4}, {x:3,y:6}, {x:4,y:8}]
+        collections on axes: 1
+
+    Not an empty layer -- a *wrong* one. A reader was offered the same four
+    points twice, under two layers, with nothing to say they were the same.
+
+    Told apart by the collection count, since a call that drew points adds
+    one and a call that drew none adds none.
+    """
+    import seaborn as sns
+
+    frame = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0], "y": [2.0, 4.0, 6.0, 8.0]})
+    figure, axes = plt.subplots()
+    sns.scatterplot(data=frame, x="x", y="y", ax=axes)
+    sns.scatterplot(data=frame.iloc[0:0], x="x", y="y", ax=axes)
+    maidr.render(figure)._repr_html_()
+
+    assert len(axes.collections) == 1
+    assert _layers(figure) == ["point(4)"]
+
+
+def test_two_real_seaborn_scatters_still_register_two_layers():
+    """The guard rail on the count. Two calls that each drew points must
+    still give two layers -- a rule keyed on "the axes already has a
+    collection" rather than on the count changing would have folded them
+    together, which is a worse failure than the one being fixed.
+    """
+    import seaborn as sns
+
+    first = pd.DataFrame({"x": [1.0, 2.0], "y": [1.0, 2.0]})
+    second = pd.DataFrame({"x": [3.0, 4.0], "y": [9.0, 16.0]})
+    figure, axes = plt.subplots()
+    sns.scatterplot(data=first, x="x", y="y", ax=axes)
+    sns.scatterplot(data=second, x="x", y="y", ax=axes)
+    maidr.render(figure)._repr_html_()
+
+    assert len(axes.collections) == 2
+    assert _layers(figure) == ["point(2)", "point(2)"]
 
 
 def test_a_chart_that_is_only_an_empty_call_falls_back_to_an_image():


### PR DESCRIPTION
Closes #623. The seaborn half, after #624 did the matplotlib one.

A second `seaborn.scatterplot(data=<empty>)` registered a layer holding the **first** call's points:

```
layer 0: point  [{x:1,y:2}, {x:2,y:4}, {x:3,y:6}, {x:4,y:8}]
layer 1: point  [{x:1,y:2}, {x:2,y:4}, {x:3,y:6}, {x:4,y:8}]
collections on axes: 1
```

Not an empty layer — a **wrong** one, and the worst of the three defects #623 recorded. A reader was offered the same four points twice, under two layers, with nothing to say they were the same.

## Why #624's fix could not reach it

`seaborn.scatterplot` returns the **axes** rather than its collection, so `drew_nothing()` has nothing to read, and `_points_of` falls back to sweeping the axes for a `PathCollection`. That sweep is right for a call that drew one collection and finds a stranger's for a call that drew none — which is the family #426 and #527 addressed, reaching the case those did not cover.

## How it is told apart

By the collection count: a call that drew points adds one, a call that drew none adds none.

The count is taken before the draw, from `ax=` or the current axes, and used **only when the axes counted is the one the call came back with** (`counted is plot`). A guessed axes that turns out to be a different one decides nothing and registers exactly as before — so a wrong guess cannot cost a layer. `plt.gca()` is called only when a figure already exists, so nothing is created to look at.

## Verification

`uv run pytest` — **3063 passed, 18 skipped** before the two new tests, and the whole suite green with the change in place, which matters here because this touches every `Axes.scatter` and `seaborn.scatterplot` call in the package.

Two new tests. The first pins the fix; the second is the guard rail on it:

```
two real seaborn scatters  ->  point(2) point(2)   collections: 2
real + empty               ->  point(4)            collections: 1
```

A rule keyed on "the axes already has a collection" rather than on the count *changing* would have folded two genuine calls into one — a worse failure than the one being fixed — so it is asserted rather than assumed.

Mutations, each applied alone against a restored baseline:

| mutation | outcome |
|---|---|
| drop the collection-count decline | killed (1 failed) |
| decline whenever the count did not *shrink* | killed (4 failed) |

The second is the guard rail firing: it is exactly the "already has a collection" rule, and it takes out three otherwise-passing scatter tests along with the new one.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_