### PR TITLE
feat(plotly): read a parallel sets trace

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -70,6 +70,11 @@ class PlotType(str, Enum):
     #: both on one trace.
     RADAR = "radar"
     POLAR_AREA = "polar_area"
+    #: Categorical dimensions side by side, with a ribbon between adjacent
+    #: ones for every combination that occurs -- a parallel sets diagram.
+    #: The same weighted flow :attr:`SANKEY` carries, drawn without a
+    #: left-to-right budget, which is why the core builds both on one trace.
+    ALLUVIAL = "alluvial"
     #: Weighted flow between nodes, drawn as ribbons whose width is the
     #: magnitude. Stated as one point per link -- the two nodes it joins and
     #: how much moves -- rather than as a series, because the chart is a

--- a/maidr/plotly/parcats.py
+++ b/maidr/plotly/parcats.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+#: What separates one dimension's level from another's in a node name.
+#: A parallel-sets diagram routinely repeats a level name across dimensions --
+#: "yes" under `Survived` and "yes" under `Boarded` -- and the grammar derives
+#: its nodes from the flows, so two nodes named alike *are* one node. Naming a
+#: node by its dimension is what keeps them apart, and it is also what a
+#: reader needs to hear: "Survived: yes" says which question was answered.
+_NODE_SEPARATOR = ": "
+
+
+class PlotlyParcatsPlot(PlotlyPlot):
+    """Extract data from a Plotly ``parcats`` trace.
+
+    A parallel *sets* diagram: categorical dimensions side by side, with a
+    ribbon between adjacent ones for every combination that occurs, drawn at
+    a width proportional to how often it does. The core reads it as
+    `ALLUVIAL`, which shares `FlowTrace` with `SANKEY` and `CHORD` -- one
+    weighted flow between two named nodes, the nodes derived from the flows.
+
+    So a ribbon spanning several dimensions becomes one flow **per adjacent
+    pair**. That is what the grammar's unit is, and it is also the reading:
+    what a parallel-sets diagram shows is how a population is re-divided at
+    each step, and each step is a pair.
+    """
+
+    def __init__(self, trace: dict, layout: dict, **kwargs: str) -> None:
+        super().__init__(trace, layout, PlotType.ALLUVIAL, **kwargs)
+
+    def _get_selector(self) -> list[str]:
+        """No selector: the drawn order is plotly's, and it is not derivable.
+
+        Measured in Chromium on a five-row trace whose first and fifth rows
+        share a combination. Plotly merges them -- four ``path`` elements for
+        five rows -- and, decisively, writes them in **its own layout order**
+        rather than the declaration order: the bound ``key`` values in
+        document order were ``0, 2, 1, 3``, carrying counts ``8, 2, 1, 4``.
+
+        So ``:nth-of-type(k)`` addresses whichever ribbon plotly happened to
+        place kth, which cannot be computed from the trace offline. A list
+        built in the data's order would resolve to real elements and to the
+        *wrong* ones -- a highlight that is confidently incorrect, which is
+        worse than none at all.
+
+        The layer therefore ships without a highlight and keeps its audio,
+        braille and text: the outcome #145 established for a layer with
+        nothing it can point at.
+        """
+        return []
+
+    def _extract_axes_data(self) -> dict:
+        """A flow layer names no axes.
+
+        `FlowTrace` announces a flow as its two nodes and its weight, and the
+        nodes carry their own dimension names. There is no x or y for a
+        reader to be told about, and inventing a pair would put words in a
+        chart that has neither.
+        """
+        return {}
+
+    def _extract_plot_data(self) -> list[dict]:
+        """One flow per adjacent pair of dimensions, per combination.
+
+        Two things are aggregated here, and both were measured rather than
+        assumed:
+
+        * **Plotly merges duplicate combinations.** Five rows whose first and
+          fifth share a combination drew four ribbons, the shared one at the
+          summed count of 8. Emitting the rows unaggregated would announce
+          two flows where the chart draws one.
+        * **A hidden dimension is not a column.** ``visible: False`` takes a
+          dimension out of the drawing, so a flow through it would join two
+          nodes the chart never places side by side.
+
+        ``counts`` weights each row and defaults to one per row, which is
+        what plotly does with it. A row longer than the shortest dimension is
+        dropped, because it has no value on every axis and so no ribbon.
+        """
+        columns = [
+            dimension
+            for dimension in as_list(self._trace.get("dimensions"))
+            if isinstance(dimension, dict) and dimension.get("visible") is not False
+        ]
+        if not columns:
+            # Only the *no* columns case needs saying: `min()` over an empty
+            # sequence raises. One column needs no guard -- there is no
+            # adjacent pair, so the loop below yields nothing and #636's
+            # payload guard drops the layer, which is the same answer arrived
+            # at once rather than twice.
+            return []
+
+        values = [as_list(column.get("values")) for column in columns]
+        rows = min(len(column) for column in values)
+        if rows == 0:
+            return []
+
+        labels = [_column_name(column, index) for index, column in enumerate(columns)]
+        weights = as_list(self._trace.get("counts")) or [1] * rows
+
+        flows: dict[tuple[str, str], float] = {}
+        order: list[tuple[str, str]] = []
+        for step in range(len(columns) - 1):
+            for row in range(rows):
+                edge = (
+                    _node_name(labels[step], values[step][row]),
+                    _node_name(labels[step + 1], values[step + 1][row]),
+                )
+                weight = weights[row] if row < len(weights) else 1
+                if edge not in flows:
+                    flows[edge] = 0.0
+                    order.append(edge)
+                flows[edge] += float(self._to_native(weight) or 0)
+
+        return [
+            {
+                MaidrKey.SOURCE: source,
+                MaidrKey.TARGET: target,
+                MaidrKey.VALUE: flows[(source, target)],
+            }
+            for source, target in order
+        ]
+
+
+def is_parcats_trace(trace: dict) -> bool:
+    """Report whether a trace is a parallel sets diagram."""
+    return trace.get("type") == "parcats"
+
+
+def _node_name(dimension: str, level: object) -> str:
+    """Name one node by the dimension it belongs to and the level it is."""
+    return f"{dimension}{_NODE_SEPARATOR}{level}"
+
+
+def _column_name(dimension: dict, index: int) -> str:
+    """Name one dimension, falling back to its position when unnamed.
+
+    ``label`` is optional and may be written empty, and plotly draws an
+    unnamed dimension with a blank title. A blank half of a node name reaches
+    the reader as ``": yes"``, which says less than the position does.
+    """
+    label = dimension.get("label")
+    if label is None:
+        return str(index + 1)
+    label = str(label)
+    return label if label else str(index + 1)

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -78,6 +78,7 @@ _PLACED_BY_DOMAIN = frozenset(
         "icicle",
         "sankey",
         "parcoords",
+        "parcats",
     }
 )
 
@@ -1038,6 +1039,24 @@ class PlotlyMaidr:
                     )
                     self._plots.append(plot)
                 merged.update(id(t) for t in parcoords_traces)
+
+            # Parallel sets, one layer each. Placed by its own `domain`
+            # rectangle like a pie, because a `parcats` names no axis pair.
+            from maidr.plotly.parcats import is_parcats_trace
+
+            parcats_traces = [t for t in group_traces if is_parcats_trace(t)]
+            if parcats_traces:
+                from maidr.plotly.parcats import PlotlyParcatsPlot
+
+                for parcats_trace in parcats_traces:
+                    plot = PlotlyParcatsPlot(parcats_trace, layout, **axis_kwargs)
+                    plot.row_index, plot.col_index = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._trace_domain_start(parcats_trace),
+                    )
+                    self._plots.append(plot)
+                merged.update(id(t) for t in parcats_traces)
 
             # Sankeys, one layer each. Only this loop knows whether the
             # figure holds a second one, which is what decides whether

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -435,16 +435,11 @@ class TestPlotlyUnrenderedDomainTraces:
             pytest.param(
                 go.Treemap(labels=["a", "b"], parents=["", ""]), id="treemap"
             ),
-            # A categorical parallel-sets diagram. `go.Parcoords` sat here
-            # until #627's parallel tranche made it render; `go.Parcats` is
-            # the same kind of trace and is still unread, so it keeps the
-            # row honest.
-            pytest.param(
-                go.Parcats(
-                    dimensions=[{"label": "A", "values": ["x", "y"]}],
-                ),
-                id="parcats",
-            ),
+            # `go.Parcoords` sat here until #627's parallel tranche made it
+            # render, then `go.Parcats` until the alluvial one did. `go.Table`
+            # above is the durable subject -- maidr has no layer for a table
+            # and is not going to grow one -- so the row no longer needs a
+            # stand-in that keeps graduating out of it.
             # A `mode="number"` indicator only. One that draws a dial *is*
             # rendered as of #627's gauge tranche, so it takes a cell like
             # a pie -- asserted by the test below rather than here.

--- a/tests/plotly/test_plotly_parcats.py
+++ b/tests/plotly/test_plotly_parcats.py
@@ -1,0 +1,271 @@
+"""A plotly parallel sets diagram produced a figure with no layers.
+
+`go.Parcats` puts categorical dimensions side by side and draws a ribbon
+between adjacent ones for every combination that occurs, at a width
+proportional to how often it does. `maidr/plotly/` had no handling for it, so
+it fell through `_extract_plots` to `PlotlyPlotFactory`, which returned
+`None` (#627). The core has had `TraceType.ALLUVIAL` for this shape, sharing
+`FlowTrace` with `SANKEY` and `CHORD`.
+
+A `FlowPoint` is one weighted flow between two named nodes, so a ribbon
+spanning several dimensions becomes one flow **per adjacent pair**. That is
+what the grammar's unit is, and it is also the reading: a parallel sets
+diagram shows how a population is re-divided at each step, and each step is
+a pair.
+
+Two things measured in Chromium decided the rest:
+
+  * **Plotly merges duplicate combinations.** Five rows whose first and fifth
+    share a combination drew *four* ribbons, the shared one at the summed
+    count of 8.
+  * **Plotly writes the ribbons in its own layout order.** The `key` values
+    bound to the four paths, in document order, were `0, 2, 1, 3`, carrying
+    counts `8, 2, 1, 4`. So the drawn order is not the declared order and is
+    not computable offline, which is why the layer takes no selector.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _flows(layer: dict) -> list[tuple]:
+    """Each flow as ``(source, target, value)``."""
+    return [(f["source"], f["target"], f["value"]) for f in layer["data"]]
+
+
+TITANIC = go.Parcats(
+    dimensions=[
+        {"label": "Sex", "values": ["M", "F", "M", "F", "M"]},
+        {"label": "Class", "values": ["1", "1", "2", "2", "1"]},
+    ],
+    counts=[3, 1, 2, 4, 5],
+)
+
+
+def test_a_parcats_is_read_as_an_alluvial_layer() -> None:
+    """The reproduction, and the type it becomes."""
+    (layer,) = _layers(go.Figure([TITANIC]))
+
+    assert layer["type"] is PlotType.ALLUVIAL
+
+
+def test_duplicate_combinations_are_one_flow_at_their_summed_weight() -> None:
+    """Which is what plotly draws, not a tidying choice.
+
+    Rows one and five are both `(M, 1)`, at counts 3 and 5. Measured, plotly
+    drew four ribbons for the five rows and gave the shared one a count of 8.
+    Emitting the rows unaggregated would announce two flows where the chart
+    draws one, and each at the wrong width.
+    """
+    (layer,) = _layers(go.Figure([TITANIC]))
+
+    assert _flows(layer) == [
+        ("Sex: M", "Class: 1", 8.0),
+        ("Sex: F", "Class: 1", 1.0),
+        ("Sex: M", "Class: 2", 2.0),
+        ("Sex: F", "Class: 2", 4.0),
+    ]
+
+
+def test_a_ribbon_across_three_dimensions_is_two_flows() -> None:
+    """One flow per adjacent pair, which is the grammar's unit.
+
+    `FlowTrace` reads a flow as two nodes and a weight, so a ribbon spanning
+    three dimensions has no single pair to be. Splitting it at each step is
+    also the reading: what the chart shows is the re-division, and each
+    re-division happens between one pair of columns.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Parcats(
+                    dimensions=[
+                        {"label": "A", "values": ["x", "x"]},
+                        {"label": "B", "values": ["p", "q"]},
+                        {"label": "C", "values": ["1", "1"]},
+                    ]
+                )
+            ]
+        )
+    )
+
+    assert _flows(layer) == [
+        ("A: x", "B: p", 1.0),
+        ("A: x", "B: q", 1.0),
+        ("B: p", "C: 1", 1.0),
+        ("B: q", "C: 1", 1.0),
+    ]
+
+
+def test_a_level_name_shared_between_dimensions_stays_two_nodes() -> None:
+    """The reason a node is named for its dimension.
+
+    A parallel sets diagram routinely repeats a level across dimensions --
+    "yes" under one question and "yes" under the next. The grammar derives
+    its nodes *from the flows*, so two nodes named alike are one node: the
+    chart's two columns would collapse into a single node with a flow to
+    itself, which is not a thing the chart draws.
+
+    It is also what the reader needs. "First: yes" says which question was
+    answered; "yes" alone does not.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Parcats(
+                    dimensions=[
+                        {"label": "First", "values": ["yes", "no"]},
+                        {"label": "Second", "values": ["yes", "yes"]},
+                    ]
+                )
+            ]
+        )
+    )
+
+    sources = {source for source, _, _ in _flows(layer)}
+    targets = {target for _, target, _ in _flows(layer)}
+
+    assert "First: yes" in sources
+    assert "Second: yes" in targets
+    assert not sources & targets
+
+
+def test_a_hidden_dimension_is_not_a_step() -> None:
+    """`visible: False` takes a dimension out of the drawing.
+
+    A flow through it would join two nodes the chart never places side by
+    side, and announce a re-division that is not drawn. The two visible
+    columns become adjacent, which is what the reader sees.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Parcats(
+                    dimensions=[
+                        {"label": "A", "values": ["x", "y"]},
+                        {"label": "H", "values": ["p", "q"], "visible": False},
+                        {"label": "B", "values": ["1", "2"]},
+                    ]
+                )
+            ]
+        )
+    )
+
+    assert _flows(layer) == [("A: x", "B: 1", 1.0), ("A: y", "B: 2", 1.0)]
+
+
+def test_a_row_weighs_one_when_the_trace_declares_no_counts() -> None:
+    """Which is what plotly does with it.
+
+    `counts` is optional; without it each row is one observation. Two
+    identical rows are therefore one flow of weight two, not one of weight
+    one.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Parcats(
+                    dimensions=[
+                        {"label": "A", "values": ["x", "x"]},
+                        {"label": "B", "values": ["p", "p"]},
+                    ]
+                )
+            ]
+        )
+    )
+
+    assert _flows(layer) == [("A: x", "B: p", 2.0)]
+
+
+def test_a_single_dimension_forms_no_layer() -> None:
+    """One column has nothing to flow to, so the chart draws no ribbon.
+
+    No guard here says so: there is no adjacent pair, so the extraction
+    yields nothing and #636's payload guard drops the layer. The answer is
+    arrived at once rather than twice, and this is what pins it.
+    """
+    assert (
+        _layers(
+            go.Figure([go.Parcats(dimensions=[{"label": "A", "values": ["x", "y"]}])])
+        )
+        == []
+    )
+
+
+def test_no_dimensions_at_all_does_not_take_the_render_down() -> None:
+    """The one case that does need its own guard.
+
+    With no columns there is nothing to take a minimum length over, and
+    `min()` on an empty sequence raises -- measured, `ValueError: min() arg
+    is an empty sequence`, which propagates out of `_flatten_maidr()` and
+    takes the whole figure with it rather than costing one layer.
+    """
+    assert _layers(go.Figure([go.Parcats(dimensions=[])])) == []
+
+
+def test_a_parcats_is_read_but_not_addressed() -> None:
+    """A stated limit, and the third distinct reason for one.
+
+    Measured in Chromium: the four `path` elements carry `key` values `0, 2,
+    1, 3` in document order, with counts `8, 2, 1, 4`. Plotly lays its
+    ribbons out in its own order, which is not the declaration order and is
+    not computable from the trace offline.
+
+    A positional selector list would therefore resolve to real elements and
+    to the *wrong* ones -- a highlight that is confidently incorrect, which
+    is worse than none. So the layer ships without one and keeps its audio,
+    braille and text, the outcome #145 established.
+    """
+    (layer,) = _layers(go.Figure([TITANIC]))
+
+    assert "selectors" not in layer
+
+
+def test_a_flow_layer_names_no_axes() -> None:
+    """`FlowTrace` announces a flow as its nodes and its weight.
+
+    Each node carries its own dimension name, so there is no x or y for a
+    reader to be told about -- and inventing a pair would put words in a
+    chart that has neither.
+    """
+    (layer,) = _layers(go.Figure([TITANIC]))
+
+    assert layer["axes"] == {}
+
+
+def test_a_parcats_takes_its_own_grid_cell() -> None:
+    """It is placed by its own `domain` rectangle, like a pie.
+
+    Now that maidr renders it, that rectangle joins the figure's column
+    universe -- otherwise a cartesian subplot beside it would sit in the
+    wrong column.
+    """
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(
+        rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]]
+    )
+    figure.add_trace(TITANIC, row=1, col=1)
+    figure.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert [len(row) for row in grid] == [2]
+    assert [layer["type"] for layer in grid[0][0]["layers"]] == [PlotType.ALLUVIAL]
+    assert [layer["type"] for layer in grid[0][1]["layers"]] == [PlotType.BAR]


### PR DESCRIPTION
Closes part of #627.

`go.Parcats` puts categorical dimensions side by side and draws a ribbon
between adjacent ones for every combination that occurs, at a width
proportional to how often it does. It fell through `_extract_plots` to
`PlotlyPlotFactory`, which returned `None`, so the figure had **no layers at
all**. The core has had `TraceType.ALLUVIAL` for this shape.

## The reading

`ALLUVIAL` shares `FlowTrace` with `SANKEY` and `CHORD`, and a `FlowPoint` is
one weighted flow between two named nodes. So a ribbon spanning several
dimensions becomes **one flow per adjacent pair** — the grammar's unit, and
also the reading: what a parallel sets diagram shows is how a population is
re-divided at each step, and each step is a pair.

```python
go.Parcats(
    dimensions=[
        {"label": "Sex",   "values": ["M", "F", "M", "F", "M"]},
        {"label": "Class", "values": ["1", "1", "2", "2", "1"]},
    ],
    counts=[3, 1, 2, 4, 5],
)
```
```json
[{"source": "Sex: M", "target": "Class: 1", "value": 8.0},
 {"source": "Sex: F", "target": "Class: 1", "value": 1.0},
 {"source": "Sex: M", "target": "Class: 2", "value": 2.0},
 {"source": "Sex: F", "target": "Class: 2", "value": 4.0}]
```

## Three answers from measurement

**Plotly merges duplicate combinations.** Rows one and five are both
`(M, 1)`, at counts 3 and 5. Measured in Chromium, plotly drew **four**
ribbons for the five rows and gave the shared one a count of **8**. Emitting
the rows unaggregated would announce two flows where the chart draws one,
each at the wrong width.

**A node is named for its dimension.** A parallel sets diagram routinely
repeats a level across dimensions — "yes" under one question and "yes" under
the next. The grammar derives its nodes *from the flows*, so two nodes named
alike **are one node**: the chart's two columns would collapse into a single
node with a flow to itself, which is not something the chart draws. It is
also what the reader needs — "First: yes" says which question was answered,
"yes" alone does not.

**There is no selector, and this is the third distinct reason for one.** The
data bound to the four `path` elements, read in document order:

```
key:    0     2     1     3
count:  8     2     1     4
```

Plotly lays its ribbons out in its own order, which is not the declaration
order and is not computable from the trace offline. A positional list would
resolve to **real elements and the wrong ones** — a highlight that is
confidently incorrect, which is worse than none at all. So the layer ships
without one and keeps its audio, braille and text (#145).

(For contrast: a barpolar has no per-series element to point at (#635), and a
parcoords renders to WebGL (#637). Same outcome, three different causes.)

Two smaller ones, also measured: a `visible: False` dimension is not a step,
and `counts` defaults to one per row.

## A rotating test subject, retired

`TestPlotlyUnrenderedDomainTraces` needs "a domain trace maidr draws no layer
for". `go.Parcoords` held that row until #637 made it render, then
`go.Parcats` until this PR does. `go.Table` was already in the list and is
the durable subject — maidr has no layer for a table and is not going to grow
one — so the row no longer needs a stand-in that keeps graduating out of it.

## One guard removed rather than added

A first draft returned early on `len(columns) < 2`. The mutation sweep showed
that half of it was dead: with one column there is no adjacent pair, so the
loop yields nothing and **#636's payload guard** drops the layer — the same
answer, arrived at once instead of twice. Only the zero-column case needs
saying, because `min()` over an empty sequence raises (measured:
`ValueError: min() arg is an empty sequence`, which takes the whole figure
down rather than costing one layer). The guard is now just that case, and a
test pins the crash it prevents.

## Verification

10 tests in `tests/plotly/test_plotly_parcats.py`.

Mutation sweep — each reverted alone against a restored baseline:

| mutation | failures |
|---|---|
| do not aggregate duplicate combinations | 2 |
| name a node by its level alone | 5 |
| keep a hidden dimension | 1 |
| flow only from the first dimension | 1 |
| `counts` default to zero | 3 |
| drop the no-columns guard | 1 |
| emit a positional selector | 1 |
| drop `parcats` from `_PLACED_BY_DOMAIN` | 1 |
| all restored | 1111/1111 pass |

Full suite green in both batches — `tests/core` 1931 passed / 5 skipped,
`tests/plotly` 1111 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_