### PR TITLE
feat(heatmap): read ax.pcolorfast as the grid its three siblings draw

### DIFF
--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -218,5 +218,23 @@ wrapt.wrap_function_wrapper(Axes, "imshow", heat)
 wrapt.wrap_function_wrapper(Axes, "pcolormesh", heat)
 wrapt.wrap_function_wrapper(Axes, "pcolor", heat)
 
+# The fourth spelling of the same grid. `pcolorfast` is matplotlib's optimised
+# path for the charts the three above draw, and it hands back one of the very
+# artists they do -- measured on matplotlib 3.10, all three of its input forms:
+#
+#     pcolorfast(Z)                    AxesImage    the artist `imshow` returns
+#     pcolorfast(x, y, Z)              AxesImage        "
+#     pcolorfast(X, Y, Z)  (2D X/Y)    QuadMesh     the artist `pcolormesh` returns
+#
+# So the extraction was already proven for every shape it can produce, and the
+# only thing keeping such a figure silent was that nothing dispatched the call
+# (xability/py-maidr#626).
+#
+# `tripcolor` is deliberately *not* here, though it colours cells too. It
+# colours the triangles of a triangulation, and a heatmap is addressed by row
+# and column -- a mesh has neither, so the grid a reader would be handed would
+# be one this call never drew. Declined for the reason `triplot` is (#572).
+wrapt.wrap_function_wrapper(Axes, "pcolorfast", heat)
+
 # Patch seaborn function.
 wrap_seaborn("heatmap", heat)

--- a/tests/core/plot/test_pcolorfast.py
+++ b/tests/core/plot/test_pcolorfast.py
@@ -1,0 +1,108 @@
+"""``ax.pcolorfast`` draws the grid its three siblings do, and read nothing.
+
+`imshow`, `pcolormesh` and `pcolor` have been patched as heatmaps since #337.
+`pcolorfast` is matplotlib's optimised path for the same charts, and nothing
+dispatched it -- so a figure drawn with it registered no layer at all and the
+caller got silence with no indication anything had been missed, which is the
+shape #337 was filed against.
+
+It is not a new reading. Measured on matplotlib 3.10, every input form
+`pcolorfast` accepts hands back an artist one of the three already produces::
+
+    pcolorfast(Z)                  AxesImage    the artist `imshow` returns
+    pcolorfast(x, y, Z)            AxesImage        "
+    pcolorfast(X, Y, Z)  (2D)      QuadMesh     the artist `pcolormesh` returns
+
+so the extraction was already proven for every shape the call can produce.
+
+`tripcolor` colours cells too and is deliberately *not* patched: it colours
+the triangles of a triangulation, and a heatmap is addressed by row and
+column, which a mesh has neither of. Declined for the reason `triplot` is
+(#572), and asserted below so the omission reads as a decision.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import maidr  # noqa: F401  (installs the patches)
+from maidr.core.figure_manager import FigureManager
+
+
+def _layer_types(figure) -> list[str]:
+    """The trace types a figure registered, in order."""
+    try:
+        plots = FigureManager.get_maidr(figure).plots
+    except Exception:  # noqa: BLE001 - nothing registered at all
+        return []
+    return [plot.type.value for plot in plots]
+
+
+@pytest.fixture()
+def grid() -> np.ndarray:
+    """A small rectangular field, the same one every form is drawn from."""
+    return np.arange(20, dtype=float).reshape(4, 5)
+
+
+@pytest.mark.parametrize(
+    "form",
+    ["uniform", "rectilinear", "irregular"],
+    ids=["pcolorfast(Z)", "pcolorfast(x, y, Z)", "pcolorfast(X, Y, Z)"],
+)
+def test_pcolorfast_registers_a_heatmap(form: str, grid: np.ndarray) -> None:
+    """Every input form reads as the heatmap it draws."""
+    figure, ax = plt.subplots()
+    try:
+        if form == "uniform":
+            ax.pcolorfast(grid)
+        elif form == "rectilinear":
+            ax.pcolorfast(np.arange(6), np.arange(5), grid)
+        else:
+            x_edges, y_edges = np.meshgrid(np.arange(6), np.arange(5))
+            ax.pcolorfast(x_edges, y_edges, grid)
+
+        assert _layer_types(figure) == ["heat"]
+    finally:
+        plt.close(figure)
+
+
+def test_pcolorfast_reads_the_same_grid_as_pcolormesh(grid: np.ndarray) -> None:
+    """The two spellings of one chart carry the same cells.
+
+    The point of routing `pcolorfast` through the existing patch rather than
+    giving it one: it is the same grid, so it has to read as the same data
+    rather than as a second heatmap that happens to look similar.
+    """
+    fast_figure, fast_ax = plt.subplots()
+    mesh_figure, mesh_ax = plt.subplots()
+    try:
+        fast_ax.pcolorfast(grid)
+        mesh_ax.pcolormesh(grid)
+
+        fast = FigureManager.get_maidr(fast_figure).plots[0].schema["data"]
+        mesh = FigureManager.get_maidr(mesh_figure).plots[0].schema["data"]
+
+        assert fast == mesh
+    finally:
+        plt.close(fast_figure)
+        plt.close(mesh_figure)
+
+
+def test_tripcolor_is_still_declined() -> None:
+    """A triangulation is not a grid, so it is not read as one.
+
+    The guard on the change: patching one more cell-colouring call must not
+    become patching every one of them. `tripcolor` colours triangles, which
+    have no row and no column for a reader to navigate by, so handing back a
+    grid would mean handing back one the call never drew.
+    """
+    rng = np.random.default_rng(0)
+    figure, ax = plt.subplots()
+    try:
+        ax.tripcolor(rng.random(9), rng.random(9), rng.random(9))
+
+        assert _layer_types(figure) == []
+    finally:
+        plt.close(figure)


### PR DESCRIPTION
The py-maidr half of the sweep I ran across the JS adapters (xability/maidr#1138, xability/maidr#1140): drive every drawing call and read what actually registers, rather than reasoning about what looks covered.

## Measured

Every `Axes` drawing method called on a real figure, asking `FigureManager` what registered. Almost everything was already read — `bar`, `plot`, `scatter`, `hist`, `boxplot`, `violinplot`, `pie`, `step`, `stem`, `stairs`, `stackplot`, `errorbar`, `eventplot`, `broken_barh`, `hexbin`, `contour`, `imshow`, `pcolor`, `pcolormesh`, `hist2d`, `ecdf`, `tricontour`, and the log-scale spellings.

**The apparent gaps turned out to be deliberate, documented declines**, each with the reason already written into the patch:

| call | why it declines |
|---|---|
| `contourf`, `tricontourf` | draw the bands *between* levels, so one outline runs along two different level curves — "announcing one as a level's curve would be right for half of its points" |
| `triplot` | draws a mesh, not a series — registering it announced a 32-point line through repeated vertices (#572) |
| `fill_between` (two-curve form) | the band's content is the *distance* between edges; read as an area it would announce `hi` and drop `lo` (#339) |
| `hlines`, `vlines`, `quiver`, `streamplot`, `fill`, `table`, `text` | no series to walk |

That is a good result to have measured rather than assumed — and it left exactly one call unaccounted for.

## The one real gap

**`ax.pcolorfast` registered nothing.** It is matplotlib's optimised path for the charts `imshow`, `pcolormesh` and `pcolor` draw — all read as heatmaps since #337 — so a figure drawn with it produced silence, with no indication anything had been missed. That is the shape #337 was filed against.

It is not a new reading. Measured on matplotlib 3.10, every input form it accepts hands back an artist one of the three already produces:

```
pcolorfast(Z)                  AxesImage    the artist `imshow` returns
pcolorfast(x, y, Z)            AxesImage        "
pcolorfast(X, Y, Z)  (2D)      QuadMesh     the artist `pcolormesh` returns
```

So the extraction was already proven for every shape the call can produce, and the change is one `wrap_function_wrapper` line. A test holds that the grid it emits is **identical** to `pcolormesh`'s for the same data rather than merely similar — the point of routing it through the existing patch rather than giving it one of its own.

## `tripcolor` stays declined, and now says so

It colours cells too, so it is the obvious next thing to reach for — but it colours the *triangles of a triangulation*, and a heatmap is addressed by row and column, which a mesh has neither of. Handing back a grid would mean handing back one the call never drew, which is the reason `triplot` is declined (#572). A test asserts it, so patching one more cell-colouring call does not drift into patching every one of them.

## Verification

Five tests in `tests/core/plot/test_pcolorfast.py`. Mutation-tested, both killed:

| mutation | tests failed |
|---|---|
| `pcolorfast` unpatched again | 4 |
| `tripcolor` wrongly patched | 1 |

`ruff check` clean on both changed files. Full suite: **3070 passed**, 18 skipped (`tests/core` 1931 passed; the rest 1139 passed).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_