### PR TITLE
feat(plotly): read a funnel trace

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -64,6 +64,12 @@ class PlotType(str, Enum):
     CANDLESTICK = "candlestick"
     VIOLIN_KDE = "violin_kde"
     VIOLIN_BOX = "violin_box"
+    #: A population shrinking across ordered stages. Read as a bar layer is,
+    #: with the one difference that decides whether the chart is legible: the
+    #: number a reader wants is the *retention* between adjacent stages
+    #: rather than the count, so that is what the core pitches. The counts
+    #: are announced alongside it.
+    FUNNEL = "funnel"
     #: A starting value carried to an ending value through a sequence of
     #: signed contributions, each bar floating between the running total
     #: before it and the running total after it. A distinct type from `BAR`

--- a/maidr/plotly/funnel.py
+++ b/maidr/plotly/funnel.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, paired_axes
+
+
+class PlotlyFunnelPlot(PlotlyPlot):
+    """Extract data from a Plotly funnel trace.
+
+    A funnel is a population shrinking across ordered stages, and the core
+    reads it as a bar layer with one difference that decides whether the
+    chart is legible: the number pitched is the **retention** between
+    adjacent stages rather than the count. `FunnelTrace` computes that from
+    `barValues`, so the payload here is a bar's -- one point per stage, plus
+    the `orientation` that says which field holds the stage name.
+
+    Which way a funnel is drawn is not the same question plotly's bar traces
+    answer. Measured in Chromium against ``gd._fullData[0].orientation``:
+
+    ==========================  =========================================
+    written                     plotly draws
+    ==========================  =========================================
+    ``y=stages, x=counts``      ``h``
+    ``x=stages, y=counts``      ``h`` -- the stage names land on the value
+                                axis and the chart is nonsense, but that is
+                                plotly's reading of it, not ours to correct
+    ``x=counts`` alone          ``h``
+    ``y=counts`` alone          ``v``
+    ==========================  =========================================
+
+    So the default is horizontal whenever the trace carries an ``x`` at all,
+    which is the opposite of the vertical default a bar layer takes.
+    """
+
+    def __init__(
+        self, trace: dict, layout: dict, *, layer_position: int = 0, **kwargs: str
+    ) -> None:
+        super().__init__(trace, layout, PlotType.FUNNEL, **kwargs)
+        self._layer_position = layer_position
+
+    def _get_selector(self) -> str:
+        """Address this trace's stages inside the subplot's funnel layer.
+
+        ``.funnellayer`` rather than ``.trace.bars`` alone: plotly draws a
+        funnel into its own ``mlayer`` and reuses the same inner class names
+        there, so the bare form matched a bar chart's bars as well (#628).
+
+        ``nth-of-type`` picks this trace out of the layer. Measured on two
+        funnels sharing a subplot, ``.funnellayer .trace .point > path``
+        resolved to 4 -- both traces' stages together -- so a layer without
+        the position would claim its neighbour's.
+        """
+        return (
+            f"{self._subplot_css_prefix()}.funnellayer "
+            f".trace.bars:nth-of-type({self._layer_position + 1}) .point > path"
+        )
+
+    def render(self) -> dict:
+        """Add ``orientation`` to the base schema.
+
+        `FunnelTrace` extends the bar trace, so it reads the stage name off
+        ``point.x`` when the layer is vertical and ``point.y`` when it is
+        horizontal. Without the key the layer defaults to vertical, and a
+        horizontal funnel -- which is what plotly draws unless told otherwise
+        -- would announce the count as the stage's identity and the stage
+        name as its value, the same failure #480 was about for bars.
+        """
+        schema = super().render()
+        schema[MaidrKey.ORIENTATION] = "horz" if self._is_horizontal() else "vert"
+        return schema
+
+    def _is_horizontal(self) -> bool:
+        """Report whether plotly draws this funnel across the page.
+
+        Read from the trace when the author set it, and otherwise from
+        whether the trace carries an ``x`` at all -- the rule measured above.
+        A bar's ``get("orientation") == "h"`` test cannot be reused, because
+        its "absent means vertical" default is the wrong way round here.
+        """
+        orientation = self._trace.get("orientation")
+        if orientation is not None:
+            return orientation == "h"
+        return self._trace.get("x") is not None
+
+    def _extract_plot_data(self) -> list[dict]:
+        """One point per stage, in the order plotly draws them.
+
+        `paired_axes` is symmetric, so a horizontal funnel's counts already
+        arrive in ``x`` and its stage names in ``y`` -- which is the
+        arrangement the core wants once it has been told the layer is
+        horizontal.
+
+        The stages are read in the trace's own order rather than through
+        ``_drawn_category_order``. A funnel's axis is its sequence: the whole
+        chart is "this many entered, this many got to the next step", and
+        sorting the stages by name would be sorting away the thing it says.
+        """
+        x, y = paired_axes(self._trace)
+        return [
+            {MaidrKey.X: self._to_native(xv), MaidrKey.Y: self._to_native(yv)}
+            for xv, yv in zip(x, y)
+        ]

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -824,6 +824,26 @@ class PlotlyMaidr:
                         self._plots.append(layer)
                 merged.update(id(t) for t in violin_traces)
 
+            # Funnels, one layer each, for the reason the waterfalls below
+            # are: plotly appends one `.trace.bars` group per funnel trace to
+            # the subplot's `funnellayer`, so a trace's selector is scoped by
+            # its position among those.
+            funnel_traces = [t for t in group_traces if t.get("type") == "funnel"]
+            if funnel_traces:
+                from maidr.plotly.funnel import PlotlyFunnelPlot
+
+                for funnel_trace in funnel_traces:
+                    plot = PlotlyFunnelPlot(
+                        funnel_trace,
+                        layout,
+                        layer_position=layer_position(group_traces, funnel_trace),
+                        **axis_kwargs,
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in funnel_traces)
+
             # Waterfalls, one layer each, built here rather than left to
             # the factory for the reason the candlesticks above are: plotly
             # appends one `.trace.bars` group per waterfall trace to the

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -126,6 +126,15 @@ class PlotlyPlotFactory:
 
             return PlotlyHistogramPlot(trace, layout, **axis_kwargs)
 
+        if trace_type == "funnel":
+            from maidr.plotly.funnel import PlotlyFunnelPlot
+
+            # ``layer_position`` is left at its default for the reason the
+            # waterfall branch below leaves its own: this factory sees one
+            # trace with no idea what else draws into the subplot's
+            # ``funnellayer``.
+            return PlotlyFunnelPlot(trace, layout, **axis_kwargs)
+
         if trace_type == "waterfall":
             from maidr.plotly.waterfall import PlotlyWaterfallPlot
 

--- a/tests/plotly/test_plotly_funnel.py
+++ b/tests/plotly/test_plotly_funnel.py
@@ -1,0 +1,194 @@
+"""A plotly funnel chart produced a figure with no layers at all.
+
+`maidr/plotly/` builds its MAIDR schema in Python and had no handling for
+`funnel`, so the trace fell through `_extract_plots` to
+`PlotlyPlotFactory`, which returned `None`::
+
+    go.Funnel(y=["a", "b", "c"], x=[100, 60, 40])   ->   layers: []
+
+The core has read funnels since `TraceType.FUNNEL` was added, and the bundle
+shipped in this wheel names the type, so a funnel written in plotly was
+silent only on the Python side (#627).
+
+`FunnelTrace` extends the bar trace: it takes one point per stage and
+computes the retention between adjacent stages from `barValues`, which is
+the number it pitches. So the payload is a bar's, and the one thing that has
+to be right beyond the values is `orientation` -- which decides whether the
+core reads the stage name off `point.x` or `point.y`.
+
+Which way plotly draws a funnel is not the question a bar answers. Measured
+in Chromium against `gd._fullData[0].orientation`:
+
+===========================  ==========================================
+written                      plotly resolves
+===========================  ==========================================
+`y=stages, x=counts`         `h`
+`x=stages, y=counts`         `h`
+`x=counts` alone             `h`
+`y=counts` alone             `v`
+`orientation="v"`            `v`
+===========================  ==========================================
+
+So the default is horizontal whenever the trace carries an `x` at all --
+the opposite of the vertical default a bar layer takes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+STAGES = ["visited", "signed up", "paid"]
+COUNTS = [100, 60, 40]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _pairs(layer: dict) -> list[tuple]:
+    """Each point as ``(x, y)``, in the order it is emitted."""
+    return [(point["x"], point["y"]) for point in layer["data"]]
+
+
+def test_a_funnel_chart_is_read_at_all() -> None:
+    """The reproduction: a whole chart that announced nothing.
+
+    Not a crash and not a mislabel -- the figure arrived with an empty layer
+    list and MAIDR had nothing to navigate.
+    """
+    layers = _layers(go.Figure([go.Funnel(y=STAGES, x=COUNTS)]))
+
+    assert [layer["type"] for layer in layers] == [PlotType.FUNNEL]
+
+
+def test_a_funnel_carries_one_point_per_stage() -> None:
+    """The counts and the stage names, in the trace's own order.
+
+    Not sorted. A funnel's axis *is* its sequence -- the chart says "this
+    many entered, this many reached the next step" -- so ordering the stages
+    by name would order away the thing it is drawn to show.
+    """
+    (layer,) = _layers(go.Figure([go.Funnel(y=STAGES, x=COUNTS)]))
+
+    assert _pairs(layer) == list(zip(COUNTS, STAGES))
+
+
+def test_a_horizontal_funnel_says_so() -> None:
+    """Without the key the layer defaults to vertical.
+
+    `FunnelTrace` reads the stage name off `point.x` when it is vertical, so
+    a horizontal funnel announced as vertical gives the count as the stage's
+    identity and the stage name as its value -- the failure #480 was about
+    for bars.
+    """
+    (layer,) = _layers(go.Figure([go.Funnel(y=STAGES, x=COUNTS)]))
+
+    assert layer["orientation"] == "horz"
+
+
+def test_a_vertical_funnel_says_so_too() -> None:
+    """The control for the key above: it must not be constant."""
+    (layer,) = _layers(
+        go.Figure([go.Funnel(x=STAGES, y=COUNTS, orientation="v")])
+    )
+
+    assert layer["orientation"] == "vert"
+    assert _pairs(layer) == list(zip(STAGES, COUNTS))
+
+
+@pytest.mark.parametrize(
+    ("trace", "expected"),
+    [
+        (go.Funnel(y=STAGES, x=COUNTS), "horz"),
+        (go.Funnel(x=STAGES, y=COUNTS), "horz"),
+        (go.Funnel(x=COUNTS), "horz"),
+        (go.Funnel(y=COUNTS), "vert"),
+    ],
+)
+def test_an_unstated_orientation_follows_what_plotly_draws(
+    trace: go.Funnel, expected: str
+) -> None:
+    """Each row measured against ``gd._fullData[0].orientation`` in Chromium.
+
+    The third and fourth rows are what separate this from a bar's rule: a
+    funnel written with counts alone is horizontal when they are on ``x``
+    and vertical when they are on ``y``, while a bar with no ``orientation``
+    is vertical either way.
+
+    The second row is plotly's answer rather than a sensible one -- stage
+    names on the value axis draw a chart of nonsense -- but it is what the
+    reader is looking at, and announcing the other orientation would
+    describe a chart that is not on the screen.
+    """
+    (layer,) = _layers(go.Figure([trace]))
+
+    assert layer["orientation"] == expected
+
+
+def test_the_selector_is_scoped_to_the_funnel_layer() -> None:
+    """`.trace.bars` is not unique to the bar layer.
+
+    Plotly draws a funnel into its own ``mlayer`` and reuses the same inner
+    class names there. Measured in Chromium on a subplot holding a bar trace
+    and a funnel, the unscoped ``.trace.bars .point > path`` matched the
+    funnel's stages too -- which is the over-match #628 was about, with
+    ``funnellayer`` in place of ``waterfalllayer``.
+    """
+    (layer,) = _layers(go.Figure([go.Funnel(y=STAGES, x=COUNTS)]))
+
+    assert ".funnellayer" in layer["selectors"]
+
+
+def test_two_funnels_on_one_subplot_address_their_own_stages() -> None:
+    """Plotly appends one `.trace.bars` group per trace, in declaration order.
+
+    Measured: ``.funnellayer .trace .point > path`` resolved to 4 on a
+    subplot holding a three-stage funnel and a two-stage one -- both traces'
+    stages together -- so a layer without the position would claim its
+    neighbour's and both highlights would be dropped.
+    """
+    first, second = _layers(
+        go.Figure(
+            [
+                go.Funnel(y=STAGES, x=COUNTS, name="one"),
+                go.Funnel(y=["a", "b"], x=[10, 5], name="two"),
+            ]
+        )
+    )
+
+    assert "nth-of-type(1)" in first["selectors"]
+    assert "nth-of-type(2)" in second["selectors"]
+    assert len(first["data"]) == 3
+    assert len(second["data"]) == 2
+
+
+def test_a_bar_beside_a_funnel_still_addresses_its_own_bars() -> None:
+    """The control that the two layers do not reach into each other.
+
+    Verified in Chromium after this change: the bar's selector resolved to
+    its 4 bars and each funnel's to its own stages, on one subplot holding
+    all three.
+    """
+    layers = _layers(
+        go.Figure(
+            [
+                go.Bar(x=["a", "b", "c", "d"], y=[1, 2, 3, 4]),
+                go.Funnel(y=STAGES, x=COUNTS),
+            ]
+        )
+    )
+    (bar,) = [layer for layer in layers if layer["type"] == PlotType.BAR]
+
+    assert ".barlayer" in bar["selectors"]
+    assert ".funnellayer" not in bar["selectors"]


### PR DESCRIPTION
Second tranche of #627, after the waterfall in #629.

## What was wrong

```python
go.Funnel(y=["visited", "signed up", "paid"], x=[100, 60, 40])   ->   layers: []
```

`_extract_plots` had no branch for `funnel` and `PlotlyPlotFactory` returned `None`. The core has read funnels since `TraceType.FUNNEL` was added, and `bundle_trace_types()` confirms the bundle in this wheel names it — a funnel written in plotly was silent only on the Python side.

## The payload

`FunnelTrace` extends the bar trace: `this.counts = this.barValues[0]`, and the retention between adjacent stages — what it pitches — is derived from that. So the payload is a bar's, one point per stage, and the one thing beyond the values that has to be right is `orientation`, which decides whether the core reads the stage name off `point.x` or `point.y`.

## Orientation is not the bar's rule

A bar with no `orientation` is vertical. A funnel is not. Measured in Chromium against `gd._fullData[0].orientation` — plotly's own resolved value, not a guess from the trace dict:

| written | plotly resolves |
|---|---|
| `y=stages, x=counts` | `h` |
| `x=stages, y=counts` | `h` |
| `x=counts` alone | `h` |
| `y=counts` alone | `v` |
| `orientation="v"` | `v` |

So: the author's value if set, else horizontal whenever the trace carries an `x` at all.

The second row is worth stating plainly. Writing stage names on `x` draws a chart of nonsense — the names land on the value axis — but plotly still resolves it horizontal, and that is what the reader is looking at. Announcing the other orientation would describe a chart that is not on the screen, so this follows plotly rather than correcting it.

## Stage order

Read in the trace's own order, not through `_drawn_category_order`. A funnel's axis *is* its sequence — "this many entered, this many reached the next step" — so ordering the stages by name would order away the thing the chart is drawn to show. That is the opposite call from #495 for bars, and deliberately so.

## Selector

`.funnellayer .trace.bars:nth-of-type(k) .point > path`.

Both halves were measured. Plotly draws a funnel into its own `mlayer` and **reuses `<g class="trace bars">` inside it** — so the bare `.trace.bars .point > path` matched a funnel's stages as well as a bar's bars, exactly the over-match #628 was about with `waterfalllayer`. And `.funnellayer .trace .point > path` resolved to 4 on a subplot holding a three-stage funnel and a two-stage one, so the position is needed to keep each layer off its neighbour's marks.

Verified in Chromium on a subplot holding a bar and two funnels:

```
OK  FUNNEL  points=3 resolved=3   .subplot.xy .funnellayer .trace.bars:nth-of-type(1) .point > path
OK  FUNNEL  points=2 resolved=2   .subplot.xy .funnellayer .trace.bars:nth-of-type(2) .point > path
OK  BAR     points=4 resolved=4   .subplot.xy .barlayer .trace.bars .point > path
```

## Tests

`tests/plotly/test_plotly_funnel.py` — 11 tests: the reproduction, the stages and their order, both orientations, the four measured inference rows as a parametrised table, the layer scoping, two funnels on one subplot, and a control that a bar beside a funnel keeps its own bars.

Mutation-swept, six mutations one at a time against a restored baseline, all caught:

```
M1  orientation key dropped        6 failed, 5 passed
M2  bar's orientation rule         4 failed, 7 passed
M3  horizontal always              1 failed, 10 passed
M4  funnellayer scope dropped      1 failed, 10 passed
M5  nth-of-type dropped            1 failed, 10 passed
M6  _extract_plots block dropped   1 failed, 10 passed
```

Full suite in two batches (the whole run OOMs in this container): `tests/core` 1931 passed, 5 skipped; the rest 1166 passed, 13 skipped.

## Not in this PR

`go.Funnelarea` is the same `TraceType.FUNNEL` but a different animal in every other respect: a domain trace drawn under `main-svg` in `funnelarealayer`, with `<g class="trace"><g class="slice"><path class="surface">` instead of `.point`, and `labels`/`values` instead of `x`/`y`. It needs the figure-level position handling a pie has rather than the subplot-level one here, so it is the next tranche.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_