### PR TITLE
feat(plotly): read a contour at the levels its author declared

### DIFF
--- a/maidr/plotly/candlestick.py
+++ b/maidr/plotly/candlestick.py
@@ -20,7 +20,25 @@ _MARK_OF = {"candlestick": "path.box", "ohlc": "> path"}
 #: Trace types that share ``g.boxlayer`` and so count towards a candlestick's
 #: position within it. A ``go.Violin`` draws into ``g.violinlayer`` and a
 #: scatter into ``g.scatterlayer``, so neither shifts the count.
-_BOXLAYER_TRACE_TYPES = frozenset({"box", "candlestick"})
+#: Groups of trace types that plotly draws into a *single* DOM layer, so each
+#: member shifts the others' group index there.
+#:
+#: ``box``/``candlestick`` share ``g.boxlayer``. Counting only same-typed
+#: traces was symmetric-looking and wrong in one direction: a candlestick
+#: counted the boxes beside it, while a box ignored the candlestick and
+#: claimed the group the candlestick had already taken (#395).
+#:
+#: ``contour``/``histogram2dcontour`` share ``g.contourlayer`` -- measured in
+#: Chromium on a figure holding one of each plus a heatmap: the contour layer
+#: held two ``g.contour`` groups in declaration order, while the heatmap sat
+#: elsewhere in a ``heatmaplayer`` of its own.
+#:
+#: A type absent from every group is numbered among its own kind, which is
+#: what a layer with one occupant needs.
+_SHARED_LAYERS = (
+    frozenset({"box", "candlestick"}),
+    frozenset({"contour", "histogram2dcontour"}),
+)
 
 
 def is_ohlc_trace(trace: dict) -> bool:
@@ -65,16 +83,11 @@ def layer_position(traces: list[dict], trace: dict) -> int:
         The zero-based position among traces drawing into the same layer.
     """
     kind = trace.get("type")
-    if kind in _BOXLAYER_TRACE_TYPES:
-        # Both directions, not just the candlestick's. `go.Box` and
-        # `go.Candlestick` draw into the same `g.boxlayer`, so each shifts
-        # the other's group index. Counting only same-typed traces was
-        # symmetric-looking and wrong in one direction: a candlestick
-        # counted the boxes beside it, while a box ignored the candlestick
-        # and claimed the group the candlestick had already taken (#395).
-        mates = _BOXLAYER_TRACE_TYPES
-    else:
-        mates = frozenset({kind}) if kind else frozenset()
+    mates = frozenset({kind}) if kind else frozenset()
+    for shared in _SHARED_LAYERS:
+        if kind in shared:
+            mates = shared
+            break
 
     position = 0
     for candidate in traces:

--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+
+#: The trace types that draw into a subplot's ``contourlayer``. Both take a
+#: ``g.contour`` group there, so a contour's position among *these* is what
+#: scopes its selector -- measured in Chromium on a figure holding a
+#: ``histogram2dcontour``, a ``contour`` and a ``heatmap``: the contour layer
+#: held two groups, in declaration order, and the heatmap was elsewhere in a
+#: ``heatmaplayer`` of its own.
+_CONTOUR_LAYER_TYPES = ("contour", "histogram2dcontour")
+
+#: Which marching-squares implementation to trace the curves with.
+#:
+#: Not a detail: ``mpl2014`` and ``serial`` disagree about the **order** they
+#: return curves in, and the order is what pairs a series with the ``<path>``
+#: that draws it. Measured on a level carrying two open curves and one closed
+#: one, plotly writes the open ones first and ``mpl2014`` returns them in
+#: exactly that order, while ``serial`` returns the closed one first. It is
+#: also what matplotlib traces its own contours with, so the two py-maidr
+#: contour readings describe curves computed the same way.
+_CURVE_ALGORITHM = "mpl2014"
+
+#: How many levels a trace may declare before it is declined.
+#:
+#: A runaway guard, not a judgement about how many levels are useful:
+#: ``size`` is the author's, so ``dict(start=0, end=1, size=1e-9)`` asks for a
+#: billion of them and would hang the export -- and building a schema must
+#: never cost the render (#421, #636). No figure anyone draws comes near this.
+_LEVEL_LIMIT = 1000
+
+#: How far past ``end`` plotly's level loop still steps, as a fraction of
+#: ``size``. Measured rather than assumed, across seven specs: a run at
+#: ``start=0.2, end=0.8, size=0.05`` draws a level at ``0.8000000000000002``
+#: -- past ``end``, so the loop is not ``<= end`` -- while ``start=0, end=0.9,
+#: size=0.5`` stops at ``0.5`` and does *not* draw ``1.0``, so it is not
+#: ``end + size / 2`` either. ``end + size / 10`` fits all seven.
+_END_TOLERANCE = 10
+
+
+class PlotlyContourPlot(PlotlyPlot):
+    """Extract data from a Plotly ``contour`` trace.
+
+    A scalar field drawn as the curves along which it is constant. The core
+    reads it as `CONTOUR`, whose point carries a `level` as well as an x and a
+    y, and whose series is **one curve** rather than one level -- a field with
+    two peaks crosses a level twice, and joining the two islands into one
+    series would announce a curve running across ground the field never took.
+
+    **The curves are not in the trace.** Plotly ships a grid and a level
+    spacing and computes the curves in the browser, so reading this chart
+    means tracing the same marching squares here. That is what `contourpy`
+    does -- it is what matplotlib traces its own contours with, and it arrives
+    with matplotlib, which py-maidr already requires.
+
+    Two independent implementations agreeing is not a contract, so what they
+    agree about was measured rather than assumed. Across 33 fields and 207
+    levels -- random sums of gaussians, a saddle, a monkey saddle, ripples, a
+    staircase, noise -- plotly and ``contourpy`` **always** found the same
+    number of curves in a level, and put them in the same order all but 18
+    times. So the curves themselves are the same curves and the reading is
+    sound, while *which drawn path is which curve* is not always answerable,
+    which is what :meth:`_get_selector` turns on.
+
+    Parameters
+    ----------
+    trace : dict
+        The Plotly trace dictionary.
+    layout : dict
+        The Plotly figure layout.
+    layer_position : int
+        The trace's zero-based position among the subplot's traces that draw
+        into the ``contourlayer`` -- see :data:`_CONTOUR_LAYER_TYPES`. Only
+        the figure-wide pass knows it, which is why this layer is built there
+        rather than by :class:`~maidr.plotly.plotly_plot_factory.PlotlyPlotFactory`.
+    **kwargs : str
+        Axis names forwarded to the parent class.
+    """
+
+    def __init__(
+        self, trace: dict, layout: dict, *, layer_position: int, **kwargs: str
+    ) -> None:
+        self._layer_position = layer_position
+        #: The level index behind each emitted series, in emission order.
+        #:
+        #: What tells each series which ``g.contourlevel`` draws it, and --
+        #: by having a repeat in it -- that a level broke into islands, which
+        #: is when the layer declines its selectors. It indexes the declared
+        #: levels rather than counting series, and that is load-bearing: a
+        #: level nothing reaches emits no series but **does** reach the
+        #: document, as a ``g.contourlevel`` holding no ``path`` at all
+        #: (measured), so the groups and the levels stay in step while the
+        #: series do not.
+        self._series_levels: list[int] = []
+        super().__init__(trace, layout, PlotType.CONTOUR, **kwargs)
+
+    def _extract_plot_data(self) -> list[list[dict]]:
+        """Trace one series per curve, each point carrying its level.
+
+        Returns
+        -------
+        list of list of dict
+            One series per curve, in plotly's own drawing order. Empty when
+            the trace declines -- see :func:`declared_levels` and
+            :func:`_grid` for the three reasons -- which leaves the figure
+            with no contour layer rather than a wrong one (#636).
+        """
+        self._series_levels = []
+
+        levels = declared_levels(self._trace)
+        grid = _grid(self._trace)
+        if levels is None or grid is None:
+            return []
+
+        x, y, z = grid
+        try:
+            from contourpy import contour_generator
+
+            generator = contour_generator(
+                x=x, y=y, z=z, name=_CURVE_ALGORITHM, line_type="SeparateCode"
+            )
+        except Exception:
+            # `mpl2014` is the one algorithm whose curve order was measured
+            # against plotly's, so a contourpy that no longer offers it
+            # leaves nothing to emit in the order the selectors assume.
+            # Declining costs one layer; guessing would put every highlight
+            # on the wrong curve.
+            return []
+
+        data: list[list[dict]] = []
+        for index, level in enumerate(levels):
+            curves, _ = generator.lines(level)
+            for curve in curves:
+                data.append(
+                    [
+                        {
+                            MaidrKey.X: float(vertex[0]),
+                            MaidrKey.Y: float(vertex[1]),
+                            MaidrKey.LEVEL: level,
+                        }
+                        for vertex in curve
+                    ]
+                )
+                self._series_levels.append(index)
+
+        return data
+
+    def _get_selector(self) -> list[str]:
+        """Return one selector per emitted series, or none for the whole layer.
+
+        Plotly gives every declared level a ``g.contourlevel`` -- including the
+        ones the field never reaches, which get the group and no ``path`` --
+        and one ``<path>`` per disjoint curve inside it. The **level** is
+        therefore addressable: the groups run in the declared order, measured
+        on every figure below.
+
+        A **curve within a level** is not. Plotly and ``contourpy`` order the
+        islands of one level differently, and not only on contrived fields: a
+        sweep of 33 fields and 207 levels -- random sums of gaussians, a
+        saddle, a monkey saddle, ripples, a staircase, noise -- put the two in
+        the opposite order 18 times, five of them on ordinary two-peaked
+        gaussian fields. A positional selector would resolve to a real element
+        and to the wrong one, and the core parses the resolved path to place
+        the per-point highlights, so every point of that series would land on
+        an island the reader is not on. Worse than none, which is the outcome
+        #145 settled.
+
+        The same sweep found **no** disagreement about how many curves a level
+        has: 207 levels, 207 agreements. So the ambiguity is exactly the
+        ordering, and it only exists where a level has more than one curve. A
+        layer whose every drawn level draws a single curve therefore has one
+        forced mapping rather than a chosen one, and keeps its highlight; a
+        layer with an island anywhere ships without one and keeps its audio,
+        braille and text.
+
+        The one further case with nothing to address is ``coloring: "fill"``
+        (the default) with ``showlines: False``: measured in Chromium, plotly
+        then writes **no** ``g.contourlevel`` at all and draws only the bands.
+        The layer still reads -- a band's boundary is exactly the level curve,
+        so what is announced is true of the drawing -- and ships without a
+        highlight.
+
+        Returns
+        -------
+        list of str
+            One selector per series, in emission order, or an empty list.
+        """
+        if not draws_its_lines(self._trace):
+            return []
+        if len(set(self._series_levels)) != len(self._series_levels):
+            return []
+
+        return [
+            f"{self._subplot_css_prefix()}.contourlayer > "
+            f"g.contour:nth-of-type({self._layer_position + 1}) "
+            f"g.contourlevel:nth-of-type({level + 1}) "
+            f"path:nth-of-type(1)"
+            for level in self._series_levels
+        ]
+
+
+def is_contour_trace(trace: dict) -> bool:
+    """Report whether a trace is a contour plot."""
+    return trace.get("type") == "contour"
+
+
+def draws_into_the_contour_layer(trace: dict) -> bool:
+    """Report whether a trace takes a ``g.contour`` group on its subplot."""
+    return trace.get("type") in _CONTOUR_LAYER_TYPES
+
+
+def draws_its_lines(trace: dict) -> bool:
+    """Report whether plotly writes this trace's level curves as paths.
+
+    ``showlines`` is only honoured under ``coloring: "fill"``, which is the
+    default. Measured: with ``coloring: "heatmap"`` and ``showlines: False``
+    the curves are still drawn, and only the filled case removes them -- and
+    removes the ``g.contourlevel`` groups with them, so there is no element
+    left to point at.
+    """
+    contours = trace.get("contours")
+    if not isinstance(contours, dict):
+        return True
+    if contours.get("coloring", "fill") != "fill":
+        return True
+    return contours.get("showlines") is not False
+
+
+def declared_levels(trace: dict) -> list[float] | None:
+    """Return the levels the author asked for, or None when plotly picks them.
+
+    Plotly steps ``start``, ``start + size``, ... while the level is below
+    ``end + size / 10``, and swaps ``start`` and ``end`` when they arrive the
+    wrong way round. Accumulated rather than computed as ``start + k * size``
+    so the announced level is bit-for-bit the one plotly drew: with
+    ``start=0.2, size=0.2`` both routes agree on 0.4 and disagree on the
+    third level, and the level is also what is handed to the curve tracer.
+
+    None is returned -- the layer declines -- whenever plotly would choose the
+    levels itself, because the rule it chooses them by lives in plotly.js and
+    could not be reproduced here: measured across nine fields, eight fit
+    "round ``(max - min) / 15`` up to a 1/2/5x10ⁿ step", and a field spanning
+    ``0 .. 3`` does not. So a trace that leaves any of ``start``, ``end`` or
+    ``size`` out, that sets ``size`` to zero (plotly replaces it), or that
+    sets ``autocontour: True`` (which overrides an explicit spec -- measured)
+    is left unread rather than read at levels the chart does not draw. See
+    #642.
+    """
+    contours = trace.get("contours")
+    if not isinstance(contours, dict):
+        return None
+    if trace.get("autocontour") is True:
+        return None
+    # A constraint contour draws one curve at `value` and means "the region
+    # where z is above it", which is a different chart from a set of levels;
+    # it carries no start/end/size and so declines here anyway.
+    if contours.get("type") not in (None, "levels"):
+        return None
+
+    start = _a_number(contours.get("start"))
+    end = _a_number(contours.get("end"))
+    size = _a_number(contours.get("size"))
+    if start is None or end is None or size is None or size <= 0:
+        return None
+
+    low, high = (start, end) if start <= end else (end, start)
+    limit = high + size / _END_TOLERANCE
+    if (high - low) / size > _LEVEL_LIMIT:
+        return None
+
+    levels = []
+    level = low
+    while level < limit:
+        levels.append(level)
+        level += size
+    return levels
+
+
+def _grid(trace: dict) -> tuple[list[float], list[float], Any] | None:
+    """Return the field as ``(x, y, z)``, or None when it cannot be traced.
+
+    ``z`` comes back masked where it is missing, which is what makes the
+    curves stop at a hole the way plotly's do -- measured on a field with the
+    peak punched out: both dropped the level the hole ate and agreed on the
+    rest.
+
+    The mask is what ``contourpy`` documents for missing points. Passing the
+    NaN array straight through gives the same curves today -- measured, and it
+    is why removing the mask breaks no test -- but that is ``mpl2014``
+    treating NaN as missing rather than anything promised, so the documented
+    route is the one taken.
+    """
+    rows = [as_list(row) for row in as_list(trace.get("z"))]
+    if not rows:
+        return None
+
+    width = len(rows[0])
+    if any(len(row) != width for row in rows):
+        # Plotly draws no rectangle from a ragged grid, and the tracer wants
+        # one array.
+        return None
+
+    # A cell that is not a finite number becomes NaN, which is what a hole in
+    # the field is: `_a_number` answers None and numpy writes NaN for it.
+    z = np.array([[_a_number(value) for value in row] for row in rows], dtype=float)
+    if trace.get("transpose") is True:
+        # `transpose` turns z over and leaves x and y alone -- measured on an
+        # asymmetric field, where the two readings put the peak in different
+        # places and plotly drew the transposed one.
+        z = z.T
+    if z.shape[0] < 2 or z.shape[1] < 2:
+        # Marching squares needs a cell, which needs two rows and two columns.
+        return None
+
+    x = _coordinates(trace, "x", z.shape[1])
+    y = _coordinates(trace, "y", z.shape[0])
+    if x is None or y is None:
+        return None
+
+    return x, y, np.ma.masked_invalid(z)
+
+
+def _coordinates(trace: dict, key: str, count: int) -> list[float] | None:
+    """Return one axis's grid coordinates, or None when they are not numbers.
+
+    An explicit array wins when it describes the grid; otherwise the
+    ``x0``/``dx`` pair does, at plotly's own defaults of 0 and 1. An array of
+    the wrong length is declined rather than padded: plotly does something
+    with it, but not something that was measured, and a grid guessed wrong
+    puts every curve in the wrong place.
+
+    A **categorical** axis is declined by the same test. A contour crosses
+    between columns, so a curve sits at a fraction of the way from one
+    category to the next -- a position a category name cannot express, and
+    which naming the nearer category would misreport.
+    """
+    declared = as_list(trace.get(key))
+    if declared:
+        if len(declared) != count:
+            return None
+        values = [_a_number(value) for value in declared]
+        if any(value is None for value in values):
+            return None
+        return values  # type: ignore[return-value]
+
+    origin = _a_number(trace.get(f"{key}0"))
+    step = _a_number(trace.get(f"d{key}"))
+    origin = 0.0 if origin is None else origin
+    step = 1.0 if step is None else step
+    return [origin + step * index for index in range(count)]
+
+
+def _a_number(value: Any) -> float | None:
+    """Return ``value`` as a finite float, or None when it is not one."""
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None

--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 from typing import Any
 
@@ -9,13 +10,7 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
-#: The trace types that draw into a subplot's ``contourlayer``. Both take a
-#: ``g.contour`` group there, so a contour's position among *these* is what
-#: scopes its selector -- measured in Chromium on a figure holding a
-#: ``histogram2dcontour``, a ``contour`` and a ``heatmap``: the contour layer
-#: held two groups, in declaration order, and the heatmap was elsewhere in a
-#: ``heatmaplayer`` of its own.
-_CONTOUR_LAYER_TYPES = ("contour", "histogram2dcontour")
+_logger = logging.getLogger(__name__)
 
 #: Which marching-squares implementation to trace the curves with.
 #:
@@ -77,9 +72,10 @@ class PlotlyContourPlot(PlotlyPlot):
         The Plotly figure layout.
     layer_position : int
         The trace's zero-based position among the subplot's traces that draw
-        into the ``contourlayer`` -- see :data:`_CONTOUR_LAYER_TYPES`. Only
-        the figure-wide pass knows it, which is why this layer is built there
-        rather than by :class:`~maidr.plotly.plotly_plot_factory.PlotlyPlotFactory`.
+        into the ``contourlayer``, from
+        :func:`~maidr.plotly.candlestick.layer_position`. Only the figure-wide
+        pass knows it, which is why this layer is built there rather than by
+        :class:`~maidr.plotly.plotly_plot_factory.PlotlyPlotFactory`.
     **kwargs : str
         Axis names forwarded to the parent class.
     """
@@ -132,6 +128,16 @@ class PlotlyContourPlot(PlotlyPlot):
             # leaves nothing to emit in the order the selectors assume.
             # Declining costs one layer; guessing would put every highlight
             # on the wrong curve.
+            #
+            # Logged rather than swallowed outright, because everything a
+            # *chart* can decline for is guarded above: reaching here means
+            # the environment is not what it was measured to be, and a layer
+            # that vanishes with nothing said is hard to tell from one that
+            # was never there.
+            _logger.debug(
+                "maidr: could not trace a plotly contour with contourpy",
+                exc_info=True,
+            )
             return []
 
         data: list[list[dict]] = []
@@ -209,11 +215,6 @@ class PlotlyContourPlot(PlotlyPlot):
 def is_contour_trace(trace: dict) -> bool:
     """Report whether a trace is a contour plot."""
     return trace.get("type") == "contour"
-
-
-def draws_into_the_contour_layer(trace: dict) -> bool:
-    """Report whether a trace takes a ``g.contour`` group on its subplot."""
-    return trace.get("type") in _CONTOUR_LAYER_TYPES
 
 
 def draws_its_lines(trace: dict) -> bool:

--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -116,12 +116,19 @@ class PlotlyContourPlot(PlotlyPlot):
             return []
 
         x, y, z = grid
+        # The whole of the tracing, not only the generator's construction.
+        # `.lines()` is where the work happens, so it is where an unforeseen
+        # grid or a stricter future contourpy would raise -- and an exception
+        # escaping here leaves `render()` and takes the entire figure's
+        # schema with it, which is the one outcome every guard in this module
+        # exists to avoid (#421, #636). Costing one layer is the point.
         try:
             from contourpy import contour_generator
 
             generator = contour_generator(
                 x=x, y=y, z=z, name=_CURVE_ALGORITHM, line_type="SeparateCode"
             )
+            traced = [generator.lines(level)[0] for level in levels]
         except Exception:
             # `mpl2014` is the one algorithm whose curve order was measured
             # against plotly's, so a contourpy that no longer offers it
@@ -140,16 +147,19 @@ class PlotlyContourPlot(PlotlyPlot):
             )
             return []
 
+        # Built after the tracing rather than during it, so a failure part
+        # way through leaves no half-filled `_series_levels` behind: the two
+        # are read together and a mismatch would put every later series on
+        # the wrong level's group.
         data: list[list[dict]] = []
-        for index, level in enumerate(levels):
-            curves, _ = generator.lines(level)
+        for index, curves in enumerate(traced):
             for curve in curves:
                 data.append(
                     [
                         {
                             MaidrKey.X: float(vertex[0]),
                             MaidrKey.Y: float(vertex[1]),
-                            MaidrKey.LEVEL: level,
+                            MaidrKey.LEVEL: levels[index],
                         }
                         for vertex in curve
                     ]
@@ -166,6 +176,15 @@ class PlotlyContourPlot(PlotlyPlot):
         and one ``<path>`` per disjoint curve inside it. The **level** is
         therefore addressable: the groups run in the declared order, measured
         on every figure below.
+
+        ``:nth-of-type`` counts by *tag* among all siblings rather than among
+        the ones matching the class beside it, so it is exact only where the
+        siblings are homogeneous. Measured across seven configurations --
+        every ``coloring`` mode, ``showlabels``, a ``histogram2dcontour``
+        sibling, and two contours on one subplot -- they are: a
+        ``.contourlayer`` holds nothing but ``g.contour``, a ``g.contourlines``
+        nothing but ``g.contourlevel``, and a ``g.contourlevel`` nothing but
+        ``path``.
 
         A **curve within a level** is not. Plotly and ``contourpy`` order the
         islands of one level differently, and not only on contrived fields: a

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -16,7 +16,7 @@ from maidr.plotly.plotly_plot import subplot_block
 from maidr.plotly.gauge import draws_a_dial
 from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
 from maidr.plotly.area import is_area_trace
-from maidr.plotly.contour import draws_into_the_contour_layer, is_contour_trace
+from maidr.plotly.contour import is_contour_trace
 from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.trendline import is_trendline_trace
 from maidr.plotly.plotly_plot import (
@@ -1271,29 +1271,18 @@ class PlotlyMaidr:
             # the factory for the reason the waterfalls above are: plotly
             # appends one `g.contour` group per trace to the subplot's
             # `contourlayer`, and a `histogram2dcontour` takes one there too
-            # -- measured -- so a contour's selector is scoped by its
-            # position among *those* traces, which the factory, seeing one
-            # trace at a time, cannot know.
-            contour_layer_traces = [
-                t for t in group_traces if draws_into_the_contour_layer(t)
-            ]
-            contour_traces = [t for t in contour_layer_traces if is_contour_trace(t)]
+            # -- so a contour's selector is scoped by its position among
+            # *those* traces, which the factory, seeing one trace at a time,
+            # cannot know. `layer_position` knows which types share a layer.
+            contour_traces = [t for t in group_traces if is_contour_trace(t)]
             if contour_traces:
                 from maidr.plotly.contour import PlotlyContourPlot
 
-                # Keyed by identity rather than found with `.index`, which
-                # compares by value: two traces drawing the same field are
-                # equal dicts, so both would be handed position 0 and the
-                # second layer would highlight the first one's curves.
-                contour_layer_position = {
-                    id(t): position
-                    for position, t in enumerate(contour_layer_traces)
-                }
                 for contour_trace in contour_traces:
                     plot = PlotlyContourPlot(
                         contour_trace,
                         layout,
-                        layer_position=contour_layer_position[id(contour_trace)],
+                        layer_position=layer_position(group_traces, contour_trace),
                         **axis_kwargs,
                     )
                     plot.row_index = row

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -16,6 +16,7 @@ from maidr.plotly.plotly_plot import subplot_block
 from maidr.plotly.gauge import draws_a_dial
 from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
 from maidr.plotly.area import is_area_trace
+from maidr.plotly.contour import draws_into_the_contour_layer, is_contour_trace
 from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.trendline import is_trendline_trace
 from maidr.plotly.plotly_plot import (
@@ -1265,6 +1266,40 @@ class PlotlyMaidr:
                     plot.col_index = col
                     self._plots.append(plot)
                 merged.update(id(t) for t in waterfall_traces)
+
+            # Contours, one layer each. Built here rather than left to
+            # the factory for the reason the waterfalls above are: plotly
+            # appends one `g.contour` group per trace to the subplot's
+            # `contourlayer`, and a `histogram2dcontour` takes one there too
+            # -- measured -- so a contour's selector is scoped by its
+            # position among *those* traces, which the factory, seeing one
+            # trace at a time, cannot know.
+            contour_layer_traces = [
+                t for t in group_traces if draws_into_the_contour_layer(t)
+            ]
+            contour_traces = [t for t in contour_layer_traces if is_contour_trace(t)]
+            if contour_traces:
+                from maidr.plotly.contour import PlotlyContourPlot
+
+                # Keyed by identity rather than found with `.index`, which
+                # compares by value: two traces drawing the same field are
+                # equal dicts, so both would be handed position 0 and the
+                # second layer would highlight the first one's curves.
+                contour_layer_position = {
+                    id(t): position
+                    for position, t in enumerate(contour_layer_traces)
+                }
+                for contour_trace in contour_traces:
+                    plot = PlotlyContourPlot(
+                        contour_trace,
+                        layout,
+                        layer_position=contour_layer_position[id(contour_trace)],
+                        **axis_kwargs,
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in contour_traces)
 
             # Remaining traces
             for trace in group_traces:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,12 @@ dependencies = [
     # an accident rather than a promise.
     "matplotlib>=3.8",
     "seaborn>=0.13",
+    # Traces the curves a `go.Contour` only declares -- plotly ships a grid
+    # and a level spacing and computes the curves in the browser, so reading
+    # that chart means running the same marching squares here. Listed rather
+    # than relied upon: it already arrives with matplotlib, which is exactly
+    # the accident the matplotlib entry above exists to stop repeating.
+    "contourpy>=1.0.1",
     # 1.11 is the first scipy installable on every interpreter
     # `requires-python` promises: 1.10 caps itself at `<3.12`. The API used
     # (`interpolate.interp1d`) is far older than either, so the floor is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,6 @@ dependencies = [
     # an accident rather than a promise.
     "matplotlib>=3.8",
     "seaborn>=0.13",
-    # Traces the curves a `go.Contour` only declares -- plotly ships a grid
-    # and a level spacing and computes the curves in the browser, so reading
-    # that chart means running the same marching squares here. Listed rather
-    # than relied upon: it already arrives with matplotlib, which is exactly
-    # the accident the matplotlib entry above exists to stop repeating.
-    "contourpy>=1.0.1",
     # 1.11 is the first scipy installable on every interpreter
     # `requires-python` promises: 1.10 caps itself at `<3.12`. The API used
     # (`interpolate.interp1d`) is far older than either, so the floor is
@@ -85,6 +79,17 @@ jupyter = [
 ]
 plotly = [
     "plotly>=5.0",
+    # Traces the curves a `go.Contour` only declares -- plotly ships a grid
+    # and a level spacing and computes them in the browser, so reading that
+    # chart means running the same marching squares here. Imported lazily by
+    # `maidr/plotly/contour.py` and by nothing else, so it belongs beside
+    # `plotly` rather than in the base list, which is what `import maidr`
+    # itself needs.
+    #
+    # Listed rather than relied upon: it already arrives with matplotlib, and
+    # arriving with something is what the matplotlib entry in the base list
+    # exists to stop treating as a promise.
+    "contourpy>=1.0.1",
 ]
 shiny = [
     "shiny>=1.0",

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -491,3 +491,33 @@ def test_a_spacing_that_asks_for_a_billion_levels_is_declined() -> None:
 
     assert declared_levels(runaway) is None
     assert declared_levels(ordinary) == [0, 0.5, 1.0]
+
+
+def test_a_tracer_that_raises_costs_one_layer_and_not_the_figure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Building a schema must never take the render down (#421, #636).
+
+    Every reason a *chart* declines is decided before contourpy is asked
+    anything, so this stands in for the one case left: an environment that is
+    not what it was measured to be. The **tracing** is where the work happens,
+    so the tracing -- not only the generator's construction -- is what has to
+    be guarded, or the exception escapes `render()` and the whole figure's
+    schema goes with it. The bar beside it is the witness: it still arrives.
+    """
+    import contourpy
+
+    class _Broken:
+        def lines(self, level: float) -> tuple:
+            raise RuntimeError("no marching squares here")
+
+    monkeypatch.setattr(contourpy, "contour_generator", lambda **_: _Broken())
+
+    figure = go.Figure(
+        [
+            go.Bar(x=["a"], y=[1]),
+            _contour(ONE_PEAK, start=0.5, end=0.5, size=0.5),
+        ]
+    )
+
+    assert [layer["type"] for layer in _layers(figure)] == [PlotType.BAR]

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -1,0 +1,493 @@
+"""A plotly contour plot produced a figure with no layers.
+
+`go.Contour` draws a scalar field as the curves along which it is constant.
+`maidr/plotly/` had no handling for it, so it fell through `_extract_plots` to
+`PlotlyPlotFactory`, which returned `None` (#627). The core has had
+`TraceType.CONTOUR` for this shape since the matplotlib side was read (#539).
+
+**The curves are not in the trace.** Plotly ships a grid and a level spacing
+and traces the curves in the browser, so reading this chart means running the
+same marching squares here -- `contourpy`, which is what matplotlib traces its
+own contours with.
+
+Two independent implementations agreeing is not a contract, so what they agree
+about was measured. Across 33 fields and 207 levels -- random sums of
+gaussians, a saddle, a monkey saddle, ripples, a staircase, noise -- plotly and
+`contourpy` **always** found the same number of curves in a level, and put them
+in the same order all but 18 times, five of those on ordinary two-peaked
+gaussian fields. So the curves are the same curves, and it is only *which drawn
+path is which curve* that is sometimes unanswerable -- which is exactly what
+the selectors turn on, and why a layer with an island anywhere ships without
+one.
+
+Plotly's level list was pinned the same way: it steps `start`, `start + size`,
+... while the level is below `end + size / 10`. Neither `<= end` (which drops
+a level plotly draws at `start=0.2, end=0.8, size=0.05`) nor `end + size / 2`
+(which adds one plotly does not draw at `start=0, end=0.9, size=0.5`) fits.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: A field with one peak, small enough to read by eye. At level 0.5 it draws a
+#: single diamond around the middle cell.
+ONE_PEAK = [
+    [0, 0, 0],
+    [0, 1, 0],
+    [0, 0, 0],
+]
+
+#: The same field with a second peak. At level 0.5 it draws two diamonds, so
+#: one level owns two curves -- the case whose drawn order is plotly's own.
+TWO_PEAKS = [
+    [0, 0, 0, 0, 0],
+    [0, 1, 0, 1, 0],
+    [0, 0, 0, 0, 0],
+]
+
+#: What both fields' single-cell peaks look like at level 0.5: the diamond
+#: whose corners are the midpoints of the four edges around the peak.
+DIAMOND = [(1.0, 0.5), (1.5, 1.0), (1.0, 1.5), (0.5, 1.0), (1.0, 0.5)]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _curve(series: list[dict]) -> list[tuple[float, float]]:
+    """One series as ``(x, y)`` pairs, rounded past floating-point noise."""
+    return [(round(point["x"], 6), round(point["y"], 6)) for point in series]
+
+
+def _levels(layer: dict) -> list[float]:
+    """The level each series runs at, in emission order."""
+    return [series[0]["level"] for series in layer["data"]]
+
+
+def _contour(z: list, **contours: object) -> go.Contour:
+    """A contour of ``z`` at explicit levels, drawn as lines."""
+    return go.Contour(z=z, contours=dict(coloring="lines", **contours))
+
+
+def test_a_contour_is_read_as_a_contour_layer() -> None:
+    """The reproduction, and the type it becomes."""
+    (layer,) = _layers(go.Figure(_contour(ONE_PEAK, start=0.5, end=0.5, size=0.5)))
+
+    assert layer["type"] is PlotType.CONTOUR
+
+
+def test_a_curve_is_traced_from_the_grid_the_trace_ships() -> None:
+    """The trace carries a grid and a spacing; the curve is computed here."""
+    (layer,) = _layers(go.Figure(_contour(ONE_PEAK, start=0.5, end=0.5, size=0.5)))
+
+    assert [_curve(series) for series in layer["data"]] == [DIAMOND]
+
+
+def test_a_level_with_two_islands_is_two_series() -> None:
+    """One series per curve, which is what the grammar's unit is.
+
+    A field with two peaks crosses a level twice. Read as one series the two
+    islands would be joined by a straight run between the peaks -- a curve
+    announced across ground the field never took, which is the defect
+    xability/maidr#1079 describes for a gappy line.
+    """
+    (layer,) = _layers(go.Figure(_contour(TWO_PEAKS, start=0.5, end=0.5, size=0.5)))
+
+    assert [_curve(series) for series in layer["data"]] == [
+        DIAMOND,
+        [(3.0, 0.5), (3.5, 1.0), (3.0, 1.5), (2.5, 1.0), (3.0, 0.5)],
+    ]
+
+
+def test_every_point_of_a_curve_carries_its_level() -> None:
+    """`ContourPoint` puts the level on the point, so a flat reader has it.
+
+    It is constant down a curve and carried on every point of it, the way `z`
+    is -- the grammar's unit is the point, and a producer emitting a flat list
+    has nowhere else to put it.
+    """
+    (layer,) = _layers(go.Figure(_contour(ONE_PEAK, start=0.5, end=0.5, size=0.5)))
+
+    (series,) = layer["data"]
+    assert {point["level"] for point in series} == {0.5}
+
+
+def test_a_level_past_the_end_is_not_stepped_to() -> None:
+    """``end + size / 2`` would add one plotly does not draw.
+
+    From 0 in steps of 0.5 with ``end`` at 0.9, plotly draws 0 and 0.5 and
+    stops. The field peaks at 2, so a level at 1.0 would cross it plainly --
+    it is absent because it is not declared, not because nothing reached it.
+    """
+    tall = [[0, 0, 0], [0, 2, 0], [0, 0, 0]]
+
+    (layer,) = _layers(go.Figure(_contour(tall, start=0, end=0.9, size=0.5)))
+
+    assert _levels(layer) == [0.0, 0.5]
+
+
+def test_a_level_that_accumulates_a_hair_past_the_end_is_still_stepped_to() -> None:
+    """``<= end`` would drop it, and plotly draws it.
+
+    Stepping 0.05 from 0.2 lands on ``0.8000000000000002`` rather than 0.8,
+    and plotly's thirteenth group is that level -- measured. The levels are
+    accumulated here for exactly this reason, so the number announced, the
+    number handed to the tracer and the number plotly drew are one number.
+    """
+    (layer,) = _layers(go.Figure(_contour(ONE_PEAK, start=0.2, end=0.8, size=0.05)))
+
+    assert len(_levels(layer)) == 13
+    assert _levels(layer)[-1] == 0.8000000000000002
+
+
+def test_a_spec_written_backwards_is_read_the_way_plotly_draws_it() -> None:
+    """Plotly swaps ``start`` and ``end`` rather than drawing nothing."""
+    (layer,) = _layers(go.Figure(_contour(ONE_PEAK, start=2.5, end=0.5, size=1.0)))
+
+    assert _levels(layer) == [0.5]
+
+
+def test_a_level_the_field_never_reaches_still_counts_for_the_selector() -> None:
+    """Plotly gives it a `g.contourlevel` holding no path at all.
+
+    Measured. So the groups follow the *declared* levels while the series
+    follow the drawn ones, and a series has to name its level's position
+    rather than its own -- here the third of three levels, from the only one
+    that draws.
+    """
+    (layer,) = _layers(go.Figure(_contour(ONE_PEAK, start=-1.5, end=0.5, size=1.0)))
+
+    assert _levels(layer) == [0.5]
+    assert layer["selectors"] == [
+        ".subplot.xy .contourlayer > g.contour:nth-of-type(1) "
+        "g.contourlevel:nth-of-type(3) path:nth-of-type(1)"
+    ]
+
+
+def test_a_layer_whose_levels_each_draw_one_curve_is_addressable() -> None:
+    """One selector per series, naming the level group that draws it.
+
+    With one curve in the level there is one path in its group, so the mapping
+    is forced rather than chosen -- and the sweep found no field where plotly
+    and `contourpy` disagreed about *how many* curves a level has.
+    """
+    (layer,) = _layers(go.Figure(_contour(ONE_PEAK, start=0.3, end=0.7, size=0.2)))
+
+    prefix = ".subplot.xy .contourlayer > g.contour:nth-of-type(1) "
+    assert layer["selectors"] == [
+        f"{prefix}g.contourlevel:nth-of-type({index}) path:nth-of-type(1)"
+        for index in (1, 2, 3)
+    ]
+
+
+def test_a_layer_with_an_island_ships_without_a_highlight() -> None:
+    """Plotly's order for a level's curves is its own, and not derivable.
+
+    Measured across 33 fields and 207 levels: 18 disagreements about the order
+    of the curves within a level, five of them on ordinary two-peaked gaussian
+    fields rather than contrived ones. A positional selector would resolve to
+    a real element and to the wrong one -- and the core parses the resolved
+    path to place the per-point highlights, so every point of that series
+    would land on an island the reader is not on.
+
+    So the layer keeps its audio, braille and text and claims no highlight,
+    the outcome #145 established.
+    """
+    (layer,) = _layers(go.Figure(_contour(TWO_PEAKS, start=0.5, end=0.5, size=0.5)))
+
+    assert len(layer["data"]) == 2
+    assert "selectors" not in layer
+
+
+def test_a_filled_contour_with_its_lines_off_has_nothing_to_point_at() -> None:
+    """Measured: plotly then writes no `g.contourlevel` at all.
+
+    The layer still reads. A band's boundary is exactly where the level curve
+    runs, so what is announced is true of the drawing -- only the element to
+    outline is missing.
+    """
+    figure = go.Figure(
+        go.Contour(z=ONE_PEAK, contours=dict(start=0.5, end=0.5, size=0.5, showlines=False))
+    )
+
+    (layer,) = _layers(figure)
+
+    assert [_curve(series) for series in layer["data"]] == [DIAMOND]
+    assert "selectors" not in layer
+
+
+def test_showlines_off_under_another_coloring_still_draws_the_curves() -> None:
+    """`showlines` is only honoured for `coloring: "fill"` -- measured.
+
+    Under `heatmap` the level groups are written whatever it says, so reading
+    it as "no lines" would drop a highlight the chart does have.
+    """
+    figure = go.Figure(
+        go.Contour(
+            z=ONE_PEAK,
+            contours=dict(
+                start=0.5, end=0.5, size=0.5, coloring="heatmap", showlines=False
+            ),
+        )
+    )
+
+    (layer,) = _layers(figure)
+
+    assert len(layer["selectors"]) == 1
+
+
+def test_auto_levels_are_declined() -> None:
+    """Plotly's rule for picking them lives in plotly.js and was not derivable.
+
+    Measured across nine z ranges, eight fit "round ``(max - min) / 15`` up to
+    a 1/2/5x10ⁿ step" and a field spanning 0 .. 3 does not. Reading the chart
+    at levels it does not draw would announce curves that are not there, so
+    the trace is left unread until the rule is settled (#642).
+    """
+    assert _layers(go.Figure(go.Contour(z=ONE_PEAK))) == []
+
+
+@pytest.mark.parametrize(
+    ("contours", "extra"),
+    [
+        pytest.param({"start": 0.5}, {}, id="start-without-end-or-size"),
+        pytest.param({"size": 0.5}, {}, id="size-alone"),
+        pytest.param({"start": 0.5, "end": 1.5}, {}, id="no-size"),
+        pytest.param({"start": 0.5, "end": 1.5, "size": 0}, {}, id="zero-size"),
+        pytest.param(
+            {"start": 0.5, "end": 1.5, "size": 0.5},
+            {"autocontour": True},
+            id="autocontour-overrides-the-spec",
+        ),
+        pytest.param(
+            {
+                "type": "constraint",
+                "operation": ">",
+                "value": 0.5,
+                "start": 0.1,
+                "end": 0.9,
+                "size": 0.2,
+            },
+            {},
+            id="a-constraint-is-a-region-not-a-set-of-levels",
+        ),
+    ],
+)
+def test_a_half_written_spec_is_declined(contours: dict, extra: dict) -> None:
+    """Each of these leaves plotly picking the levels, or picking a chart.
+
+    ``size: 0`` is replaced by plotly with a computed spacing, and
+    ``autocontour: True`` overrides an otherwise complete spec -- both
+    measured. A ``constraint`` contour draws one curve at ``value`` and means
+    "the region beyond it", which is a different chart from a set of levels --
+    and it is written here *with* a full ``start``/``end``/``size`` on purpose,
+    because plotly ignores them (measured: one group, at 0.5) while anything
+    reading them would announce five levels the chart does not draw.
+    """
+    assert _layers(go.Figure(go.Contour(z=ONE_PEAK, contours=contours, **extra))) == []
+
+
+def test_a_grid_with_no_coordinates_is_read_at_its_indices() -> None:
+    """Which is what plotly draws it at."""
+    (layer,) = _layers(go.Figure(_contour(ONE_PEAK, start=0.5, end=0.5, size=0.5)))
+
+    assert _curve(layer["data"][0]) == DIAMOND
+
+
+def test_x0_and_dx_place_the_grid() -> None:
+    """Plotly's other way of writing evenly spaced coordinates."""
+    figure = go.Figure(
+        go.Contour(
+            z=ONE_PEAK,
+            x0=10,
+            dx=2,
+            y0=100,
+            dy=5,
+            contours=dict(coloring="lines", start=0.5, end=0.5, size=0.5),
+        )
+    )
+
+    (layer,) = _layers(figure)
+
+    assert _curve(layer["data"][0]) == [
+        (12.0, 102.5),
+        (13.0, 105.0),
+        (12.0, 107.5),
+        (11.0, 105.0),
+        (12.0, 102.5),
+    ]
+
+
+def test_transpose_turns_the_grid_over_and_leaves_the_coordinates() -> None:
+    """Measured on an asymmetric field: plotly draws the transposed reading.
+
+    The peak sits in column 1 of a 2x3 grid; transposed it is in row 1 of a
+    3x2 one, which puts the curve somewhere else entirely.
+    """
+    z = [[0, 1, 0], [0, 0, 0]]
+
+    plain = _layers(go.Figure(_contour(z, start=0.5, end=0.5, size=0.5)))
+    turned = _layers(
+        go.Figure(go.Contour(z=z, transpose=True, contours=dict(start=0.5, end=0.5, size=0.5)))
+    )
+
+    assert plain != []
+    # Transposed the grid is 3x2 with the peak on its edge, so the level
+    # crosses it differently -- the point is that the two readings differ.
+    assert [_curve(s) for s in plain[0]["data"]] != [_curve(s) for s in turned[0]["data"]]
+
+
+def test_a_hole_in_the_grid_stops_the_curves_the_way_plotly_does() -> None:
+    """A missing z is a hole in the field, not a reason to decline the trace.
+
+    Measured on a field with its peak punched out: plotly and the tracer both
+    dropped the level the hole ate and agreed on the rest.
+    """
+    z = [[0, 0, 0], [0, None, 0], [0, 0, 0]]
+
+    assert _layers(go.Figure(_contour(z, start=0.5, end=0.5, size=0.5))) == []
+
+
+@pytest.mark.parametrize(
+    ("z", "extra"),
+    [
+        pytest.param([], {}, id="no-grid"),
+        pytest.param([[1, 2, 3]], {}, id="one-row"),
+        pytest.param([[1], [2], [3]], {}, id="one-column"),
+        pytest.param([[0, 0, 0], [0, 1], [0, 0, 0]], {}, id="ragged"),
+        pytest.param(
+            ONE_PEAK, {"x": ["a", "b", "c"]}, id="a-category-is-not-a-position"
+        ),
+        pytest.param(ONE_PEAK, {"x": [0, 1]}, id="an-x-that-misses-the-width"),
+    ],
+)
+def test_a_grid_that_cannot_be_traced_forms_no_layer(z: list, extra: dict) -> None:
+    """Each of these has no field to trace, or none that was measured.
+
+    Marching squares needs a cell, so it needs two rows and two columns. A
+    **categorical** x is declined for a reason of its own: a contour crosses
+    *between* columns, so a curve sits a fraction of the way from one category
+    to the next -- a position a category name cannot express, and which naming
+    the nearer category would misreport.
+    """
+    figure = go.Figure(
+        go.Contour(z=z, contours=dict(start=0.5, end=0.5, size=0.5), **extra)
+    )
+
+    assert _layers(figure) == []
+
+
+def test_a_contour_names_the_axes_the_author_titled() -> None:
+    """It is a cartesian trace, so its axis titles are the layout's."""
+    figure = go.Figure(_contour(ONE_PEAK, start=0.5, end=0.5, size=0.5))
+    figure.update_layout(xaxis_title="Easting", yaxis_title="Northing")
+
+    (layer,) = _layers(figure)
+
+    assert layer["axes"]["x"]["label"] == "Easting"
+    assert layer["axes"]["y"]["label"] == "Northing"
+
+
+def test_two_contours_on_one_subplot_address_their_own_groups() -> None:
+    """Plotly appends one `g.contour` per trace to the subplot's layer."""
+    figure = go.Figure(
+        [
+            _contour(ONE_PEAK, start=0.5, end=0.5, size=0.5),
+            _contour(ONE_PEAK, start=0.5, end=0.5, size=0.5),
+        ]
+    )
+
+    first, second = _layers(figure)
+
+    assert "g.contour:nth-of-type(1)" in first["selectors"][0]
+    assert "g.contour:nth-of-type(2)" in second["selectors"][0]
+
+
+def test_a_histogram2dcontour_shifts_the_group_index() -> None:
+    """It draws into the same `contourlayer` -- measured.
+
+    Counting only the contour traces would hand this one group 1, which is the
+    histogram's, and the highlight would land on a chart the reader is not
+    reading. maidr renders no layer for the histogram itself, so it is only
+    ever counted, never emitted.
+    """
+    figure = go.Figure(
+        [
+            go.Histogram2dContour(x=[0, 1, 2, 1, 0], y=[0, 1, 2, 0, 1]),
+            _contour(ONE_PEAK, start=0.5, end=0.5, size=0.5),
+        ]
+    )
+
+    contours = [layer for layer in _layers(figure) if layer["type"] is PlotType.CONTOUR]
+
+    assert len(contours) == 1
+    assert "g.contour:nth-of-type(2)" in contours[0]["selectors"][0]
+
+
+def test_a_contour_on_a_second_subplot_is_scoped_to_it() -> None:
+    """Two subplots each hold a `contourlayer`, so the prefix separates them."""
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(rows=1, cols=2)
+    figure.add_trace(go.Bar(x=["a"], y=[1]), row=1, col=1)
+    figure.add_trace(_contour(ONE_PEAK, start=0.5, end=0.5, size=0.5), row=1, col=2)
+
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert [len(row) for row in grid] == [2]
+    (contour_layer,) = grid[0][1]["layers"]
+    assert contour_layer["selectors"][0].startswith(".subplot.x2y2 ")
+
+
+def test_a_contour_with_no_grid_forms_no_layer() -> None:
+    """Nothing is drawn, so there is nothing to read (#636)."""
+    assert _layers(go.Figure(_contour([], start=0.5, end=0.5, size=0.5))) == []
+
+
+def test_a_grid_that_cannot_be_traced_is_declined_outright() -> None:
+    """Rather than left for the tracer to raise about.
+
+    ``contourpy`` rejects both of these -- a coordinate array that does not
+    describe the grid, and a grid with no cell in it -- and
+    :meth:`PlotlyContourPlot._extract_plot_data` catches that, so the layer is
+    dropped either way and no rendered figure can tell the two apart. They are
+    still decisions rather than accidents: plotly draws *something* from a
+    short ``x`` (measured), and declining says this reader will not guess
+    what. Asserted here because that is the only place the difference shows.
+    """
+    from maidr.plotly.contour import _grid
+
+    assert _grid({"z": ONE_PEAK, "x": [0, 1]}) is None
+    assert _grid({"z": ONE_PEAK, "y": [0, 1, 2, 3]}) is None
+    assert _grid({"z": [[1, 2, 3]]}) is None
+    assert _grid({"z": [[1], [2], [3]]}) is None
+    assert _grid({"z": ONE_PEAK, "x": [0, 1, 2]}) is not None
+
+
+def test_a_spacing_that_asks_for_a_billion_levels_is_declined() -> None:
+    """A schema must never cost the render (#421, #636).
+
+    ``size`` is the author's, so this spec is writable, and tracing a billion
+    levels would hang the export rather than produce a chart. Reached by
+    calling the level list directly: a test that actually built one would be
+    the hang it is guarding against.
+    """
+    from maidr.plotly.contour import declared_levels
+
+    runaway = {"contours": {"start": 0, "end": 1, "size": 1e-9}}
+    ordinary = {"contours": {"start": 0, "end": 1, "size": 0.5}}
+
+    assert declared_levels(runaway) is None
+    assert declared_levels(ordinary) == [0, 0.5, 1.0]

--- a/uv.lock
+++ b/uv.lock
@@ -23,11 +23,11 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "jinja2" },
-    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "narwhals" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "jinja2", marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "narwhals", marker = "python_full_version < '3.10'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/16/b1/f2969c7bdb8ad8bbdda031687defdce2c19afba2aa2c8e1d2a17f78376d8/altair-5.5.0.tar.gz", hash = "sha256:d960ebe6178c56de3855a68c47b516be38640b73fb3b5111c2a9ca90546dd73d", size = 705305, upload-time = "2024-11-23T23:39:58.542Z" }
 wheels = [
@@ -51,11 +51,11 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "jinja2" },
-    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "narwhals" },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+    { name = "jinja2", marker = "python_full_version >= '3.10'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "narwhals", marker = "python_full_version >= '3.10'" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.15'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/1e/365a9144db3254f86f1b974660b9ede1e9a38c9dc0730e4a9b1192eec5d6/altair-6.1.0.tar.gz", hash = "sha256:dda699216cf85b040d968ae5a569ad45957616811e38760a85e5118269daca67", size = 765519, upload-time = "2026-04-21T13:08:46.44Z" }
 wheels = [
@@ -79,9 +79,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "exceptiongroup" },
-    { name = "idna" },
-    { name = "typing-extensions" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -105,9 +105,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -192,7 +192,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
@@ -216,7 +216,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
 wheels = [
@@ -240,7 +240,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/4d/71ec4d3939dc755264f680f6c2b4906423a304c3d18e96853f0a595dfe97/async_lru-2.0.5.tar.gz", hash = "sha256:481d52ccdd27275f42c43a928b4a50c3bfb2d67af4e78b170e3e0bb39c66e5bb", size = 10380, upload-time = "2025-03-16T17:25:36.919Z" }
 wheels = [
@@ -264,7 +264,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
 wheels = [
@@ -319,14 +319,14 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "mypy-extensions" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pathspec" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pytokens" },
-    { name = "tomli" },
-    { name = "typing-extensions" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mypy-extensions", marker = "python_full_version < '3.10'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pathspec", marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytokens", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8c/ad/33adf4708633d047950ff2dfdea2e215d84ac50ef95aff14a614e4b6e9b2/black-25.11.0.tar.gz", hash = "sha256:9a323ac32f5dc75ce7470501b887250be5005a01602e931a15e45593f70f6e08", size = 655669, upload-time = "2025-11-10T01:53:50.558Z" }
 wheels = [
@@ -374,14 +374,14 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "mypy-extensions" },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pathspec" },
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pytokens" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "mypy-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pathspec", marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytokens", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
 wheels = [
@@ -421,7 +421,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "webencodings" },
+    { name = "webencodings", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/9a/0e33f5054c54d349ea62c277191c020c2d6ef1d65ab2cb1993f91ec846d1/bleach-6.2.0.tar.gz", hash = "sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f", size = 203083, upload-time = "2024-10-29T18:30:40.477Z" }
 wheels = [
@@ -430,7 +430,7 @@ wheels = [
 
 [package.optional-dependencies]
 css = [
-    { name = "tinycss2" },
+    { name = "tinycss2", marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]
@@ -450,7 +450,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "webencodings" },
+    { name = "webencodings", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
 wheels = [
@@ -459,7 +459,7 @@ wheels = [
 
 [package.optional-dependencies]
 css = [
-    { name = "tinycss2" },
+    { name = "tinycss2", marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]
@@ -779,7 +779,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -803,7 +803,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
@@ -849,7 +849,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/31a8f28b4a2a4fa0e01085e542f3081ab0588eff8e589d39d775172c9792/contourpy-1.3.0.tar.gz", hash = "sha256:7ffa0db17717a8ffb127efd0c95a4362d996b892c2904db72428d5b52e1938a4", size = 13464370, upload-time = "2024-08-27T21:00:03.328Z" }
 wheels = [
@@ -927,7 +927,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1005,7 +1005,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1210,7 +1210,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1524,10 +1524,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.10.*'",
 ]
@@ -1642,8 +1642,8 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/1d/c568d17e9fb5ad5aa0ca3531c58d36fe69deb8eee4e53ff6425c1f99f210/htmltools-0.6.0.tar.gz", hash = "sha256:e8a3fb023d748935035db7ff17f620612ffc814a6a80b6ae388f7b7ab182adf7", size = 97152, upload-time = "2024-10-29T20:21:43.378Z" }
 wheels = [
@@ -1667,8 +1667,8 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/e6/a4dcaf072ecf76fd32854bf37c63d246c83acdf7a80fa81cba9c232558af/htmltools-0.6.1.tar.gz", hash = "sha256:3dc4505b5134055cb10be251f8f17431bcdad9f5de11667f53a1405aec221f38", size = 97717, upload-time = "2026-05-01T15:07:58.293Z" }
 wheels = [
@@ -1811,7 +1811,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1835,7 +1835,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1895,19 +1895,19 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
-    { name = "comm" },
-    { name = "debugpy" },
-    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-client", version = "8.6.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "nest-asyncio" },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "psutil" },
-    { name = "pyzmq" },
-    { name = "tornado" },
-    { name = "traitlets" },
+    { name = "appnope", marker = "python_full_version < '3.10' and sys_platform == 'darwin'" },
+    { name = "comm", marker = "python_full_version < '3.10'" },
+    { name = "debugpy", marker = "python_full_version < '3.10'" },
+    { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jupyter-client", version = "8.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.10'" },
+    { name = "nest-asyncio", marker = "python_full_version < '3.10'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "psutil", marker = "python_full_version < '3.10'" },
+    { name = "pyzmq", marker = "python_full_version < '3.10'" },
+    { name = "tornado", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a5/1d/d5ba6edbfe6fae4c3105bca3a9c889563cc752c7f2de45e333164c7f4846/ipykernel-6.31.0.tar.gz", hash = "sha256:2372ce8bc1ff4f34e58cafed3a0feb2194b91fc7cad0fc72e79e47b45ee9e8f6", size = 167493, upload-time = "2025-10-20T11:42:39.948Z" }
 wheels = [
@@ -1931,20 +1931,20 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
-    { name = "comm" },
-    { name = "debugpy" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "appnope", marker = "python_full_version >= '3.10' and sys_platform == 'darwin'" },
+    { name = "comm", marker = "python_full_version >= '3.10'" },
+    { name = "debugpy", marker = "python_full_version >= '3.10'" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "jupyter-client", version = "8.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "nest-asyncio" },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "psutil" },
-    { name = "pyzmq" },
-    { name = "tornado" },
-    { name = "traitlets" },
+    { name = "jupyter-client", version = "8.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.10'" },
+    { name = "nest-asyncio", marker = "python_full_version >= '3.10'" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "psutil", marker = "python_full_version >= '3.10'" },
+    { name = "pyzmq", marker = "python_full_version >= '3.10'" },
+    { name = "tornado", marker = "python_full_version >= '3.10'" },
+    { name = "traitlets", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/8d/b68b728e2d06b9e0051019640a40a9eb7a88fcd82c2e1b5ce70bef5ff044/ipykernel-7.2.0.tar.gz", hash = "sha256:18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e", size = 176046, upload-time = "2026-02-06T16:43:27.403Z" }
 wheels = [
@@ -1959,17 +1959,17 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi", version = "0.19.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.10'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "jedi", version = "0.19.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.10'" },
+    { name = "pexpect", marker = "python_full_version < '3.10' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "stack-data", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/b9/3ba6c45a6df813c09a48bac313c22ff83efa26cbb55011218d925a46e2ad/ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27", size = 5486330, upload-time = "2023-11-27T09:58:34.596Z" }
 wheels = [
@@ -1984,17 +1984,17 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi", version = "0.20.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version == '3.10.*' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version == '3.10.*'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "jedi", version = "0.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "matplotlib-inline", marker = "python_full_version == '3.10.*'" },
+    { name = "pexpect", marker = "python_full_version == '3.10.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version == '3.10.*'" },
+    { name = "pygments", marker = "python_full_version == '3.10.*'" },
+    { name = "stack-data", marker = "python_full_version == '3.10.*'" },
+    { name = "traitlets", marker = "python_full_version == '3.10.*'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -2017,18 +2017,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi", version = "0.20.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", version = "0.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -2040,7 +2040,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -2094,7 +2094,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "parso" },
+    { name = "parso", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
 wheels = [
@@ -2118,7 +2118,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "parso" },
+    { name = "parso", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
@@ -2187,10 +2187,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing", version = "0.36.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version < '3.10'" },
+    { name = "jsonschema-specifications", marker = "python_full_version < '3.10'" },
+    { name = "referencing", version = "0.36.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
 wheels = [
@@ -2199,15 +2199,15 @@ wheels = [
 
 [package.optional-dependencies]
 format-nongpl = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "rfc3987-syntax" },
-    { name = "uri-template" },
-    { name = "webcolors", version = "24.11.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "fqdn", marker = "python_full_version < '3.10'" },
+    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "isoduration", marker = "python_full_version < '3.10'" },
+    { name = "jsonpointer", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "rfc3339-validator", marker = "python_full_version < '3.10'" },
+    { name = "rfc3986-validator", marker = "python_full_version < '3.10'" },
+    { name = "rfc3987-syntax", marker = "python_full_version < '3.10'" },
+    { name = "uri-template", marker = "python_full_version < '3.10'" },
+    { name = "webcolors", version = "24.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 
 [[package]]
@@ -2227,10 +2227,10 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version >= '3.10'" },
+    { name = "jsonschema-specifications", marker = "python_full_version >= '3.10'" },
+    { name = "referencing", version = "0.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -2239,15 +2239,15 @@ wheels = [
 
 [package.optional-dependencies]
 format-nongpl = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer", version = "3.1.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "rfc3987-syntax" },
-    { name = "uri-template" },
-    { name = "webcolors", version = "25.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "fqdn", marker = "python_full_version >= '3.10'" },
+    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "isoduration", marker = "python_full_version >= '3.10'" },
+    { name = "jsonpointer", version = "3.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "rfc3339-validator", marker = "python_full_version >= '3.10'" },
+    { name = "rfc3986-validator", marker = "python_full_version >= '3.10'" },
+    { name = "rfc3987-syntax", marker = "python_full_version >= '3.10'" },
+    { name = "uri-template", marker = "python_full_version >= '3.10'" },
+    { name = "webcolors", version = "25.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [[package]]
@@ -2289,12 +2289,12 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pyzmq" },
-    { name = "tornado" },
-    { name = "traitlets" },
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
+    { name = "pyzmq", marker = "python_full_version < '3.10'" },
+    { name = "tornado", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/22/bf9f12fdaeae18019a468b68952a60fe6dbab5d67cd2a103cac7659b41ca/jupyter_client-8.6.3.tar.gz", hash = "sha256:35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419", size = 342019, upload-time = "2024-09-17T10:44:17.613Z" }
 wheels = [
@@ -2318,11 +2318,11 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pyzmq" },
-    { name = "tornado" },
-    { name = "traitlets" },
+    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
+    { name = "pyzmq", marker = "python_full_version >= '3.10'" },
+    { name = "tornado", marker = "python_full_version >= '3.10'" },
+    { name = "traitlets", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
 wheels = [
@@ -2361,9 +2361,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
-    { name = "traitlets" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pywin32", marker = "python_full_version < '3.10' and platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/1b/72906d554acfeb588332eaaa6f61577705e9ec752ddb486f302dafa292d9/jupyter_core-5.8.1.tar.gz", hash = "sha256:0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941", size = 88923, upload-time = "2025-05-27T07:38:16.655Z" }
 wheels = [
@@ -2387,8 +2387,8 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "traitlets" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "traitlets", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
@@ -2804,7 +2804,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "uc-micro-py", version = "1.0.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "uc-micro-py", version = "1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
 wheels = [
@@ -2828,7 +2828,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "uc-micro-py", version = "2.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "uc-micro-py", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
 wheels = [
@@ -2974,6 +2974,9 @@ name = "maidr"
 version = "1.21.0"
 source = { editable = "." }
 dependencies = [
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "htmltools", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "htmltools", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "lxml" },
@@ -3057,6 +3060,7 @@ dev = [
 requires-dist = [
     { name = "altair", marker = "extra == 'altair'", specifier = ">=5.0" },
     { name = "altair", marker = "extra == 'test'", specifier = ">=5.0" },
+    { name = "contourpy", specifier = ">=1.0.1" },
     { name = "cssselect", marker = "extra == 'test'", specifier = ">=1.2" },
     { name = "flask", marker = "extra == 'test'", specifier = ">=3.0.0" },
     { name = "flask", marker = "extra == 'visualization'", specifier = ">=3.0.0" },
@@ -3108,7 +3112,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
@@ -3132,7 +3136,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
@@ -3243,16 +3247,16 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools", version = "4.60.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "importlib-resources" },
-    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "cycler", marker = "python_full_version < '3.10'" },
+    { name = "fonttools", version = "4.60.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "importlib-resources", marker = "python_full_version < '3.10'" },
+    { name = "kiwisolver", version = "1.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyparsing", marker = "python_full_version < '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/17/1747b4154034befd0ed33b52538f5eb7752d05bb51c5e2a31470c3bc7d52/matplotlib-3.9.4.tar.gz", hash = "sha256:1e00e8be7393cbdc6fedfa8a6fba02cf3e83814b285db1c60b906a023ba41bc3", size = 36106529, upload-time = "2024-12-13T05:56:34.184Z" }
 wheels = [
@@ -3315,17 +3319,17 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler" },
-    { name = "fonttools", version = "4.62.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "kiwisolver", version = "1.5.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cycler", marker = "python_full_version >= '3.10'" },
+    { name = "fonttools", version = "4.62.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "kiwisolver", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.10'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -3405,7 +3409,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542, upload-time = "2024-09-09T20:27:49.564Z" }
 wheels = [
@@ -3429,7 +3433,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
 wheels = [
@@ -3498,10 +3502,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "jupyter-client", version = "8.6.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "nbformat" },
-    { name = "traitlets" },
+    { name = "jupyter-client", version = "8.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "jupyter-core", version = "5.8.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "nbformat", marker = "python_full_version < '3.10'" },
+    { name = "traitlets", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/66/7ffd18d58eae90d5721f9f39212327695b749e23ad44b3881744eaf4d9e8/nbclient-0.10.2.tar.gz", hash = "sha256:90b7fc6b810630db87a6d0c2250b1f0ab4cf4d3c27a299b0cde78a4ed3fd9193", size = 62424, upload-time = "2024-12-19T10:32:27.164Z" }
 wheels = [
@@ -3525,10 +3529,10 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "jupyter-client", version = "8.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "nbformat" },
-    { name = "traitlets" },
+    { name = "jupyter-client", version = "8.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "jupyter-core", version = "5.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "nbformat", marker = "python_full_version >= '3.10'" },
+    { name = "traitlets", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/91/1c1d5a4b9a9ebba2b4e32b8c852c2975c872aec1fe42ab5e516b2cecd193/nbclient-0.10.4.tar.gz", hash = "sha256:1e54091b16e6da39e297b0ece3e10f6f29f4ac4e8ee515d29f8a7099bd6553c9", size = 62554, upload-time = "2025-12-23T07:45:46.369Z" }
 wheels = [
@@ -3843,7 +3847,7 @@ name = "opentelemetry-api"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
@@ -4082,11 +4086,11 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.10.*'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4162,9 +4166,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -4263,7 +4267,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4560,10 +4564,10 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.10.*'",
 ]
@@ -4634,9 +4638,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "beartype" },
-    { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "beartype", marker = "python_full_version >= '3.10'" },
+    { name = "rich", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/84146ae5ff6c40d11357acdb36aafe3db7e104de01c1026d8e1b0ce3e7f1/plum_dispatch-2.9.0.tar.gz", hash = "sha256:fb45c5b2dd4dadd57def51bcf321dfa3a258df5c725f43adea7e7f6db3b79b52", size = 244502, upload-time = "2026-04-28T08:38:34.442Z" }
 wheels = [
@@ -5140,8 +5144,8 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "tomli" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/fd/437901c891f58a7b9096511750247535e891d2d5a5a6eefbc9386a2b41d5/pyproject_api-1.9.1.tar.gz", hash = "sha256:43c9918f49daab37e302038fc1aed54a8c7a91a9fa935d00b9a485f37e0f5335", size = 22710, upload-time = "2025-05-12T14:41:58.025Z" }
 wheels = [
@@ -5165,8 +5169,8 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/7b/c0e1333b61d41c69e59e5366e727b18c4992688caf0de1be10b3e5265f6b/pyproject_api-1.10.0.tar.gz", hash = "sha256:40c6f2d82eebdc4afee61c773ed208c04c19db4c4a60d97f8d7be3ebc0bbb330", size = 22785, upload-time = "2025-10-09T19:12:27.21Z" }
 wheels = [
@@ -5253,7 +5257,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
 wheels = [
@@ -5638,7 +5642,7 @@ name = "questionary"
 version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "prompt-toolkit" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
@@ -5653,9 +5657,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "attrs", marker = "python_full_version < '3.10'" },
+    { name = "rpds-py", version = "0.27.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
@@ -5679,9 +5683,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "attrs", marker = "python_full_version >= '3.10'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -5696,10 +5700,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version < '3.10'" },
+    { name = "charset-normalizer", marker = "python_full_version < '3.10'" },
+    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "urllib3", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -5723,10 +5727,10 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version >= '3.10'" },
+    { name = "charset-normalizer", marker = "python_full_version >= '3.10'" },
+    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "urllib3", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
@@ -6125,7 +6129,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/00/48c2f661e2816ccf2ecd77982f6605b2950afe60f60a52b4cbbc2504aa8f/scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c", size = 57210720, upload-time = "2024-05-23T03:29:26.079Z" }
 wheels = [
@@ -6163,7 +6167,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -6230,7 +6234,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -6349,25 +6353,25 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "asgiref", version = "3.11.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "htmltools", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "linkify-it-py", version = "2.0.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "narwhals" },
-    { name = "orjson", version = "3.11.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "prompt-toolkit", marker = "sys_platform != 'emscripten'" },
-    { name = "python-multipart", version = "0.0.20", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "questionary", marker = "sys_platform != 'emscripten'" },
-    { name = "shinychat", version = "0.2.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "watchfiles", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "asgiref", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'emscripten'" },
+    { name = "htmltools", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "linkify-it-py", version = "2.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "narwhals", marker = "python_full_version < '3.10'" },
+    { name = "orjson", version = "3.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.10' and sys_platform != 'emscripten'" },
+    { name = "python-multipart", version = "0.0.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'emscripten'" },
+    { name = "questionary", marker = "python_full_version < '3.10' and sys_platform != 'emscripten'" },
+    { name = "shinychat", version = "0.2.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "starlette", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "uvicorn", version = "0.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'emscripten'" },
+    { name = "watchfiles", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and sys_platform != 'emscripten'" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/00/588d12aaeb1179bcbb20d5841a6db722d1c01c922858bbbb49de58ea03c7/shiny-1.5.0.tar.gz", hash = "sha256:6a07b5057db4471a804b5f915def5db9eeec5ce0cc45d58ee2e174324c5471e0", size = 4905968, upload-time = "2025-09-11T22:26:56.495Z" }
 wheels = [
@@ -6391,27 +6395,27 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "asgiref", version = "3.12.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "htmltools", version = "0.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "linkify-it-py", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "mdit-py-plugins", version = "0.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "narwhals" },
-    { name = "opentelemetry-api" },
-    { name = "orjson", version = "3.12.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "prompt-toolkit", marker = "sys_platform != 'emscripten'" },
-    { name = "python-multipart", version = "0.0.32", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "questionary", marker = "sys_platform != 'emscripten'" },
+    { name = "asgiref", version = "3.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
+    { name = "htmltools", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "linkify-it-py", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py", version = "4.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "mdit-py-plugins", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "narwhals", marker = "python_full_version >= '3.10'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.10'" },
+    { name = "orjson", version = "3.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
+    { name = "python-multipart", version = "0.0.32", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
+    { name = "questionary", marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
     { name = "setuptools", marker = "python_full_version >= '3.12'" },
-    { name = "shinychat", version = "0.3.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "uvicorn", version = "0.52.3", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "watchfiles", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'emscripten'" },
-    { name = "websockets", version = "16.1.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "shinychat", version = "0.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "starlette", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "uvicorn", version = "0.52.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
+    { name = "watchfiles", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and sys_platform != 'emscripten'" },
+    { name = "websockets", version = "16.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3c/09/cbb28b11ac6556aa654c2cbc403aa75c89844e699d4f45897743c91ea139/shiny-1.6.1.tar.gz", hash = "sha256:f58450c36faffc6ca27773331a0007d9455d7c396360257a4c4df924162f5f69", size = 5112401, upload-time = "2026-05-01T16:01:28.358Z" }
 wheels = [
@@ -6426,8 +6430,8 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "htmltools", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "shiny", version = "1.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "htmltools", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "shiny", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/c6/6887a3618842e65794e5dcfb345825ccd43d58c56fefa9d31286d8e14d16/shinychat-0.2.8.tar.gz", hash = "sha256:d27f28ddf1d512a05ef2cc2f0cffbb75b5b6e3157d5e3690ce4e63d18bfa7492", size = 547318, upload-time = "2025-09-11T20:13:20.367Z" }
 wheels = [
@@ -6451,8 +6455,8 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "htmltools", version = "0.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "shiny", version = "1.6.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "htmltools", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "shiny", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/6d/d37a85041b5fc356b4a8bb3a5f9b057a7a3677a3c2204ff81363c67cabc6/shinychat-0.3.1.tar.gz", hash = "sha256:ed66c2ca42987a0afb09fb6ac8e51fba64b9c57eb3f4f6d1105108307189caeb", size = 1018448, upload-time = "2026-05-01T00:11:12.94Z" }
 wheels = [
@@ -6494,9 +6498,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "certifi" },
-    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version < '3.10'" },
+    { name = "certifi", marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/9a/4887ebe7b46f4669a896dc286a3ac559101d2ceadbbea4614472960c2222/sphobjinv-2.3.1.3.tar.gz", hash = "sha256:a1d51e4cf3d968b9e0d3ed1cbccea0071e5e5795f24a2d7401a4e37d6bd75717", size = 268835, upload-time = "2025-05-26T15:18:16.994Z" }
 wheels = [
@@ -6520,9 +6524,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "attrs" },
-    { name = "certifi" },
-    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "attrs", marker = "python_full_version >= '3.10'" },
+    { name = "certifi", marker = "python_full_version >= '3.10'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/67/19f33eeb4ffff0e2fd39afd4783a6ee38a6d58bcc1ddade779712a7e2e49/sphobjinv-2.4.tar.gz", hash = "sha256:44d57e7e87e17d8c7b053c853dcc36f80cbf7d1fc152d57634fd7bcae38ca48a", size = 249997, upload-time = "2026-03-23T05:04:54.011Z" }
 wheels = [
@@ -6621,24 +6625,24 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "altair", version = "5.5.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "blinker" },
-    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "gitpython" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pydeck" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "tenacity", version = "9.1.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "toml" },
-    { name = "tornado" },
-    { name = "typing-extensions" },
-    { name = "watchdog", marker = "sys_platform != 'darwin'" },
+    { name = "altair", version = "5.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "blinker", marker = "python_full_version < '3.10'" },
+    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "gitpython", marker = "python_full_version < '3.10'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pillow", version = "11.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pydeck", marker = "python_full_version < '3.10'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "tenacity", version = "9.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "toml", marker = "python_full_version < '3.10'" },
+    { name = "tornado", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "watchdog", marker = "python_full_version < '3.10' and sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d6/f6/f7d3a0146577c1918439d3163707040f7111a7d2e7e2c73fa7adeb169c06/streamlit-1.50.0.tar.gz", hash = "sha256:87221d568aac585274a05ef18a378b03df332b93e08103fffcf3cd84d852af46", size = 9664808, upload-time = "2025-09-23T19:24:00.31Z" }
 wheels = [
@@ -6662,30 +6666,30 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "altair", version = "6.1.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "blinker" },
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "httptools" },
-    { name = "itsdangerous" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "altair", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "blinker", marker = "python_full_version >= '3.10'" },
+    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "httptools", marker = "python_full_version >= '3.10'" },
+    { name = "itsdangerous", marker = "python_full_version >= '3.10'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "protobuf", version = "7.35.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "pyarrow", version = "24.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pydeck" },
-    { name = "python-multipart", version = "0.0.32", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "starlette" },
-    { name = "tenacity", version = "9.1.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "toml" },
-    { name = "typing-extensions" },
-    { name = "uvicorn", version = "0.52.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "watchdog", marker = "sys_platform != 'darwin'" },
-    { name = "websockets", version = "16.1.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow", version = "12.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "protobuf", version = "7.35.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyarrow", version = "24.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pydeck", marker = "python_full_version >= '3.10'" },
+    { name = "python-multipart", version = "0.0.32", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "starlette", marker = "python_full_version >= '3.10'" },
+    { name = "tenacity", version = "9.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "toml", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+    { name = "uvicorn", version = "0.52.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "watchdog", marker = "python_full_version >= '3.10' and sys_platform != 'darwin'" },
+    { name = "websockets", version = "16.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/4a/6d0bf2f78de59924564caf47298341c09f61bf3814f15f0d15ef09fe1e3d/streamlit-1.61.1.tar.gz", hash = "sha256:68acf1ff1b6005b19205c2777d832deea0c1edd6fbbf7f43f091b96220e5e35f", size = 9907073, upload-time = "2026-08-05T14:51:01.956Z" }
 wheels = [
@@ -6890,17 +6894,17 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "chardet" },
-    { name = "colorama" },
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "pluggy" },
-    { name = "pyproject-api", version = "1.9.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "tomli" },
-    { name = "typing-extensions" },
-    { name = "virtualenv" },
+    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "chardet", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "python_full_version < '3.10'" },
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", version = "25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pyproject-api", version = "1.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "virtualenv", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/b2/cee55172e5e10ce030b087cd3ac06641e47d08a3dc8d76c17b157dba7558/tox-4.30.3.tar.gz", hash = "sha256:f3dd0735f1cd4e8fbea5a3661b77f517456b5f0031a6256432533900e34b90bf", size = 202799, upload-time = "2025-10-02T16:24:39.974Z" }
 wheels = [
@@ -6924,18 +6928,18 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "cachetools", version = "7.1.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "colorama" },
-    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pluggy" },
-    { name = "pyproject-api", version = "1.10.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-discovery" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tomli-w" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "virtualenv" },
+    { name = "cachetools", version = "7.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "colorama", marker = "python_full_version >= '3.10'" },
+    { name = "filelock", version = "3.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "platformdirs", version = "4.9.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pyproject-api", version = "1.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "python-discovery", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "tomli-w", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+    { name = "virtualenv", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/d7/a8e0f889eb6872740e2f013a93a8f9c6c23c3f02fe0911bbd91673615636/tox-4.53.1.tar.gz", hash = "sha256:7be9805ed4a34242510c7acc9a7e3a01a35942e08f31f8bd69067c3a37130afc", size = 276809, upload-time = "2026-05-02T08:34:41.655Z" }
 wheels = [
@@ -7040,9 +7044,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "h11" },
-    { name = "typing-extensions" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "h11", marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/4f/f9fdac7cf6dd79790eb165639b5c452ceeabc7bbabbba4569155470a287d/uvicorn-0.39.0.tar.gz", hash = "sha256:610512b19baa93423d2892d7823741f6d27717b642c8964000d7194dded19302", size = 82001, upload-time = "2025-12-21T13:05:17.973Z" }
 wheels = [
@@ -7066,9 +7070,9 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "click", version = "8.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "h11", marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
 wheels = [
@@ -7138,7 +7142,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
@@ -7266,7 +7270,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.10' and sys_platform != 'emscripten') or (python_full_version == '3.10.*' and sys_platform == 'emscripten')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -2974,9 +2974,6 @@ name = "maidr"
 version = "1.21.0"
 source = { editable = "." }
 dependencies = [
-    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "htmltools", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "htmltools", version = "0.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "lxml" },
@@ -3008,6 +3005,9 @@ jupyter = [
     { name = "jupyter" },
 ]
 plotly = [
+    { name = "contourpy", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "plotly" },
 ]
 shiny = [
@@ -3060,7 +3060,7 @@ dev = [
 requires-dist = [
     { name = "altair", marker = "extra == 'altair'", specifier = ">=5.0" },
     { name = "altair", marker = "extra == 'test'", specifier = ">=5.0" },
-    { name = "contourpy", specifier = ">=1.0.1" },
+    { name = "contourpy", marker = "extra == 'plotly'", specifier = ">=1.0.1" },
     { name = "cssselect", marker = "extra == 'test'", specifier = ">=1.2" },
     { name = "flask", marker = "extra == 'test'", specifier = ">=3.0.0" },
     { name = "flask", marker = "extra == 'visualization'", specifier = ">=3.0.0" },


### PR DESCRIPTION
Closes part of #627; implements step 1 of #642.

`go.Contour` produced a figure with no layers. The core has had
`TraceType.CONTOUR` since the matplotlib side was read (#539) — one curve per
level, each point carrying the level it runs at.

## The curves are not in the trace

Plotly ships a grid and a level spacing and traces the curves in the browser,
so reading this chart means running the same marching squares here. `contourpy`
does it, and is what matplotlib traces its own contours with — so the two
py-maidr contour readings now describe curves computed the same way. It is
declared in `pyproject.toml` rather than relied upon to arrive with matplotlib,
which is exactly the accident the `matplotlib` entry beside it already exists to
stop repeating.

Which contourpy algorithm is load-bearing, not incidental: `mpl2014` and
`serial` disagree about the order they return curves in. On a level holding two
open curves and one closed one, plotly writes the open ones first and `mpl2014`
returns them in exactly that order, while `serial` returns the closed one first.

## Only an explicit spec is read

`contours.start`/`end`/`size`, all three, `size > 0`, and `autocontour` not
`True` — which overrides an otherwise complete spec (measured). Plotly's rule
for picking levels itself lives in plotly.js and did not reduce to a formula:
across the nine z ranges tabulated in #642, eight fit "round `(max - min) / 15`
up to a 1/2/5×10ⁿ step" and a field spanning `0 … 3` does not. Reading a chart at
levels it does not draw would announce curves that are not there, so the auto
case stays with #642 and the layer declines — leaving the figure with no contour
layer rather than a wrong one (#636).

A `contours.type: "constraint"` declines too, and not only for want of a spec:
it draws **one** curve at `value` and means "the region beyond it", so a
`constraint` written *with* a full `start`/`end`/`size` (which plotly ignores —
measured, one group, at 0.5) would otherwise be read as five levels the chart
does not draw. The test writes it that way on purpose.

## The level list, measured

Plotly steps `start`, `start + size`, … while the level is **below
`end + size / 10`**. Neither obvious rule fits:

| spec | `<= end` | `end + size/2` | `end + size/10` | plotly draws |
|---|---|---|---|---|
| `start=0.2, end=0.8, size=0.05` | 12 | 13 | **13** | 13 |
| `start=0, end=0.9, size=0.5` | 2 | 3 | **2** | 2 |

Accumulated rather than computed as `start + k * size`, so the level announced,
the level handed to the tracer and the level plotly drew are one number —
stepping 0.05 from 0.2 lands on `0.8000000000000002`, and that is the
thirteenth group's `__data__.level`.

`start > end` is swapped, which is what plotly does with it.

## The highlight, and where it stops

Plotly gives every **declared** level a `g.contourlevel` — including the ones
the field never reaches, which get the group and no `path` at all — and one
`<path>` per disjoint curve inside it. So a level is addressable: the groups run
in declared order on every figure measured. A **curve within a level** is not.

A sweep of 33 fields and 207 levels — random sums of gaussians, a saddle, a
monkey saddle, ripples, a staircase, noise:

- **count disagreements: 0.** Plotly and contourpy always found the same number
  of curves in a level.
- **order disagreements: 18**, and *not only on contrived fields* — five were
  ordinary two-peaked gaussians.

So a positional per-curve selector would resolve to a real element and to the
wrong one. The core parses the resolved path to place the per-point highlights
(`LineTrace.mapViaPathParsing`), so every point of that series would land on an
island the reader is not on — worse than none, which is the outcome #145
settled.

A layer whose every drawn level draws a single curve therefore has one *forced*
mapping rather than a chosen one, and keeps its highlight; a layer with an
island anywhere ships without one and keeps its audio, braille and text.

The other case with nothing to point at is `coloring: "fill"` (the default) with
`showlines: False`: plotly then writes **no** `g.contourlevel` and draws only
the bands. The layer still reads — a band's boundary is exactly where the level
curve runs — and claims no highlight. `showlines` is honoured only under `fill`;
under `heatmap` the groups are written whatever it says (measured), so reading
it as "no lines" there would drop a highlight the chart does have.

### Verified end to end

Every emitted selector was resolved in Chromium against the rendered figure and
checked to match one element whose geometry is the curve it was emitted for —
across a two-peak field, a saddle, a mixed open/closed field, levels above the
field, two traces on one subplot, two subplots, a third subplot, a contour after
a `histogram2dcontour`, and a filled contour. 0 failures.

## Placement and scoping

A contour is a cartesian trace, so it groups by axis pair and needs no domain
work. Its selector is scoped by its position among the subplot's traces that
draw into the `contourlayer` — which includes `histogram2dcontour`, measured: a
figure holding one of each gave the layer two `g.contour` groups in declaration
order, while a `heatmap` sat elsewhere in a `heatmaplayer`. Counting only
contour traces would hand the contour the histogram's group. The position map is
keyed by identity rather than found with `.index`, which compares by value: two
traces drawing the same field are equal dicts, so both would be handed position
0.

## Grid handling

`x`/`y` when they describe the grid, `x0`/`dx` otherwise at plotly's defaults;
`transpose` turns `z` over and leaves the coordinates (measured on an asymmetric
field, where the two readings put the peak in different places and plotly drew
the transposed one); a missing cell is a hole and the curves stop at it, which
plotly does too. A **descending** coordinate array needs no special handling —
measured, plotly and contourpy both map column index → `x[index]` and put the
curve in the same place.

Declined: a grid with no cell in it, a ragged grid, a coordinate array that
misses the grid's width, and a **categorical** axis — a contour crosses
*between* columns, so a curve sits a fraction of the way from one category to
the next, a position a category name cannot express.

A runaway `size` (`dict(start=0, end=1, size=1e-9)` is writable) is declined
rather than traced: building a schema must never cost the render (#421, #636).

## Tests

36 new tests in `tests/plotly/test_plotly_contour.py`. Two assert against
`_grid` and `declared_levels` directly, because those decisions have no other
window — contourpy's own error masks the first, and reaching the second through
a figure would be the hang it guards against.

## Mutation sweep

23 mutations, each reverting one decision alone against a restored baseline.
**22 killed, 1 survivor**, and the sweep changed the shipped code three times:

- The `len(curve) < 2` guard I had copied from the matplotlib reading **survived
  and was removed** — contourpy's `SeparateCode` output never returns a curve
  shorter than two vertices (probed across five degenerate fields), unlike a
  matplotlib compound path, so it was dead code.
- The `nan=True` parameter on the number reader **survived and was removed** —
  numpy already writes NaN for a `None` in a float array, so it changed nothing.
- The bare `constraint` test **survived** and was sharpened to carry a full
  spec, which is the only form that reaches the guard.

**The one documented survivor** is `np.ma.masked_invalid`: passing the NaN array
straight through gives the same curves today, so removing the mask breaks no
test. That is `mpl2014` treating NaN as missing rather than anything contourpy
promises — the mask is what its documentation specifies for missing points — so
it stays, and the docstring says exactly this.

## Checks

- `ruff check` clean on the touched files
- `uv lock --check` clean
- `tests/core`: 1931 passed, 5 skipped
- `tests/plotly`: 1156 passed
- `tests/altair tests/patch tests/util tests/widget tests/test_backend.py`: 185 passed

## Still open under #627

`histogram2d` and `histogram2dcontour`, which carry raw samples and need
plotly's 2-D autobinning matched first; and #642's auto-level rule, which this
PR's decline is waiting on.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_