### PR TITLE
feat(plotly): read an indicator that draws a gauge

### DIFF
--- a/maidr/core/enum/maidr_key.py
+++ b/maidr/core/enum/maidr_key.py
@@ -70,6 +70,12 @@ class MaidrKey(str, Enum):
     END = "end"
     LANES = "lanes"
 
+    # Gauge keys. One measure, the two ends of the dial it sits on -- which
+    # reuse `MIN` and `MAX` above -- and the target a bullet chart marks.
+    # The measure's own name reuses `LABEL`.
+    VALUE = "value"
+    TARGET = "target"
+
     # Waterfall keys. A step carries the two running totals it sits between
     # -- reusing `START` and `END` above, which mean the same two things a
     # gantt interval's ends do -- plus its own signed contribution and which

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -64,6 +64,10 @@ class PlotType(str, Enum):
     CANDLESTICK = "candlestick"
     VIOLIN_KDE = "violin_kde"
     VIOLIN_BOX = "violin_box"
+    #: One measure against a dial, with the range it sits in and -- when the
+    #: chart draws one -- the target it is measured against. The one type
+    #: here whose payload is a single point rather than a list of them.
+    GAUGE = "gauge"
     #: A population shrinking across ordered stages. Read as a bar layer is,
     #: with the one difference that decides whether the chart is legible: the
     #: number a reader wants is the *retention* between adjacent stages

--- a/maidr/plotly/gauge.py
+++ b/maidr/plotly/gauge.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from typing import Any
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+
+def draws_a_dial(trace: dict) -> bool:
+    """Report whether a plotly indicator draws a gauge this can read.
+
+    Three things separate an indicator MAIDR can read from one it cannot,
+    and all three were measured against ``gd._fullData[0]`` in Chromium:
+
+    * ``mode="number"`` draws no dial at all -- no arc, no axis, and
+      ``gauge.axis.range`` absent from the resolved trace. A `GaugePoint`
+      needs a range to place its measure in, and a bare number is not a
+      chart to navigate.
+    * a gauge with no explicit ``axis.range`` still gets one, computed from
+      the value: ``[0, 1.5 * value]``, with ``value = 0`` a special case at
+      ``[-1, 1]``. Measured across 42 -> [0, 63], 100 -> [0, 150],
+      7 -> [0, 10.5], 3.5 -> [0, 5.25], 0 -> [-1, 1].
+    * that rule runs backwards for a negative value: -20 -> ``[0, -30]``,
+      a dial whose upper end is below its lower one. `GaugePoint` names its
+      two ends "lower" and "upper", so that pair is outside what the
+      grammar describes, and such a chart is declined rather than emitted
+      inverted.
+
+    Parameters
+    ----------
+    trace : dict
+        One trace of the figure.
+
+    Returns
+    -------
+    bool
+        True when the trace draws a dial with a range this can state.
+    """
+    if trace.get("type") != "indicator":
+        return False
+
+    # `mode`, not the presence of a `gauge` dict. `Figure.to_dict()` omits
+    # `gauge` entirely when the author set nothing inside it, so
+    # `go.Indicator(mode="gauge+number", value=42)` arrives with no `gauge`
+    # key at all -- and it draws a full dial. Plotly's own default mode is
+    # `"number"`, which is why an absent mode declines.
+    if "gauge" not in str(trace.get("mode", "number")):
+        return False
+
+    gauge = trace.get("gauge")
+    if isinstance(gauge, dict) and _explicit_range(gauge) is not None:
+        return True
+
+    value = _number(trace.get("value"))
+    return value is not None and value >= 0
+
+
+def _explicit_range(gauge: dict) -> tuple[float, float] | None:
+    """Return the author's ``gauge.axis.range``, when they set one."""
+    axis = gauge.get("axis")
+    if not isinstance(axis, dict):
+        return None
+    bounds = [_number(bound) for bound in as_list(axis.get("range"))]
+    if len(bounds) != 2 or any(bound is None for bound in bounds):
+        return None
+    return bounds[0], bounds[1]  # type: ignore[return-value]
+
+
+def _number(value: Any) -> float | None:
+    """Coerce one of plotly's numbers, or None when it is not one."""
+    value = PlotlyPlot._to_native(value)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+class PlotlyGaugePlot(PlotlyPlot):
+    """Extract data from a Plotly indicator trace that draws a gauge.
+
+    A gauge is one measure against a dial, so its payload is a single
+    `GaugePoint` rather than a list of them -- the one plot type here whose
+    ``data`` is an object.
+
+    ``gauge.threshold.value`` becomes the point's ``target``: that is what a
+    bullet chart's marker is, and the core announces it alongside the
+    measure precisely so "220 against a target of 200" is one sentence
+    rather than two navigations.
+
+    ``gauge.steps`` deliberately does **not** become ``bands``. A
+    `GaugeBand` carries a required ``label`` -- it exists so a reader hears
+    "in the 'ok' band" -- and a plotly step is a colour over a range with no
+    name at all. Synthesising one would announce a name the chart does not
+    carry, which is worse than announcing no band: the reader would have no
+    way to know the word was ours.
+    """
+
+    def __init__(
+        self, trace: dict, layout: dict, *, gauge_position: int = 0, **kwargs: str
+    ) -> None:
+        super().__init__(trace, layout, PlotType.GAUGE, **kwargs)
+        self._gauge_position = gauge_position
+
+    def _get_selector(self) -> str:
+        """Address this indicator's drawn value arc.
+
+        Measured in Chromium on two indicators sharing a figure:
+        ``.indicatorlayer .value-arc`` matched both arcs, and
+        ``> .trace:nth-child(k) .value-arc`` matched exactly the kth. The
+        arc is the mark that moves with the measure -- the background arc,
+        the outline and the tick marks are all frame.
+
+        An indicator is drawn into a figure-level ``indicatorlayer`` under
+        ``main-svg`` rather than into a subplot group, so the position among
+        that layer's trace groups stands in for the subplot prefix, as it
+        does for a pie.
+
+        That position counts **every** indicator, not only the ones this
+        reads. Plotly appends a ``.trace`` group for a `mode="number"`
+        indicator too -- it has a number to draw, just no dial -- so
+        numbering only the dial-drawing ones put the second gauge of
+        `[gauge, number, gauge]` on ``nth-child(2)``, which is the bare
+        number's group and holds no arc at all. Measured: that selector
+        resolved to 0. The same lesson #395 records for boxes and
+        candlesticks sharing a layer.
+        """
+        return (
+            f".indicatorlayer > .trace:nth-child({self._gauge_position + 1}) "
+            f".value-arc"
+        )
+
+    def _extract_axes_data(self) -> dict:
+        """Name the measure's two dimensions.
+
+        An indicator draws no cartesian axes, and the core reads
+        ``this.xAxis`` for what the measure is called and ``this.yAxis`` for
+        the measure itself. Plotly names neither, so the generic pair stands
+        in -- the same fallback a pie takes, in this chart's own words.
+        """
+        return {
+            MaidrKey.X: self._axis_config(label="Measure"),
+            MaidrKey.Y: self._axis_config(label="Value"),
+        }
+
+    def _extract_plot_data(self) -> dict:
+        """Return the single ``GaugePoint`` this dial states.
+
+        The range is the author's when they set one and plotly's computed
+        default otherwise -- see :func:`draws_a_dial` for the measurements
+        behind that rule and for why a negative value with no explicit range
+        never reaches here.
+        """
+        gauge = self._trace.get("gauge") or {}
+        value = _number(self._trace.get("value")) or 0.0
+
+        bounds = _explicit_range(gauge) if gauge else None
+        if bounds is None:
+            bounds = (-1.0, 1.0) if value == 0 else (0.0, 1.5 * value)
+
+        point: dict = {
+            MaidrKey.VALUE: value,
+            MaidrKey.MIN: bounds[0],
+            MaidrKey.MAX: bounds[1],
+        }
+
+        label = self._indicator_title()
+        if label:
+            point[MaidrKey.LABEL] = label
+
+        threshold = gauge.get("threshold")
+        if isinstance(threshold, dict):
+            target = _number(threshold.get("value"))
+            if target is not None:
+                point[MaidrKey.TARGET] = target
+
+        return point
+
+    def _indicator_title(self) -> str:
+        """Return what the indicator calls its measure, or an empty string.
+
+        ``title`` on an indicator is the measure's own name -- "Speed",
+        "Profit" -- rather than the figure's, which is why it becomes the
+        point's ``label`` rather than the layer's title.
+        """
+        title = self._trace.get("title")
+        if isinstance(title, dict):
+            title = title.get("text", "")
+        return str(title) if title else ""

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -12,6 +12,7 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.candlestick import is_ohlc_trace, layer_position
+from maidr.plotly.gauge import draws_a_dial
 from maidr.plotly.area import is_area_trace
 from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.trendline import is_trendline_trace
@@ -66,7 +67,40 @@ from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_plotly
 #: maidr has anything to put in, to column 1 behind an empty cell.
 #:
 #: Add a type here when maidr learns to render it, not before.
-_PLACED_BY_DOMAIN = frozenset({"pie", "funnelarea"})
+_PLACED_BY_DOMAIN = frozenset({"pie", "funnelarea", "indicator"})
+
+
+def _occupies_a_cell(trace: dict) -> bool:
+    """Report whether this trace's ``domain`` rectangle belongs in the grid.
+
+    Membership in :data:`_PLACED_BY_DOMAIN` is the type-level half of the
+    question. The other half is whether maidr renders the trace at all: the
+    grid describes what maidr can describe, so a trace it draws no layer for
+    occupies no cell -- reserving one would both add an empty cell to tab
+    through and shift every renderable subplot beside it into a different
+    column.
+
+    Only ``indicator`` splits on that. A pie and a funnelarea are always
+    read; an indicator is read only when it draws a dial, so a
+    ``mode="number"`` one is a domain trace that renders nothing, exactly
+    like a ``go.Table``.
+
+    Parameters
+    ----------
+    trace : dict
+        One trace of the figure.
+
+    Returns
+    -------
+    bool
+        True when the trace's rectangle should join the column universe.
+    """
+    kind = trace.get("type")
+    if kind not in _PLACED_BY_DOMAIN:
+        return False
+    if kind == "indicator":
+        return draws_a_dial(trace)
+    return True
 
 #: Every trace type plotly places by a ``domain`` rectangle rather than by a
 #: cartesian axis pair. These share the default ``("x", "y")`` trace group with
@@ -201,7 +235,7 @@ class PlotlyMaidr:
                 y_starts.add(_domain_start(val, "domain"))
 
         for trace in traces:
-            if trace.get("type") not in _PLACED_BY_DOMAIN:
+            if not _occupies_a_cell(trace):
                 continue
             domain = trace.get("domain")
             if isinstance(domain, dict):
@@ -387,6 +421,18 @@ class PlotlyMaidr:
             ]
             funnelarea_traces = [
                 t for t in group_traces if t.get("type") == "funnelarea"
+            ]
+            # Only the indicators that draw a dial. One that draws none is
+            # not a chart to navigate, and letting it take a position here
+            # would push its dial-drawing neighbours onto trace groups that
+            # do not exist -- the same reason `is_drawn` filters hidden
+            # traces at the source.
+            # Every indicator, because every one of them takes a `.trace`
+            # group in the layer -- see `PlotlyGaugePlot._get_selector`. The
+            # ones that draw no dial are skipped when the layers are built,
+            # not when the positions are counted.
+            indicator_traces = [
+                t for t in group_traces if t.get("type") == "indicator"
             ]
 
             # `nth-child` counts within the subplot's SVG `scatterlayer`, so a
@@ -806,6 +852,30 @@ class PlotlyMaidr:
                     )
                     self._plots.append(plot)
                 merged.update(id(t) for t in funnelarea_traces)
+
+            # Gauges, one layer each, for the reasons the pies are: their
+            # own figure-level layer, their own ``domain`` rectangle for the
+            # grid cell, and a position among that layer's trace groups.
+            if indicator_traces:
+                from maidr.plotly.gauge import PlotlyGaugePlot
+
+                for position, indicator_trace in enumerate(indicator_traces):
+                    if not draws_a_dial(indicator_trace):
+                        # No dial to read, but its group still counts above.
+                        continue
+                    plot = PlotlyGaugePlot(
+                        indicator_trace,
+                        layout,
+                        gauge_position=position,
+                        **axis_kwargs,
+                    )
+                    plot.row_index, plot.col_index = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._trace_domain_start(indicator_trace),
+                    )
+                    self._plots.append(plot)
+                merged.update(id(t) for t in indicator_traces)
 
             # OHLC series, one layer each. Built here rather than left to
             # `PlotlyPlotFactory` for the same reason a lone line is: the

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -126,6 +126,21 @@ class PlotlyPlotFactory:
 
             return PlotlyHistogramPlot(trace, layout, **axis_kwargs)
 
+        if trace_type == "indicator":
+            from maidr.plotly.gauge import PlotlyGaugePlot, draws_a_dial
+
+            # An indicator that draws no dial -- `mode="number"` -- or one
+            # whose computed range runs backwards is not a chart this can
+            # state; see `draws_a_dial`. Declined here rather than emitted
+            # with a range invented for it.
+            if not draws_a_dial(trace):
+                return None
+
+            # ``gauge_position`` is left at its default for the reason the
+            # pie branch leaves its own: plotly draws every indicator into
+            # one figure-level ``indicatorlayer``.
+            return PlotlyGaugePlot(trace, layout, **axis_kwargs)
+
         if trace_type == "funnelarea":
             from maidr.plotly.funnelarea import PlotlyFunnelareaPlot
 

--- a/tests/plotly/test_plotly_gauge.py
+++ b/tests/plotly/test_plotly_gauge.py
@@ -1,0 +1,232 @@
+"""A plotly gauge produced a figure with no layers at all.
+
+`go.Indicator` is plotly's gauge and bullet chart, and `maidr/plotly/` had
+no handling for it: the trace fell through `_extract_plots` to
+`PlotlyPlotFactory`, which returned `None` (#627). The core has drawn gauges
+since xability/maidr#827.
+
+A gauge is one measure against a dial, so its payload is a single
+`GaugePoint` rather than a list of them -- the one plot type here whose
+`data` is an object.
+
+Three things separate an indicator this can read from one it cannot, and
+all three were measured against `gd._fullData[0]` in Chromium:
+
+  * `mode="number"` draws no dial at all. A `GaugePoint` needs a range to
+    place its measure in, and a bare number is not a chart to navigate.
+  * a gauge with no explicit `axis.range` still gets one, computed from the
+    value: `[0, 1.5 * value]`, with `value = 0` a special case at `[-1, 1]`.
+    Measured across 42 -> [0, 63], 100 -> [0, 150], 7 -> [0, 10.5],
+    3.5 -> [0, 5.25], 0 -> [-1, 1].
+  * that rule runs backwards for a negative value: -20 -> `[0, -30]`, a
+    dial whose upper end is below its lower one. `GaugePoint` names its two
+    ends "lower" and "upper", so that pair is outside what the grammar
+    describes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _gauge(**kwargs: object) -> go.Figure:
+    """A figure holding one indicator."""
+    return go.Figure([go.Indicator(**kwargs)])
+
+
+def test_a_gauge_is_read_at_all() -> None:
+    """The reproduction: a whole chart that announced nothing."""
+    layers = _layers(
+        _gauge(mode="gauge+number", value=42, gauge={"axis": {"range": [0, 100]}})
+    )
+
+    assert [layer["type"] for layer in layers] == [PlotType.GAUGE]
+
+
+def test_a_gauge_carries_its_measure_and_its_dial() -> None:
+    """One point, not a list of them -- a gauge states a single measure."""
+    (layer,) = _layers(
+        _gauge(
+            mode="gauge+number",
+            value=42,
+            gauge={"axis": {"range": [0, 100]}},
+            title={"text": "Speed"},
+        )
+    )
+
+    assert layer["data"] == {"value": 42.0, "min": 0.0, "max": 100.0, "label": "Speed"}
+
+
+def test_a_threshold_becomes_the_target() -> None:
+    """What a bullet chart's marker is.
+
+    The core announces it alongside the measure precisely so "220 against a
+    target of 270" is one sentence rather than two navigations. Dropping it
+    would leave the marker drawn and unmentioned.
+    """
+    (layer,) = _layers(
+        _gauge(
+            mode="gauge+number",
+            value=220,
+            gauge={
+                "shape": "bullet",
+                "axis": {"range": [0, 300]},
+                "threshold": {"value": 270},
+            },
+        )
+    )
+
+    assert layer["data"]["target"] == 270.0
+
+
+def test_colour_steps_do_not_become_bands() -> None:
+    """A `GaugeBand` needs a name and a plotly step has none.
+
+    `bands` exists so a reader hears "in the 'ok' band"; a plotly step is a
+    colour over a range with no label at all. Synthesising one would
+    announce a name the chart does not carry, and the reader would have no
+    way to know the word was ours.
+    """
+    (layer,) = _layers(
+        _gauge(
+            mode="gauge+number",
+            value=220,
+            gauge={
+                "axis": {"range": [0, 300]},
+                "steps": [
+                    {"range": [0, 150], "color": "lightgray"},
+                    {"range": [150, 250], "color": "gray"},
+                ],
+            },
+        )
+    )
+
+    assert "bands" not in layer["data"]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(42, (0.0, 63.0)), (100, (0.0, 150.0)), (7, (0.0, 10.5)), (3.5, (0.0, 5.25)),
+     (0, (-1.0, 1.0))],
+)
+def test_an_unstated_range_follows_what_plotly_computes(
+    value: float, expected: tuple[float, float]
+) -> None:
+    """Each row measured against ``gd._fullData[0].gauge.axis.range``.
+
+    `Figure.to_dict()` omits `gauge` entirely when the author set nothing
+    inside it, so these traces arrive with no `gauge` key at all -- and they
+    draw a full dial. Reading the *mode* rather than the presence of that
+    key is what makes them reachable.
+    """
+    (layer,) = _layers(_gauge(mode="gauge+number", value=value))
+
+    assert (layer["data"]["min"], layer["data"]["max"]) == expected
+
+
+def test_a_bare_number_is_declined() -> None:
+    """`mode="number"` draws no dial, and plotly's default mode is `number`.
+
+    There is no range to place a measure in, so there is no `GaugePoint` to
+    build. Emitting one with a range invented for it would announce a dial
+    nobody drew.
+    """
+    assert _layers(_gauge(mode="number", value=7)) == []
+    assert _layers(_gauge(value=7)) == []
+
+
+def test_a_backwards_default_range_is_declined() -> None:
+    """Measured: value -20 with no explicit range draws `[0, -30]`.
+
+    `GaugePoint` names its two ends "lower" and "upper", so a pair whose
+    upper end is below its lower one is outside what the grammar describes.
+    Declined rather than emitted inverted.
+    """
+    assert _layers(_gauge(mode="gauge+number", value=-20)) == []
+
+
+def test_a_negative_value_reads_when_the_author_gives_a_range() -> None:
+    """The control for the decline above: it is about the *default* rule.
+
+    An author who states the dial has said which end is which, and a
+    negative measure on it is an ordinary chart.
+    """
+    (layer,) = _layers(
+        _gauge(mode="gauge+number", value=-20, gauge={"axis": {"range": [-50, 50]}})
+    )
+
+    assert (layer["data"]["min"], layer["data"]["max"]) == (-50.0, 50.0)
+    assert layer["data"]["value"] == -20.0
+
+
+def test_the_selector_addresses_the_value_arc() -> None:
+    """The mark that moves with the measure.
+
+    Measured in Chromium: the background arc, the outline and the tick
+    marks are all frame; `.value-arc` is the one that is drawn to the
+    measure.
+    """
+    (layer,) = _layers(
+        _gauge(mode="gauge+number", value=42, gauge={"axis": {"range": [0, 100]}})
+    )
+
+    assert layer["selectors"] == ".indicatorlayer > .trace:nth-child(1) .value-arc"
+
+
+def test_a_bare_number_still_takes_its_place_in_the_layer() -> None:
+    """The position counts every indicator, not only the readable ones.
+
+    Plotly appends a `.trace` group for a `mode="number"` indicator too --
+    it has a number to draw, just no dial. Numbering only the dial-drawing
+    ones put the second gauge of `[gauge, number, gauge]` on
+    `nth-child(2)`, which is the bare number's group and holds no arc:
+    measured, that selector resolved to **0** elements. The same lesson
+    #395 records for boxes and candlesticks sharing a layer.
+    """
+    figure = go.Figure(
+        [
+            go.Indicator(
+                mode="gauge+number", value=42,
+                gauge={"axis": {"range": [0, 100]}}, domain={"x": [0, 0.45]},
+            ),
+            go.Indicator(mode="number", value=7, domain={"x": [0.5, 0.6]}),
+            go.Indicator(
+                mode="gauge+number", value=80,
+                gauge={"axis": {"range": [0, 100]}}, domain={"x": [0.65, 1]},
+            ),
+        ]
+    )
+
+    first, second = _layers(figure)
+
+    assert "nth-child(1)" in first["selectors"]
+    assert "nth-child(3)" in second["selectors"]
+
+
+def test_a_gauge_names_its_two_dimensions() -> None:
+    """An indicator draws no cartesian axes, so the generic pair stands in.
+
+    The core reads `this.xAxis` for what the measure is called and
+    `this.yAxis` for the measure itself, and plotly names neither.
+    """
+    (layer,) = _layers(
+        _gauge(mode="gauge+number", value=42, gauge={"axis": {"range": [0, 100]}})
+    )
+
+    assert layer["axes"]["x"]["label"] == "Measure"
+    assert layer["axes"]["y"]["label"] == "Value"

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -426,6 +426,9 @@ class TestPlotlyUnrenderedDomainTraces:
             ),
             pytest.param(go.Sunburst(labels=["a"], parents=[""]), id="sunburst"),
             pytest.param(go.Treemap(labels=["a"], parents=[""]), id="treemap"),
+            # A `mode="number"` indicator only. One that draws a dial *is*
+            # rendered as of #627's gauge tranche, so it takes a cell like
+            # a pie -- asserted by the test below rather than here.
             pytest.param(go.Indicator(value=42, mode="number"), id="indicator"),
         ],
     )
@@ -441,6 +444,27 @@ class TestPlotlyUnrenderedDomainTraces:
         fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
 
         assert self._cells(fig) == [(0, 0)]
+
+    def test_an_indicator_that_draws_a_dial_does_take_a_cell(self):
+        # The control for the `indicator` row above: the scoping is about
+        # what maidr *renders*, not about the trace type. A gauge is a
+        # domain trace maidr does draw a layer for, so its rectangle joins
+        # the column universe and the bar beside it lands in column 1.
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]]
+        )
+        fig.add_trace(
+            go.Indicator(
+                value=42, mode="gauge+number", gauge={"axis": {"range": [0, 100]}}
+            ),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+        assert self._cells(fig) == [(0, 0), (0, 1)]
 
     def test_a_pie_beside_it_is_still_placed_by_its_own_domain(self):
         # The scoping is by trace type, not by "ignore trace domains": a pie


### PR DESCRIPTION
Fourth tranche of #627, after the waterfall (#629), the funnel (#630) and the funnelarea (#631).

## What was wrong

```python
go.Indicator(mode="gauge+number", value=42, gauge={"axis": {"range": [0, 100]}})   ->   layers: []
```

`go.Indicator` is plotly's gauge and bullet chart. The core has drawn gauges since xability/maidr#827, and the bundle in this wheel names the type.

## The payload

A gauge is one measure against a dial, so `data` is a single `GaugePoint` object rather than a list — the only plot type here shaped that way.

`gauge.threshold.value` → `target`. That is what a bullet chart's marker is, and the core announces it alongside the measure precisely so "220 against a target of 270" is one sentence rather than two navigations.

`gauge.steps` deliberately does **not** become `bands`. A `GaugeBand` carries a required `label` — it exists so a reader hears *"in the 'ok' band"* — and a plotly step is a colour over a range with no name at all. Synthesising one would announce a name the chart does not carry, and the reader would have no way to know the word was ours.

## Three declines, all measured

Against `gd._fullData[0]` in Chromium:

| case | plotly | this |
|---|---|---|
| `mode="number"` (also the default when no mode is set) | no dial, no range | declined |
| `gauge+number`, no `axis.range`, value 42 | range `[0, 63]` | read |
| …value 100 / 7 / 3.5 | `[0, 150]` / `[0, 10.5]` / `[0, 5.25]` | read |
| …value 0 | `[-1, 1]` | read |
| …value **-20** | `[0, -30]` | **declined** |

So the default range is `[0, 1.5 × value]`, with zero a special case — and it runs **backwards** for a negative value. `GaugePoint` names its ends "lower" and "upper", so `min=0, max=-30` is outside what the grammar describes; that chart is declined rather than emitted inverted. An author who states the range is unaffected, and a test covers exactly that.

The **mode** is what decides, not the presence of a `gauge` dict: `Figure.to_dict()` omits `gauge` entirely when nothing was set inside it, so `go.Indicator(mode="gauge+number", value=42)` arrives with no `gauge` key and draws a full dial.

## Two defects the browser check caught that reasoning had not

Worth stating plainly, because both would have shipped on the strength of a plausible-looking implementation:

**1. The position must count every indicator.** Plotly appends a `.trace` group to `indicatorlayer` for a bare number too — it has a number to draw, just no dial. Numbering only the dial-drawing ones put the second gauge of `[gauge, number, gauge]` on `nth-child(2)`, which is the bare number's group and holds no arc:

```
OK  Speed  resolved=1  .indicatorlayer > .trace:nth-child(1) .value-arc
BAD Load   resolved=0  .indicatorlayer > .trace:nth-child(2) .value-arc     <- before
OK  Load   resolved=1  .indicatorlayer > .trace:nth-child(3) .value-arc     <- after
```

The same lesson #395 records for boxes and candlesticks sharing a layer.

**2. A bare number must stay out of the grid.** `_PLACED_BY_DOMAIN` gaining `indicator` folded *every* indicator's rectangle into the figure's column universe, including the ones maidr renders nothing for — which is the exact thing `TestPlotlyUnrenderedDomainTraces` exists to prevent, and its `indicator` row caught it. Placement now asks whether maidr renders the trace, not only its type, and that test gained a control asserting a dial-drawing indicator *does* take a cell.

The selector addresses `.value-arc` — the background arc, the outline and the tick marks are all frame.

## Tests

`tests/plotly/test_plotly_gauge.py` — 15 tests: the reproduction, the point's fields, the threshold, steps *not* becoming bands, the five measured default-range rows as a parametrised table, both declines, the negative-with-explicit-range control, the selector, the bare-number position, and the axis names.

Mutation-swept, nine mutations one at a time against a restored baseline, all caught — including the two the browser found:

```
M1  gauge-dict test instead of mode   5 failed, 10 passed
M2  bare number accepted              2 failed, 13 passed
M3  backwards range accepted          1 failed, 14 passed
M4  zero special case dropped         1 failed, 14 passed
M5  default multiplier wrong          4 failed, 11 passed
M6  threshold dropped                 1 failed, 14 passed
M7  title dropped                     1 failed, 14 passed
M8  position skips bare numbers       1 failed, 14 passed
M9  _extract_plots block dropped      1 failed, 14 passed
```

Full suite in two batches (the whole run OOMs in this container): `tests/core` 1931 passed, 5 skipped; the rest 1199 passed, 13 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_