### PR TITLE
feat(plotly): read a funnelarea trace

### DIFF
--- a/maidr/plotly/funnelarea.py
+++ b/maidr/plotly/funnelarea.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.pie import PlotlyPiePlot
+
+
+class PlotlyFunnelareaPlot(PlotlyPiePlot):
+    """Extract data from a Plotly funnelarea trace.
+
+    A funnelarea is a funnel drawn as nested trapezoids rather than as bars,
+    and it is stated the way a pie is -- ``labels`` and ``values``, placed by
+    a ``domain`` rectangle rather than by an axis pair. So it inherits the
+    pie's slice builder rather than growing a second copy of it: measured
+    against ``gd.calcdata`` in Chromium, every rule matched, one by one --
+
+    ==========================  ==============================================
+    written                     drawn
+    ==========================  ==============================================
+    ``labels=[a, b, a]``        two slices, ``a`` = the sum, at ``a``'s first
+                                position
+    ``values=[10, 0, 5]``       three slices; the zero is kept
+    ``values=[10, -5, 5]``      two slices; the negative is dropped
+    no ``values``               every entry weighs 1
+    no ``labels``               slices named ``0``, ``1``, ``2``
+    an empty label              the entry's own index
+    ``layout.hiddenlabels``     the named slice is not drawn
+    ==========================  ==============================================
+
+    -- with exactly one exception, which is why the sort is a hook on the
+    parent: a funnelarea has no ``sort`` attribute and never reorders.
+    ``values=[40, 100, 60]`` stayed in that order, where a pie would have
+    drawn 100, 60, 40.
+
+    That exception is the whole reason the two cannot simply be one class.
+    A funnel's axis *is* its sequence, so a funnelarea keeps the stages the
+    author wrote; reusing the pie's sorting default would reorder the stages
+    of a funnel by size and announce a conversion path nobody drew.
+    """
+
+    #: A funnelarea's slices are the stages of a funnel and their counts,
+    #: which is what the reader should be told they are when the layout names
+    #: nothing. "Category" and "Value" would be true of a pie and vague here.
+    _AXIS_FALLBACKS = ("Stage", "Count")
+
+    def __init__(
+        self,
+        trace: dict,
+        layout: dict,
+        *,
+        pie_position: int = 0,
+        borrows_axis_titles: bool = True,
+        **kwargs: str,
+    ) -> None:
+        super().__init__(
+            trace,
+            layout,
+            pie_position=pie_position,
+            borrows_axis_titles=borrows_axis_titles,
+            **kwargs,
+        )
+        # Set after the parent has stamped `PlotType.PIE` on it. A funnelarea
+        # is read as the funnel it draws: `FunnelTrace` extends the bar trace
+        # and pitches the retention between adjacent stages, which is the
+        # number this chart exists to show and the one a pie layer has no
+        # notion of.
+        self.type = PlotType.FUNNEL
+
+    def _sorts_wedges(self) -> bool:
+        """A funnelarea never reorders its stages.
+
+        Measured: plotly gives the trace no ``sort`` attribute --
+        ``gd._fullData[0].sort`` is undefined -- and ``values=[40, 100, 60]``
+        drew in that order.
+        """
+        return False
+
+    def _get_selector(self) -> str:
+        """Address this trace's slices inside the figure's funnelarea layer.
+
+        ``funnelarealayer`` rather than ``pielayer``: measured in Chromium on
+        a figure holding one of each, ``.pielayer .trace .slice path.surface``
+        matched the pie's 2 slices and ``.funnelarealayer ...`` the
+        funnelarea's 3, with neither reaching the other.
+
+        Both layers sit directly under ``main-svg`` rather than inside a
+        ``.subplot.xy`` group, which is why the position among the layer's
+        trace groups stands in for the subplot prefix. Measured on two
+        funnelareas: ``> .trace:nth-child(1)`` resolved to 3 slices and
+        ``nth-child(2)`` to 2, against 5 for the unpositioned form.
+        """
+        return (
+            f".funnelarealayer > .trace:nth-child({self._pie_position + 1}) "
+            f"> .slice > path.surface"
+        )
+
+    def render(self) -> dict:
+        """Add ``orientation`` to the base schema.
+
+        `FunnelTrace` reads the stage name off ``point.x`` when the layer is
+        vertical and off ``point.y`` when it is horizontal, and a funnelarea
+        carries its stage names in ``x`` -- it has no axes to be drawn along,
+        so there is no second arrangement for it to be in. Declared rather
+        than left to the default so the payload says what it holds, which is
+        what xability/maidr#947 asks of a producer.
+        """
+        schema = super().render()
+        schema[MaidrKey.ORIENTATION] = "vert"
+        return schema

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -202,7 +202,7 @@ class PlotlyPiePlot(PlotlyPlot):
                 wedges[position][1] += value
 
         wedges = [wedge for wedge in wedges if wedge[1] >= 0]
-        if self._trace.get("sort", True):
+        if self._sorts_wedges():
             wedges.sort(key=lambda wedge: wedge[1], reverse=True)
 
         # Plotly matches `hiddenlabels` with `indexOf` against the *stringified*
@@ -218,6 +218,29 @@ class PlotlyPiePlot(PlotlyPlot):
             if isinstance(label, str)
         }
         return [(label, value) for label, value in wedges if label not in hidden]
+
+    def _sorts_wedges(self) -> bool:
+        """Report whether plotly orders this trace's wedges by value.
+
+        A hook rather than a `self._trace.get("sort", True)` in place,
+        because :class:`~maidr.plotly.funnelarea.PlotlyFunnelareaPlot` shares
+        every other rule in :meth:`_slices` and breaks this one: plotly gives
+        a funnelarea no ``sort`` attribute at all, and measured against
+        ``gd.calcdata``, ``values=[40, 100, 60]`` stayed in that order rather
+        than being reordered largest-first.
+
+        Returns
+        -------
+        bool
+            True when the wedges are drawn largest-first, which is plotly's
+            default for a pie.
+        """
+        return bool(self._trace.get("sort", True))
+
+    #: What this trace's two dimensions are called when the layout names
+    #: neither. A pie's slices are categories carrying values; a subclass
+    #: whose slices mean something else says so by overriding this.
+    _AXIS_FALLBACKS = ("Category", "Value")
 
     def _extract_axes_data(self) -> dict:
         """Extract the two axis labels a pie carries.
@@ -243,9 +266,10 @@ class PlotlyPiePlot(PlotlyPlot):
         else:
             x_axis, y_axis = {}, {}
 
+        x_default, y_default = self._AXIS_FALLBACKS
         return {
-            MaidrKey.X: self._axis_config(label=_axis_title(x_axis, "Category")),
-            MaidrKey.Y: self._axis_config(label=_axis_title(y_axis, "Value")),
+            MaidrKey.X: self._axis_config(label=_axis_title(x_axis, x_default)),
+            MaidrKey.Y: self._axis_config(label=_axis_title(y_axis, y_default)),
         }
 
 

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -66,7 +66,7 @@ from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_plotly
 #: maidr has anything to put in, to column 1 behind an empty cell.
 #:
 #: Add a type here when maidr learns to render it, not before.
-_PLACED_BY_DOMAIN = frozenset({"pie"})
+_PLACED_BY_DOMAIN = frozenset({"pie", "funnelarea"})
 
 #: Every trace type plotly places by a ``domain`` rectangle rather than by a
 #: cartesian axis pair. These share the default ``("x", "y")`` trace group with
@@ -384,6 +384,9 @@ class PlotlyMaidr:
             ]
             pie_traces = [
                 t for t in group_traces if t.get("type") == "pie"
+            ]
+            funnelarea_traces = [
+                t for t in group_traces if t.get("type") == "funnelarea"
             ]
 
             # `nth-child` counts within the subplot's SVG `scatterlayer`, so a
@@ -766,6 +769,43 @@ class PlotlyMaidr:
                     )
                     self._plots.append(plot)
                 merged.update(id(t) for t in pie_traces)
+
+            # Funnelareas, one layer each, for every reason the pies above
+            # are: their own figure-level layer, their own ``domain``
+            # rectangle for the grid cell, and a position among that layer's
+            # trace groups that only this loop knows.
+            #
+            # Numbered among the *funnelarea* traces rather than alongside the
+            # pies: the two layers are siblings under ``main-svg``, so a pie
+            # does not shift a funnelarea's group index. Measured in Chromium
+            # on a figure holding one of each -- each layer held exactly its
+            # own trace at ``nth-child(1)``.
+            if funnelarea_traces:
+                from maidr.plotly.funnelarea import PlotlyFunnelareaPlot
+
+                # Same question the pies answer, and the same answer: a
+                # funnelarea draws no axes, so it may name its dimensions from
+                # ``layout.xaxis``/``yaxis`` only when no cartesian trace has
+                # claimed them.
+                funnelarea_owns_axes = all(
+                    _is_domain_trace(trace) for trace in group_traces
+                )
+
+                for position, funnelarea_trace in enumerate(funnelarea_traces):
+                    plot = PlotlyFunnelareaPlot(
+                        funnelarea_trace,
+                        layout,
+                        pie_position=position,
+                        borrows_axis_titles=funnelarea_owns_axes,
+                        **axis_kwargs,
+                    )
+                    plot.row_index, plot.col_index = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._trace_domain_start(funnelarea_trace),
+                    )
+                    self._plots.append(plot)
+                merged.update(id(t) for t in funnelarea_traces)
 
             # OHLC series, one layer each. Built here rather than left to
             # `PlotlyPlotFactory` for the same reason a lone line is: the

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -126,6 +126,15 @@ class PlotlyPlotFactory:
 
             return PlotlyHistogramPlot(trace, layout, **axis_kwargs)
 
+        if trace_type == "funnelarea":
+            from maidr.plotly.funnelarea import PlotlyFunnelareaPlot
+
+            # ``pie_position`` is left at its default for the reason the pie
+            # branch below leaves its own: plotly draws every funnelarea into
+            # one figure-level ``funnelarealayer``, and this factory sees one
+            # trace with no idea what else the figure holds.
+            return PlotlyFunnelareaPlot(trace, layout, **axis_kwargs)
+
         if trace_type == "funnel":
             from maidr.plotly.funnel import PlotlyFunnelPlot
 

--- a/tests/plotly/test_plotly_funnelarea.py
+++ b/tests/plotly/test_plotly_funnelarea.py
@@ -1,0 +1,246 @@
+"""A plotly funnelarea chart produced a figure with no layers at all.
+
+`go.Funnelarea` is a funnel drawn as nested trapezoids rather than as bars.
+`maidr/plotly/` had no handling for it, so the trace fell through
+`_extract_plots` to `PlotlyPlotFactory`, which returned `None` and left the
+figure with nothing to navigate (#627).
+
+It is *stated* the way a pie is -- `labels` and `values`, placed by a
+`domain` rectangle rather than by an axis pair -- so it inherits the pie's
+slice builder rather than growing a second copy that could drift from it.
+Every rule was measured against `gd.calcdata` in Chromium and matched:
+
+===========================  ===============================================
+written                      drawn
+===========================  ===============================================
+`labels=[a, b, a]`           two slices; `a` holds the sum, at its first
+                             position
+`values=[10, 0, 5]`          three slices; the zero is kept
+`values=[10, -5, 5]`         two slices; the negative is dropped
+no `values`                  every entry weighs 1
+no `labels`                  slices named `0`, `1`, `2`
+an empty label               the entry's own index
+`layout.hiddenlabels`        the named slice is not drawn
+===========================  ===============================================
+
+With exactly one exception, which is the whole reason the two cannot be one
+class: a funnelarea has no `sort` attribute and never reorders.
+`values=[40, 100, 60]` stayed in that order, where a pie draws 100, 60, 40.
+
+That is not a detail. A funnel's axis *is* its sequence, so reusing the pie's
+sorting default would reorder the stages of a funnel by size and announce a
+conversion path nobody drew.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+STAGES = ["visited", "signed up", "paid"]
+COUNTS = [100, 60, 40]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _pairs(layer: dict) -> list[tuple]:
+    """Each slice as ``(label, value)``, in the order it is emitted."""
+    return [(point["x"], point["y"]) for point in layer["data"]]
+
+
+def test_a_funnelarea_chart_is_read_at_all() -> None:
+    """The reproduction: a whole chart that announced nothing."""
+    layers = _layers(go.Figure([go.Funnelarea(labels=STAGES, values=COUNTS)]))
+
+    assert [layer["type"] for layer in layers] == [PlotType.FUNNEL]
+
+
+def test_a_funnelarea_is_read_as_the_funnel_it_draws() -> None:
+    """Not as a pie, which is what it is written like.
+
+    `FunnelTrace` pitches the retention between adjacent stages, which is the
+    number this chart exists to show. A pie layer has no notion of it: it
+    would announce each slice's share of the whole, which is a different
+    question and one the trapezoids are not drawn to answer.
+    """
+    (layer,) = _layers(go.Figure([go.Funnelarea(labels=STAGES, values=COUNTS)]))
+
+    assert layer["type"] == PlotType.FUNNEL
+    assert _pairs(layer) == list(zip(STAGES, COUNTS))
+
+
+def test_a_funnelarea_keeps_the_stages_in_the_order_written() -> None:
+    """The one rule a funnelarea does not share with a pie.
+
+    Measured: `values=[40, 100, 60]` drew in that order, and
+    `gd._fullData[0].sort` is undefined -- the attribute does not exist on
+    the trace. A pie with the same numbers draws 100, 60, 40.
+    """
+    (layer,) = _layers(
+        go.Figure([go.Funnelarea(labels=["a", "b", "c"], values=[40, 100, 60])])
+    )
+
+    assert _pairs(layer) == [("a", 40), ("b", 100), ("c", 60)]
+
+
+def test_a_pie_beside_it_still_sorts() -> None:
+    """The control for the rule above: the hook must not change the pie.
+
+    Both layers come out of one slice builder, so a flag applied to the wrong
+    side would reorder every pie in the world and pass a funnelarea-only
+    test.
+    """
+    pie, funnelarea = _layers(
+        go.Figure(
+            [
+                go.Pie(labels=["a", "b", "c"], values=[40, 100, 60]),
+                go.Funnelarea(labels=["a", "b", "c"], values=[40, 100, 60]),
+            ]
+        )
+    )
+
+    assert _pairs(pie) == [("b", 100), ("c", 60), ("a", 40)]
+    assert _pairs(funnelarea) == [("a", 40), ("b", 100), ("c", 60)]
+
+
+@pytest.mark.parametrize(
+    ("trace", "expected"),
+    [
+        (go.Funnelarea(labels=["a", "b", "a"], values=[10, 5, 7]), [("a", 17), ("b", 5)]),
+        (go.Funnelarea(labels=["a", "b", "c"], values=[10, 0, 5]),
+         [("a", 10), ("b", 0), ("c", 5)]),
+        (go.Funnelarea(labels=["a", "b", "c"], values=[10, -5, 5]),
+         [("a", 10), ("c", 5)]),
+        (go.Funnelarea(labels=["a", "b", "c"]), [("a", 1), ("b", 1), ("c", 1)]),
+        (go.Funnelarea(values=[10, 5, 2]), [("0", 10), ("1", 5), ("2", 2)]),
+        (go.Funnelarea(labels=["", "b"], values=[10, 5]), [("0", 10), ("b", 5)]),
+    ],
+)
+def test_the_slice_rules_are_the_pies(trace: go.Funnelarea, expected: list) -> None:
+    """Each row measured against ``gd.calcdata`` in Chromium.
+
+    These are the rules the inheritance is *for*. A second copy of them would
+    be a second thing to keep in step with plotly, and the pie's own
+    docstring already records why that matters: the selector is positional,
+    so the first divergence lands every later slice on another wedge.
+    """
+    (layer,) = _layers(go.Figure([trace]))
+
+    assert _pairs(layer) == expected
+
+
+def test_a_hidden_label_is_not_emitted() -> None:
+    """`layout.hiddenlabels` applies here too.
+
+    Measured: with `hiddenlabels=["b"]` the funnelarea drew 2 slices of 3.
+    Emitting the hidden one would slide every later slice onto the wrong
+    trapezoid.
+    """
+    figure = go.Figure([go.Funnelarea(labels=["a", "b", "c"], values=[10, 5, 2])])
+    figure.update_layout(hiddenlabels=["b"])
+
+    (layer,) = _layers(figure)
+
+    assert _pairs(layer) == [("a", 10), ("c", 2)]
+
+
+def test_the_selector_is_scoped_to_the_funnelarea_layer() -> None:
+    """Plotly draws it into its own figure-level layer, not the pie's.
+
+    Measured on a figure holding one of each: `.pielayer .trace .slice
+    path.surface` matched the pie's 2 slices and `.funnelarealayer ...` the
+    funnelarea's 3, with neither reaching the other.
+    """
+    (layer,) = _layers(go.Figure([go.Funnelarea(labels=STAGES, values=COUNTS)]))
+
+    assert ".funnelarealayer" in layer["selectors"]
+    assert ".pielayer" not in layer["selectors"]
+
+
+def test_two_funnelareas_address_their_own_slices() -> None:
+    """The position stands in for a subplot prefix.
+
+    Both layers sit directly under `main-svg` rather than inside a
+    `.subplot.xy` group. Measured on two funnelareas: `> .trace:nth-child(1)`
+    resolved to 3 slices and `nth-child(2)` to 2, against 5 for the
+    unpositioned form.
+    """
+    first, second = _layers(
+        go.Figure(
+            [
+                go.Funnelarea(labels=STAGES, values=COUNTS, domain={"x": [0, 0.45]}),
+                go.Funnelarea(labels=["m", "n"], values=[9, 4], domain={"x": [0.55, 1]}),
+            ]
+        )
+    )
+
+    assert "nth-child(1)" in first["selectors"]
+    assert "nth-child(2)" in second["selectors"]
+
+
+def test_a_pie_does_not_shift_a_funnelareas_position() -> None:
+    """The two layers are siblings, so they number independently.
+
+    Measured on a figure holding one of each: each layer held exactly its own
+    trace at `nth-child(1)`.
+    """
+    layers = _layers(
+        go.Figure(
+            [
+                go.Pie(labels=["p", "q"], values=[1, 2], domain={"x": [0, 0.45]}),
+                go.Funnelarea(labels=STAGES, values=COUNTS, domain={"x": [0.55, 1]}),
+            ]
+        )
+    )
+    (funnelarea,) = [layer for layer in layers if layer["type"] == PlotType.FUNNEL]
+    (pie,) = [layer for layer in layers if layer["type"] == PlotType.PIE]
+
+    assert "nth-child(1)" in funnelarea["selectors"]
+    assert "nth-child(1)" in pie["selectors"]
+
+
+def test_the_stages_are_named_as_stages() -> None:
+    """The generic fallback pair, said in this chart's own words.
+
+    A funnelarea draws no axes, so an author who wants them named says so
+    through the layout's axis titles. "Category" and "Value" would be true of
+    a pie and vague here; a funnel's two dimensions are its stages and their
+    counts.
+    """
+    (layer,) = _layers(go.Figure([go.Funnelarea(labels=STAGES, values=COUNTS)]))
+
+    assert layer["axes"]["x"]["label"] == "Stage"
+    assert layer["axes"]["y"]["label"] == "Count"
+
+
+def test_a_pie_keeps_its_own_fallback_pair() -> None:
+    """The control: the fallbacks are per class, not swapped globally."""
+    (layer,) = _layers(go.Figure([go.Pie(labels=["a", "b"], values=[1, 2])]))
+
+    assert layer["axes"]["x"]["label"] == "Category"
+    assert layer["axes"]["y"]["label"] == "Value"
+
+
+def test_a_funnelarea_says_which_field_holds_the_stage() -> None:
+    """`FunnelTrace` reads the stage off `point.x` when the layer is vertical.
+
+    A funnelarea has no axes to be drawn along, so there is no second
+    arrangement for it to be in -- but the payload says what it holds rather
+    than leaving it to the default, which is what xability/maidr#947 asks of
+    a producer.
+    """
+    (layer,) = _layers(go.Figure([go.Funnelarea(labels=STAGES, values=COUNTS)]))
+
+    assert layer["orientation"] == "vert"


### PR DESCRIPTION
Third tranche of #627, after the waterfall (#629) and the funnel (#630).

## What was wrong

```python
go.Funnelarea(labels=["visited", "signed up", "paid"], values=[100, 60, 40])   ->   layers: []
```

`_extract_plots` had no branch for `funnelarea` and `PlotlyPlotFactory` returned `None`.

## Written like a pie, read like a funnel

A funnelarea is a funnel drawn as nested trapezoids. It is *stated* the way a pie is — `labels` and `values`, placed by a `domain` rectangle rather than by an axis pair — so it inherits `PlotlyPiePlot`'s slice builder rather than growing a second copy of it. That builder mirrors plotly's own `calc.js` rules, and its docstring already says why a second copy would be dangerous: the selector is positional, so the first divergence lands every later slice on another wedge.

Every rule measured against `gd.calcdata` in Chromium, and every one matched:

| written | drawn |
|---|---|
| `labels=[a, b, a]` | two slices; `a` holds the sum, at its first position |
| `values=[10, 0, 5]` | three slices; the zero is kept |
| `values=[10, -5, 5]` | two slices; the negative is dropped |
| no `values` | every entry weighs 1 |
| no `labels` | slices named `0`, `1`, `2` |
| an empty label | the entry's own index |
| `layout.hiddenlabels` | the named slice is not drawn |

**One rule differs, and it is the reason the two cannot be one class.** A funnelarea has no `sort` attribute — `gd._fullData[0].sort` is undefined — and never reorders. `values=[40, 100, 60]` drew in that order, where a pie draws 100, 60, 40.

That is not cosmetic. A funnel's axis *is* its sequence, so reusing the pie's sorting default would reorder the stages by size and announce a conversion path nobody drew. The sort is now a one-line hook on the pie (`_sorts_wedges`), overridden here — no behaviour change for pies, and the test suite confirms it.

## Read as a funnel, not as a pie

`PlotType.FUNNEL`, not `PlotType.PIE`. `FunnelTrace` pitches the retention between adjacent stages, which is what this chart exists to show; a pie layer would announce each slice's share of the whole, a different question and one the trapezoids are not drawn to answer.

The generic axis fallbacks follow: **"Stage"** and **"Count"** where a pie says "Category" and "Value". Also a one-line hook on the pie, with a control test that a pie keeps its own pair.

`orientation: vert` is declared rather than defaulted. A funnelarea has no axes to be drawn along, so there is no second arrangement — but `FunnelTrace` reads the stage off `point.x` only when vertical, and xability/maidr#947 asks a producer to say what its payload holds.

## Placement and selector

Built in `_extract_plots` for every reason a pie is: its own figure-level layer, its own `domain` rectangle for the grid cell (so `_PLACED_BY_DOMAIN` gains `funnelarea`), and a position among that layer's trace groups that only that loop knows.

Numbered among the **funnelarea** traces alone. The two layers are siblings under `main-svg`, so a pie does not shift a funnelarea's group index — measured, each layer held exactly its own trace at `nth-child(1)`.

Verified in Chromium on a figure holding a pie and two funnelareas, which also shows the sort divergence side by side:

```
PIE     data=[('q', 2), ('p', 1)]                    <- sorted
FUNNEL  data=[('a', 40), ('b', 100), ('c', 60)]      <- data order
FUNNEL  data=[('m', 9), ('n', 4)]

OK  PIE     points=2 resolved=2   .pielayer > .trace:nth-child(1) > .slice > path.surface
OK  FUNNEL  points=3 resolved=3   .funnelarealayer > .trace:nth-child(1) > .slice > path.surface
OK  FUNNEL  points=2 resolved=2   .funnelarealayer > .trace:nth-child(2) > .slice > path.surface
```

## Tests

`tests/plotly/test_plotly_funnelarea.py` — 16 tests, including the six measured slice rules as a parametrised table, `hiddenlabels`, the layer scoping, two funnelareas, a pie not shifting the position, the axis fallbacks, `orientation`, and **two controls on the shared code**: a pie beside a funnelarea still sorts, and a pie keeps its own fallback pair.

Mutation-swept, eight mutations one at a time against a restored baseline, all caught:

```
M1  sort hook returns pie's default    3 failed, 64 passed
M2  sort hook applied globally         2 failed, 65 passed
M3  type stays PIE                     3 failed, 64 passed
M4  orientation dropped                1 failed, 66 passed
M5  funnelarealayer -> pielayer        1 failed, 66 passed
M6  axis fallbacks not overridden      1 failed, 66 passed
M7  _extract_plots block dropped       1 failed, 66 passed
M8  positions shared with pies         1 failed, 66 passed
```

M2 is the one that matters most: it mutates the *pie's* side of the shared hook, and the pie control catches it — which is what makes the inheritance safe rather than merely shorter.

Full suite in two batches (the whole run OOMs in this container): `tests/core` 1931 passed, 5 skipped; the rest 1183 passed, 13 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_