### PR TITLE
feat(plotly): read a choropleth map

### DIFF
--- a/maidr/core/enum/plot_type.py
+++ b/maidr/core/enum/plot_type.py
@@ -70,6 +70,11 @@ class PlotType(str, Enum):
     #: both on one trace.
     RADAR = "radar"
     POLAR_AREA = "polar_area"
+    #: Regions of a map shaded by a value. Stated as a region and its number
+    #: rather than as a grid, because a map has no rows and columns -- and
+    #: without centroids, which a plotly trace does not carry, it is read as
+    #: a list of regions in the order they were declared.
+    CHOROPLETH = "choropleth"
     #: Categorical dimensions side by side, with a ribbon between adjacent
     #: ones for every combination that occurs -- a parallel sets diagram.
     #: The same weighted flow :attr:`SANKEY` carries, drawn without a

--- a/maidr/plotly/choropleth.py
+++ b/maidr/plotly/choropleth.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+#: What the two halves of a region's reading are, when the author named
+#: neither. A choropleth has no cartesian axes to read titles off, and these
+#: are what the fields hold: the region it is, and the number it is shaded by.
+_AXIS_FALLBACKS = ("Region", "Value")
+
+
+class PlotlyChoroplethPlot(PlotlyPlot):
+    """Extract data from a Plotly ``choropleth`` trace.
+
+    A map whose regions are shaded by a value. The core reads it as
+    `CHOROPLETH`, whose point is a region's name and the number it carries.
+
+    **The centroids are not here to be read.** `ChoroplethPoint` takes an
+    optional ``lon``/``lat`` pair in degrees, which is what lets a reader
+    walk the map spatially rather than down a list. A ``go.Choropleth``
+    carries neither: it names its regions -- ``"USA"``, ``"FRA"``, a US state
+    -- and plotly resolves those names against geometry it fetches in the
+    browser. So the pair genuinely is not in the figure, and the grammar
+    already says what that means: "the map is read as a region list in
+    declared order, which is a poorer reading but the one the data supports".
+
+    ``neighbors`` is absent for the same reason and a stronger one -- the
+    grammar notes adjacency "is not derivable from rendered SVG paths, and
+    not from centroids either".
+    """
+
+    def __init__(self, trace: dict, layout: dict, **kwargs: str) -> None:
+        super().__init__(trace, layout, PlotType.CHOROPLETH, **kwargs)
+
+    def _get_selector(self) -> list[str]:
+        """No selector, and this one is a limit rather than a decision.
+
+        The other three plotly layers that ship without a highlight do so
+        because of something about the chart: a barpolar draws no per-series
+        path (#635), a parcoords renders to WebGL (#637), and a parcats is
+        laid out in an order that cannot be computed offline (#639).
+
+        This is not that. A choropleth almost certainly *is* addressable --
+        plotly draws one ``path`` per region -- but the map could not be
+        measured where this was written: plotly requests its geometry from
+        ``https://cdn.plot.ly/un/world_110m.json`` at render time, and with
+        no network the ``.geolayer`` stays empty (measured:
+        ``geo._topojson`` false, zero ``path`` elements, one entry in
+        ``calcdata``).
+
+        Emitting a selector that has never resolved would be guessing, and a
+        highlight that lands on the wrong region is worse than none. So the
+        layer ships without one and keeps its audio, braille and text, and
+        the selector is left to whoever can load the map. See #640.
+        """
+        return []
+
+    def _extract_axes_data(self) -> dict:
+        """Name the region and the value it is shaded by.
+
+        A choropleth draws no cartesian axes, so ``layout.xaxis`` holds
+        neither name -- reading it would take another trace's titles. The
+        colour bar's title is the one thing the author may have written about
+        the *value*, and it is exactly what it means, so it is used when it
+        is there.
+        """
+        region, value = _AXIS_FALLBACKS
+        return {
+            MaidrKey.X: self._axis_config(label=region),
+            MaidrKey.Y: self._axis_config(label=self._colorbar_title() or value),
+        }
+
+    def _extract_plot_data(self) -> list[dict]:
+        """One point per region the trace names.
+
+        Read in the trace's own order, which is the order the grammar says a
+        centroid-less map is navigated in. A region with no value is dropped:
+        plotly leaves it unshaded, so announcing it would put a region on the
+        map that the reader cannot be told anything about.
+        """
+        locations = as_list(self._trace.get("locations"))
+        values = as_list(self._trace.get("z"))
+
+        return [
+            {
+                MaidrKey.X: str(self._to_native(location)),
+                MaidrKey.Y: self._to_native(value),
+            }
+            for location, value in zip(locations, values)
+            if value is not None
+        ]
+
+    def _colorbar_title(self) -> str:
+        """The title the author gave the colour bar, or an empty string."""
+        colorbar = self._trace.get("colorbar")
+        if not isinstance(colorbar, dict):
+            return ""
+        title = colorbar.get("title", "")
+        if isinstance(title, dict):
+            title = title.get("text", "")
+        return str(title) if title else ""
+
+
+def is_choropleth_trace(trace: dict) -> bool:
+    """Report whether a trace is a choropleth map."""
+    return trace.get("type") == "choropleth"

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -12,6 +12,7 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.candlestick import is_ohlc_trace, layer_position
+from maidr.plotly.plotly_plot import subplot_block
 from maidr.plotly.gauge import draws_a_dial
 from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
 from maidr.plotly.area import is_area_trace
@@ -58,6 +59,14 @@ from maidr.util.environment import Environment
 from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_plotly
 
 
+#: The layout keys that hold a subplot *block* -- a rectangle plotly writes
+#: for a subplot that has no cartesian axis pair, and that a trace addresses
+#: by name. ``polar``/``polar2`` for the two polar traces, ``geo``/``geo2``
+#: for a choropleth. Collected into the figure's row and column universe
+#: exactly as ``xaxis``/``yaxis`` domains are.
+_SUBPLOT_BLOCK_PREFIXES = ("polar", "geo")
+
+
 #: Trace types placed by their own ``domain`` rectangle that maidr renders as
 #: a layer. Plotly has other domain traces -- ``table``, ``sunburst``,
 #: ``treemap``, ``indicator`` -- and maidr draws no layer for any of them, so
@@ -79,6 +88,7 @@ _PLACED_BY_DOMAIN = frozenset(
         "sankey",
         "parcoords",
         "parcats",
+        "choropleth",
     }
 )
 
@@ -310,13 +320,15 @@ class PlotlyMaidr:
             if key.startswith("yaxis") and isinstance(val, dict):
                 y_starts.add(_domain_start(val, "domain"))
 
-            # A polar subplot is placed like a cartesian one -- by a
+            # A polar or geo subplot is placed like a cartesian one -- by a
             # rectangle `make_subplots` wrote into the layout -- but under
             # its own key rather than an axis pair, so it needs its own
             # branch. Without it a `[bar, polar]` grid collected one x start
             # and collapsed to a single cell holding both layers, and two
-            # polar subplots side by side collected none at all.
-            if key.startswith("polar") and isinstance(val, dict):
+            # polar subplots side by side collected none at all. A geo
+            # subplot is the same shape: `layout.geo.domain`, named by the
+            # trace's `geo` rather than by an axis pair.
+            if key.startswith(_SUBPLOT_BLOCK_PREFIXES) and isinstance(val, dict):
                 domain = val.get("domain")
                 if isinstance(domain, dict):
                     x_starts.add(_domain_start(domain, "x"))
@@ -384,31 +396,29 @@ class PlotlyMaidr:
         return _domain_start(domain, "x"), _domain_start(domain, "y")
 
     @staticmethod
-    def _polar_domain_start(layout: dict, trace: dict) -> tuple[float, float]:
-        """Return where a polar trace's own subplot starts in the figure.
+    def _block_domain_start(layout: dict, name: str) -> tuple[float, float]:
+        """Return where a named subplot *block* starts in the figure.
 
-        A polar trace carries neither an axis pair nor a ``domain`` of its
-        own, so neither of the two helpers above can place it. Its rectangle
-        is written into the layout under the subplot it names --
-        ``layout.polar``, ``layout.polar2``, ... -- which is what tells two
-        polar charts of a grid apart.
+        A polar or geo trace carries neither an axis pair nor a ``domain`` of
+        its own, so neither of the two helpers above can place it. Its
+        rectangle is written into the layout under the subplot it names --
+        ``layout.polar``, ``layout.polar2``, ``layout.geo``, ... -- which is
+        what tells two of them in one grid apart.
 
         Parameters
         ----------
         layout : dict
             The Plotly figure layout.
-        trace : dict
-            One ``scatterpolar`` or ``barpolar`` trace.
+        name : str
+            The layout key naming the subplot, as the trace spells it.
 
         Returns
         -------
         tuple of (float, float)
-            The x and y start of the trace's polar subplot. A subplot plotly
-            never placed covers the whole figure, which is the first cell.
+            The x and y start of that subplot. One plotly never placed covers
+            the whole figure, which is the first cell.
         """
-        from maidr.plotly.polar import subplot_name
-
-        block = layout.get(subplot_name(trace))
+        block = layout.get(name)
         domain = block.get("domain") if isinstance(block, dict) else None
         return _domain_start(domain, "x"), _domain_start(domain, "y")
 
@@ -1010,7 +1020,7 @@ class PlotlyMaidr:
                     polar_row, polar_col = self._grid_position(
                         x_starts,
                         y_starts,
-                        self._polar_domain_start(layout, polar_trace),
+                        self._block_domain_start(layout, name),
                     )
                     plot.row_index = polar_row
                     plot.col_index = polar_col
@@ -1039,6 +1049,31 @@ class PlotlyMaidr:
                     )
                     self._plots.append(plot)
                 merged.update(id(t) for t in parcoords_traces)
+
+            # Choropleth maps, one layer each. Placed by its own `domain`
+            # rectangle -- a `geo` subplot's, which plotly writes onto the
+            # trace like a pie's.
+            from maidr.plotly.choropleth import is_choropleth_trace
+
+            choropleth_traces = [
+                t for t in group_traces if is_choropleth_trace(t)
+            ]
+            if choropleth_traces:
+                from maidr.plotly.choropleth import PlotlyChoroplethPlot
+
+                for choropleth_trace in choropleth_traces:
+                    plot = PlotlyChoroplethPlot(
+                        choropleth_trace, layout, **axis_kwargs
+                    )
+                    plot.row_index, plot.col_index = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._block_domain_start(
+                            layout, subplot_block(choropleth_trace, "geo")
+                        ),
+                    )
+                    self._plots.append(plot)
+                merged.update(id(t) for t in choropleth_traces)
 
             # Parallel sets, one layer each. Placed by its own `domain`
             # rectangle like a pie, because a `parcats` names no axis pair.

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -1124,3 +1124,34 @@ def draws_marks(trace: dict) -> bool:
     """
     xs, ys = paired_axes(trace)
     return bool(xs) and bool(ys)
+
+
+def subplot_block(trace: dict, key: str, default: str | None = None) -> str:
+    """Return the layout key naming this trace's subplot *block*.
+
+    Some traces are placed by neither an axis pair nor a ``domain`` of their
+    own, but by a rectangle plotly writes under a named block --
+    ``layout.polar``, ``layout.polar2``, ``layout.geo`` -- which the trace
+    addresses by name. That name is what tells two of them in one grid apart,
+    and for a polar trace it is also the class plotly gives its ``<g>``.
+
+    The field and the default are separate because they do not always agree:
+    a polar trace names its block under ``subplot`` and defaults to
+    ``"polar"``, while a choropleth names its under ``geo`` and defaults to
+    the same word.
+
+    Parameters
+    ----------
+    trace : dict
+        One trace of the figure.
+    key : str
+        The trace field naming its block.
+    default : str, optional
+        The block a trace naming none belongs to. Defaults to ``key``.
+
+    Returns
+    -------
+    str
+        The block name.
+    """
+    return str(trace.get(key) or default or key)

--- a/maidr/plotly/polar.py
+++ b/maidr/plotly/polar.py
@@ -4,7 +4,7 @@ import math
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list, subplot_block
 
 
 class PlotlyPolarPlot(PlotlyPlot):
@@ -146,7 +146,7 @@ def subplot_name(trace: dict) -> str:
     str
         The subplot name, defaulting to ``"polar"``.
     """
-    return str(trace.get("subplot") or "polar")
+    return subplot_block(trace, "subplot", "polar")
 
 
 def _is_a_radius(value: object) -> bool:

--- a/tests/plotly/test_plotly_choropleth.py
+++ b/tests/plotly/test_plotly_choropleth.py
@@ -1,0 +1,174 @@
+"""A plotly choropleth map produced a figure with no layers.
+
+`go.Choropleth` shades named regions by a value. `maidr/plotly/` had no
+handling for it, so it fell through `_extract_plots` to
+`PlotlyPlotFactory`, which returned `None` (#627). The core has had
+`TraceType.CHOROPLETH` for this shape.
+
+**The centroids are not here to be read.** `ChoroplethPoint` takes an
+optional `lon`/`lat` pair in degrees, which is what lets a reader walk the
+map spatially rather than down a list. A `go.Choropleth` carries neither: it
+names its regions -- `"USA"`, `"FRA"`, a US state -- and plotly resolves
+those names against geometry it fetches in the browser. The grammar already
+says what that means: "the map is read as a region list in declared order,
+which is a poorer reading but the one the data supports". `neighbors` is
+absent for the same reason and a stronger one -- adjacency "is not derivable
+from rendered SVG paths, and not from centroids either".
+
+**The map could not be measured where this was written**, which is why the
+layer ships without a selector. See the test that says so.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _regions(layer: dict) -> list[tuple]:
+    """Each region as ``(name, value)``."""
+    return [(point["x"], point["y"]) for point in layer["data"]]
+
+
+COUNTRIES = go.Choropleth(
+    locations=["USA", "CAN", "MEX"],
+    z=[10, 20, 30],
+    locationmode="ISO-3",
+    colorbar={"title": {"text": "Score"}},
+)
+
+
+def test_a_choropleth_is_read_as_a_map_layer() -> None:
+    """The reproduction, and the type it becomes."""
+    (layer,) = _layers(go.Figure([COUNTRIES]))
+
+    assert layer["type"] is PlotType.CHOROPLETH
+
+
+def test_each_region_carries_its_name_and_its_value() -> None:
+    """In the trace's own order, which is what the reader navigates.
+
+    Without centroids there is no spatial order to walk, so declared order is
+    the order -- the grammar's own answer for a map that carries no
+    ``lon``/``lat``.
+    """
+    (layer,) = _layers(go.Figure([COUNTRIES]))
+
+    assert _regions(layer) == [("USA", 10), ("CAN", 20), ("MEX", 30)]
+
+
+def test_the_colour_bar_title_names_the_value() -> None:
+    """It is the one thing the author may have written about the value.
+
+    A choropleth draws no cartesian axes, so `layout.xaxis` holds neither
+    name and reading it would take another trace's titles. The colour bar's
+    title is exactly what the shading means, so it is used where it is there.
+    """
+    (layer,) = _layers(go.Figure([COUNTRIES]))
+
+    assert layer["axes"]["x"]["label"] == "Region"
+    assert layer["axes"]["y"]["label"] == "Score"
+
+
+def test_an_unnamed_colour_bar_falls_back_to_the_generic_word() -> None:
+    """What the field holds, said plainly, rather than left blank."""
+    (layer,) = _layers(go.Figure([go.Choropleth(locations=["USA"], z=[1])]))
+
+    assert layer["axes"]["y"]["label"] == "Value"
+
+
+def test_a_region_with_no_value_is_dropped() -> None:
+    """Plotly leaves it unshaded, so it is not on the map to be read.
+
+    Announcing it would put a region in the walk that the reader cannot be
+    told anything about -- a name with nothing attached.
+    """
+    (layer,) = _layers(
+        go.Figure([go.Choropleth(locations=["USA", "CAN", "MEX"], z=[1, None, 3])])
+    )
+
+    assert _regions(layer) == [("USA", 1), ("MEX", 3)]
+
+
+def test_a_map_beside_a_cartesian_subplot_keeps_its_own_column() -> None:
+    """A geo subplot is placed like a polar one, not like a pie.
+
+    `go.Choropleth` carries no `domain` of its own -- its rectangle is
+    `layout.geo.domain`, named by the trace's `geo` field. Read as a domain
+    trace it would land at the origin, and the figure would collapse to one
+    column holding both charts, which is the bug #635 fixed for polar.
+    """
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(
+        rows=1, cols=2, specs=[[{"type": "xy"}, {"type": "choropleth"}]]
+    )
+    figure.add_trace(go.Bar(x=["a"], y=[1]), row=1, col=1)
+    figure.add_trace(go.Choropleth(locations=["USA"], z=[1]), row=1, col=2)
+
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert [len(row) for row in grid] == [2]
+    assert [layer["type"] for layer in grid[0][0]["layers"]] == [PlotType.BAR]
+    assert [layer["type"] for layer in grid[0][1]["layers"]] == [PlotType.CHOROPLETH]
+
+
+def test_two_maps_are_two_cells() -> None:
+    """`layout.geo` and `layout.geo2`, exactly as `polar` and `polar2`."""
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(
+        rows=1, cols=2, specs=[[{"type": "choropleth"}] * 2]
+    )
+    figure.add_trace(go.Choropleth(locations=["USA"], z=[1]), row=1, col=1)
+    figure.add_trace(go.Choropleth(locations=["CAN"], z=[2]), row=1, col=2)
+
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert [len(row) for row in grid] == [2]
+    assert _regions(grid[0][0]["layers"][0]) == [("USA", 1)]
+    assert _regions(grid[0][1]["layers"][0]) == [("CAN", 2)]
+
+
+def test_a_choropleth_ships_without_a_highlight() -> None:
+    """A limit of where this was written, not a property of the chart.
+
+    The other three plotly layers with no highlight have a reason in the
+    chart: a barpolar draws no per-series path (#635), a parcoords renders to
+    WebGL (#637), a parcats is laid out in an order not computable offline
+    (#639). This is none of those -- a choropleth almost certainly *is*
+    addressable.
+
+    It could not be measured. Plotly requests its geometry from
+    `https://cdn.plot.ly/un/world_110m.json` at render time, and with no
+    network the map never draws. Measured in Chromium: the request is made,
+    `geo._topojson` stays false, `.geolayer` holds one empty `g.geo`, and
+    there are **zero** `path` elements -- while `calcdata` has the one entry,
+    so plotly did compute the trace and only the geometry is missing.
+
+    A selector that has never resolved would be a guess, and a highlight on
+    the wrong region is worse than none. Left to whoever can load the map;
+    see #640.
+    """
+    (layer,) = _layers(go.Figure([COUNTRIES]))
+
+    assert "selectors" not in layer
+
+
+def test_a_map_with_no_regions_forms_no_layer() -> None:
+    """Nothing is shaded, so there is nothing to read (#636)."""
+    assert _layers(go.Figure([go.Choropleth(locations=[], z=[])])) == []


### PR DESCRIPTION
Closes part of #627.

`go.Choropleth` shades named regions by a value. It fell through
`_extract_plots` to `PlotlyPlotFactory`, which returned `None`, so the
figure had **no layers at all**. The core has had `TraceType.CHOROPLETH`
for this shape.

## The reading

Each region becomes a point — its name and the number it is shaded by, in
the trace's declared order:

```python
go.Choropleth(locations=["USA", "CAN", "MEX"], z=[10, 20, 30],
              colorbar={"title": {"text": "Score"}})
```
```json
{"axes": {"x": {"label": "Region"}, "y": {"label": "Score"}},
 "data": [{"x": "USA", "y": 10}, {"x": "CAN", "y": 20}, {"x": "MEX", "y": 30}]}
```

The colour bar's title names the value where the author wrote one. It is the
one thing they may have said about the shading, and it is exactly what the
shading means. A choropleth draws no cartesian axes, so `layout.xaxis` holds
neither name and reading it would take another trace's titles.

A region with no `z` is dropped — plotly leaves it unshaded, so announcing
it would put a name in the walk with nothing attached.

## The centroids are not here to be read

`ChoroplethPoint` takes an optional `lon`/`lat` pair in degrees, which is
what lets a reader walk the map spatially rather than down a list, plus
`neighbors` for the bordering regions.

A `go.Choropleth` carries **none of them**. It names its regions — `"USA"`,
`"FRA"`, a US state — and plotly resolves those names against geometry it
fetches in the browser. Supplying them would mean shipping a gazetteer. The
grammar anticipates exactly this: without them "the map is read as a region
list in declared order, which is a poorer reading but the one the data
supports". `neighbors` has a stronger reason still — adjacency "is not
derivable from rendered SVG paths, and not from centroids either".

## No selector — and this one is a limit, not a decision

The other three plotly layers that ship without a highlight each have a
reason in the chart:

| layer | why |
|---|---|
| `barpolar` (#635) | no per-series path to point at |
| `parcoords` (#637) | renders to WebGL |
| `parcats` (#639) | drawn in an order not computable offline |

A choropleth is none of those and almost certainly **is** addressable. It
could not be measured here. Plotly fetches its geometry at render time:

```
topojson requests: ['https://cdn.plot.ly/un/world_110m.json']
{'hasGeo': True, 'loaded': False, 'calcdataLen': 1, 'pathCount': 0}
```

`calcdata` has its entry — plotly computed the trace — and `.geolayer` holds
one empty `<g class="geo geo">`. Only the geometry is missing. A selector
that has never resolved would be a guess, and a highlight on the wrong
region is worse than none. Filed as **#640** with what finishing it needs.

## A geo subplot is placed like a polar one

Not like a pie. The trace carries no `domain`; its rectangle is
`layout.geo.domain`, named by the trace's `geo` field — exactly the shape
`layout.polar` has. Read as a domain trace it lands at the origin, and a
`[bar, choropleth]` grid collapses to one cell holding both charts. That is
the bug #635 fixed for polar, and it would have arrived here unchanged.

Rather than a second near-copy, the polar helper generalises:

- `_polar_domain_start(layout, trace)` → `_block_domain_start(layout, name)`,
  taking the block name rather than deriving it.
- `subplot_block(trace, key, default)` moves to `plotly_plot.py`, where both
  `polar.subplot_name` and the geo call can reach it without a cycle. The
  field and the default are separate arguments because they do not always
  agree: a polar trace names its block under `subplot` and defaults to
  `"polar"`, a choropleth names its under `geo`.
- One `_subplot_domain_starts` branch now covers both prefixes.

So the layout branch and the placement helper are shared, not duplicated.

## Verification

9 tests in `tests/plotly/test_plotly_choropleth.py`, covering both grid
cases (mixed and two maps).

Mutation sweep — each reverted alone against a restored baseline:

| mutation | failures |
|---|---|
| keep a region with no value | 1 |
| ignore the colour bar title | 1 |
| swap region and value onto the wrong fields | 3 |
| emit a selector | 1 |
| place by the trace domain instead of the geo block | 2 |
| drop `geo` from the block prefixes | 2 |
| `subplot_block` ignores the trace field | 5 |
| all restored | 1120/1120 pass |

The last one is the check that the generalisation did not quietly break
polar: five failures, spread across both trace families.

Full suite green in both batches — `tests/core` 1931 passed / 5 skipped,
`tests/plotly` 1120 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_