### PR TITLE
feat(plotly): read the three hierarchy paintings

### DIFF
--- a/maidr/core/enum/maidr_key.py
+++ b/maidr/core/enum/maidr_key.py
@@ -70,6 +70,11 @@ class MaidrKey(str, Enum):
     END = "end"
     LANES = "lanes"
 
+    # Hierarchy keys. A node carries its name in `X`, its declared value in
+    # `Y` and the chain of ancestors above it here -- root first, and never
+    # including the node itself.
+    PATH = "path"
+
     # Gauge keys. One measure, the two ends of the dial it sits on -- which
     # reuse `MIN` and `MAX` above -- and the target a bullet chart marks.
     # The measure's own name reuses `LABEL`.

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -64,6 +64,14 @@ class PlotType(str, Enum):
     CANDLESTICK = "candlestick"
     VIOLIN_KDE = "violin_kde"
     VIOLIN_BOX = "violin_box"
+    #: A hierarchy drawn as nested rectangles, and the two paintings of the
+    #: same tree that differ from it only in shape: concentric rings for a
+    #: sunburst, stacked bands for an icicle. Kept apart because the chart
+    #: type is announced, and a reader told "treemap" about a sunburst has
+    #: been told something false about the picture beside them.
+    TREEMAP = "treemap"
+    SUNBURST = "sunburst"
+    ICICLE = "icicle"
     #: One measure against a dial, with the range it sits in and -- when the
     #: chart draws one -- the target it is measured against. The one type
     #: here whose payload is a single point rather than a list of them.

--- a/maidr/plotly/hierarchy.py
+++ b/maidr/plotly/hierarchy.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from typing import Any
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+#: Plotly's three hierarchy traces and the MAIDR type each one is.
+#:
+#: One class serves all three because they differ only in how the same tree
+#: is painted -- nested rectangles, concentric rings, stacked bands -- and
+#: not at all in what they are handed or in how a reader walks them. The
+#: grammar keeps them apart for the same reason it keeps a lollipop apart
+#: from a bar: the chart type is announced, and a reader told "treemap"
+#: about a sunburst has been told something false about the picture beside
+#: them.
+HIERARCHY_TYPES: dict[str, PlotType] = {
+    "treemap": PlotType.TREEMAP,
+    "sunburst": PlotType.SUNBURST,
+    "icicle": PlotType.ICICLE,
+}
+
+
+def is_hierarchy_trace(trace: dict) -> bool:
+    """Report whether this trace is one of plotly's three hierarchy paintings."""
+    return trace.get("type") in HIERARCHY_TYPES
+
+
+def has_one_root(trace: dict) -> bool:
+    """Report whether the tree the trace states has a single root.
+
+    Plotly accepts several top-level nodes and **invents a parent** for
+    them. Measured against ``gd.calcdata``: ``labels=[r1, r2, a]`` with
+    ``parents=["", "", "r1"]`` came back as four nodes, the first one an
+    id plotly made up (``c02ba4``) with an empty label, and four slices were
+    drawn for the three the author wrote.
+
+    That node is not in the data and has no name. Emitting it would announce
+    a nameless root the author never wrote, and omitting it would leave the
+    positional selector one place out for every node -- so a many-rooted
+    hierarchy is declined rather than guessed at.
+
+    Parameters
+    ----------
+    trace : dict
+        One trace of the figure.
+
+    Returns
+    -------
+    bool
+        True when exactly one node names no parent.
+    """
+    parents = as_list(trace.get("parents"))
+    if not parents:
+        return False
+    return sum(1 for parent in parents if not str(parent or "")) == 1
+
+
+class PlotlyHierarchyPlot(PlotlyPlot):
+    """Extract data from a Plotly treemap, sunburst or icicle trace.
+
+    The three state one tree the same way -- ``labels``, ``parents`` and an
+    optional ``values`` -- and `TreemapPoint` wants that tree flattened: one
+    point per node, carrying its name, its declared value and the chain of
+    ancestors above it.
+
+    The emitted order is the trace's own. Measured against ``gd.calcdata``
+    with an input deliberately in neither depth-first nor breadth-first
+    order (``r, a1, b, a, b1``), plotly kept it exactly:
+    ``['r', 'a1', 'b', 'a', 'b1']``. ``sort`` changes the drawn layout, not
+    that order, and a four-deep chain came back in input order too. This
+    matters because the selector is positional -- one element per node -- so
+    a reordering here would land every later node on another slice.
+    """
+
+    def __init__(
+        self,
+        trace: dict,
+        layout: dict,
+        *,
+        hierarchy_position: int = 0,
+        **kwargs: str,
+    ) -> None:
+        kind = str(trace.get("type"))
+        super().__init__(trace, layout, HIERARCHY_TYPES[kind], **kwargs)
+        self._kind = kind
+        self._hierarchy_position = hierarchy_position
+
+    def _get_selector(self) -> str:
+        """Address this trace's nodes inside its own figure-level layer.
+
+        Each painting has its own layer -- ``treemaplayer``,
+        ``sunburstlayer``, ``iciclelayer`` -- sitting directly under
+        ``main-svg`` rather than inside a ``.subplot.xy`` group, so the
+        position among that layer's trace groups stands in for the subplot
+        prefix, as it does for a pie.
+
+        Measured on all three: ``{kind}layer > .trace:nth-child(1) .slice
+        path.surface`` resolved to one element per node.
+        """
+        return (
+            f".{self._kind}layer > "
+            f".trace:nth-child({self._hierarchy_position + 1}) "
+            f".slice > path.surface"
+        )
+
+    def _extract_axes_data(self) -> dict:
+        """Name the two dimensions a hierarchy carries.
+
+        A hierarchy draws no axes. The core announces a node as its name
+        paired with its magnitude, so the generic pair says what those two
+        are -- the same stand-in a pie takes, in this chart's own words.
+        """
+        return {
+            MaidrKey.X: self._axis_config(label="Node"),
+            MaidrKey.Y: self._axis_config(label="Value"),
+        }
+
+    def _extract_plot_data(self) -> list[dict]:
+        """One point per node, in the trace's own order.
+
+        ``ids`` is honoured where the author gives it: plotly then reads
+        ``parents`` as *ids* rather than as labels, which is how a tree with
+        two nodes of the same name is written at all. The path is resolved
+        through those ids and then spelled in labels, because
+        `TreemapPoint.x` is the node's name and its `path` has to be in the
+        same vocabulary for a reader to follow it.
+
+        ``y`` is emitted only when the author declared values. Without them
+        plotly counts leaves, and ``calcdata`` reports ``None`` for every
+        node -- there is no declared magnitude to pass on, and
+        `TreemapPoint.y` is optional precisely for that case.
+        """
+        labels = [self._to_native(label) for label in as_list(self._trace.get("labels"))]
+        parents = [str(parent or "") for parent in as_list(self._trace.get("parents"))]
+        raw_ids = as_list(self._trace.get("ids"))
+        ids = (
+            [str(node_id) for node_id in raw_ids]
+            if len(raw_ids) == len(labels)
+            else [str(label) for label in labels]
+        )
+
+        # No `has_values` flag beside this. `as_list(None)` is `[]`, so the
+        # length check below already answers "did the author declare
+        # values" -- a mutation removing the flag changed no test, which is
+        # what a redundant guard looks like.
+        values = as_list(self._trace.get("values"))
+
+        parent_of = dict(zip(ids, parents))
+        label_of = dict(zip(ids, labels))
+
+        points: list[dict] = []
+        for index, node_id in enumerate(ids):
+            if index >= len(labels):
+                break
+            point: dict = {MaidrKey.X: labels[index]}
+
+            if index < len(values):
+                number = _number(values[index])
+                if number is not None:
+                    point[MaidrKey.Y] = number
+
+            path = self._ancestors(node_id, parent_of, label_of)
+            if path:
+                point[MaidrKey.PATH] = path
+            points.append(point)
+
+        return points
+
+    @staticmethod
+    def _ancestors(
+        node_id: str, parent_of: dict[str, str], label_of: dict[str, Any]
+    ) -> list[Any]:
+        """Return a node's ancestors, root first, excluding the node itself.
+
+        Walks by id and spells the answer in labels. Guarded against a cycle
+        -- ``parents`` is author-supplied and nothing upstream checks it --
+        by refusing to visit an id twice; a cycle then yields the chain up to
+        the repeat rather than looping forever.
+        """
+        chain: list[Any] = []
+        seen = {node_id}
+        current = parent_of.get(node_id, "")
+        while current and current not in seen:
+            seen.add(current)
+            chain.append(label_of.get(current, current))
+            current = parent_of.get(current, "")
+        chain.reverse()
+        return chain
+
+
+def _number(value: Any) -> float | None:
+    """Coerce one of plotly's numbers, or None when it is not one."""
+    value = PlotlyPlot._to_native(value)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -13,6 +13,7 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.candlestick import is_ohlc_trace, layer_position
 from maidr.plotly.gauge import draws_a_dial
+from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
 from maidr.plotly.area import is_area_trace
 from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.trendline import is_trendline_trace
@@ -67,7 +68,9 @@ from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_plotly
 #: maidr has anything to put in, to column 1 behind an empty cell.
 #:
 #: Add a type here when maidr learns to render it, not before.
-_PLACED_BY_DOMAIN = frozenset({"pie", "funnelarea", "indicator"})
+_PLACED_BY_DOMAIN = frozenset(
+    {"pie", "funnelarea", "indicator", "treemap", "sunburst", "icicle"}
+)
 
 
 def _occupies_a_cell(trace: dict) -> bool:
@@ -100,6 +103,8 @@ def _occupies_a_cell(trace: dict) -> bool:
         return False
     if kind == "indicator":
         return draws_a_dial(trace)
+    if is_hierarchy_trace(trace):
+        return has_one_root(trace)
     return True
 
 #: Every trace type plotly places by a ``domain`` rectangle rather than by a
@@ -852,6 +857,32 @@ class PlotlyMaidr:
                     )
                     self._plots.append(plot)
                 merged.update(id(t) for t in funnelarea_traces)
+
+            # Hierarchies, one layer each. Each painting has its own
+            # figure-level layer, so a trace is numbered among its own kind
+            # -- a treemap does not shift a sunburst's group index.
+            for kind in ("treemap", "sunburst", "icicle"):
+                same_kind = [t for t in group_traces if t.get("type") == kind]
+                if not same_kind:
+                    continue
+
+                from maidr.plotly.hierarchy import PlotlyHierarchyPlot
+
+                for position, hierarchy_trace in enumerate(same_kind):
+                    if has_one_root(hierarchy_trace):
+                        plot = PlotlyHierarchyPlot(
+                            hierarchy_trace,
+                            layout,
+                            hierarchy_position=position,
+                            **axis_kwargs,
+                        )
+                        plot.row_index, plot.col_index = self._grid_position(
+                            x_starts,
+                            y_starts,
+                            self._trace_domain_start(hierarchy_trace),
+                        )
+                        self._plots.append(plot)
+                merged.update(id(t) for t in same_kind)
 
             # Gauges, one layer each, for the reasons the pies are: their
             # own figure-level layer, their own ``domain`` rectangle for the

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -126,6 +126,16 @@ class PlotlyPlotFactory:
 
             return PlotlyHistogramPlot(trace, layout, **axis_kwargs)
 
+        if trace_type in ("treemap", "sunburst", "icicle"):
+            from maidr.plotly.hierarchy import PlotlyHierarchyPlot, has_one_root
+
+            # A many-rooted hierarchy is one plotly invents a parent for;
+            # see `has_one_root`.
+            if not has_one_root(trace):
+                return None
+
+            return PlotlyHierarchyPlot(trace, layout, **axis_kwargs)
+
         if trace_type == "indicator":
             from maidr.plotly.gauge import PlotlyGaugePlot, draws_a_dial
 

--- a/tests/plotly/test_plotly_hierarchy.py
+++ b/tests/plotly/test_plotly_hierarchy.py
@@ -1,0 +1,242 @@
+"""Plotly's three hierarchy paintings produced figures with no layers.
+
+`go.Treemap`, `go.Sunburst` and `go.Icicle` state one tree the same way --
+`labels`, `parents` and an optional `values` -- and differ only in how it is
+painted. `maidr/plotly/` had no handling for any of them, so each fell
+through `_extract_plots` to `PlotlyPlotFactory`, which returned `None`
+(#627). The core has drawn all three since xability/maidr#808.
+
+`TreemapPoint` wants that tree flattened: one point per node carrying its
+name, its declared value and the chain of ancestors above it.
+
+Two things were measured rather than assumed, because the selector is
+positional -- one element per node -- so either one being wrong lands every
+later node on another slice:
+
+  * **the order is the trace's own.** Given an input in neither depth-first
+    nor breadth-first order (`r, a1, b, a, b1`), `gd.calcdata` kept it
+    exactly. `sort` changes the drawn layout, not that order, and a
+    four-deep chain came back in input order too.
+  * **the kth element is the kth node.** Verified in Chromium against the
+    `text.slicetext` sitting parallel to each slice: `['r', 'a', 'b', 'a1']`
+    for all three paintings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: A tree written in neither depth-first nor breadth-first order, so an
+#: emitted order that reshuffled it could not pass by coincidence.
+SHUFFLED = {
+    "labels": ["r", "a1", "b", "a", "b1"],
+    "parents": ["", "a", "r", "r", "b"],
+    "values": [10, 1, 4, 6, 2],
+}
+
+PAINTINGS = [
+    (go.Treemap, PlotType.TREEMAP, "treemaplayer"),
+    (go.Sunburst, PlotType.SUNBURST, "sunburstlayer"),
+    (go.Icicle, PlotType.ICICLE, "iciclelayer"),
+]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+@pytest.mark.parametrize(("cls", "expected", "layer"), PAINTINGS)
+def test_each_painting_is_read_as_itself(cls, expected, layer) -> None:
+    """The reproduction, and the reason one class serves three types.
+
+    They differ only in shape, but the chart type is announced -- a reader
+    told "treemap" about a sunburst has been told something false about the
+    picture beside them.
+    """
+    (emitted,) = _layers(go.Figure([cls(**SHUFFLED)]))
+
+    assert emitted["type"] == expected
+    assert f".{layer}" in emitted["selectors"]
+
+
+def test_the_nodes_keep_the_order_they_were_written_in() -> None:
+    """Measured against ``gd.calcdata``, which kept the input order exactly.
+
+    The selector is positional, so a reordering here would land every later
+    node on another slice -- and the reading would still look plausible,
+    which is what makes it worth pinning.
+    """
+    (layer,) = _layers(go.Figure([go.Treemap(**SHUFFLED)]))
+
+    assert [point["x"] for point in layer["data"]] == SHUFFLED["labels"]
+
+
+def test_each_node_carries_the_ancestors_above_it() -> None:
+    """Root first, excluding the node itself; a top-level node has none."""
+    (layer,) = _layers(go.Figure([go.Treemap(**SHUFFLED)]))
+    paths = {point["x"]: point.get("path") for point in layer["data"]}
+
+    assert paths == {
+        "r": None,
+        "a": ["r"],
+        "b": ["r"],
+        "a1": ["r", "a"],
+        "b1": ["r", "b"],
+    }
+
+
+def test_declared_values_are_passed_on() -> None:
+    """Every node's, including the interior ones.
+
+    `TreemapPoint.y` keeps a declared value even where it disagrees with the
+    sum of its children: a parent may carry mass no child accounts for, and
+    recomputing it would be inventing data.
+    """
+    (layer,) = _layers(go.Figure([go.Treemap(**SHUFFLED)]))
+
+    assert [point["y"] for point in layer["data"]] == [10.0, 1.0, 4.0, 6.0, 2.0]
+
+
+def test_a_tree_with_no_values_carries_none() -> None:
+    """Plotly counts leaves instead, and declares nothing.
+
+    Measured: ``gd.calcdata`` reports ``None`` for every node. There is no
+    declared magnitude to pass on, and `TreemapPoint.y` is optional exactly
+    for that.
+    """
+    (layer,) = _layers(go.Figure([go.Treemap(labels=["r", "a"], parents=["", "r"])]))
+
+    assert all("y" not in point for point in layer["data"])
+    assert [point["x"] for point in layer["data"]] == ["r", "a"]
+
+
+def test_ids_resolve_the_tree_and_labels_name_it() -> None:
+    """How a tree with two nodes of the same name is written at all.
+
+    With `ids` given, plotly reads `parents` as ids rather than as labels.
+    The path is resolved through those ids and then spelled in labels,
+    because `TreemapPoint.x` is the node's *name* and its `path` has to be
+    in the same vocabulary for a reader to follow it.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Treemap(
+                    ids=["r", "a", "b", "a-1"],
+                    labels=["root", "node", "node", "leaf"],
+                    parents=["", "r", "r", "a"],
+                    values=[10, 6, 4, 4],
+                )
+            ]
+        )
+    )
+
+    assert [point["x"] for point in layer["data"]] == ["root", "node", "node", "leaf"]
+    assert layer["data"][3]["path"] == ["root", "node"]
+
+
+def test_a_many_rooted_hierarchy_is_declined() -> None:
+    """Plotly invents a parent for it.
+
+    Measured: `labels=[r1, r2, a]` with `parents=["", "", "r1"]` came back
+    as **four** nodes, the first an id plotly made up with an empty label,
+    and four slices were drawn for three authored nodes. Emitting that node
+    would announce a nameless root the author never wrote; omitting it would
+    leave the positional selector one place out for every node.
+    """
+    figure = go.Figure(
+        [go.Treemap(labels=["r1", "r2", "a"], parents=["", "", "r1"], values=[5, 3, 2])]
+    )
+
+    assert _layers(figure) == []
+
+
+def test_a_declined_hierarchy_does_not_take_a_grid_cell() -> None:
+    """It renders nothing, so it reserves nothing.
+
+    The same rule `TestPlotlyUnrenderedDomainTraces` holds for a
+    `go.Table`: a domain trace maidr draws no layer for occupies no cell,
+    because reserving one would shift every renderable subplot beside it.
+    """
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(
+        rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]]
+    )
+    figure.add_trace(
+        go.Treemap(labels=["r1", "r2"], parents=["", ""], values=[5, 3]), row=1, col=1
+    )
+    figure.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+    cells = [(plot.row_index, plot.col_index) for plot in PlotlyMaidr(figure)._plots]
+
+    assert cells == [(0, 0)]
+
+
+def test_each_painting_numbers_among_its_own_kind() -> None:
+    """Each has its own figure-level layer, so they do not shift each other.
+
+    A treemap beside a sunburst beside an icicle: all three are the first
+    trace group of their own layer.
+    """
+    layers = _layers(
+        go.Figure(
+            [
+                go.Treemap(**SHUFFLED, domain={"x": [0, 0.3]}),
+                go.Sunburst(**SHUFFLED, domain={"x": [0.35, 0.65]}),
+                go.Icicle(**SHUFFLED, domain={"x": [0.7, 1]}),
+            ]
+        )
+    )
+
+    assert len(layers) == 3
+    assert all("nth-child(1)" in layer["selectors"] for layer in layers)
+
+
+def test_two_treemaps_address_their_own_slices() -> None:
+    """The position stands in for a subplot prefix, as it does for a pie."""
+    first, second = _layers(
+        go.Figure(
+            [
+                go.Treemap(**SHUFFLED, domain={"x": [0, 0.45]}),
+                go.Treemap(
+                    labels=["r", "a"], parents=["", "r"], domain={"x": [0.55, 1]}
+                ),
+            ]
+        )
+    )
+
+    assert "nth-child(1)" in first["selectors"]
+    assert "nth-child(2)" in second["selectors"]
+
+
+def test_a_hierarchy_names_its_two_dimensions() -> None:
+    """It draws no axes, so the generic pair says what the two are."""
+    (layer,) = _layers(go.Figure([go.Treemap(**SHUFFLED)]))
+
+    assert layer["axes"]["x"]["label"] == "Node"
+    assert layer["axes"]["y"]["label"] == "Value"
+
+
+def test_a_cycle_in_parents_does_not_hang() -> None:
+    """`parents` is author-supplied and nothing upstream checks it.
+
+    The walk refuses to visit an id twice, so a cycle yields the chain up to
+    the repeat rather than looping forever.
+    """
+    (layer,) = _layers(
+        go.Figure([go.Treemap(labels=["r", "a", "b"], parents=["", "b", "a"])])
+    )
+
+    assert [point["x"] for point in layer["data"]] == ["r", "a", "b"]

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -424,8 +424,21 @@ class TestPlotlyUnrenderedDomainTraces:
                 go.Table(header={"values": ["a"]}, cells={"values": [[1, 2]]}),
                 id="table",
             ),
-            pytest.param(go.Sunburst(labels=["a"], parents=[""]), id="sunburst"),
-            pytest.param(go.Treemap(labels=["a"], parents=[""]), id="treemap"),
+            # A hierarchy plotly invents a root for. A single-rooted one
+            # *is* rendered as of #627's hierarchy tranche, so it takes a
+            # cell like a pie -- asserted by the test below rather than
+            # here. This pair keeps the row's original subject: a domain
+            # trace maidr draws no layer for.
+            pytest.param(
+                go.Sunburst(labels=["a", "b"], parents=["", ""]), id="sunburst"
+            ),
+            pytest.param(
+                go.Treemap(labels=["a", "b"], parents=["", ""]), id="treemap"
+            ),
+            pytest.param(
+                go.Parcoords(dimensions=[{"label": "A", "values": [1, 2]}]),
+                id="parcoords",
+            ),
             # A `mode="number"` indicator only. One that draws a dial *is*
             # rendered as of #627's gauge tranche, so it takes a cell like
             # a pie -- asserted by the test below rather than here.
@@ -444,6 +457,25 @@ class TestPlotlyUnrenderedDomainTraces:
         fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
 
         assert self._cells(fig) == [(0, 0)]
+
+    def test_a_single_rooted_hierarchy_does_take_a_cell(self):
+        # The control for the `treemap` and `sunburst` rows above: the
+        # scoping is about what maidr *renders*, not about the trace type.
+        # A hierarchy with one root is a domain trace maidr does draw a
+        # layer for, so its rectangle joins the column universe.
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]]
+        )
+        fig.add_trace(
+            go.Treemap(labels=["r", "a"], parents=["", "r"], values=[3, 1]),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+        assert self._cells(fig) == [(0, 0), (0, 1)]
 
     def test_an_indicator_that_draws_a_dial_does_take_a_cell(self):
         # The control for the `indicator` row above: the scoping is about


### PR DESCRIPTION
Fifth tranche of #627, after the waterfall (#629), funnel (#630), funnelarea (#631) and gauge (#632). Three of the fifteen at once.

## What was wrong

```python
go.Treemap(labels=["r", "a", "b"], parents=["", "r", "r"], values=[10, 6, 4])   ->   layers: []
go.Sunburst(...)                                                                ->   layers: []
go.Icicle(...)                                                                  ->   layers: []
```

The core has drawn all three since xability/maidr#808.

## One class, three types

They state one tree the same way — `labels`, `parents`, optional `values` — and differ only in how it is painted: nested rectangles, concentric rings, stacked bands. So one class serves all three.

They stay **three** MAIDR types, because the chart type is announced. A reader told "treemap" about a sunburst has been told something false about the picture beside them — the same reason the grammar keeps a lollipop apart from a bar.

## Two things measured, not assumed

The selector is positional, one element per node, so either being wrong would land every later node on another slice — and the reading would still sound plausible.

**Order is the trace's own.** Given an input in neither depth-first nor breadth-first order, `gd.calcdata` kept it exactly:

```
input  labels=['r', 'a1', 'b', 'a', 'b1']   parents=['', 'a', 'r', 'r', 'b']
calc   ['r', 'a1', 'b', 'a', 'b1']
```

`sort` changes the drawn layout, not that order (`sort=False` and the default both came back in input order), and a four-deep chain did too.

**The kth element is the kth node.** Verified in Chromium against the `text.slicetext` that sits *parallel* to each slice — they are sibling lists under `g.trace`, not nested:

```
OK  TREEMAP   n=4 resolved=4 aligned=True texts=['r', 'a', 'b', 'a1']
OK  SUNBURST  n=4 resolved=4 aligned=True texts=['r', 'a', 'b', 'a1']
OK  ICICLE    n=4 resolved=4 aligned=True texts=['r', 'a', 'b', 'a1']
```

(My first alignment probe climbed one parent too far and reported `['r','r','r','r']` for everything — a broken probe, not a broken selector. Worth saying because a probe that answers the same thing for every input answers nothing.)

## `ids`, and the vocabulary the path is in

With `ids` given, plotly reads `parents` as **ids** rather than as labels — which is how a tree with two nodes of the same name is written at all. The path is resolved through ids and then spelled in **labels**, because `TreemapPoint.x` is the node's name and its `path` has to be in the same vocabulary for a reader to follow it. Measured with `labels=["root","node","node","leaf"]`: the leaf's path comes out `["root", "node"]`.

The walk refuses to visit an id twice, so an author-supplied cycle yields the chain up to the repeat rather than looping forever. `parents` is author-supplied and nothing upstream checks it.

## A many-rooted hierarchy is declined

Plotly **invents a parent** for it. Measured against `gd.calcdata`:

```
labels=['r1','r2','a']  parents=['','','r1']
  ->  [['c02ba4', '', None, ''], ['r1','r1',5,'c02ba4'], ['r2','r2',3,'c02ba4'], ['a','a',2,'r1']]
      4 slices drawn for 3 authored nodes
```

That first node is not in the data and has no name. Emitting it would announce a nameless root the author never wrote; omitting it would leave the positional selector one place out for every node. Declined rather than guessed at.

## A surviving mutation removed code

The `has_values` flag beside the length check turned out to be dead — `as_list(None)` is `[]`, so `index < len(values)` already answers "did the author declare values". A mutation deleting the flag changed no test, which is what a redundant guard looks like, so it is gone and the reason is a comment.

## Tests

`tests/plotly/test_plotly_hierarchy.py` — 14 tests: each painting read as itself (parametrised over all three), the input order, the ancestor chains, declared values kept on interior nodes, a valueless tree carrying no `y`, `ids` with duplicate labels, the many-root decline **and** that it takes no grid cell, per-kind numbering, two treemaps, the axis names, and a cycle that must not hang.

Mutation-swept, ten mutations one at a time against a restored baseline, all caught after the redundant guard came out:

```
M1  one type for all three          2 failed, 12 passed
M2  many roots accepted             2 failed, 12 passed
M3  path includes the node          2 failed, 12 passed
M4  path not reversed               2 failed, 12 passed
M5  ids ignored                     1 failed, 13 passed
M6  values invented when absent     1 failed, 13 passed
M7  layer name fixed to treemap     2 failed, 12 passed
M8  nth-child dropped               2 failed, 12 passed
M9  declined tree still takes a cell 1 failed, 13 passed
M10 _extract_plots block dropped    1 failed, 13 passed
```

Full suite in two batches (the whole run OOMs in this container): `tests/core` 1931 passed, 5 skipped; the rest 1215 passed, 13 skipped.

## Two existing rows changed exemplar

`TestPlotlyUnrenderedDomainTraces` used a single-node treemap and sunburst as its examples of a domain trace maidr renders nothing for. Those now render, so the rows use **many-rooted** ones — keeping the row's original subject — and `go.Parcoords` joins them as a third. A new control asserts that a single-rooted hierarchy *does* take a cell, mirroring the one #632 added for the gauge.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_