### PR TITLE
feat(plotly): read the two polar traces

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -64,6 +64,12 @@ class PlotType(str, Enum):
     CANDLESTICK = "candlestick"
     VIOLIN_KDE = "violin_kde"
     VIOLIN_BOX = "violin_box"
+    #: Spokes around a circle, one radius per angle. `RADAR` joins them into
+    #: an outline and `POLAR_AREA` fills the wedge between them; a reader
+    #: navigates the same spokes either way, which is why the core builds
+    #: both on one trace.
+    RADAR = "radar"
+    POLAR_AREA = "polar_area"
     #: Weighted flow between nodes, drawn as ribbons whose width is the
     #: magnitude. Stated as one point per link -- the two nodes it joins and
     #: how much moves -- rather than as a series, because the chart is a
@@ -128,6 +134,7 @@ _DISPLAY_NAMES = {
     PlotType.STACKED: "stacked bar",
     PlotType.STACKED_AREA: "stacked area",
     PlotType.NORMALIZED_AREA: "100% stacked area",
+    PlotType.POLAR_AREA: "polar area",
     PlotType.VIOLIN_BOX: "violin",
     PlotType.VIOLIN_KDE: "violin",
 }

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -858,6 +858,39 @@ class PlotlyMaidr:
                     self._plots.append(plot)
                 merged.update(id(t) for t in funnelarea_traces)
 
+            # Polar traces, one layer each. A `scatterpolar` is numbered
+            # among the polar *scatter* traces, because that is what the
+            # `.polarlayer .scatterlayer` groups hold -- a `barpolar` draws
+            # into `.polarlayer .barlayer` and shifts nothing there.
+            polar_traces = [
+                t for t in group_traces if t.get("type") in ("scatterpolar", "barpolar")
+            ]
+            if polar_traces:
+                # `PlotType` is imported here rather than at module level
+                # because `_extract_plots` already imports it locally
+                # further down, which makes the name local to the whole
+                # function -- a module-level reference above that point is
+                # an unbound local, not the module's.
+                from maidr.core.enum.plot_type import PlotType
+                from maidr.plotly.polar import PlotlyPolarPlot
+
+                scatter_position = 0
+                for polar_trace in polar_traces:
+                    is_scatter = polar_trace.get("type") == "scatterpolar"
+                    plot = PlotlyPolarPlot(
+                        polar_trace,
+                        layout,
+                        PlotType.RADAR if is_scatter else PlotType.POLAR_AREA,
+                        trace_position=scatter_position,
+                        **axis_kwargs,
+                    )
+                    if is_scatter:
+                        scatter_position += 1
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in polar_traces)
+
             # Sankeys, one layer each. Only this loop knows whether the
             # figure holds a second one, which is what decides whether
             # either can be addressed -- see `PlotlySankeyPlot._get_selector`.

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -239,6 +239,18 @@ class PlotlyMaidr:
             if key.startswith("yaxis") and isinstance(val, dict):
                 y_starts.add(_domain_start(val, "domain"))
 
+            # A polar subplot is placed like a cartesian one -- by a
+            # rectangle `make_subplots` wrote into the layout -- but under
+            # its own key rather than an axis pair, so it needs its own
+            # branch. Without it a `[bar, polar]` grid collected one x start
+            # and collapsed to a single cell holding both layers, and two
+            # polar subplots side by side collected none at all.
+            if key.startswith("polar") and isinstance(val, dict):
+                domain = val.get("domain")
+                if isinstance(domain, dict):
+                    x_starts.add(_domain_start(domain, "x"))
+                    y_starts.add(_domain_start(domain, "y"))
+
         for trace in traces:
             if not _occupies_a_cell(trace):
                 continue
@@ -298,6 +310,35 @@ class PlotlyMaidr:
         placed covers the whole figure, which is the first cell.
         """
         domain = trace.get("domain")
+        return _domain_start(domain, "x"), _domain_start(domain, "y")
+
+    @staticmethod
+    def _polar_domain_start(layout: dict, trace: dict) -> tuple[float, float]:
+        """Return where a polar trace's own subplot starts in the figure.
+
+        A polar trace carries neither an axis pair nor a ``domain`` of its
+        own, so neither of the two helpers above can place it. Its rectangle
+        is written into the layout under the subplot it names --
+        ``layout.polar``, ``layout.polar2``, ... -- which is what tells two
+        polar charts of a grid apart.
+
+        Parameters
+        ----------
+        layout : dict
+            The Plotly figure layout.
+        trace : dict
+            One ``scatterpolar`` or ``barpolar`` trace.
+
+        Returns
+        -------
+        tuple of (float, float)
+            The x and y start of the trace's polar subplot. A subplot plotly
+            never placed covers the whole figure, which is the first cell.
+        """
+        from maidr.plotly.polar import subplot_name
+
+        block = layout.get(subplot_name(trace))
+        domain = block.get("domain") if isinstance(block, dict) else None
         return _domain_start(domain, "x"), _domain_start(domain, "y")
 
     def _extract_plots(self) -> None:
@@ -858,10 +899,18 @@ class PlotlyMaidr:
                     self._plots.append(plot)
                 merged.update(id(t) for t in funnelarea_traces)
 
-            # Polar traces, one layer each. A `scatterpolar` is numbered
-            # among the polar *scatter* traces, because that is what the
-            # `.polarlayer .scatterlayer` groups hold -- a `barpolar` draws
-            # into `.polarlayer .barlayer` and shifts nothing there.
+            # Polar traces, one layer each, and every question about one is
+            # asked of its own polar subplot rather than of the trace group.
+            # A polar trace names no axis pair, so `group_traces` is keyed by
+            # the cartesian defaults and holds *every* polar trace of the
+            # figure however many subplots they are spread over -- which is
+            # the same trap `_trace_domain_start` exists for on the pie side.
+            #
+            # A `scatterpolar` is numbered among the scatter traces of its
+            # own subplot, because that is what one `.scatterlayer` holds --
+            # a `barpolar` draws into that subplot's `.barlayer` and shifts
+            # nothing there, and a trace in the *next* subplot is numbered
+            # from one again.
             polar_traces = [
                 t for t in group_traces if t.get("type") in ("scatterpolar", "barpolar")
             ]
@@ -872,22 +921,28 @@ class PlotlyMaidr:
                 # function -- a module-level reference above that point is
                 # an unbound local, not the module's.
                 from maidr.core.enum.plot_type import PlotType
-                from maidr.plotly.polar import PlotlyPolarPlot
+                from maidr.plotly.polar import PlotlyPolarPlot, subplot_name
 
-                scatter_position = 0
+                scatter_positions: dict[str, int] = {}
                 for polar_trace in polar_traces:
+                    name = subplot_name(polar_trace)
                     is_scatter = polar_trace.get("type") == "scatterpolar"
                     plot = PlotlyPolarPlot(
                         polar_trace,
                         layout,
                         PlotType.RADAR if is_scatter else PlotType.POLAR_AREA,
-                        trace_position=scatter_position,
+                        trace_position=scatter_positions.get(name, 0),
                         **axis_kwargs,
                     )
                     if is_scatter:
-                        scatter_position += 1
-                    plot.row_index = row
-                    plot.col_index = col
+                        scatter_positions[name] = scatter_positions.get(name, 0) + 1
+                    polar_row, polar_col = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._polar_domain_start(layout, polar_trace),
+                    )
+                    plot.row_index = polar_row
+                    plot.col_index = polar_col
                     self._plots.append(plot)
                 merged.update(id(t) for t in polar_traces)
 

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot
 from maidr.plotly.step_shape import is_connected_line_trace, is_step_trace
 
@@ -125,6 +126,16 @@ class PlotlyPlotFactory:
             from maidr.plotly.histogram import PlotlyHistogramPlot
 
             return PlotlyHistogramPlot(trace, layout, **axis_kwargs)
+
+        if trace_type in ("scatterpolar", "barpolar"):
+            from maidr.plotly.polar import PlotlyPolarPlot
+
+            polar_type = (
+                PlotType.RADAR if trace_type == "scatterpolar" else PlotType.POLAR_AREA
+            )
+            # ``trace_position`` is left at its default: this factory sees
+            # one trace with no idea what else shares the polar subplot.
+            return PlotlyPolarPlot(trace, layout, polar_type, **axis_kwargs)
 
         if trace_type == "sankey":
             from maidr.plotly.sankey import PlotlySankeyPlot

--- a/maidr/plotly/polar.py
+++ b/maidr/plotly/polar.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+
+class PlotlyPolarPlot(PlotlyPlot):
+    """Extract data from a Plotly ``scatterpolar`` or ``barpolar`` trace.
+
+    Both draw spokes around a circle -- one radius per angle -- and the core
+    builds both on `RadarTrace`: a radar joins the spokes into an outline and
+    a polar area fills the wedge between them, and a reader navigates the
+    same spokes either way. So the payload is a line's: a list of series,
+    each a list of ``{x: angle, y: radius}``.
+
+    A polar chart has no orientation. `IS_ORIENTED` marks both false --
+    "spokes sit around a circle rather than along an axis, so there is no
+    main and cross axis to swap" -- so nothing is declared.
+    """
+
+    def __init__(
+        self,
+        trace: dict,
+        layout: dict,
+        plot_type: PlotType,
+        *,
+        trace_position: int = 0,
+        **kwargs: str,
+    ) -> None:
+        super().__init__(trace, layout, plot_type, **kwargs)
+        self._trace_position = trace_position
+
+    def _get_selector(self) -> list[str]:
+        """Address this trace's drawn outline, when it draws one.
+
+        A radar-family layer resolves **one selector per series**, not one
+        per point: `LineTrace.mapToSvgElements` compares
+        ``selectors.length`` against the series count. A ``scatterpolar``
+        draws exactly one ``path.js-line`` per trace, which is that element.
+
+        Measured in Chromium: one scatterpolar gives one ``js-line``, two
+        give two, each inside its own ``.polarlayer .scatterlayer .trace``.
+
+        A ``barpolar`` gets none, and that is a limit worth stating. It
+        draws no per-series path at all -- only one bar per spoke, four of
+        them for four spokes. Four selectors would be read as four *series*,
+        and the one selector its single series is allowed would have to
+        point at the whole ``.trace.bars`` group, which outlines every bar
+        at once and so highlights the same thing at every step of the walk.
+        Neither says what a reader means by "where am I", so the layer ships
+        without a highlight and keeps its audio, braille and text -- the
+        outcome #145 established for a layer with nothing to point at.
+        """
+        if self.type is not PlotType.RADAR:
+            return []
+        return [
+            f".polarlayer .scatterlayer "
+            f".trace:nth-child({self._trace_position + 1}) path.js-line"
+        ]
+
+    def _extract_axes_data(self) -> dict:
+        """Name the angle and the radius.
+
+        A polar chart draws no cartesian axes, so ``layout.xaxis`` is not
+        where its names live -- borrowing from there would take another
+        trace's titles or the generic fallback where the author had in fact
+        named these.
+
+        Only the radius can be named. ``layout.polar.radialaxis`` takes a
+        ``title``; ``angularaxis`` does not have the property at all --
+        plotly rejects it outright ("Invalid property specified for object
+        of type plotly.graph_objs.layout.polar.AngularAxis: 'title'"). So
+        the angle always takes the generic word, and reading a title off it
+        would be reading a key plotly never writes.
+        """
+        polar = self._layout.get("polar") or {}
+        return {
+            MaidrKey.X: self._axis_config(label="Angle"),
+            MaidrKey.Y: self._axis_config(
+                label=_axis_title(polar.get("radialaxis"), "Radius")
+            ),
+        }
+
+    def _extract_plot_data(self) -> list[list[dict]]:
+        """One series of spokes, wrapped for the list-of-series shape.
+
+        ``theta`` is the angle and ``r`` the radius, which is the pair a
+        polar trace states -- not ``x`` and ``y``, which it does not carry
+        at all. A spoke with no radius is dropped: plotly draws nothing for
+        it, and `RadarTrace` places its spokes at an equal share of the
+        circle by *count*, so keeping a gap would rotate every later spoke.
+        """
+        angles = as_list(self._trace.get("theta"))
+        radii = as_list(self._trace.get("r"))
+
+        spokes = [
+            {MaidrKey.X: self._to_native(angle), MaidrKey.Y: self._to_native(radius)}
+            for angle, radius in zip(angles, radii)
+            if radius is not None
+        ]
+        return [spokes] if spokes else []
+
+
+def _axis_title(axis: object, default: str) -> str:
+    """Return a plotly polar axis's title text, or ``default`` when unset."""
+    if not isinstance(axis, dict):
+        return default
+    title = axis.get("title", "")
+    if isinstance(title, dict):
+        title = title.get("text", "")
+    return str(title) if title else default

--- a/maidr/plotly/polar.py
+++ b/maidr/plotly/polar.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
@@ -25,11 +27,12 @@ class PlotlyPolarPlot(PlotlyPlot):
         layout: dict,
         plot_type: PlotType,
         *,
-        trace_position: int = 0,
+        trace_position: int,
         **kwargs: str,
     ) -> None:
         super().__init__(trace, layout, plot_type, **kwargs)
         self._trace_position = trace_position
+        self._subplot = subplot_name(trace)
 
     def _get_selector(self) -> list[str]:
         """Address this trace's drawn outline, when it draws one.
@@ -40,7 +43,18 @@ class PlotlyPolarPlot(PlotlyPlot):
         draws exactly one ``path.js-line`` per trace, which is that element.
 
         Measured in Chromium: one scatterpolar gives one ``js-line``, two
-        give two, each inside its own ``.polarlayer .scatterlayer .trace``.
+        give two, each inside its own ``.scatterlayer .trace``.
+
+        The selector is scoped to **this trace's own polar subplot**, and
+        the position counted among that subplot's scatterpolar traces only.
+        A figure may hold several: plotly draws each as its own
+        ``<g class="polar">`` / ``<g class="polar2">`` under one shared
+        ``.polarlayer``, each with its own ``.scatterlayer`` numbered from
+        one. Unscoped, ``.trace:nth-child(1)`` matched the first trace of
+        *every* polar subplot -- one keypress outlining two charts -- and
+        ``nth-child(2)`` matched nothing at all, because no subplot held a
+        second. Measured on a 1x2 polar grid before this: 2 elements and 0.
+        Scoped, every (subplot, position) pair resolves to exactly one.
 
         A ``barpolar`` gets none, and that is a limit worth stating. It
         draws no per-series path at all -- only one bar per spoke, four of
@@ -55,7 +69,7 @@ class PlotlyPolarPlot(PlotlyPlot):
         if self.type is not PlotType.RADAR:
             return []
         return [
-            f".polarlayer .scatterlayer "
+            f".polarlayer > g.{self._subplot} .scatterlayer "
             f".trace:nth-child({self._trace_position + 1}) path.js-line"
         ]
 
@@ -65,7 +79,10 @@ class PlotlyPolarPlot(PlotlyPlot):
         A polar chart draws no cartesian axes, so ``layout.xaxis`` is not
         where its names live -- borrowing from there would take another
         trace's titles or the generic fallback where the author had in fact
-        named these.
+        named these. The titles are read from *this* trace's own polar
+        block: a figure's second polar subplot is ``layout.polar2``, and
+        reading ``layout.polar`` for it would hand a reader the first
+        chart's radial title.
 
         Only the radius can be named. ``layout.polar.radialaxis`` takes a
         ``title``; ``angularaxis`` does not have the property at all --
@@ -74,7 +91,7 @@ class PlotlyPolarPlot(PlotlyPlot):
         the angle always takes the generic word, and reading a title off it
         would be reading a key plotly never writes.
         """
-        polar = self._layout.get("polar") or {}
+        polar = self._layout.get(self._subplot) or {}
         return {
             MaidrKey.X: self._axis_config(label="Angle"),
             MaidrKey.Y: self._axis_config(
@@ -90,6 +107,14 @@ class PlotlyPolarPlot(PlotlyPlot):
         at all. A spoke with no radius is dropped: plotly draws nothing for
         it, and `RadarTrace` places its spokes at an equal share of the
         circle by *count*, so keeping a gap would rotate every later spoke.
+
+        "No radius" is ``None`` or a non-finite number, because a gap
+        reaches this in either spelling and the difference is not the
+        author's. A list written with ``None`` arrives as ``None``; the
+        same list as a numpy array arrives base64-encoded and comes back
+        through `as_list` as ``nan``. Dropping only ``None`` would have made
+        the same chart read correctly or rotate depending on how its author
+        happened to hold the data.
         """
         angles = as_list(self._trace.get("theta"))
         radii = as_list(self._trace.get("r"))
@@ -97,9 +122,42 @@ class PlotlyPolarPlot(PlotlyPlot):
         spokes = [
             {MaidrKey.X: self._to_native(angle), MaidrKey.Y: self._to_native(radius)}
             for angle, radius in zip(angles, radii)
-            if radius is not None
+            if _is_a_radius(radius)
         ]
         return [spokes] if spokes else []
+
+
+def subplot_name(trace: dict) -> str:
+    """Return the ``layout`` key naming this polar trace's own subplot.
+
+    A polar trace is addressed by ``subplot`` -- ``"polar"``, ``"polar2"``,
+    ... -- rather than by an axis pair, and the same string is both the
+    ``layout`` key holding that subplot's axes and domain and the class
+    plotly gives its ``<g>`` under ``.polarlayer``. A trace that names none
+    belongs to the first.
+
+    Parameters
+    ----------
+    trace : dict
+        One ``scatterpolar`` or ``barpolar`` trace.
+
+    Returns
+    -------
+    str
+        The subplot name, defaulting to ``"polar"``.
+    """
+    return str(trace.get("subplot") or "polar")
+
+
+def _is_a_radius(value: object) -> bool:
+    """Report whether a ``r`` entry is a radius rather than a gap."""
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, (int, float)):
+        return math.isfinite(value)
+    return True
 
 
 def _axis_title(axis: object, default: str) -> str:

--- a/tests/plotly/test_plotly_polar.py
+++ b/tests/plotly/test_plotly_polar.py
@@ -35,6 +35,7 @@ import pytest
 plotly = pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
+from plotly.subplots import make_subplots  # noqa: E402
 
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
@@ -109,6 +110,34 @@ def test_a_spoke_with_no_radius_is_dropped() -> None:
     assert _spokes(layer) == [("N", 3), ("S", 5)]
 
 
+def test_a_gap_written_as_nan_is_dropped_too() -> None:
+    """The same chart, held differently, must read the same way.
+
+    A gap reaches the extractor in two spellings and the difference is not
+    the author's: a plain list keeps its `None`, while the same list as a
+    numpy array is exported base64-encoded and comes back through `as_list`
+    as `nan`. Measured on `go.Scatter(y=np.array([4, np.nan, 6]))`, whose
+    `to_dict()` is `{"dtype": "f8", "bdata": ...}`.
+
+    Dropping only `None` left this chart with a spoke `RadarTrace` would
+    count, rotating every later spoke -- the very thing the test above
+    exists to prevent.
+    """
+    numpy = pytest.importorskip("numpy")
+
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Scatterpolar(
+                    r=numpy.array([3.0, numpy.nan, 5.0]), theta=["N", "E", "S"]
+                )
+            ]
+        )
+    )
+
+    assert _spokes(layer) == [("N", 3.0), ("S", 5.0)]
+
+
 def test_a_radar_addresses_its_outline() -> None:
     """One selector for one series, which is what the contract wants.
 
@@ -117,7 +146,7 @@ def test_a_radar_addresses_its_outline() -> None:
     (layer,) = _layers(go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES)]))
 
     assert layer["selectors"] == [
-        ".polarlayer .scatterlayer .trace:nth-child(1) path.js-line"
+        ".polarlayer > g.polar .scatterlayer .trace:nth-child(1) path.js-line"
     ]
 
 
@@ -203,3 +232,114 @@ def test_unnamed_polar_axes_fall_back_to_the_generic_pair() -> None:
 
     assert layer["axes"]["x"]["label"] == "Angle"
     assert layer["axes"]["y"]["label"] == "Radius"
+
+
+def test_two_polar_subplots_are_two_cells() -> None:
+    """A polar subplot's rectangle has to join the figure's grid.
+
+    A polar trace names no axis pair, so `_extract_plots` groups every one
+    of them under the cartesian defaults however many subplots they are
+    spread over, and the grid is built from `layout.xaxis`/`yaxis` domains
+    and from domain *traces* -- neither of which a polar subplot is. Its
+    rectangle lives under `layout.polar`/`layout.polar2`, so before this a
+    1x2 polar grid collected no starts at all and both charts landed in one
+    cell.
+    """
+    figure = make_subplots(rows=1, cols=2, specs=[[{"type": "polar"}] * 2])
+    figure.add_trace(go.Scatterpolar(r=[3, 9, 5], theta=SPOKES[:3]), row=1, col=1)
+    figure.add_trace(go.Scatterpolar(r=[2, 6, 4], theta=SPOKES[:3]), row=1, col=2)
+
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert [len(row) for row in grid] == [2]
+    assert [layer["type"] for layer in grid[0][0]["layers"]] == [PlotType.RADAR]
+    assert [layer["type"] for layer in grid[0][1]["layers"]] == [PlotType.RADAR]
+
+
+def test_a_polar_beside_a_cartesian_subplot_keeps_its_own_column() -> None:
+    """The common mixed grid, and the same omission.
+
+    `make_subplots(1, 2, [xy, polar])` writes the bar's rectangle into
+    `layout.xaxis.domain` and the radar's into `layout.polar.domain`. Only
+    the first was collected, so the figure had one column and both layers
+    were read as one chart.
+    """
+    figure = make_subplots(
+        rows=1, cols=2, specs=[[{"type": "xy"}, {"type": "polar"}]]
+    )
+    figure.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=1)
+    figure.add_trace(go.Scatterpolar(r=[3, 9, 5], theta=SPOKES[:3]), row=1, col=2)
+
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert [len(row) for row in grid] == [2]
+    assert [layer["type"] for layer in grid[0][0]["layers"]] == [PlotType.BAR]
+    assert [layer["type"] for layer in grid[0][1]["layers"]] == [PlotType.RADAR]
+
+
+def test_each_polar_subplot_addresses_its_own_outline() -> None:
+    """One `.polarlayer` holds every polar subplot, so the scope matters.
+
+    Measured in Chromium on a 1x2 polar grid: plotly draws
+    `<g class="polar">` and `<g class="polar2">` under one `.polarlayer`,
+    each with its own `.scatterlayer` numbered from one. The unscoped
+    selector therefore matched *both* first traces -- one keypress outlining
+    two charts -- while `nth-child(2)` matched nothing, because no subplot
+    held a second. Scoped, each of these resolved to exactly one element,
+    and the two to different ones.
+    """
+    figure = make_subplots(rows=1, cols=2, specs=[[{"type": "polar"}] * 2])
+    figure.add_trace(go.Scatterpolar(r=[3, 9, 5], theta=SPOKES[:3]), row=1, col=1)
+    figure.add_trace(go.Scatterpolar(r=[2, 6, 4], theta=SPOKES[:3]), row=1, col=2)
+
+    first, second = _layers(figure)
+
+    assert first["selectors"] == [
+        ".polarlayer > g.polar .scatterlayer .trace:nth-child(1) path.js-line"
+    ]
+    assert second["selectors"] == [
+        ".polarlayer > g.polar2 .scatterlayer .trace:nth-child(1) path.js-line"
+    ]
+
+
+def test_a_second_subplot_numbers_its_traces_from_one() -> None:
+    """The position is a place in one `.scatterlayer`, not in the figure.
+
+    A running counter across every polar trace gave the second subplot's
+    only radar `nth-child(2)`, which resolves to nothing inside its own
+    group. Measured on this figure: `g.polar2 ... nth-child(1)` and
+    `nth-child(2)` are the two radars of that subplot, and the barpolar
+    between them shifts neither -- it draws into `g.polar2`'s `.barlayer`.
+    """
+    figure = make_subplots(rows=1, cols=2, specs=[[{"type": "polar"}] * 2])
+    figure.add_trace(go.Scatterpolar(r=[3, 9, 5], theta=SPOKES[:3]), row=1, col=1)
+    figure.add_trace(go.Scatterpolar(r=[2, 6, 4], theta=SPOKES[:3]), row=1, col=2)
+    figure.add_trace(go.Barpolar(r=[1, 4, 8], theta=SPOKES[:3]), row=1, col=2)
+    figure.add_trace(go.Scatterpolar(r=[7, 8, 9], theta=SPOKES[:3]), row=1, col=2)
+
+    left, right_first, _bars, right_second = _layers(figure)
+
+    assert "g.polar .scatterlayer .trace:nth-child(1)" in left["selectors"][0]
+    assert "g.polar2 .scatterlayer .trace:nth-child(1)" in right_first["selectors"][0]
+    assert "g.polar2 .scatterlayer .trace:nth-child(2)" in right_second["selectors"][0]
+
+
+def test_each_polar_subplot_is_named_from_its_own_layout_block() -> None:
+    """`layout.polar2` is the second chart's, and only its own.
+
+    The titles were read from `layout.polar` for every polar trace, so the
+    second subplot announced the first one's radial name -- a wrong word
+    rather than a missing one, which a reader has no way to catch.
+    """
+    figure = make_subplots(rows=1, cols=2, specs=[[{"type": "polar"}] * 2])
+    figure.add_trace(go.Scatterpolar(r=[3, 9, 5], theta=SPOKES[:3]), row=1, col=1)
+    figure.add_trace(go.Scatterpolar(r=[2, 6, 4], theta=SPOKES[:3]), row=1, col=2)
+    figure.update_layout(
+        polar={"radialaxis": {"title": "Left R"}},
+        polar2={"radialaxis": {"title": "Right R"}},
+    )
+
+    first, second = _layers(figure)
+
+    assert first["axes"]["y"]["label"] == "Left R"
+    assert second["axes"]["y"]["label"] == "Right R"

--- a/tests/plotly/test_plotly_polar.py
+++ b/tests/plotly/test_plotly_polar.py
@@ -1,0 +1,205 @@
+"""Plotly's two polar traces produced figures with no layers.
+
+`go.Scatterpolar` and `go.Barpolar` draw spokes around a circle -- one
+radius per angle -- and the core builds both on `RadarTrace`: a radar joins
+the spokes into an outline, a polar area fills the wedge between them, and a
+reader navigates the same spokes either way. `maidr/plotly/` had no handling
+for either, so both fell through `_extract_plots` to `PlotlyPlotFactory`,
+which returned `None` (#627). The core has drawn them since
+xability/maidr#833.
+
+The payload is a line's -- a list of *series*, each a list of points --
+because that is what `RadarTrace` extends. So is the selector contract, and
+that is what decides how far this goes: `LineTrace.mapToSvgElements`
+compares `selectors.length` against the **series** count, not the point
+count.
+
+Measured in Chromium:
+
+  * a `scatterpolar` draws exactly one `path.js-line` per trace, inside its
+    own `.polarlayer .scatterlayer .trace` -- one element for one series,
+    which is the shape the contract wants.
+  * a `barpolar` draws no per-series path at all: four bars for four spokes,
+    under `.polarlayer .barlayer`. Four selectors would be read as four
+    series, and the one selector its single series is allowed would have to
+    point at the whole `.trace.bars` group, which outlines every bar at once
+    and so highlights the same thing at every step of the walk.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+SPOKES = ["N", "E", "S", "W"]
+RADII = [3, 9, 5, 1]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _spokes(layer: dict) -> list[tuple]:
+    """The one series' spokes as ``(angle, radius)``."""
+    return [(point["x"], point["y"]) for point in layer["data"][0]]
+
+
+def test_a_scatterpolar_is_read_as_a_radar() -> None:
+    """The reproduction, and the type it becomes."""
+    (layer,) = _layers(
+        go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES, fill="toself")])
+    )
+
+    assert layer["type"] == PlotType.RADAR
+
+
+def test_a_barpolar_is_read_as_a_polar_area() -> None:
+    """The other painting of the same spokes."""
+    (layer,) = _layers(go.Figure([go.Barpolar(r=RADII, theta=SPOKES)]))
+
+    assert layer["type"] == PlotType.POLAR_AREA
+
+
+@pytest.mark.parametrize("cls", [go.Scatterpolar, go.Barpolar])
+def test_theta_is_the_angle_and_r_the_radius(cls) -> None:
+    """Not `x` and `y`, which a polar trace does not carry at all.
+
+    Reading the pair off the wrong keys would give an empty layer, and
+    reading them the wrong way round would put the angle where the magnitude
+    belongs -- no number to pitch, and the announcement inverted.
+    """
+    (layer,) = _layers(go.Figure([cls(r=RADII, theta=SPOKES)]))
+
+    assert _spokes(layer) == list(zip(SPOKES, RADII))
+
+
+def test_the_series_is_wrapped_for_the_list_of_series_shape() -> None:
+    """`RadarTrace` extends the line trace, so `data` is a list of series.
+
+    Shipping the spokes one level too shallow would have the frontend read
+    the whole chart as a single series of one point.
+    """
+    (layer,) = _layers(go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES)]))
+
+    assert len(layer["data"]) == 1
+    assert len(layer["data"][0]) == len(SPOKES)
+
+
+def test_a_spoke_with_no_radius_is_dropped() -> None:
+    """Plotly draws nothing for it, and the gap would rotate the rest.
+
+    `RadarTrace` places its spokes at an equal share of the circle by
+    *count*, so keeping an empty one would move every later spoke's angle --
+    and the panning with it.
+    """
+    (layer,) = _layers(
+        go.Figure([go.Scatterpolar(r=[3, None, 5], theta=["N", "E", "S"])])
+    )
+
+    assert _spokes(layer) == [("N", 3), ("S", 5)]
+
+
+def test_a_radar_addresses_its_outline() -> None:
+    """One selector for one series, which is what the contract wants.
+
+    Measured: a scatterpolar draws exactly one `path.js-line` per trace.
+    """
+    (layer,) = _layers(go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES)]))
+
+    assert layer["selectors"] == [
+        ".polarlayer .scatterlayer .trace:nth-child(1) path.js-line"
+    ]
+
+
+def test_a_polar_area_is_read_but_not_addressed() -> None:
+    """A stated limit, not an oversight.
+
+    A barpolar draws one bar per spoke and no per-series path. Four
+    selectors would be read as four series; the single selector its one
+    series is allowed would have to name the whole `.trace.bars` group,
+    which outlines every bar at once and highlights the same thing at every
+    step. Neither answers "where am I", so the layer ships without a
+    highlight and keeps its audio, braille and text -- the outcome #145
+    established for a layer with nothing to point at.
+    """
+    (layer,) = _layers(go.Figure([go.Barpolar(r=RADII, theta=SPOKES)]))
+
+    assert "selectors" not in layer
+    assert _spokes(layer) == list(zip(SPOKES, RADII))
+
+
+def test_a_barpolar_does_not_shift_a_radar_position() -> None:
+    """They are drawn into different layers.
+
+    A `scatterpolar` is numbered among the polar *scatter* traces, because
+    that is what the `.polarlayer .scatterlayer` groups hold. Measured on
+    `[radar, bars, radar]`: the second radar's `nth-child(2)` resolved to
+    its own outline.
+    """
+    first, _bars, second = _layers(
+        go.Figure(
+            [
+                go.Scatterpolar(r=[3, 9, 5], theta=["N", "E", "S"], name="a"),
+                go.Barpolar(r=[1, 4, 8], theta=["N", "E", "S"], name="bars"),
+                go.Scatterpolar(r=[2, 6, 4], theta=["N", "E", "S"], name="b"),
+            ]
+        )
+    )
+
+    assert "nth-child(1)" in first["selectors"][0]
+    assert "nth-child(2)" in second["selectors"][0]
+
+
+def test_the_radius_is_named_from_the_polar_layout() -> None:
+    """Plotly names it under `layout.polar`, not `xaxis`/`yaxis`.
+
+    A polar chart has no cartesian axes to borrow from, so reading the
+    cartesian pair would take another trace's titles or the generic
+    fallback where the author had in fact named this one.
+    """
+    figure = go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES)])
+    figure.update_layout(polar={"radialaxis": {"title": {"text": "Speed"}}})
+
+    (layer,) = _layers(figure)
+
+    assert layer["axes"]["y"]["label"] == "Speed"
+
+
+def test_the_angle_has_no_title_to_read() -> None:
+    """`angularaxis` does not have the property at all.
+
+    Measured: plotly rejects it outright -- *"Invalid property specified for
+    object of type plotly.graph_objs.layout.polar.AngularAxis: 'title'"* --
+    and `'title' in AngularAxis._valid_props` is False while the radial
+    axis's is True. So the angle always takes the generic word, and reading
+    a title off it would be reading a key plotly never writes.
+    """
+    from plotly.graph_objs.layout.polar import AngularAxis, RadialAxis
+
+    assert "title" not in AngularAxis._valid_props
+    assert "title" in RadialAxis._valid_props
+
+    figure = go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES)])
+    figure.update_layout(polar={"radialaxis": {"title": {"text": "Speed"}}})
+
+    (layer,) = _layers(figure)
+
+    assert layer["axes"]["x"]["label"] == "Angle"
+
+
+def test_unnamed_polar_axes_fall_back_to_the_generic_pair() -> None:
+    """The control: the fallback must not overwrite a stated title."""
+    (layer,) = _layers(go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES)]))
+
+    assert layer["axes"]["x"]["label"] == "Angle"
+    assert layer["axes"]["y"]["label"] == "Radius"


### PR DESCRIPTION
Seventh tranche of #627. Eleven of the fifteen now read.

## What was wrong

```python
go.Scatterpolar(r=[3, 9, 5, 1], theta=["N", "E", "S", "W"])   ->   layers: []
go.Barpolar(r=[3, 9, 5, 1], theta=["N", "E", "S", "W"])       ->   layers: []
```

Both draw spokes around a circle, and the core builds both on `RadarTrace` — a radar joins the spokes into an outline, a polar area fills the wedge between them, and a reader navigates the same spokes either way. Drawn since xability/maidr#833.

## The pair a polar trace states

`theta` is the angle and `r` the radius. There is no `x` or `y` on the trace at all, so reading the cartesian pair would give an empty layer and reading them the wrong way round would put the angle where the magnitude belongs.

A spoke with no radius is dropped. Plotly draws nothing for it, and `RadarTrace` places its spokes at an equal share of the circle **by count** — so keeping a gap would rotate every later spoke, and the stereo panning with it.

The payload is a line's, a list of series, because that is what `RadarTrace` extends.

## Why the barpolar gets no selector

So is the *selector* contract, and that is what decides how far this goes: `LineTrace.mapToSvgElements` compares `selectors.length` against the **series** count, not the point count.

Measured in Chromium:

| trace | drawn |
|---|---|
| `scatterpolar` | one `path.js-line` per trace, inside its own `.polarlayer .scatterlayer .trace` |
| `barpolar` | no per-series path at all — four bars for four spokes, under `.polarlayer .barlayer` |

For a radar that is exactly one element for one series. For a polar area there is nothing that fits: four selectors would be read as four *series*, and the one selector its single series is allowed would have to name the whole `.trace.bars` group, which outlines every bar at once and so highlights the same thing at every step of the walk. Neither answers "where am I", so the layer ships without a highlight and keeps its audio, braille and text — the outcome #145 established for a layer with nothing to point at.

Verified on `[radar, bars, radar]`, which also pins that a barpolar does not shift a radar's position (they are numbered among the polar *scatter* traces, since that is what `scatterlayer` holds):

```
OK  RADAR       series=1 resolved=1   .polarlayer .scatterlayer .trace:nth-child(1) path.js-line
--  POLAR_AREA  no selector (as designed)
OK  RADAR       series=1 resolved=1   .polarlayer .scatterlayer .trace:nth-child(2) path.js-line
```

## Two things I got wrong first, and how

**The angular axis has no title.** I wrote `_extract_axes_data` to read `layout.polar.angularaxis.title` alongside the radial one. Plotly rejects it outright — *"Invalid property specified for object of type plotly.graph_objs.layout.polar.AngularAxis: 'title'"* — and `'title' in AngularAxis._valid_props` is False while the radial axis's is True. The test I wrote for the assumption failed rather than the code, which is the order I want it in. The angle now always takes the generic word, with the measurement in the docstring.

**`POLAR_AREA` had no `display_name`.** The existing guard in `test_areaplot.py` caught it on the full-suite run: without the override a user who wrote `go.Barpolar` would be told **"polar_area"** — a schema token — in the same sentence as "stacked bar". That test exists for exactly this class of mistake, and this is the first multi-word type added since it was written.

## Tests

`tests/plotly/test_plotly_polar.py` — 12 tests: each trace read as its own type, `theta`/`r` parametrised over both, the list-of-series wrapping, the dropped spoke, the radar selector, the polar area read-but-unaddressed, the barpolar not shifting a radar's position, the radial title, the angular axis having no title to read, and the generic fallback.

Mutation-swept, eight mutations one at a time against a restored baseline, all caught:

```
M1  x/y read instead of theta/r        5 failed, 7 passed
M2  angle and radius swapped           4 failed, 8 passed
M3  series wrapping dropped            5 failed, 7 passed
M4  empty radius kept                  1 failed, 11 passed
M5  barpolar gets a selector           1 failed, 11 passed
M6  radial title ignored               1 failed, 11 passed
M7  barpolar shifts the radar position 1 failed, 11 passed
M8  _extract_plots block dropped       1 failed, 11 passed
```

Full suite in two batches (the whole run OOMs in this container): `tests/core` 1931 passed, 5 skipped; the rest 1235 passed, 13 skipped.

## Remaining on #627

`parcats`, `parcoords`, `contour`, `histogram2dcontour`, `histogram2d`, `choropleth`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_