### PR TITLE
feat(plotly): read a parallel coordinates trace

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -93,6 +93,12 @@ class PlotType(str, Enum):
     #: rather than the count, so that is what the core pitches. The counts
     #: are announced alongside it.
     FUNNEL = "funnel"
+    #: One polyline per observation crossing a row of vertical axes, each a
+    #: different variable. Structurally a multi-line layer, which is what the
+    #: core builds it on -- and a distinct type for the one thing that makes
+    #: the chart legible: the columns are not one scale, so a value is
+    #: pitched against *its own* axis rather than against the layer.
+    PARALLEL = "parallel_coordinates"
     #: A starting value carried to an ending value through a sequence of
     #: signed contributions, each bar floating between the running total
     #: before it and the running total after it. A distinct type from `BAR`
@@ -134,6 +140,7 @@ _DISPLAY_NAMES = {
     PlotType.STACKED: "stacked bar",
     PlotType.STACKED_AREA: "stacked area",
     PlotType.NORMALIZED_AREA: "100% stacked area",
+    PlotType.PARALLEL: "parallel coordinates",
     PlotType.POLAR_AREA: "polar area",
     PlotType.VIOLIN_BOX: "violin",
     PlotType.VIOLIN_KDE: "violin",

--- a/maidr/plotly/parcoords.py
+++ b/maidr/plotly/parcoords.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+#: What the columns are, and what the numbers on them are. A parallel
+#: coordinates plot draws no cartesian axes, so neither name can be read off
+#: the layout -- and these are the trace's own vocabulary: `ParallelTrace`
+#: holds an `axisMin`/`axisMax` per column and asks where each value sits on
+#: *its own axis*.
+_AXIS_FALLBACKS = ("Axis", "Value")
+
+
+class PlotlyParcoordsPlot(PlotlyPlot):
+    """Extract data from a Plotly ``parcoords`` trace.
+
+    One polyline per observation crossing a row of vertical axes, each axis a
+    different variable. The core builds `ParallelTrace` on `LineTrace`, so the
+    payload is a line's -- a list of series, each a list of
+    ``{x: axis name, y: value}`` -- and navigation, braille and text all
+    transfer.
+
+    What the trace adds is the reason the chart exists: **the columns are not
+    one scale.** Miles per gallon beside horsepower beside weight share
+    nothing except each value's position within its own axis, so
+    `ParallelTrace` pitches each column against its own extent. That is a
+    property of the trace type rather than of this payload -- all this has to
+    do is hand over the columns in the order they are drawn, and name them.
+    """
+
+    def __init__(self, trace: dict, layout: dict, **kwargs: str) -> None:
+        super().__init__(trace, layout, PlotType.PARALLEL, **kwargs)
+
+    def _get_selector(self) -> list[str]:
+        """No selector: plotly draws the observations to a WebGL canvas.
+
+        Measured in Chromium on a two-axis ``go.Parcoords``: the page holds
+        three ``<canvas>`` elements and the ``.parcoords`` group contains two
+        ``<path>`` elements, neither of them an observation -- the axes, their
+        ticks and their brush handles are the only SVG the chart draws.
+
+        There is therefore nothing to point at. A `ParallelTrace` resolves one
+        selector per observation, and no element in the document corresponds
+        to one, so the layer ships without a highlight and keeps its audio,
+        braille and text -- the outcome #145 established for a layer with
+        nothing to point at.
+        """
+        return []
+
+    def _extract_axes_data(self) -> dict:
+        """Name the columns and the numbers on them.
+
+        A ``parcoords`` has no cartesian axes, so ``layout.xaxis`` holds
+        neither name -- reading it would take some other trace's titles, or
+        the generic fallback where the author had in fact named these. Each
+        column carries its own name on the point, which is what a reader is
+        told when they arrive at it; these two say what those names and those
+        numbers *are*.
+        """
+        x_label, y_label = _AXIS_FALLBACKS
+        return {
+            MaidrKey.X: self._axis_config(label=x_label),
+            MaidrKey.Y: self._axis_config(label=y_label),
+        }
+
+    def _extract_plot_data(self) -> list[list[dict]]:
+        """One series per observation, across the axes the chart draws.
+
+        Two things decide which values are in it, and both were measured
+        rather than assumed:
+
+        * **A hidden dimension is not a column.** ``visible: False`` makes
+          plotly draw no axis for it -- measured, the drawn axis titles were
+          ``["A", "B"]`` with the middle dimension hidden -- so including it
+          would announce a variable that is not on the chart.
+        * **Ragged dimensions are truncated to the shortest.** Given columns
+          of 3 and 2 values, plotly reported ``_length: 2`` for *both* and
+          scaled the longer axis to its first two values only. So the third
+          observation is not drawn at all, and reading it would announce a
+          line that is not there.
+        """
+        columns = [
+            dimension
+            for dimension in as_list(self._trace.get("dimensions"))
+            if isinstance(dimension, dict) and dimension.get("visible") is not False
+        ]
+        if not columns:
+            return []
+
+        values = [as_list(column.get("values")) for column in columns]
+        rows = min(len(column) for column in values)
+        if rows == 0:
+            return []
+
+        labels = [_column_name(column, index) for index, column in enumerate(columns)]
+        return [
+            [
+                {
+                    MaidrKey.X: label,
+                    MaidrKey.Y: self._to_native(column[row]),
+                }
+                for label, column in zip(labels, values)
+            ]
+            for row in range(rows)
+        ]
+
+
+def is_parcoords_trace(trace: dict) -> bool:
+    """Report whether a trace is a parallel coordinates plot."""
+    return trace.get("type") == "parcoords"
+
+
+def _column_name(dimension: dict, index: int) -> str:
+    """Name one axis, falling back to its position when the author named none.
+
+    ``label`` is optional and may be written empty, and plotly draws an
+    unnamed axis with a blank title. A blank name reaches the reader as the
+    one thing they cannot navigate by, so the position stands in -- the same
+    answer a `dotchart` with no labels gives.
+    """
+    label = dimension.get("label")
+    if label is None:
+        return str(index + 1)
+    label = str(label)
+    return label if label else str(index + 1)

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -958,9 +958,9 @@ class PlotlyMaidr:
             # Parallel coordinates, one layer each. Placed by its own
             # `domain` rectangle like a pie, because a `parcoords` names no
             # axis pair either.
-            parcoords_traces = [
-                t for t in group_traces if t.get("type") == "parcoords"
-            ]
+            from maidr.plotly.parcoords import is_parcoords_trace
+
+            parcoords_traces = [t for t in group_traces if is_parcoords_trace(t)]
             if parcoords_traces:
                 from maidr.plotly.parcoords import PlotlyParcoordsPlot
 

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -69,7 +69,16 @@ from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_plotly
 #:
 #: Add a type here when maidr learns to render it, not before.
 _PLACED_BY_DOMAIN = frozenset(
-    {"pie", "funnelarea", "indicator", "treemap", "sunburst", "icicle", "sankey"}
+    {
+        "pie",
+        "funnelarea",
+        "indicator",
+        "treemap",
+        "sunburst",
+        "icicle",
+        "sankey",
+        "parcoords",
+    }
 )
 
 
@@ -945,6 +954,29 @@ class PlotlyMaidr:
                     plot.col_index = polar_col
                     self._plots.append(plot)
                 merged.update(id(t) for t in polar_traces)
+
+            # Parallel coordinates, one layer each. Placed by its own
+            # `domain` rectangle like a pie, because a `parcoords` names no
+            # axis pair either.
+            parcoords_traces = [
+                t for t in group_traces if t.get("type") == "parcoords"
+            ]
+            if parcoords_traces:
+                from maidr.plotly.parcoords import PlotlyParcoordsPlot
+
+                for parcoords_trace in parcoords_traces:
+                    plot = PlotlyParcoordsPlot(
+                        parcoords_trace,
+                        layout,
+                        **axis_kwargs,
+                    )
+                    plot.row_index, plot.col_index = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._trace_domain_start(parcoords_trace),
+                    )
+                    self._plots.append(plot)
+                merged.update(id(t) for t in parcoords_traces)
 
             # Sankeys, one layer each. Only this loop knows whether the
             # figure holds a second one, which is what decides whether

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -435,9 +435,15 @@ class TestPlotlyUnrenderedDomainTraces:
             pytest.param(
                 go.Treemap(labels=["a", "b"], parents=["", ""]), id="treemap"
             ),
+            # A categorical parallel-sets diagram. `go.Parcoords` sat here
+            # until #627's parallel tranche made it render; `go.Parcats` is
+            # the same kind of trace and is still unread, so it keeps the
+            # row honest.
             pytest.param(
-                go.Parcoords(dimensions=[{"label": "A", "values": [1, 2]}]),
-                id="parcoords",
+                go.Parcats(
+                    dimensions=[{"label": "A", "values": ["x", "y"]}],
+                ),
+                id="parcats",
             ),
             # A `mode="number"` indicator only. One that draws a dial *is*
             # rendered as of #627's gauge tranche, so it takes a cell like
@@ -470,6 +476,25 @@ class TestPlotlyUnrenderedDomainTraces:
         )
         fig.add_trace(
             go.Treemap(labels=["r", "a"], parents=["", "r"], values=[3, 1]),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+        assert self._cells(fig) == [(0, 0), (0, 1)]
+
+    def test_a_parallel_coordinates_plot_does_take_a_cell(self):
+        # The counterpart to the `parcats` row above, and the reason that row
+        # had to change: a `go.Parcoords` is a domain trace maidr *does* draw
+        # a layer for as of #627's parallel tranche, so its rectangle joins
+        # the column universe and the bar beside it keeps column 1.
+        from plotly.subplots import make_subplots
+
+        fig = make_subplots(
+            rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]]
+        )
+        fig.add_trace(
+            go.Parcoords(dimensions=[{"label": "A", "values": [1, 2]}]),
             row=1,
             col=1,
         )

--- a/tests/plotly/test_plotly_parcoords.py
+++ b/tests/plotly/test_plotly_parcoords.py
@@ -1,0 +1,214 @@
+"""A plotly parallel coordinates plot produced a figure with no layers.
+
+`go.Parcoords` draws one polyline per observation crossing a row of vertical
+axes, each axis a different variable. `maidr/plotly/` had no handling for it,
+so it fell through `_extract_plots` to `PlotlyPlotFactory`, which returned
+`None` (#627). The core has drawn it since xability/maidr's
+`TraceType.PARALLEL`.
+
+The payload is a line's -- a list of series, each a list of points -- because
+`ParallelTrace` extends `LineTrace`. What the trace adds is the reason the
+chart exists: the columns are not one scale, so a value is pitched against
+*its own* axis rather than against the layer. Nothing here has to arrange
+that; it only has to hand over the columns in the order they are drawn, and
+name them.
+
+Measured in Chromium, which decided two things this file asserts:
+
+  * **There is nothing to highlight.** A two-axis `go.Parcoords` renders its
+    observations to WebGL: the page holds three `<canvas>` elements, and the
+    two `<path>`s inside `.parcoords` are axis furniture rather than
+    observations.
+  * **plotly truncates ragged dimensions.** Given columns of 3 and 2 values,
+    `gd._fullData[0].dimensions` reported `_length: 2` for *both*, and the
+    longer axis was scaled to its first two values. The third observation is
+    not drawn at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+CARS = [
+    {"label": "MPG", "values": [21.0, 22.8, 18.7]},
+    {"label": "HP", "values": [110, 93, 175]},
+    {"label": "Weight", "values": [2.62, 2.32, 3.44]},
+]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _rows(layer: dict) -> list[list[tuple]]:
+    """Each observation as ``(axis name, value)`` pairs."""
+    return [[(point["x"], point["y"]) for point in row] for row in layer["data"]]
+
+
+def test_a_parcoords_is_read_as_a_parallel_coordinates_layer() -> None:
+    """The reproduction, and the type it becomes."""
+    (layer,) = _layers(go.Figure([go.Parcoords(dimensions=CARS)]))
+
+    assert layer["type"] is PlotType.PARALLEL
+
+
+def test_an_observation_is_a_series_across_the_axes() -> None:
+    """The payload a `LineTrace` takes, transposed out of the columns.
+
+    plotly declares a parcoords by *column* -- one `dimensions` entry per
+    variable, each holding every observation's value -- and the core reads it
+    by *row*, one series per polyline. Getting this transposed would announce
+    three observations of one variable as one observation of three.
+    """
+    (layer,) = _layers(go.Figure([go.Parcoords(dimensions=CARS)]))
+
+    assert _rows(layer) == [
+        [("MPG", 21.0), ("HP", 110), ("Weight", 2.62)],
+        [("MPG", 22.8), ("HP", 93), ("Weight", 2.32)],
+        [("MPG", 18.7), ("HP", 175), ("Weight", 3.44)],
+    ]
+
+
+def test_each_point_names_the_axis_it_sits_on() -> None:
+    """What a reader is told on arriving at a value.
+
+    The axis name is per *point*, not per layer, because that is the whole
+    difference from a line chart: a line's columns are samples of one
+    quantity and a parallel plot's are different quantities entirely.
+    """
+    (layer,) = _layers(go.Figure([go.Parcoords(dimensions=CARS)]))
+
+    assert [point["x"] for point in layer["data"][0]] == ["MPG", "HP", "Weight"]
+
+
+def test_a_hidden_dimension_is_not_a_column() -> None:
+    """`visible: False` draws no axis, so announcing it invents one.
+
+    Measured: with the middle dimension hidden, the drawn axis titles were
+    `["A", "B"]` and `gd._fullData[0].dimensions[1]._length` was `null`. A
+    reader arrowing across would otherwise pass through a variable that is
+    not on the chart.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Parcoords(
+                    dimensions=[
+                        {"label": "A", "values": [1, 2]},
+                        {"label": "Hidden", "values": [7, 8], "visible": False},
+                        {"label": "B", "values": [3, 4]},
+                    ]
+                )
+            ]
+        )
+    )
+
+    assert _rows(layer) == [[("A", 1), ("B", 3)], [("A", 2), ("B", 4)]]
+
+
+def test_ragged_dimensions_are_read_to_the_shortest() -> None:
+    """Which is what plotly draws, not a defensive choice.
+
+    Measured on columns of 3 and 2 values: `_length` came back as 2 for
+    *both* dimensions and the longer axis was scaled to its first two values.
+    The third observation has no line, so emitting it would announce one that
+    is not there.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Parcoords(
+                    dimensions=[
+                        {"label": "A", "values": [1, 2, 3]},
+                        {"label": "B", "values": [4, 5]},
+                    ]
+                )
+            ]
+        )
+    )
+
+    assert _rows(layer) == [[("A", 1), ("B", 4)], [("A", 2), ("B", 5)]]
+
+
+def test_an_unnamed_axis_is_navigable_by_its_position() -> None:
+    """plotly draws it with a blank title, which a reader cannot navigate by.
+
+    The same answer a `dotchart` with no labels gives: positions are not
+    names, but a reader with nothing at all cannot tell one axis from the
+    next. Both spellings of "unnamed" are covered -- absent and empty --
+    because plotly accepts either.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Parcoords(
+                    dimensions=[
+                        {"values": [1, 2]},
+                        {"label": "", "values": [3, 4]},
+                        {"label": "C", "values": [5, 6]},
+                    ]
+                )
+            ]
+        )
+    )
+
+    assert [point["x"] for point in layer["data"][0]] == ["1", "2", "C"]
+
+
+def test_the_axes_say_what_the_names_and_the_numbers_are() -> None:
+    """A parcoords draws no cartesian axes, so neither name is in the layout.
+
+    Reading `layout.xaxis` would take some other trace's titles, or the
+    generic fallback where the author had in fact named these. The words are
+    the trace's own vocabulary: `ParallelTrace` asks where a value sits on
+    its own *axis*.
+    """
+    (layer,) = _layers(go.Figure([go.Parcoords(dimensions=CARS)]))
+
+    assert layer["axes"]["x"]["label"] == "Axis"
+    assert layer["axes"]["y"]["label"] == "Value"
+
+
+def test_a_parcoords_is_read_but_not_addressed() -> None:
+    """A stated limit, not an oversight.
+
+    plotly renders the observations to WebGL -- measured, three `<canvas>`
+    elements and no per-observation SVG element. A `ParallelTrace` resolves
+    one selector per observation and there is nothing in the document that is
+    one, so the layer ships without a highlight and keeps its audio, braille
+    and text: the outcome #145 established for a layer with nothing to point
+    at.
+    """
+    (layer,) = _layers(go.Figure([go.Parcoords(dimensions=CARS)]))
+
+    assert "selectors" not in layer
+
+
+def test_a_parcoords_with_no_columns_carries_no_observations() -> None:
+    """Nothing is drawn, so there is nothing to read.
+
+    The layer itself still reaches the schema with an empty payload, which is
+    the #421 ghost -- and *not* something this trace type introduced: an
+    empty `go.Pie`, `go.Sankey` and `go.Scatterpolar` each emit one too,
+    because the `draws_marks()` guard that filters an empty scatter only
+    covers the line and area families. Filed separately rather than patched
+    here, so the four are fixed in one place; this pins what the payload is
+    meanwhile.
+    """
+    for empty in (
+        go.Parcoords(dimensions=[]),
+        go.Parcoords(dimensions=[{"label": "A"}]),
+    ):
+        (layer,) = _layers(go.Figure([empty]))
+        assert layer["data"] == []


### PR DESCRIPTION
Closes part of #627.

`go.Parcoords` draws one polyline per observation across a row of vertical
axes, each axis a different variable. It fell through `_extract_plots` to
`PlotlyPlotFactory`, which returned `None`, so the figure had **no layers at
all**. The core has had `TraceType.PARALLEL` for this shape.

## The reading

The payload is a line's, because `ParallelTrace` extends `LineTrace`: a list
of series, each a list of `{x: axis name, y: value}`.

plotly declares the chart by **column** — one `dimensions` entry per
variable, each holding every observation's value — and the core reads it by
**row**, one series per polyline. So the transpose happens here:

```python
go.Parcoords(dimensions=[
    {"label": "MPG",    "values": [21.0, 22.8, 18.7]},
    {"label": "HP",     "values": [110, 93, 175]},
    {"label": "Weight", "values": [2.62, 2.32, 3.44]},
])
```
becomes
```json
[[{"x":"MPG","y":21.0},  {"x":"HP","y":110}, {"x":"Weight","y":2.62}],
 [{"x":"MPG","y":22.8},  {"x":"HP","y":93},  {"x":"Weight","y":2.32}],
 [{"x":"MPG","y":18.7},  {"x":"HP","y":175}, {"x":"Weight","y":3.44}]]
```

The axis name is per **point**, not per layer, because that is the whole
difference from a line chart: a line's columns are samples of one quantity
and a parallel plot's are different quantities entirely. `ParallelTrace`
pitches each value against its own column's extent — nothing here has to
arrange that, only hand the columns over in the order they are drawn and
name them.

## Measured, not assumed

Three answers came out of Chromium rather than out of the plotly docs:

| Question | Measurement | Consequence |
|---|---|---|
| Does a `visible: False` dimension count? | drawn axis titles were `["A", "B"]` with the middle one hidden; its `_length` was `null` | excluded — otherwise a variable not on the chart gets announced |
| What does plotly do with ragged columns? | given 3 and 2 values, `_length` came back as **2 for both**, and the longer axis was scaled to its first two values | read to the shortest — the third observation has no line |
| Is there anything to highlight? | three `<canvas>` elements; the two `<path>`s inside `.parcoords` are axis furniture | **no selector** |

The last is the #145 outcome, the same call as the barpolar in #635: a
`ParallelTrace` resolves one selector per observation, no element in the
document is one, so the layer ships without a highlight and keeps its audio,
braille and text.

## Grid placement

`parcoords` joins `_PLACED_BY_DOMAIN`. It is placed by its own `domain`
rectangle like a pie, and now that maidr renders it, its rectangle belongs in
the figure's column universe — otherwise a cartesian subplot beside it would
sit in the wrong column.

That is also why one existing test had to move: `go.Parcoords` was the
control in `TestPlotlyUnrenderedDomainTraces` for "a domain trace maidr draws
no layer for", which it no longer is. `go.Parcats` takes that row — unread,
and the same kind of trace — and a new test asserts the counterpart, that a
parcoords *does* take a cell. Same shape as the `treemap`/`sunburst` swap in
#633 and the `indicator` swap in #632.

## One thing deliberately not fixed here

An empty `go.Parcoords` still emits a ghost layer with `data: []`. That is
not something this trace introduced — measured, an empty `go.Pie`,
`go.Sankey` and `go.Scatterpolar` each emit one too, because #421's
`draws_marks()` guard only covers the line and area families. Filed as
**#636** and to be fixed for all four in one place rather than patched into
a feature PR. A test here pins the current payload meanwhile.

## Verification

9 tests in `tests/plotly/test_plotly_parcoords.py`, plus the new grid test.

Mutation sweep — each reverted alone against a restored baseline:

| mutation | failures |
|---|---|
| keep a hidden dimension | 1 |
| read to the longest column | 1 |
| emit column-major instead of row-major | 5 |
| leave an unnamed axis blank | 1 |
| drop `parcoords` from `_PLACED_BY_DOMAIN` | 1 |
| emit a `.parcoords path` selector | 1 |
| all restored | 65/65 pass |

Full suite green in both batches — `tests/core` 1931 passed / 5 skipped,
`tests/plotly` 1066 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_