### PR TITLE
feat(plotly): read a sankey trace

### DIFF
--- a/maidr/core/enum/maidr_key.py
+++ b/maidr/core/enum/maidr_key.py
@@ -70,6 +70,14 @@ class MaidrKey(str, Enum):
     END = "end"
     LANES = "lanes"
 
+    # Flow keys. One link states the two nodes it joins and how much moves.
+    # Only the source needs a key of its own: the amount reuses `VALUE` and
+    # the far node reuses `TARGET`, both below. `TARGET` carrying two
+    # meanings is the wire format's doing rather than ours -- a gauge's is
+    # the value a bullet chart marks, a link's is the node it arrives at --
+    # and they never appear in one payload, because a layer is one type.
+    SOURCE = "source"
+
     # Hierarchy keys. A node carries its name in `X`, its declared value in
     # `Y` and the chain of ancestors above it here -- root first, and never
     # including the node itself.

--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -64,6 +64,11 @@ class PlotType(str, Enum):
     CANDLESTICK = "candlestick"
     VIOLIN_KDE = "violin_kde"
     VIOLIN_BOX = "violin_box"
+    #: Weighted flow between nodes, drawn as ribbons whose width is the
+    #: magnitude. Stated as one point per link -- the two nodes it joins and
+    #: how much moves -- rather than as a series, because the chart is a
+    #: graph and there is no grid reading of it.
+    SANKEY = "sankey"
     #: A hierarchy drawn as nested rectangles, and the two paintings of the
     #: same tree that differ from it only in shape: concentric rings for a
     #: sunburst, stacked bands for an icicle. Kept apart because the chart

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -69,7 +69,7 @@ from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_plotly
 #:
 #: Add a type here when maidr learns to render it, not before.
 _PLACED_BY_DOMAIN = frozenset(
-    {"pie", "funnelarea", "indicator", "treemap", "sunburst", "icicle"}
+    {"pie", "funnelarea", "indicator", "treemap", "sunburst", "icicle", "sankey"}
 )
 
 
@@ -857,6 +857,28 @@ class PlotlyMaidr:
                     )
                     self._plots.append(plot)
                 merged.update(id(t) for t in funnelarea_traces)
+
+            # Sankeys, one layer each. Only this loop knows whether the
+            # figure holds a second one, which is what decides whether
+            # either can be addressed -- see `PlotlySankeyPlot._get_selector`.
+            sankey_traces = [t for t in group_traces if t.get("type") == "sankey"]
+            if sankey_traces:
+                from maidr.plotly.sankey import PlotlySankeyPlot
+
+                for sankey_trace in sankey_traces:
+                    plot = PlotlySankeyPlot(
+                        sankey_trace,
+                        layout,
+                        addressable=len(sankey_traces) == 1,
+                        **axis_kwargs,
+                    )
+                    plot.row_index, plot.col_index = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._trace_domain_start(sankey_trace),
+                    )
+                    self._plots.append(plot)
+                merged.update(id(t) for t in sankey_traces)
 
             # Hierarchies, one layer each. Each painting has its own
             # figure-level layer, so a trace is numbered among its own kind

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -126,6 +126,15 @@ class PlotlyPlotFactory:
 
             return PlotlyHistogramPlot(trace, layout, **axis_kwargs)
 
+        if trace_type == "sankey":
+            from maidr.plotly.sankey import PlotlySankeyPlot
+
+            # ``addressable`` is left at its default: this factory sees one
+            # trace with no idea whether the figure holds a second sankey,
+            # and "assume it is the only one" is the only assumption
+            # available -- the same one the pie branch makes about position.
+            return PlotlySankeyPlot(trace, layout, **axis_kwargs)
+
         if trace_type in ("treemap", "sunburst", "icicle"):
             from maidr.plotly.hierarchy import PlotlyHierarchyPlot, has_one_root
 

--- a/maidr/plotly/sankey.py
+++ b/maidr/plotly/sankey.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+
+class PlotlySankeyPlot(PlotlyPlot):
+    """Extract data from a Plotly sankey trace.
+
+    A sankey is weighted flow between nodes, and `FlowPoint` states one link
+    as the two nodes it joins and how much moves: ``{source, target,
+    value}``. Plotly states the same thing by *index* -- ``link.source`` and
+    ``link.target`` point into ``node.label`` -- so the whole of the mapping
+    is resolving those indices back to the names a reader is told.
+
+    The links are emitted in the trace's own order. Measured against the
+    ``__data__`` d3 binds onto each drawn ribbon, with values written out of
+    order so a re-sort by magnitude would show: ``value=[3, 9, 5, 1]`` came
+    back as indices 0, 1, 2, 3 in that order.
+    """
+
+    def __init__(
+        self, trace: dict, layout: dict, *, addressable: bool = True, **kwargs: str
+    ) -> None:
+        super().__init__(trace, layout, PlotType.SANKEY, **kwargs)
+        self._addressable = addressable
+
+    def _get_selector(self) -> str:
+        """Address the ribbons, when this figure's sankey can be picked out.
+
+        ``.sankey .sankey-link`` matches one ``<path>`` per link, in the
+        trace's own order.
+
+        A figure holding **two** sankeys gets no selector, and that is a
+        limit rather than an oversight. Measured: both ``.sankey`` groups
+        are bare ``<g class="sankey">`` siblings under ``main-svg`` with no
+        id and no data attribute -- they differ only by a ``transform``,
+        which moves with the layout. ``:nth-of-type`` cannot separate them
+        either, because it counts *every* ``<g>`` sibling and the two
+        sankeys were the 15th and 16th: ``.sankey:nth-of-type(1)`` resolved
+        to **0** elements.
+
+        So a second sankey has no addressable geometry, and emitting a
+        selector that matched both traces' ribbons would be worse than
+        emitting none -- the resolved count would not equal either layer's
+        link count, and both highlights would be dropped anyway. The layer
+        still reads: its audio, braille and text are unaffected, which is
+        the same honest outcome #145 established for a layer with nothing to
+        point at.
+        """
+        return ".sankey .sankey-link" if self._addressable else ""
+
+    def _extract_axes_data(self) -> dict:
+        """Name the two dimensions a flow carries.
+
+        A sankey draws no axes. The core announces a link as the pair of
+        nodes it joins and the amount that moves, so the generic pair says
+        what those are -- the stand-in a pie takes, in this chart's words.
+        """
+        return {
+            MaidrKey.X: self._axis_config(label="Flow"),
+            MaidrKey.Y: self._axis_config(label="Value"),
+        }
+
+    def _extract_plot_data(self) -> list[dict]:
+        """One point per link, in the trace's own order.
+
+        A link whose endpoint is not a node plotly could name is skipped.
+        `FlowPoint` has no shape for a nameless end, and plotly draws
+        nothing for an out-of-range index either -- so passing one on would
+        announce a ribbon that is not on the screen.
+        """
+        node = self._trace.get("node") or {}
+        link = self._trace.get("link") or {}
+
+        labels = [self._to_native(label) for label in as_list(node.get("label"))]
+        sources = as_list(link.get("source"))
+        targets = as_list(link.get("target"))
+        values = as_list(link.get("value"))
+
+        count = min(len(sources), len(targets), len(values))
+        points: list[dict] = []
+        for index in range(count):
+            source = _node_name(sources[index], labels)
+            target = _node_name(targets[index], labels)
+            value = _number(values[index])
+            if source is None or target is None or value is None:
+                continue
+            points.append(
+                {
+                    MaidrKey.SOURCE: source,
+                    MaidrKey.TARGET: target,
+                    MaidrKey.VALUE: value,
+                }
+            )
+        return points
+
+
+def _node_name(index: Any, labels: list[Any]) -> Any:
+    """Return the label an endpoint index points at, or None when it has none."""
+    position = _number(index)
+    if position is None or position != int(position):
+        return None
+    position = int(position)
+    if 0 <= position < len(labels):
+        return labels[position]
+    return None
+
+
+def _number(value: Any) -> float | None:
+    """Coerce one of plotly's numbers, or None when it is not one."""
+    value = PlotlyPlot._to_native(value)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None

--- a/tests/plotly/test_plotly_sankey.py
+++ b/tests/plotly/test_plotly_sankey.py
@@ -1,0 +1,175 @@
+"""A plotly sankey produced a figure with no layers at all.
+
+`go.Sankey` states weighted flow the way `FlowPoint` wants it -- one link,
+two nodes, an amount -- except by **index**: `link.source` and `link.target`
+point into `node.label`. Resolving those indices back to the names a reader
+is told is the whole of the mapping. `maidr/plotly/` had none of it, so the
+trace fell through `_extract_plots` to `PlotlyPlotFactory`, which returned
+`None` (#627). The core has drawn sankeys since xability/maidr#810.
+
+Two things measured in Chromium:
+
+  * **the links are drawn in the trace's own order.** Read off the
+    `__data__` d3 binds onto each ribbon, with values written out of order
+    so a re-sort by magnitude would show: `value=[3, 9, 5, 1]` came back as
+    indices 0, 1, 2, 3 in that order.
+  * **two sankeys in one figure cannot be told apart.** Both `.sankey`
+    groups are bare `<g class="sankey">` siblings under `main-svg` with no
+    id and no data attribute; they differ only by a `transform`, which
+    moves with the layout. `:nth-of-type` cannot separate them either --
+    it counts *every* `<g>` sibling, and the two sankeys were the 15th and
+    16th, so `.sankey:nth-of-type(1)` resolved to **0** elements.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Values written out of ascending order, so an emitted order that sorted
+#: them could not pass by coincidence.
+FLOW = {
+    "node": {"label": ["a", "b", "c", "d"]},
+    "link": {"source": [0, 0, 1, 2], "target": [1, 2, 3, 3], "value": [3, 9, 5, 1]},
+}
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _links(layer: dict) -> list[tuple]:
+    """Each link as ``(source, target, value)``, in the order emitted."""
+    return [
+        (point["source"], point["target"], point["value"]) for point in layer["data"]
+    ]
+
+
+def test_a_sankey_is_read_at_all() -> None:
+    """The reproduction: a whole chart that announced nothing."""
+    layers = _layers(go.Figure([go.Sankey(**FLOW)]))
+
+    assert [layer["type"] for layer in layers] == [PlotType.SANKEY]
+
+
+def test_the_endpoints_are_resolved_to_node_names() -> None:
+    """Indices are what plotly states; names are what a reader is told.
+
+    Passing the indices through would announce "0 to 1" -- true of the wire
+    format and meaningless to anyone listening.
+    """
+    (layer,) = _layers(go.Figure([go.Sankey(**FLOW)]))
+
+    assert _links(layer) == [
+        ("a", "b", 3.0),
+        ("a", "c", 9.0),
+        ("b", "d", 5.0),
+        ("c", "d", 1.0),
+    ]
+
+
+def test_the_links_keep_the_order_they_were_written_in() -> None:
+    """Measured off the `__data__` on each drawn ribbon.
+
+    The selector is positional, so a reordering here would land every later
+    link on another ribbon -- and the reading would still sound plausible.
+    """
+    (layer,) = _layers(go.Figure([go.Sankey(**FLOW)]))
+
+    assert [point["value"] for point in layer["data"]] == [3.0, 9.0, 5.0, 1.0]
+
+
+def test_a_link_to_a_node_that_does_not_exist_is_skipped() -> None:
+    """`FlowPoint` has no shape for a nameless end.
+
+    Plotly draws nothing for an out-of-range index either, so passing one on
+    would announce a ribbon that is not on the screen.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Sankey(
+                    node={"label": ["a", "b"]},
+                    link={"source": [0, 9], "target": [1, 0], "value": [5, 2]},
+                )
+            ]
+        )
+    )
+
+    assert _links(layer) == [("a", "b", 5.0)]
+
+
+def test_a_lone_sankey_addresses_its_ribbons() -> None:
+    """Measured: `.sankey .sankey-link` resolved to one path per link."""
+    (layer,) = _layers(go.Figure([go.Sankey(**FLOW)]))
+
+    assert layer["selectors"] == ".sankey .sankey-link"
+
+
+def test_two_sankeys_are_read_but_not_addressed() -> None:
+    """A stated limit, not an oversight.
+
+    The two `.sankey` groups cannot be separated by any stable selector, so
+    a second sankey has no addressable geometry. Emitting a selector that
+    matched both traces' ribbons would be worse than emitting none: the
+    resolved count would equal neither layer's link count, so both
+    highlights would be dropped anyway *and* the payload would claim an
+    address it does not have.
+
+    The layers still read -- audio, braille and text are unaffected -- which
+    is the outcome #145 established for a layer with nothing to point at.
+    """
+    first, second = _layers(
+        go.Figure(
+            [
+                go.Sankey(
+                    node={"label": ["a", "b"]},
+                    link={"source": [0], "target": [1], "value": [5]},
+                    domain={"x": [0, 0.45]},
+                ),
+                go.Sankey(
+                    node={"label": ["p", "q", "r"]},
+                    link={"source": [0, 1], "target": [1, 2], "value": [2, 3]},
+                    domain={"x": [0.55, 1]},
+                ),
+            ]
+        )
+    )
+
+    assert "selectors" not in first
+    assert "selectors" not in second
+    assert _links(first) == [("a", "b", 5.0)]
+    assert _links(second) == [("p", "q", 2.0), ("q", "r", 3.0)]
+
+
+def test_a_sankey_names_its_two_dimensions() -> None:
+    """It draws no axes, so the generic pair says what the two are."""
+    (layer,) = _layers(go.Figure([go.Sankey(**FLOW)]))
+
+    assert layer["axes"]["x"]["label"] == "Flow"
+    assert layer["axes"]["y"]["label"] == "Value"
+
+
+def test_a_sankey_takes_a_grid_cell_of_its_own() -> None:
+    """It is placed by its own `domain`, as a pie is."""
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(
+        rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]]
+    )
+    figure.add_trace(go.Sankey(**FLOW), row=1, col=1)
+    figure.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+    cells = [(plot.row_index, plot.col_index) for plot in PlotlyMaidr(figure)._plots]
+
+    assert cells == [(0, 0), (0, 1)]


### PR DESCRIPTION
Sixth tranche of #627, after the waterfall (#629), funnel (#630), funnelarea (#631), gauge (#632) and the hierarchy trio (#633). Nine of the fifteen now read.

## What was wrong

```python
go.Sankey(node={"label": ["a","b","c","d"]},
          link={"source": [0,0,1,2], "target": [1,2,3,3], "value": [3,9,5,1]})   ->   layers: []
```

The core has drawn sankeys since xability/maidr#810.

## The mapping is an index lookup

`FlowPoint` is `{source, target, value}` in **names**. Plotly states the same links in **indices** into `node.label`. Passing the indices through would announce *"0 to 1"* — true of the wire format and meaningless to anyone listening.

A link whose endpoint is not a node plotly could name is skipped: plotly draws nothing for an out-of-range index either, so passing one on would announce a ribbon that is not on the screen.

## Order, measured

The links come out in the trace's own order. Read off the `__data__` d3 binds onto each drawn ribbon, with values written out of ascending order so a re-sort by magnitude would show:

```
value=[3, 9, 5, 1]  ->  drawn order  [a→b 3], [a→c 9], [b→d 5], [c→d 1]   (indices 0,1,2,3)
```

The selector is positional, so a reordering here would land every later link on another ribbon.

## Two sankeys read but are not addressed

A stated limit, not an oversight. Measured on a figure holding two:

```
.sankey                              2
path.sankey-link                     3     (1 + 2)
.sankey:nth-of-type(1) ...link       0     <- matches nothing
.sankey:nth-of-type(2) ...link       0
```

Both `.sankey` groups are bare `<g class="sankey">` siblings under `main-svg` — no id, no data attribute, differing only by a `transform` that moves with the layout. `:nth-of-type` cannot separate them because it counts *every* `<g>` sibling, and the two sankeys were the 15th and 16th children.

So a second sankey has no addressable geometry. Emitting `.sankey .sankey-link` anyway would be worse than emitting nothing: the resolved count would equal neither layer's link count, so both highlights would be dropped regardless, *and* the payload would claim an address it does not have. The layers still read — audio, braille and text are unaffected — which is the outcome #145 established for a layer with nothing to point at.

Verified for the single-sankey case: `.sankey .sankey-link` resolved to 4 for 4 links, in the emitted order.

## `TARGET` is reused, not added

The gauge already carries the key. Its two meanings — a bullet chart's marker value, a link's far node — are the wire format's doing rather than ours, and they never appear in one payload because a layer is one type. The enum says so at the definition.

(Adding a second `TARGET` member is what I tried first; `Enum` refuses it outright with `Attempted to reuse key`, which is a better error than a silent shadow.)

## Tests

`tests/plotly/test_plotly_sankey.py` — 8 tests: the reproduction, endpoints resolved to names, the order, the out-of-range skip, the lone-sankey selector, two sankeys read-but-unaddressed, the axis names, and the grid cell.

Mutation-swept, seven mutations one at a time against a restored baseline, all caught:

```
M1  indices passed through          3 failed, 5 passed
M2  source and target swapped       3 failed, 5 passed
M3  bad index kept                  1 failed, 7 passed
M4  links sorted by value           2 failed, 6 passed
M5  selector always emitted         1 failed, 7 passed
M6  addressable ignores the count   1 failed, 7 passed
M7  _extract_plots block dropped    2 failed, 6 passed
```

Full suite in two batches (the whole run OOMs in this container): `tests/core` 1931 passed, 5 skipped; the rest 1223 passed, 13 skipped.

## Remaining on #627

`parcats`, `parcoords`, `contour`, `histogram2dcontour`, `histogram2d`, `barpolar`, `scatterpolar`, `choropleth`. The two `histogram2d*` are last for the reason the issue gives: plotly bins them in the browser, so the Python side holds the raw samples and not the binned counts the `heat`/`contour` layers need.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_