### PR TITLE
fix(plotly): drop a layer whose payload holds nothing

### DIFF
--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -137,6 +137,67 @@ _DOMAIN_TRACE_TYPES = frozenset(
 )
 
 
+def _carries_data(plot: Any) -> bool:
+    """Report whether a built plot has anything for a reader to navigate.
+
+    A trace that draws nothing forms no layer. #421 established that for the
+    line and area families, by excluding an undrawn trace from their groupings
+    with ``draws_marks()`` -- which does more than this, because it also keeps
+    the *positions* of the surviving series contiguous, something a later
+    filter cannot recover. Every other family appended unconditionally, so an
+    empty pie, sankey, hierarchy, polar or parcoords became a layer with an
+    empty payload (#636).
+
+    That is not a harmless no-op. It is a cell the reader can tab into and
+    find nothing in, and for the line-family types it is worse: `LineTrace`
+    dereferences an undefined point on an empty series and throws, which
+    propagates out of `Figure` and takes the whole render down
+    (xability/maidr#905). `ParallelTrace` and `RadarTrace` are both built on
+    it.
+
+    Asked of the *rendered* payload rather than of the trace, so one question
+    covers all three shapes maidr emits: a list of points, a list of series,
+    and a mapping. `plot.schema` is memoised, so this costs no extra work.
+
+    A mapping needs the extra step, because two of them look alike at the top
+    level and mean opposite things. A gauge's is
+    ``{"value": 0, "min": -1, "max": 1}`` -- a full reading whose first field
+    happens to be falsy -- and an empty heatmap's is ``{"points": []}``, a
+    field with nothing in it. So a mapping carries data when any of its values
+    is a scalar or a non-empty collection.
+
+    One level, deliberately. ``{"points": [[]]}`` -- a heatmap of one empty
+    row -- is kept, because recursing to decide that a nested structure is
+    "really" empty is guessing at a shape rather than reading it, and dropping
+    a layer that should have shipped is the more damaging of the two mistakes.
+
+    Parameters
+    ----------
+    plot : PlotlyPlot
+        A built plot.
+
+    Returns
+    -------
+    bool
+        True when the payload holds something for a reader to navigate. A
+        payload that is neither a list nor a mapping is kept, for the same
+        reason: an unfamiliar shape is not evidence of emptiness.
+    """
+    data = plot.schema.get(MaidrKey.DATA)
+    if isinstance(data, (list, tuple)):
+        return bool(data)
+    if isinstance(data, dict):
+        return any(_holds_something(value) for value in data.values())
+    return data is not None
+
+
+def _holds_something(value: Any) -> bool:
+    """Report whether one field of a mapping payload has anything in it."""
+    if isinstance(value, (list, tuple, dict)):
+        return bool(value)
+    return value is not None
+
+
 def _is_domain_trace(trace: dict) -> bool:
     """Report whether plotly places this trace by a domain rather than an axis.
 
@@ -1162,6 +1223,8 @@ class PlotlyMaidr:
                     plot.row_index = row
                     plot.col_index = col
                     self._plots.append(plot)
+
+        self._plots = [plot for plot in self._plots if _carries_data(plot)]
 
     def render(self, use_cdn: bool | Literal["auto"] = "auto") -> Tag:
         """Return the maidr plot inside an iframe.

--- a/tests/plotly/test_plotly_drawn_positions.py
+++ b/tests/plotly/test_plotly_drawn_positions.py
@@ -272,10 +272,17 @@ class TestATraceThatDrawsNothingFormsNoLayer:
         assert len(layers) == 1
         assert len(layers[0]["data"]) == 2
 
-    def test_a_bar_with_no_data_is_left_to_its_own_path(self):
-        # Bars are not scatter-family, so this exclusion does not reach them.
-        # Pinned so a later widening of the predicate is a deliberate choice
-        # rather than a side effect.
+    def test_a_bar_with_no_data_forms_no_layer_either(self):
+        # This exclusion is scatter-family only, so it never reached bars --
+        # and the assertion here used to be `len(layers) == 1`, pinned so that
+        # a later widening would be a deliberate choice rather than a side
+        # effect. #636 is that choice: an empty bar layer is the same ghost
+        # #421 named, and it is now dropped by payload rather than by family.
+        #
+        # The two answers are not interchangeable. `draws_marks()` still runs
+        # here, because it does something a later filter cannot: it keeps the
+        # *positions* of the surviving series contiguous. This only removes
+        # the layer that would otherwise ship empty.
         fig = go.Figure([go.Bar(x=[], y=[], name="a")])
         layers = PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
-        assert len(layers) == 1
+        assert layers == []

--- a/tests/plotly/test_plotly_empty_layers.py
+++ b/tests/plotly/test_plotly_empty_layers.py
@@ -1,0 +1,219 @@
+"""A trace that draws nothing formed a layer anyway, for most families.
+
+#421 established the rule -- a trace plotly draws nothing for forms no layer
+-- and implemented it where it mattered then, by excluding an undrawn trace
+from the line and area *groupings* with `draws_marks()`. Every other family's
+build block appended unconditionally, so an empty pie, sankey, hierarchy,
+polar or parcoords became a layer with an empty payload (#636).
+
+Measured before the fix, layers per figure:
+
+    empty pie          [[1]]
+    empty sankey       [[1]]
+    empty scatterpolar [[1]]
+    empty parcoords    [[1]]
+    empty scatter      [[0]]   <- the one that was filtered
+
+That is not a harmless no-op. It is a cell the reader can tab into and find
+nothing in, and for the line-family types it is worse: `LineTrace` throws on
+an empty series and takes the whole render down (xability/maidr#905).
+`ParallelTrace` and `RadarTrace` are both built on it.
+
+The fix is one guard on the rendered payload, after the build blocks, so
+every trace type reaches the same answer and a new one added later inherits
+it. `draws_marks()` stays where it is: it does something a later filter
+cannot, keeping the *positions* of the surviving series contiguous.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+EMPTY = [
+    pytest.param(go.Pie(labels=[], values=[]), id="pie"),
+    pytest.param(
+        go.Sankey(
+            node={"label": []},
+            link={"source": [], "target": [], "value": []},
+        ),
+        id="sankey",
+    ),
+    pytest.param(go.Scatterpolar(r=[], theta=[]), id="scatterpolar"),
+    pytest.param(go.Parcoords(dimensions=[]), id="parcoords"),
+    pytest.param(go.Treemap(labels=[], parents=[]), id="treemap"),
+    pytest.param(go.Bar(x=[], y=[]), id="bar"),
+    pytest.param(go.Scatter(x=[], y=[]), id="scatter"),
+    pytest.param(go.Histogram(), id="histogram"),
+    pytest.param(go.Heatmap(z=[]), id="heatmap"),
+]
+
+
+@pytest.mark.parametrize("trace", EMPTY)
+def test_a_trace_that_draws_nothing_forms_no_layer(trace) -> None:
+    """The whole point, across every family that reaches the guard.
+
+    `scatter` is in the list as the control: it was already filtered, by
+    #421's `draws_marks()`, and has to stay filtered -- the new guard must
+    not be the *only* thing keeping it out, or removing `draws_marks()` would
+    look harmless when it is not.
+    """
+    assert _layers(go.Figure([trace])) == []
+
+
+DRAWN = [
+    pytest.param(go.Pie(labels=["a", "b"], values=[1, 2]), id="pie"),
+    pytest.param(
+        go.Sankey(
+            node={"label": ["a", "b"]},
+            link={"source": [0], "target": [1], "value": [5]},
+        ),
+        id="sankey",
+    ),
+    pytest.param(go.Scatterpolar(r=[1, 2], theta=[0, 90]), id="scatterpolar"),
+    pytest.param(
+        go.Parcoords(dimensions=[{"label": "A", "values": [1, 2]}]), id="parcoords"
+    ),
+    pytest.param(
+        go.Treemap(labels=["r", "a"], parents=["", "r"], values=[3, 1]), id="treemap"
+    ),
+    pytest.param(go.Bar(x=["a"], y=[1]), id="bar"),
+    pytest.param(go.Scatter(x=[1], y=[2]), id="scatter"),
+    pytest.param(go.Heatmap(z=[[1, 2], [3, 4]]), id="heatmap"),
+]
+
+
+@pytest.mark.parametrize("trace", DRAWN)
+def test_a_trace_that_draws_something_still_forms_a_layer(trace) -> None:
+    """The controls. A guard this broad has to be shown not to overreach."""
+    assert len(_layers(go.Figure([trace]))) == 1
+
+
+def test_a_gauge_whose_every_number_is_zero_is_not_an_empty_payload() -> None:
+    """The case a naive truthiness test gets wrong.
+
+    A gauge's payload is a single *mapping* rather than a list, and every one
+    of its three fields is a number. Measured, a dial declared
+    `range=[0, 0]` with a reading of `0` emits
+    `{"value": 0.0, "min": 0.0, "max": 0.0}` -- three fields, all falsy, and a
+    complete reading of a chart the author asked for.
+
+    `any(bool(v) for v in data.values())` drops it. That is why the mapping
+    branch asks whether each field *holds something* rather than whether it is
+    truthy: a zero is a number, and silencing a correct chart is the exact
+    failure this guard exists to avoid causing.
+    """
+    figure = go.Figure(
+        [go.Indicator(mode="gauge+number", value=0, gauge={"axis": {"range": [0, 0]}})]
+    )
+
+    (layer,) = _layers(figure)
+
+    assert layer["data"]["value"] == 0
+
+
+#: Every plot type maidr builds for a plotly figure, with a drawn example.
+#: Kept exhaustive on purpose -- see the contract test below.
+EVERY_TYPE = [
+    pytest.param(go.Bar(x=["a"], y=[1]), id="bar"),
+    pytest.param(go.Scatter(x=[1], y=[2]), id="scatter"),
+    pytest.param(go.Pie(labels=["a"], values=[1]), id="pie"),
+    pytest.param(go.Heatmap(z=[[1, 2], [3, 4]]), id="heatmap"),
+    pytest.param(go.Histogram(x=[1, 2, 2, 3]), id="histogram"),
+    pytest.param(go.Box(y=[1, 2, 3]), id="box"),
+    pytest.param(go.Violin(y=[1, 2, 3]), id="violin"),
+    pytest.param(
+        go.Sankey(
+            node={"label": ["a", "b"]},
+            link={"source": [0], "target": [1], "value": [5]},
+        ),
+        id="sankey",
+    ),
+    pytest.param(
+        go.Treemap(labels=["r", "a"], parents=["", "r"], values=[3, 1]), id="treemap"
+    ),
+    pytest.param(
+        go.Indicator(mode="gauge+number", value=1, gauge={"axis": {"range": [0, 2]}}),
+        id="gauge",
+    ),
+    pytest.param(go.Scatterpolar(r=[1], theta=[0]), id="scatterpolar"),
+    pytest.param(
+        go.Parcoords(dimensions=[{"label": "A", "values": [1, 2]}]), id="parcoords"
+    ),
+    pytest.param(go.Funnel(y=["a", "b"], x=[10, 5]), id="funnel"),
+    pytest.param(go.Waterfall(x=["a"], y=[1]), id="waterfall"),
+    pytest.param(
+        go.Candlestick(x=[1], open=[1], high=[2], low=[0], close=[1.5]),
+        id="candlestick",
+    ),
+]
+
+
+@pytest.mark.parametrize("trace", EVERY_TYPE)
+def test_a_payload_is_one_of_the_shapes_the_guard_knows(trace) -> None:
+    """The contract the guard is written against, asserted rather than assumed.
+
+    Measured across every plot type maidr builds, a payload is one of exactly
+    three shapes: a list (thirteen of them), the gauge's
+    `{value, min, max}` mapping of numbers, and the heatmap's
+    `{points: [...]}`.
+
+    The guard handles a list and a mapping and *keeps* anything else, on the
+    grounds that an unfamiliar shape is not evidence of emptiness. That branch
+    is unreachable today, which is exactly why this test exists: a fourth
+    shape added later has to come with a decision about what empty means for
+    it, and this is where that decision gets asked for.
+    """
+    for layer in _layers(go.Figure([trace])):
+        data = layer["data"]
+        assert isinstance(data, (list, dict)), type(data)
+        if isinstance(data, dict):
+            assert all(
+                isinstance(value, (int, float, list)) for value in data.values()
+            ), data
+
+
+def test_a_heatmap_of_one_empty_row_is_kept() -> None:
+    """Where the guard deliberately stops.
+
+    `go.Heatmap(z=[[]])` renders as `{"points": [[]]}` -- a mapping whose one
+    field holds a non-empty list whose one entry is empty. Recursing to decide
+    that is "really" empty would be guessing at a shape rather than reading
+    it, and dropping a layer that should have shipped is the more damaging of
+    the two mistakes. One level, and this pins that boundary.
+    """
+    (layer,) = _layers(go.Figure([go.Heatmap(z=[[]])]))
+
+    assert layer["data"] == {"points": [[]]}
+
+
+def test_an_empty_trace_does_not_reserve_a_grid_cell() -> None:
+    """The consequence for a figure that holds a drawn chart beside it.
+
+    A dropped layer must not leave an empty cell behind for the reader to tab
+    through, which is the other half of what #421 was about.
+    """
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(rows=1, cols=2)
+    figure.add_trace(go.Scatter(x=[], y=[]), row=1, col=1)
+    figure.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert [layer["type"] for row in grid for cell in row for layer in cell["layers"]]
+    assert sum(len(cell.get("layers", [])) for row in grid for cell in row) == 1

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -66,6 +66,11 @@ def bins(fig) -> list[tuple[float, float, int]]:
     return [(d[low], d[high], d[count]) for d in layer["data"]]
 
 
+def layers(fig) -> list[dict]:
+    """Every layer of a single-subplot figure, which may now be none."""
+    return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+
+
 class TestOccupiedSpan:
     """The helper, in isolation."""
 
@@ -228,8 +233,13 @@ class TestBothCallersSeedTheShiftEquivalently:
 
 
 class TestNothingToAnnounce:
-    def test_a_window_holding_no_data_yields_no_bins(self):
+    def test_a_window_holding_no_data_forms_no_layer(self):
         # Every bin empty. Emitting them would announce a distribution made
         # entirely of gaps, none of which the chart draws an element for.
+        #
+        # This asserted `bins(fig) == []` until #636 -- an empty payload on a
+        # layer that still shipped. The layer is now dropped outright, which
+        # is the same judgement one step further: a cell holding no bins is a
+        # cell the reader can tab into and find nothing in.
         fig = go.Figure([go.Histogram(x=NARROW, xbins=dict(start=20, end=24, size=1))])
-        assert bins(fig) == []
+        assert layers(fig) == []

--- a/tests/plotly/test_plotly_histogram_orientation.py
+++ b/tests/plotly/test_plotly_histogram_orientation.py
@@ -231,16 +231,27 @@ class TestCategoricalHorizontal:
 
 
 class TestEmptyTrace:
-    """An orientation with nothing on it still declines rather than guessing."""
+    """An orientation with nothing on it still declines rather than guessing.
 
-    def test_a_trace_with_neither_array_yields_no_data(self):
-        assert only_layer(go.Figure([go.Histogram()]))["data"] == []
+    Both of these asserted `only_layer(fig)["data"] == []` until #636 -- an
+    empty payload on a layer that still shipped. The decision they are about
+    is unchanged: the extractor declines rather than announcing a
+    distribution the chart does not show. What changed is that a layer with
+    nothing in it no longer reaches the schema at all.
+    """
 
-    def test_an_explicit_orientation_pointing_at_an_absent_axis_yields_no_data(
+    @staticmethod
+    def _layers(fig) -> list[dict]:
+        return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+
+    def test_a_trace_with_neither_array_forms_no_layer(self):
+        assert self._layers(go.Figure([go.Histogram()])) == []
+
+    def test_an_explicit_orientation_pointing_at_an_absent_axis_forms_no_layer(
         self,
     ):
         # Plotly draws essentially nothing for this figure -- one empty entry
         # in calcdata -- so announcing the `x` sample instead would describe a
         # distribution the chart does not show.
         fig = go.Figure([go.Histogram(x=SAMPLE, orientation="h")])
-        assert only_layer(fig)["data"] == []
+        assert self._layers(fig) == []

--- a/tests/plotly/test_plotly_parcoords.py
+++ b/tests/plotly/test_plotly_parcoords.py
@@ -195,20 +195,18 @@ def test_a_parcoords_is_read_but_not_addressed() -> None:
     assert "selectors" not in layer
 
 
-def test_a_parcoords_with_no_columns_carries_no_observations() -> None:
+def test_a_parcoords_with_no_columns_forms_no_layer() -> None:
     """Nothing is drawn, so there is nothing to read.
 
-    The layer itself still reaches the schema with an empty payload, which is
-    the #421 ghost -- and *not* something this trace type introduced: an
-    empty `go.Pie`, `go.Sankey` and `go.Scatterpolar` each emit one too,
-    because the `draws_marks()` guard that filters an empty scatter only
-    covers the line and area families. Filed separately rather than patched
-    here, so the four are fixed in one place; this pins what the payload is
-    meanwhile.
+    This pinned the ghost payload when the parallel tranche landed -- the
+    layer still shipped with `data: []`, which #421 named as a cell the
+    reader can tab into and find nothing in. #636 drops it, and for this
+    trace it is not only untidy: `ParallelTrace` extends `LineTrace`, whose
+    `text` dereferences an undefined point on an empty series and throws,
+    taking the whole render down (xability/maidr#905).
     """
     for empty in (
         go.Parcoords(dimensions=[]),
         go.Parcoords(dimensions=[{"label": "A"}]),
     ):
-        (layer,) = _layers(go.Figure([empty]))
-        assert layer["data"] == []
+        assert _layers(go.Figure([empty])) == []


### PR DESCRIPTION
Closes #636.

## What was happening

#421 established the rule — a trace plotly draws nothing for forms no layer
— and implemented it where it mattered then, by excluding an undrawn trace
from the **line and area groupings** with `draws_marks()`. Every other
family's build block appended unconditionally.

Measured, layers per figure:

```
empty pie          [[1]]     go.Pie(labels=[], values=[])
empty sankey       [[1]]     go.Sankey(node={'label':[]}, link={...empty...})
empty scatterpolar [[1]]     go.Scatterpolar(r=[], theta=[])
empty parcoords    [[1]]     go.Parcoords(dimensions=[])
empty scatter      [[0]]     <- the one that was filtered
```

Not a harmless no-op. It is a cell the reader can tab into and find nothing
in — #421's own words — and for the line-family types it is worse:
`LineTrace` dereferences an undefined point on an empty series and throws,
which propagates out of `Figure` and takes the whole render down
(xability/maidr#905). `ParallelTrace` and `RadarTrace` are both built on it,
so #635 and #637 each shipped a type sitting on that path.

## The fix

One guard on the rendered payload, after the build blocks, so every trace
type reaches the same answer and a new one added later inherits it —
instead of five build blocks each having to remember.

`draws_marks()` stays exactly where it is. It does something a later filter
cannot: it keeps the **positions** of the surviving series contiguous, which
is what #412 was about. A control test proves it is still what excludes an
empty scatter, so removing it could not look harmless.

## Why the payload and not the trace

Because there are three shapes and only one question. Measured across every
plot type maidr builds for a plotly figure:

| shape | types |
|---|---|
| `list` | bar, scatter, pie, histogram, box, violin, sankey, treemap, scatterpolar, parcoords, funnel, waterfall, candlestick |
| `{value, min, max}` of numbers | gauge |
| `{points: [...]}` | heatmap |

A mapping needs an extra step, because two of them look alike at the top
level and mean opposite things. Measured:

```python
go.Indicator(mode="gauge+number", value=0, gauge={"axis": {"range": [0, 0]}})
# -> {"value": 0.0, "min": 0.0, "max": 0.0}
go.Heatmap(z=[])
# -> {"points": []}
```

The first is a **complete reading** of a chart the author asked for, whose
three fields all happen to be falsy. `any(bool(v) for v in data.values())`
drops it — silencing a correct chart, the exact failure this guard exists to
avoid causing. So a mapping carries data when any field is a scalar or a
non-empty collection.

## Where it deliberately stops

One level. `go.Heatmap(z=[[]])` renders as `{"points": [[]]}` — a field
holding a non-empty list whose one entry is empty — and is **kept**.
Recursing to decide a nested structure is "really" empty is guessing at a
shape rather than reading it, and dropping a layer that should have shipped
is the more damaging of the two mistakes. A payload that is neither a list
nor a mapping is kept for the same reason.

That last branch is unreachable today, which is why a new test asserts the
three-shape contract across every plot type: a fourth shape has to arrive
with its own decision about what empty means for it, and that test is where
it gets asked for.

## Five existing tests changed

All five asserted the old behaviour. One said so outright:

> Pinned so a later widening of the predicate is a deliberate choice rather
> than a side effect.

This is that choice. The other four asserted `data == []` on a layer that
still shipped; they now assert the layer is not there, which is the same
judgement one step further.

| test | was | is |
|---|---|---|
| `test_a_bar_with_no_data_is_left_to_its_own_path` | `len(layers) == 1` | `layers == []` |
| `test_a_window_holding_no_data_yields_no_bins` | `bins(fig) == []` | `layers(fig) == []` |
| `test_a_trace_with_neither_array_yields_no_data` | `layer["data"] == []` | no layer |
| `...orientation_pointing_at_an_absent_axis...` | `layer["data"] == []` | no layer |
| `test_a_parcoords_with_no_columns...` (#637) | `layer["data"] == []` | no layer |

## Verification

New `tests/plotly/test_plotly_empty_layers.py` — 9 empty cases, 8 drawn
controls, the all-zero gauge, the empty-row heatmap boundary, the
three-shape contract across 15 plot types, and a grid test that a dropped
layer leaves no empty cell behind.

Mutation sweep, each reverted alone against a restored baseline:

| mutation | failures |
|---|---|
| remove the filter entirely | 12 |
| plain truthiness on a mapping | 1 |
| treat any mapping as carrying data | 1 |
| recurse one level further | 1 |
| drop a payload that is neither list nor mapping | **0 — survives** |
| all restored | 1101/1101 pass |

The survivor is reported rather than hidden: that branch is unreachable
because no plot type emits such a payload, which is precisely what the
three-shape contract test asserts. Adding a contrived test would pin a
shape that does not exist; deleting the branch would make a future fourth
shape get dropped silently, which is the wrong direction to fail.

Full suite green in both batches — `tests/core` 1931 passed / 5 skipped,
`tests/plotly` 1101 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_