### PR TITLE
feat(plotly): read a waterfall trace

### DIFF
--- a/maidr/core/enum/maidr_key.py
+++ b/maidr/core/enum/maidr_key.py
@@ -70,6 +70,15 @@ class MaidrKey(str, Enum):
     END = "end"
     LANES = "lanes"
 
+    # Waterfall keys. A step carries the two running totals it sits between
+    # -- reusing `START` and `END` above, which mean the same two things a
+    # gantt interval's ends do -- plus its own signed contribution and which
+    # way it moved. `DELTA` is carried rather than derived because a producer
+    # may round the two totals for display, and a delta recomputed from
+    # rounded ends is not the number the chart's own label shows.
+    DELTA = "delta"
+    KIND = "kind"
+
     # Histogram plot keys.
     X_MIN = "xMin"
     X_MAX = "xMax"

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -64,6 +64,13 @@ class PlotType(str, Enum):
     CANDLESTICK = "candlestick"
     VIOLIN_KDE = "violin_kde"
     VIOLIN_BOX = "violin_box"
+    #: A starting value carried to an ending value through a sequence of
+    #: signed contributions, each bar floating between the running total
+    #: before it and the running total after it. A distinct type from `BAR`
+    #: because a step carries two numbers a bar conflates -- the contribution
+    #: it made and the total it produced -- and announcing either alone
+    #: answers half the question the chart is drawn for.
+    WATERFALL = "waterfall"
 
     @property
     def display_name(self) -> str:

--- a/maidr/plotly/bar.py
+++ b/maidr/plotly/bar.py
@@ -43,7 +43,7 @@ class PlotlyBarPlot(PlotlyPlot):
         better of the two failures, and it only arises on a chart that
         declares an order.
         """
-        prefix = f"{self._subplot_css_prefix()}.trace.bars"
+        prefix = f"{self._subplot_css_prefix()}.barlayer .trace.bars"
         if self._drawn is None:
             return f"{prefix} .point > path"
         return [

--- a/maidr/plotly/grouped_bar.py
+++ b/maidr/plotly/grouped_bar.py
@@ -77,7 +77,7 @@ class PlotlyGroupedBarPlot(PlotlyPlot):
         wrong element, so the highlight is lost while the announced order
         stays corrected.
         """
-        prefix = f"{self._subplot_css_prefix()}.trace.bars"
+        prefix = f"{self._subplot_css_prefix()}.barlayer .trace.bars"
         if self._drawn is None:
             return f"{prefix} .point > path"
         return [

--- a/maidr/plotly/grouped_histogram.py
+++ b/maidr/plotly/grouped_histogram.py
@@ -139,7 +139,7 @@ class PlotlyGroupedHistogramPlot(PlotlyPlot):
         }
 
     def _get_selector(self) -> str:
-        return f"{self._subplot_css_prefix()}.trace.bars .point > path"
+        return f"{self._subplot_css_prefix()}.barlayer .trace.bars .point > path"
 
     def _shared_edges(self, samples: list[np.ndarray]) -> np.ndarray | None:
         """One grid, from every trace's values together.

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -538,7 +538,7 @@ class PlotlyHistogramPlot(PlotlyPlot):
         return schema
 
     def _get_selector(self) -> str:
-        return f"{self._subplot_css_prefix()}.trace.bars .point > path"
+        return f"{self._subplot_css_prefix()}.barlayer .trace.bars .point > path"
 
     @staticmethod
     def _bin_assignment(arr: np.ndarray, bin_edges: np.ndarray) -> np.ndarray:

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -297,6 +297,8 @@ class PlotlyMaidr:
         * Pie traces stay one layer each, but are built here rather than by
           the factory so every pie carries its position among the figure's
           pie traces — the only thing its selector can be scoped by.
+        * Waterfall traces stay one layer each for the same reason, scoped by
+          their position among the subplot's waterfall traces.
 
         Every scatter-family trace is assigned a selector index from its
         position within the subplot, not within the layer it lands in — see
@@ -821,6 +823,30 @@ class PlotlyMaidr:
                         layer.col_index = col
                         self._plots.append(layer)
                 merged.update(id(t) for t in violin_traces)
+
+            # Waterfalls, one layer each, built here rather than left to
+            # the factory for the reason the candlesticks above are: plotly
+            # appends one `.trace.bars` group per waterfall trace to the
+            # subplot's `waterfalllayer`, so a trace's selector is scoped by
+            # its position among *those* traces -- which the factory, seeing
+            # one trace at a time, cannot know.
+            waterfall_traces = [
+                t for t in group_traces if t.get("type") == "waterfall"
+            ]
+            if waterfall_traces:
+                from maidr.plotly.waterfall import PlotlyWaterfallPlot
+
+                for waterfall_trace in waterfall_traces:
+                    plot = PlotlyWaterfallPlot(
+                        waterfall_trace,
+                        layout,
+                        layer_position=layer_position(group_traces, waterfall_trace),
+                        **axis_kwargs,
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in waterfall_traces)
 
             # Remaining traces
             for trace in group_traces:

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -126,6 +126,17 @@ class PlotlyPlotFactory:
 
             return PlotlyHistogramPlot(trace, layout, **axis_kwargs)
 
+        if trace_type == "waterfall":
+            from maidr.plotly.waterfall import PlotlyWaterfallPlot
+
+            # ``layer_position`` is left at its default for the same reason
+            # the candlestick branch leaves its own: this factory sees one
+            # trace with no idea what else draws into the subplot's
+            # ``waterfalllayer``, and "assume it is the only one" is the only
+            # assumption available. ``PlotlyMaidr`` never reaches here
+            # precisely because it does know, and passes real positions.
+            return PlotlyWaterfallPlot(trace, layout, **axis_kwargs)
+
         if trace_type == "pie":
             from maidr.plotly.pie import PlotlyPiePlot
 

--- a/maidr/plotly/waterfall.py
+++ b/maidr/plotly/waterfall.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import Any
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+#: Plotly's own default when a step names no measure. Every step is a
+#: contribution unless the author says otherwise, which is why a waterfall
+#: written with `x` and `y` alone accumulates.
+_DEFAULT_MEASURE = "relative"
+
+
+class PlotlyWaterfallPlot(PlotlyPlot):
+    """Extract data from a Plotly waterfall trace.
+
+    Plotly states a waterfall in *offsets* -- a `measure` array saying what
+    each `y` means -- while `WaterfallPoint` wants the two absolute running
+    totals a step sits between. Converting between them is the whole of this
+    class, and the conversion is not a rename: what `y` means depends on the
+    step's measure, and one of the three measures ignores `y` entirely.
+
+    The semantics were measured rather than read off the documentation, by
+    rendering each case in Chromium and inverting the drawn rectangles back
+    through plotly's own axis map:
+
+    ======================  ==================================================
+    ``measure=[…]``         drawn
+    ======================  ==================================================
+    absent                  every step relative: ``y=[10, -4, 7]`` draws
+                            ``0->10``, ``10->6``, ``6->13``
+    ``relative``            adds ``y`` to the running total
+    ``total``               draws from ``base`` to the running total and
+                            leaves it there; the step's own ``y`` is ignored
+                            (``y=999`` on a total drew ``0->15``)
+    ``absolute``            *sets* the running total to ``y``: after
+                            ``[relative, absolute, relative]`` on
+                            ``[10, 100, 5]`` the third step drew ``100->105``
+    ======================  ==================================================
+
+    ``base`` moves where the accumulation starts, totals included:
+    ``base=100`` on ``y=[10, 5, 0(total)]`` drew ``100->110``, ``110->115``,
+    ``100->115``.
+    """
+
+    def __init__(
+        self, trace: dict, layout: dict, *, layer_position: int = 0, **kwargs: str
+    ) -> None:
+        super().__init__(trace, layout, PlotType.WATERFALL, **kwargs)
+        self._layer_position = layer_position
+
+    def _get_selector(self) -> str:
+        """Address this trace's steps inside the subplot's waterfall layer.
+
+        ``.waterfalllayer`` rather than ``.trace.bars`` alone. Plotly gives
+        each trace family its own ``mlayer`` group and reuses the inner class
+        names inside every one of them, so on a subplot holding a bar trace
+        and a waterfall the bare ``.trace.bars`` matched seven elements --
+        four bars and three steps (#628).
+
+        ``nth-of-type`` picks this trace's group out of the layer, for the
+        reason ``PlotlyGroupedBarPlot`` numbers its own: plotly appends one
+        ``.trace.bars`` group per waterfall trace, in declaration order, so
+        two waterfalls on one subplot would otherwise each claim both sets.
+        """
+        return (
+            f"{self._subplot_css_prefix()}.waterfalllayer "
+            f".trace.bars:nth-of-type({self._layer_position + 1}) .point > path"
+        )
+
+    def _extract_axes_data(self) -> dict:
+        """Name the category axis ``x`` however the chart is drawn.
+
+        ``WaterfallTrace`` fixes ``mainAxis: 'x'`` and announces the step's
+        label against ``this.xAxis``, because the core holds that a waterfall
+        has no orientation -- "the steps run along the category axis and the
+        contributions along the value axis, but the trace reads the same
+        either way round" (``IS_ORIENTED`` in ``src/util/orientation.ts``).
+
+        So a horizontal waterfall is emitted with its category in ``x``, and
+        the two axis titles have to travel with it. Leaving them in plotly's
+        arrangement would announce the value axis's title beside the category
+        name and the category axis's title beside the contribution -- both
+        labels attached to the wrong number.
+        """
+        axes = super()._extract_axes_data()
+        if self._is_horizontal():
+            axes[MaidrKey.X], axes[MaidrKey.Y] = axes[MaidrKey.Y], axes[MaidrKey.X]
+        return axes
+
+    def _is_horizontal(self) -> bool:
+        """Report whether plotly draws this waterfall across the page."""
+        return self._trace.get("orientation") == "h"
+
+    def _extract_plot_data(self) -> list[dict]:
+        """The steps, as the absolute pair each one sits between.
+
+        A step's ``kind`` is read from its measure rather than from the sign
+        of its contribution: an ``absolute`` step and a ``total`` step both
+        *restate* the running value rather than moving it, which is what
+        ``'total'`` means to the core -- it excludes those steps from
+        "largest contribution" and from the extrema targets, precisely so the
+        opening and closing bars do not bury the answer the reader wanted.
+        """
+        horizontal = self._is_horizontal()
+        labels = as_list(self._trace.get("y" if horizontal else "x"))
+        values = as_list(self._trace.get("x" if horizontal else "y"))
+        measures = as_list(self._trace.get("measure"))
+
+        base = self._number(self._trace.get("base"), 0.0)
+        running = base
+
+        points: list[dict] = []
+        for index, label in enumerate(labels):
+            measure = (
+                str(measures[index]) if index < len(measures) else _DEFAULT_MEASURE
+            )
+            value = self._number(values[index] if index < len(values) else None, 0.0)
+
+            if measure == "total":
+                start, end = base, running
+            elif measure == "absolute":
+                start, end = base, value
+                running = value
+            else:
+                start, end = running, running + value
+                running = end
+
+            points.append(
+                {
+                    MaidrKey.X: self._to_native(label),
+                    MaidrKey.START: start,
+                    MaidrKey.END: end,
+                    MaidrKey.DELTA: end - start,
+                    MaidrKey.KIND: self._kind(measure, end - start),
+                }
+            )
+        return points
+
+    @staticmethod
+    def _kind(measure: str, delta: float) -> str:
+        """Return the ``WaterfallKind`` a measure and its contribution make.
+
+        A zero-contribution relative step reads as an ``increase``: it is a
+        step that happened to net to nothing, not a restatement of the total,
+        and calling it a total would take it out of the extrema search and
+        out of the increase/decrease counts the description reports.
+        """
+        if measure in ("total", "absolute"):
+            return "total"
+        return "decrease" if delta < 0 else "increase"
+
+    @staticmethod
+    def _number(value: Any, default: float) -> float:
+        """Coerce one of plotly's numbers, falling back when it is absent."""
+        if value is None:
+            return default
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default

--- a/tests/plotly/test_plotly_bar_category_order.py
+++ b/tests/plotly/test_plotly_bar_category_order.py
@@ -85,7 +85,7 @@ def test_an_unsorted_bar_chart_is_untouched():
     fig = _bar()
 
     assert _pairs(fig) == [("charlie", 3), ("alpha", 1), ("bravo", 2)]
-    assert _layer(fig)["selectors"] == ".subplot.xy .trace.bars .point > path"
+    assert _layer(fig)["selectors"] == ".subplot.xy .barlayer .trace.bars .point > path"
 
 
 def test_an_ascending_sort_is_emitted_in_the_drawn_order():
@@ -124,7 +124,7 @@ def test_each_selector_names_the_bar_whose_point_it_carries():
     positions measured in Chromium -- `alpha` is the trace's second entry, so
     it is `nth-of-type(2)`.
     """
-    prefix = ".subplot.xy .trace.bars"
+    prefix = ".subplot.xy .barlayer .trace.bars"
 
     assert _layer(_bar("category ascending"))["selectors"] == [
         f"{prefix} .point:nth-of-type(2) > path",
@@ -180,7 +180,7 @@ def test_every_resolved_sort_permutes_the_selectors_too(order, axis, positions):
     """Not only the ascending one. Each sort is its own permutation, and a
     path that reordered the data while leaving the selectors alone would read
     correctly and outline the wrong bar."""
-    prefix = ".subplot.xy .trace.bars"
+    prefix = ".subplot.xy .barlayer .trace.bars"
 
     assert _layer(_bar(order, **axis))["selectors"] == [
         f"{prefix} .point:nth-of-type({index}) > path" for index in positions
@@ -281,7 +281,7 @@ def test_an_unsorted_group_is_untouched(barmode):
         [("charlie", 3), ("alpha", 1), ("bravo", 2)],
         [("charlie", 1), ("alpha", 4), ("bravo", 2)],
     ]
-    assert _layer(fig)["selectors"] == ".subplot.xy .trace.bars .point > path"
+    assert _layer(fig)["selectors"] == ".subplot.xy .barlayer .trace.bars .point > path"
 
 
 @pytest.mark.parametrize("barmode", ["group", "stack"])
@@ -301,7 +301,7 @@ def test_a_sorted_group_addresses_each_cell_by_trace_and_category():
     the drawn order, pointing at the position each holds in *that trace's*
     own arrays.
     """
-    prefix = ".subplot.xy .trace.bars"
+    prefix = ".subplot.xy .barlayer .trace.bars"
     expected = [
         [
             f"{prefix}:nth-of-type({group}) .point:nth-of-type({index}) > path"
@@ -361,7 +361,7 @@ def test_traces_written_in_different_orders_each_get_their_own_permutation():
 
     # And each group's selectors point into its own arrays: A is written out
     # of order and permutes, B is already sorted and does not.
-    prefix = ".subplot.xy .trace.bars"
+    prefix = ".subplot.xy .barlayer .trace.bars"
     assert _layer(fig)["selectors"] == [
         [
             f"{prefix}:nth-of-type(1) .point:nth-of-type({index}) > path"

--- a/tests/plotly/test_plotly_waterfall.py
+++ b/tests/plotly/test_plotly_waterfall.py
@@ -1,0 +1,319 @@
+"""A plotly waterfall chart produced a figure with no layers at all.
+
+`maidr/plotly/` builds its MAIDR schema in Python and had no handling for
+`waterfall`, so the trace fell through `_extract_plots` to
+`PlotlyPlotFactory`, which returned `None`::
+
+    go.Waterfall(...)   ->  layers: []
+
+The core has drawn waterfalls since xability/maidr#790 and the bundle shipped
+in this wheel names the type, so nothing was missing downstream: a waterfall
+written in plotly was silent only on the Python side (#627).
+
+Plotly states a waterfall in *offsets* -- a `measure` array saying what each
+`y` means -- while `WaterfallPoint` wants the two absolute running totals a
+step sits between. The three measures were measured rather than read off the
+documentation, by rendering each case in Chromium and inverting the drawn
+rectangles back through plotly's own axis map. Every expectation below is one
+of those measurements:
+
+===========================  =================================================
+input                        drawn (rounded off the 0.3px stroke bleed)
+===========================  =================================================
+`y=[10, -4, 7]`, no measure  `0->10`, `10->6`, `6->13`
+the plotly docs' example     `0->60`, `60->140`, `0->140`, `140->100`,
+                             `100->80`, `0->80`
+`[relative, absolute,        `0->10`, `0->100`, `100->105`
+ relative]` on `[10,100,5]`
+`[.., .., total]` on         `0->10`, `10->15`, `0->15` -- the total's own
+`[10, 5, 999]`               999 is ignored
+`base=100` on `[10, 5, 0]`   `100->110`, `110->115`, `100->115`
+===========================  =================================================
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: The example from plotly's own waterfall documentation, whose two `total`
+#: steps are what separate a waterfall from a bar chart of deltas.
+DOC = {
+    "measure": ["relative", "relative", "total", "relative", "relative", "total"],
+    "x": ["Sales", "Consulting", "Net revenue", "Purchases", "Other", "Profit"],
+    "y": [60, 80, 0, -40, -20, 0],
+}
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _spans(layer: dict) -> list[tuple[float, float]]:
+    """Each step's `(start, end)` pair -- the bar's two ends."""
+    return [(point["start"], point["end"]) for point in layer["data"]]
+
+
+def test_a_waterfall_chart_is_read_at_all() -> None:
+    """The reproduction: a whole chart that announced nothing.
+
+    Not a crash and not a mislabel -- the figure arrived with an empty layer
+    list and MAIDR had nothing to navigate.
+    """
+    layers = _layers(go.Figure([go.Waterfall(x=["a", "b", "c"], y=[10, -4, 7])]))
+
+    assert [layer["type"] for layer in layers] == [PlotType.WATERFALL]
+
+
+def test_a_measureless_waterfall_accumulates() -> None:
+    """Every step is a contribution unless the author says otherwise.
+
+    This is the whole difference from a bar chart: the same three numbers
+    read as a bar layer would be `10`, `-4` and `7` at three independent
+    positions, and the running total the chart is drawn to show would be
+    nowhere in the payload.
+    """
+    (layer,) = _layers(go.Figure([go.Waterfall(x=["a", "b", "c"], y=[10, -4, 7])]))
+
+    assert _spans(layer) == [(0, 10), (10, 6), (6, 13)]
+    assert [point["delta"] for point in layer["data"]] == [10, -4, 7]
+
+
+def test_a_total_step_restates_the_running_total() -> None:
+    """A `total` draws from the base to wherever the chart has got to.
+
+    The measured geometry of plotly's own example, step for step. A total
+    read as a relative step would put `0` in `delta` and leave the reader
+    with a bar the chart draws two hundred pixels tall and MAIDR calls
+    nothing.
+    """
+    (layer,) = _layers(go.Figure([go.Waterfall(**DOC)]))
+
+    assert _spans(layer) == [
+        (0, 60),
+        (60, 140),
+        (0, 140),
+        (140, 100),
+        (100, 80),
+        (0, 80),
+    ]
+
+
+def test_a_total_step_ignores_its_own_value() -> None:
+    """`y` on a total is not drawn, so it must not be read.
+
+    Measured: `y=999` on the third step drew `0->15`, the running total. The
+    999 is what an author writes when they have not noticed plotly ignores
+    it, and transcribing it would announce a number the chart never shows.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Waterfall(
+                    measure=["relative", "relative", "total"],
+                    x=["a", "b", "c"],
+                    y=[10, 5, 999],
+                )
+            ]
+        )
+    )
+
+    assert _spans(layer) == [(0, 10), (10, 15), (0, 15)]
+
+
+def test_an_absolute_step_resets_the_running_total() -> None:
+    """`absolute` sets the total rather than adding to it.
+
+    Measured: after `[relative, absolute, relative]` on `[10, 100, 5]` the
+    third step drew `100->105`, not `115->120`. Reading `absolute` as
+    `relative` would leave every later step offset by the difference -- a
+    whole chart wrong from the middle onwards, with nothing to say so.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Waterfall(
+                    measure=["relative", "absolute", "relative"],
+                    x=["a", "b", "c"],
+                    y=[10, 100, 5],
+                )
+            ]
+        )
+    )
+
+    assert _spans(layer) == [(0, 10), (0, 100), (100, 105)]
+
+
+def test_base_moves_where_the_accumulation_starts() -> None:
+    """`base` shifts the relative steps and the totals alike.
+
+    Measured: `base=100` drew `100->110`, `110->115` and -- for the total --
+    `100->115`, so the total's own floor is the base rather than zero.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Waterfall(
+                    measure=["relative", "relative", "total"],
+                    x=["a", "b", "c"],
+                    y=[10, 5, 0],
+                    base=100,
+                )
+            ]
+        )
+    )
+
+    assert _spans(layer) == [(100, 110), (110, 115), (100, 115)]
+
+
+def test_each_step_says_which_way_it_moved() -> None:
+    """`kind` comes from the measure, not from the sign alone.
+
+    The core excludes `total` steps from "largest contribution" and from the
+    extrema targets, precisely so an opening or closing bar -- which restates
+    the whole running value -- does not bury the answer the reader wanted. A
+    total announced as an increase would do exactly that.
+    """
+    (layer,) = _layers(go.Figure([go.Waterfall(**DOC)]))
+
+    assert [point["kind"] for point in layer["data"]] == [
+        "increase",
+        "increase",
+        "total",
+        "decrease",
+        "decrease",
+        "total",
+    ]
+
+
+def test_an_absolute_step_is_a_total_too() -> None:
+    """`absolute` restates the running value, which is what `total` means.
+
+    It is the measure an author uses for an opening balance, and the core's
+    reason for excluding totals applies to it unchanged.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Waterfall(
+                    measure=["absolute", "relative"], x=["open", "a"], y=[100, 5]
+                )
+            ]
+        )
+    )
+
+    assert [point["kind"] for point in layer["data"]] == ["total", "increase"]
+
+
+def test_a_step_that_nets_to_nothing_is_still_a_step() -> None:
+    """A zero contribution is an increase, not a total.
+
+    It is a step that happened to net to nothing, and calling it a total
+    would take it out of the increase/decrease counts the description
+    reports as well as out of the extrema search.
+    """
+    (layer,) = _layers(go.Figure([go.Waterfall(x=["a", "b"], y=[10, 0])]))
+
+    assert [point["kind"] for point in layer["data"]] == ["increase", "increase"]
+
+
+def test_a_horizontal_waterfall_keeps_its_categories_in_x() -> None:
+    """The core fixes a waterfall's main axis, so the payload has to fit it.
+
+    `IS_ORIENTED` marks `WATERFALL` false -- "a horizontal waterfall swaps
+    nothing a reader would hear" -- and `WaterfallTrace` announces the step's
+    label against `this.xAxis`. So the category belongs in `x` however the
+    chart is drawn, and the values accumulate out of the trace's `x` array.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Waterfall(
+                    orientation="h",
+                    measure=["relative", "relative", "total"],
+                    y=["a", "b", "c"],
+                    x=[10, -4, 0],
+                )
+            ]
+        )
+    )
+
+    assert [point["x"] for point in layer["data"]] == ["a", "b", "c"]
+    assert _spans(layer) == [(0, 10), (10, 6), (0, 6)]
+
+
+def test_a_horizontal_waterfall_carries_its_axis_titles_across() -> None:
+    """The titles travel with the values they name.
+
+    Left in plotly's arrangement they would announce the value axis's title
+    beside the category name and the category axis's title beside the
+    contribution -- both labels attached to the wrong number.
+    """
+    figure = go.Figure(
+        [go.Waterfall(orientation="h", y=["a", "b"], x=[10, -4])]
+    )
+    figure.update_layout(
+        xaxis={"title": {"text": "Amount"}}, yaxis={"title": {"text": "Stage"}}
+    )
+
+    (layer,) = _layers(figure)
+
+    assert layer["axes"]["x"]["label"] == "Stage"
+    assert layer["axes"]["y"]["label"] == "Amount"
+
+
+def test_a_vertical_waterfall_leaves_its_axis_titles_alone() -> None:
+    """The control for the swap above: it must not fire both ways."""
+    figure = go.Figure([go.Waterfall(x=["a", "b"], y=[10, -4])])
+    figure.update_layout(
+        xaxis={"title": {"text": "Stage"}}, yaxis={"title": {"text": "Amount"}}
+    )
+
+    (layer,) = _layers(figure)
+
+    assert layer["axes"]["x"]["label"] == "Stage"
+    assert layer["axes"]["y"]["label"] == "Amount"
+
+
+def test_the_selector_is_scoped_to_the_waterfall_layer() -> None:
+    """`.trace.bars` alone is not unique to any one trace family.
+
+    Measured in Chromium on a subplot holding one bar trace and one
+    waterfall: `.subplot.xy .trace.bars .point > path` matched **7**
+    elements -- the four bars and the three steps -- while
+    `.subplot.xy .waterfalllayer .trace.bars .point > path` matched exactly
+    the 3 steps.
+    """
+    (layer,) = _layers(go.Figure([go.Waterfall(x=["a", "b", "c"], y=[10, -4, 7])]))
+
+    assert ".waterfalllayer" in layer["selectors"]
+
+
+def test_two_waterfalls_on_one_subplot_address_their_own_steps() -> None:
+    """Plotly appends one `.trace.bars` group per trace, in declaration order.
+
+    Without the position each layer's selector would claim both groups, so
+    every resolved count would be the sum of the two and both highlights
+    would be dropped.
+    """
+    first, second = _layers(
+        go.Figure(
+            [
+                go.Waterfall(x=["a", "b"], y=[1, 2]),
+                go.Waterfall(x=["a", "b"], y=[3, 4]),
+            ]
+        )
+    )
+
+    assert "nth-of-type(1)" in first["selectors"]
+    assert "nth-of-type(2)" in second["selectors"]

--- a/tests/plotly/test_plotly_waterfall.py
+++ b/tests/plotly/test_plotly_waterfall.py
@@ -317,3 +317,45 @@ def test_two_waterfalls_on_one_subplot_address_their_own_steps() -> None:
 
     assert "nth-of-type(1)" in first["selectors"]
     assert "nth-of-type(2)" in second["selectors"]
+
+
+def test_a_bar_beside_a_waterfall_still_addresses_its_own_bars() -> None:
+    """The other half of the same over-match (#628).
+
+    The bar layer's selector was `.trace.bars` with no layer to scope it, so
+    it matched the waterfall's steps too. `BarTrace.mapToSvgElements` needs
+    the resolved count to equal the point count, so 7 against 4 dropped the
+    highlight for the whole bar layer.
+
+    The layer is found by type rather than by position: `_extract_plots`
+    emits its merge blocks before the traces that fall through to the
+    factory, so a waterfall precedes a bar declared ahead of it -- exactly
+    as a box or a candlestick already does. That ordering is older than this
+    change and is not what this test is about.
+    """
+    layers = _layers(
+        go.Figure(
+            [
+                go.Bar(x=["a", "b", "c", "d"], y=[1, 2, 3, 4]),
+                go.Waterfall(x=["a", "b", "c"], y=[10, -4, 7]),
+            ]
+        )
+    )
+    (bar,) = [layer for layer in layers if layer["type"] == PlotType.BAR]
+
+    assert ".barlayer" in bar["selectors"]
+    assert sorted(layer["type"] for layer in layers) == [
+        PlotType.BAR,
+        PlotType.WATERFALL,
+    ]
+
+
+def test_a_lone_bar_chart_is_unchanged_apart_from_the_scope() -> None:
+    """The control: scoping must not disturb what the selector resolved to.
+
+    `.barlayer` is the group plotly already put the bars in, so the added
+    step narrows the match without moving it.
+    """
+    (layer,) = _layers(go.Figure([go.Bar(x=["a", "b"], y=[1, 2])]))
+
+    assert layer["selectors"] == ".subplot.xy .barlayer .trace.bars .point > path"


### PR DESCRIPTION
First tranche of #627. Closes #628.

## What was wrong

`maidr/plotly/` builds its MAIDR schema in Python and had no handling for `waterfall`, so the trace fell through `_extract_plots` to `PlotlyPlotFactory`, which returned `None`:

```python
go.Waterfall(x=["a", "b", "c"], y=[10, -4, 7])   ->   layers: []
```

Not a crash and not a mislabel — the figure arrived with an empty layer list and MAIDR had nothing to navigate. Nothing was missing downstream: the core has drawn waterfalls since xability/maidr#790 and `bundle_trace_types()` confirms the bundle in this wheel names the type. A waterfall written in plotly was silent only on the Python side.

## Measuring plotly's `measure`

Plotly states a waterfall in *offsets* — a `measure` array saying what each `y` means — while `WaterfallPoint` wants the two absolute running totals a step sits between. That mapping is not a rename: what `y` means depends on the step's measure, and one of the three measures ignores `y` entirely.

I measured it rather than reading it off the documentation, by rendering each case in Chromium and inverting the drawn rectangles back through plotly's own axis map (`gd._fullLayout.yaxis.p2d`). Rounded off the ~0.3px stroke bleed `getBBox` includes:

| input | drawn |
|---|---|
| `y=[10, -4, 7]`, no `measure` | `0→10`, `10→6`, `6→13` |
| the plotly docs' own example | `0→60`, `60→140`, `0→140`, `140→100`, `100→80`, `0→80` |
| `[relative, absolute, relative]` on `[10, 100, 5]` | `0→10`, `0→100`, `100→105` |
| `[relative, relative, total]` on `[10, 5, 999]` | `0→10`, `10→15`, `0→15` — the total's own 999 is ignored |
| `base=100` on `[10, 5, 0(total)]` | `100→110`, `110→115`, `100→115` |

So: `total` draws from `base` to the running total and leaves it there; `absolute` *sets* the running total; `base` moves where the accumulation starts, totals included. Every expectation in the test file is one of those measurements.

## Judgement calls

**`kind` follows the measure, not the sign.** An `absolute` step is a `total` too: the core excludes totals from "largest contribution" and from the extrema targets, precisely so an opening or closing bar — which restates the whole running value — does not bury the answer the reader wanted. That reasoning applies to an opening balance written as `absolute` unchanged. A *relative* step that nets to zero stays an `increase`: it is a step that happened to net to nothing, and calling it a total would take it out of the increase/decrease counts too.

**The category stays in `x` however the chart is drawn.** `IS_ORIENTED` marks `WATERFALL` false — "a horizontal waterfall swaps nothing a reader would hear" — and `WaterfallTrace` fixes `mainAxis: 'x'` and announces the step against `this.xAxis`. So a horizontal waterfall is emitted with its categories in `x` and its axis *titles* swapped to travel with them. Left in plotly's arrangement both labels would be attached to the wrong number.

## The bar selector (#628)

`.trace.bars` is not unique to the bar layer. Measured in Chromium on `go.Bar(4 bars)` beside `go.Waterfall(3 steps)`:

```
7  .subplot.xy .trace.bars .point > path              <- what was emitted
4  .subplot.xy .barlayer .trace.bars .point > path
3  .subplot.xy .waterfalllayer .trace.bars .point > path
```

`BarTrace.mapToSvgElements` needs the resolved count to equal the point count, so 7 against 4 dropped the highlight for the whole bar layer. Scoping to `.barlayer` narrows the match without moving it — that is the group plotly already puts the bars in.

This is a separate commit, and it is second rather than first for a reason: without a readable waterfall the over-match cannot be demonstrated from py-maidr's own API at all, because no other trace type it reads shares a layer group with `barlayer`.

Verified in Chromium after both commits, across all four `.trace.bars` emitters plus the waterfalls:

```
OK  WATERFALL   points=3 resolved=3   .subplot.xy .waterfalllayer .trace.bars:nth-of-type(1) .point > path
OK  WATERFALL   points=2 resolved=2   .subplot.xy .waterfalllayer .trace.bars:nth-of-type(2) .point > path
OK  BAR         points=4 resolved=4   .subplot.xy .barlayer .trace.bars .point > path
OK  DODGED      points=6 resolved=6
OK  HIST        points=3 resolved=3
```

## Tests

`tests/plotly/test_plotly_waterfall.py` — 18 tests. Each measure, `base`, the `total`-ignores-`y` case, `kind` per step, both orientations, the axis-title swap **and its control** (a vertical waterfall must not swap), the two selector scopings, and the two bar controls.

Mutation-swept: ten mutations applied one at a time against a restored baseline, every one caught.

```
M1  total -> relative              4 failed, 12 passed
M2  absolute -> relative           1 failed, 15 passed
M3  base ignored                   1 failed, 15 passed
M4  kind ignores total             2 failed, 14 passed
M5  axis swap dropped              1 failed, 15 passed
M6  labels always from x           1 failed, 15 passed
M7  waterfalllayer scope dropped   1 failed, 15 passed
M8  nth-of-type dropped            1 failed, 15 passed
M9  barlayer scope dropped         2 failed, 14 passed
M10 _extract_plots block dropped   1 failed, 15 passed
```

Full suite, run in two batches because the whole run OOMs in this container: `tests/core` 1931 passed, 5 skipped; the rest 1155 passed, 13 skipped.

## Noted, not changed

`_extract_plots` emits its merge blocks before the traces that fall through to the factory, so a waterfall declared *after* a bar is announced *before* it. That is older than this change — a box or a candlestick already does the same — and one test says so outright rather than encoding the order as if it were intended.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_