### PR TITLE
feat(plotly): read a 2-D histogram as the heatmap it draws

### DIFF
--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -29,7 +29,7 @@ def _plotly_round_up(val: float, array: list[float], reverse: bool = False) -> f
     return array[lo]
 
 
-def _plotly_default_size0(arr: np.ndarray) -> float:
+def _plotly_default_size0(arr: np.ndarray, *, is_2d: bool = False) -> float:
     """Compute the default rough bin size when ``nbinsx`` is not given.
 
     Mirrors the logic in Plotly.js ``axes.autoBin`` (the ``else`` branch
@@ -38,7 +38,20 @@ def _plotly_default_size0(arr: np.ndarray) -> float:
         distinctData = Lib.distinctVals(data)
         msexp = 10 ** floor(log(minDiff) / LN10)
         minSize = msexp * roundUp(minDiff / msexp, [0.9, 1.9, 4.9, 9.9], true)
-        size0 = max(minSize, 2 * stdev(data) / n^0.4)
+        size0 = max(minSize, 2 * stdev(data) / n^(is2d ? 0.25 : 0.4))
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        The raw data values.
+    is_2d : bool, default False
+        Bin an axis of a **two-dimensional** histogram, which plotly bins
+        more coarsely: the sample-size exponent is ``0.25`` rather than
+        ``0.4``, which is `autoBin`'s own ``is2d`` flag and the only thing
+        that differs between the two. Measured against the browser on eight
+        axes across four figures -- gaussian, uniform, a six-value sample and
+        a normalised one -- ``0.4`` matched none of them and ``0.25`` matched
+        all eight.
     """
     sorted_arr = np.sort(arr)
     n = len(sorted_arr)
@@ -61,9 +74,9 @@ def _plotly_default_size0(arr: np.ndarray) -> float:
         min_diff / msexp, [0.9, 1.9, 4.9, 9.9], reverse=True
     )
 
-    # size0 = max(minSize, 2 * stdev / n^0.4)
+    # size0 = max(minSize, 2 * stdev / n^(is2d ? 0.25 : 0.4))
     stdev = float(np.std(arr, ddof=0))
-    size0 = max(min_size, 2 * stdev / (n ** 0.4))
+    size0 = max(min_size, 2 * stdev / (n ** (0.25 if is_2d else 0.4)))
 
     if not np.isfinite(size0) or size0 <= 0:
         return 1.0
@@ -725,7 +738,11 @@ class PlotlyHistogramPlot(PlotlyPlot):
 
 
 def compute_bin_edges(
-    arr: np.ndarray, bins: dict | None = None, nbins: int | None = None
+    arr: np.ndarray,
+    bins: dict | None = None,
+    nbins: int | None = None,
+    *,
+    is_2d: bool = False,
 ) -> np.ndarray:
     """Compute bin edges that match Plotly's autobinning algorithm.
 
@@ -747,6 +764,11 @@ def compute_bin_edges(
     ----------
     arr : np.ndarray
         The raw data values.
+    is_2d : bool, default False
+        Bin one axis of a ``histogram2d``, which changes only the sample-size
+        exponent of the automatic width -- see :func:`_plotly_default_size0`.
+        An explicit ``size`` or ``nbins`` is honoured identically either way,
+        which is why this reaches no further than that one branch.
 
     Returns
     -------
@@ -797,7 +819,7 @@ def compute_bin_edges(
     if nbins is not None:
         size0 = data_range / max(1, nbins)
     else:
-        size0 = _plotly_default_size0(arr)
+        size0 = _plotly_default_size0(arr, is_2d=is_2d)
     dtick = _plotly_dtick(size0)
 
     # 2. Initial bin start: one tick below the first tick >= data_min

--- a/maidr/plotly/histogram2d.py
+++ b/maidr/plotly/histogram2d.py
@@ -333,6 +333,12 @@ def _normalised(
 ) -> list[list[float | None]]:
     """Rescale the cells the way ``histnorm`` does.
 
+    Only the numbers. A cell holding ``None`` is one nothing landed in, and
+    what plotly shows *there* depends on the ``histnorm`` as well as the
+    ``histfunc`` -- so it is left as it is and :func:`_as_payload`, which
+    knows both, decides. Splitting it that way keeps the two questions apart:
+    what a cell's number becomes, and what a cell with no number becomes.
+
     The one-dimensional rule with the bin's **area** where it uses the bin's
     width -- measured against the browser for all four forms on a grid of
     unequal x and y widths: ``percent`` and ``probability`` divide by the

--- a/maidr/plotly/histogram2d.py
+++ b/maidr/plotly/histogram2d.py
@@ -133,9 +133,8 @@ class PlotlyHistogram2dPlot(PlotlyHeatmapPlot):
         histnorm = self._trace.get("histnorm")
         if histnorm in _HISTNORM_NAMES:
             return _HISTNORM_NAMES[histnorm]
-        histfunc = self._trace.get("histfunc")
-        if histfunc in _HISTFUNC_NAMES and _values(self._trace) is not None:
-            return _HISTFUNC_NAMES[histfunc]
+        if _reduces_values(self._trace):
+            return _HISTFUNC_NAMES[str(self._trace.get("histfunc"))]
         return "Count"
 
 
@@ -157,7 +156,26 @@ def _binned_grid(trace: dict) -> tuple[list[list], list[str], list[str]] | None:
     """
     x = as_numeric(as_list(trace.get("x")))
     y = as_numeric(as_list(trace.get("y")))
+
+    # A sample is an x, a y, and -- when a `histfunc` reduces them -- a z, so
+    # the shortest of those decides how many samples there are. Measured both
+    # ways: with `histfunc="avg"` and a `z` two long against four x and y,
+    # plotly uses **two** samples and leaves the rest of the grid unpainted;
+    # with the default `count`, the same short `z` changes nothing and all
+    # four are counted. So `z` shortens the pairing only when it is read.
+    #
+    # Truncating here rather than at the point of use, which is the mistake
+    # `paired_arrays` in `histogram.py` documents for the 1-D path: a late
+    # truncation raised out of a rendering path for a figure plotly draws
+    # without complaint. Here it was a `ValueError` from numpy broadcasting
+    # a mask of four against an array of two, which took the whole figure.
+    values = _values(trace)
+    aggregating = _reduces_values(trace)
+
     paired = min(x.size, y.size)
+    if aggregating and values is not None:
+        paired = min(paired, values.size)
+        values = values[:paired]
     x, y = x[:paired], y[:paired]
     # A sample missing either coordinate is not on the chart. Measured: one
     # `None` among three x values drops that pair rather than placing it
@@ -188,9 +206,10 @@ def _binned_grid(trace: dict) -> tuple[list[list], list[str], list[str]] | None:
     placed = inside & (column_of >= 0) & (row_of >= 0)
 
     histfunc = trace.get("histfunc")
-    values = _values(trace)
-    if histfunc in _AGGREGATING and values is not None:
-        cells = _aggregate(row_of, column_of, placed, values[:paired], rows, columns, histfunc)
+    if aggregating and values is not None:
+        cells = _aggregate(
+            row_of, column_of, placed, values, rows, columns, str(histfunc)
+        )
     else:
         # Plotly falls back to counting when an aggregating `histfunc` has no
         # `z` to reduce -- measured, `histfunc="sum"` without one draws the
@@ -212,6 +231,16 @@ def _values(trace: dict) -> np.ndarray | None:
     """The ``z`` array an aggregating ``histfunc`` reduces, or None."""
     declared = as_list(trace.get("z"))
     return as_numeric(declared) if declared else None
+
+
+def _reduces_values(trace: dict) -> bool:
+    """Whether this trace's ``histfunc`` has a ``z`` to reduce.
+
+    Asked in two places -- to decide what a cell measures and to decide
+    whether ``z`` shortens the sample pairing -- so it is one rule rather
+    than two that could drift apart.
+    """
+    return trace.get("histfunc") in _AGGREGATING and bool(as_list(trace.get("z")))
 
 
 def _bin_of(values: np.ndarray, edges: np.ndarray) -> np.ndarray:
@@ -260,7 +289,8 @@ def _aggregate(
     turns it into and what is dropped here -- the same reading the
     one-dimensional path settled (#405).
     """
-    usable = placed & np.isfinite(values[: placed.size])
+    # `values` arrives the same length as `placed`, paired down by the caller.
+    usable = placed & np.isfinite(values)
     gathered: dict[tuple[int, int], list[float]] = {}
     for row, column, value in zip(row_of[usable], column_of[usable], values[usable]):
         gathered.setdefault((int(row), int(column)), []).append(float(value))

--- a/maidr/plotly/histogram2d.py
+++ b/maidr/plotly/histogram2d.py
@@ -75,6 +75,13 @@ class PlotlyHistogram2dPlot(PlotlyHeatmapPlot):
     ``n**0.25`` rather than ``n**0.4``. Measured against the browser on eight
     axes across four figures, ``0.4`` matched none and ``0.25`` matched all
     eight.
+
+    Sharing the selector shares its one limit: `.heatmaplayer image` names the
+    first image on the subplot rather than this trace's, so a subplot holding
+    two of them -- a `go.Heatmap` beside a `histogram2d`, or two of either --
+    has both layers pointing at the first. That predates this class and
+    applies to two heatmaps today; reading a second trace type into the same
+    layer is what makes it reachable a second way. See #647.
     """
 
     def _extract_plot_data(self) -> dict:
@@ -217,8 +224,9 @@ def _binned_grid(trace: dict) -> tuple[list[list], list[str], list[str]] | None:
         cells = _count(row_of, column_of, placed, rows, columns)
         histfunc = "count"
 
-    cells = _normalised(cells, trace.get("histnorm"), x_edges, y_edges)
-    counts = _as_payload(cells, histfunc)
+    histnorm = trace.get("histnorm")
+    cells = _normalised(cells, histnorm, x_edges, y_edges)
+    counts = _as_payload(cells, histfunc, histnorm)
 
     return (
         counts,
@@ -266,11 +274,20 @@ def _count(
     rows: int,
     columns: int,
 ) -> list[list[float | None]]:
-    """How many samples landed in each cell, bottom row first."""
-    cells: list[list[float | None]] = [[0.0] * columns for _ in range(rows)]
-    for row, column in zip(row_of[placed], column_of[placed]):
-        cells[int(row)][int(column)] += 1.0
-    return cells
+    """How many samples landed in each cell, bottom row first.
+
+    Counted with ``bincount`` over the flattened cell index rather than a
+    Python loop over the samples, so the work scales with the *grid* rather
+    than with the sample count -- which is the shape the one-dimensional
+    `aggregate_bins` already has, and the one that matters on a scatter of a
+    hundred thousand points.
+    """
+    flat = row_of[placed] * columns + column_of[placed]
+    tally = np.bincount(flat.astype(int), minlength=rows * columns)
+    return [
+        [float(tally[row * columns + column]) for column in range(columns)]
+        for row in range(rows)
+    ]
 
 
 def _aggregate(
@@ -352,14 +369,24 @@ def _normalised(
 
 
 def _as_payload(
-    cells: list[list[float | None]], histfunc: str
+    cells: list[list[float | None]], histfunc: str, histnorm: str | None
 ) -> list[list[float | None]]:
     """Turn a cell nothing landed in into what plotly shows there.
 
     ``count`` and ``sum`` paint a zero; ``avg``, ``min`` and ``max`` leave the
     cell unpainted, and there is no number to announce for it.
+
+    **Unless a ``histnorm`` is set, which brings the empty cells back as
+    zeros.** Measured across all three of those functions and all four norms:
+    ``avg`` alone leaves the cell ``NaN``, and ``avg`` with any ``histnorm``
+    puts a **0** there. Rescaling evidently runs over the whole grid and does
+    not carry the "no answer" marker through, so the composition is not simply
+    one step after the other. The one-dimensional path found exactly this and
+    says so in `PlotlyHistogramPlot._extract_plot_data`; the same rule, on a
+    grid.
     """
-    empty: float | None = None if histfunc in _UNDEFINED_WHEN_EMPTY else 0.0
+    undefined = histfunc in _UNDEFINED_WHEN_EMPTY and not histnorm
+    empty: float | None = None if undefined else 0.0
     return [[empty if value is None else value for value in row] for row in cells]
 
 

--- a/maidr/plotly/histogram2d.py
+++ b/maidr/plotly/histogram2d.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.plotly.heatmap import PlotlyHeatmapPlot
+from maidr.plotly.histogram import (
+    apply_histnorm,
+    as_numeric,
+    compute_bin_edges,
+)
+from maidr.plotly.plotly_plot import as_list
+
+#: What separates a bin's two edges when it is named.
+#:
+#: A bin's label is its coordinate *range*, not its index or its centre: "a
+#: count of 4" says nothing without "between -2.2 and -1.1", and the range is
+#: what a sighted reader takes off the axis. r-maidr settled the same question
+#: the same way for `geom_bin_2d` (xability/r-maidr#136).
+_RANGE_SEPARATOR = " – "
+
+#: How many significant figures a bin edge is named to. Plotly's automatic
+#: widths are 1/2/5x10ⁿ, so an edge is usually short already; this only keeps
+#: an explicit ``size`` of 0.1 from reaching the reader as
+#: ``0.30000000000000004``.
+_EDGE_FIGURES = 6
+
+#: What the cells hold, said plainly, when the author named no colour bar.
+#: ``histnorm`` decides the units when it is set -- measured, a ``histfunc``
+#: of ``sum`` under ``histnorm="percent"`` still totals 100 -- so it wins over
+#: the aggregate, and the aggregate wins over the default count.
+_HISTNORM_NAMES = {
+    "percent": "Percent",
+    "probability": "Probability",
+    "density": "Density",
+    "probability density": "Probability density",
+}
+_HISTFUNC_NAMES = {
+    "sum": "Sum",
+    "avg": "Average",
+    "min": "Minimum",
+    "max": "Maximum",
+}
+
+#: ``histfunc`` values that reduce a second array rather than counting rows.
+_AGGREGATING = frozenset(_HISTFUNC_NAMES)
+
+#: Of those, the ones with no answer for a cell nothing landed in. Measured:
+#: ``count`` and ``sum`` put a **0** there and plotly paints the cell, while
+#: ``avg``/``min``/``max`` put ``NaN`` and plotly leaves it unpainted. So an
+#: empty cell is emitted as ``None`` under these three -- there is no number
+#: to announce -- and as ``0`` under the other two, which is what the chart
+#: shows.
+_UNDEFINED_WHEN_EMPTY = frozenset({"avg", "min", "max"})
+
+
+class PlotlyHistogram2dPlot(PlotlyHeatmapPlot):
+    """Extract data from a Plotly ``histogram2d`` trace.
+
+    A two-dimensional histogram **is** a heatmap -- a rectangular grid of
+    cells, each carrying a number -- which is why this extends
+    :class:`~maidr.plotly.heatmap.PlotlyHeatmapPlot` and why the two share a
+    selector: measured in Chromium, a ``histogram2d`` draws a single
+    ``<image>`` into its subplot's ``heatmaplayer``, exactly as a
+    ``go.Heatmap`` does.
+
+    What differs is where the grid comes from. A heatmap is handed one; a
+    ``histogram2d`` carries raw samples and lets plotly bin them in the
+    browser, so reading it means binning them here on the same rule. That
+    rule is the one py-maidr already matches for a one-dimensional histogram,
+    with a single change: plotly bins a 2-D axis more coarsely, dividing by
+    ``n**0.25`` rather than ``n**0.4``. Measured against the browser on eight
+    axes across four figures, ``0.4`` matched none and ``0.25`` matched all
+    eight.
+    """
+
+    def _extract_plot_data(self) -> dict:
+        """Bin the samples and read the grid as a heatmap's.
+
+        Returns
+        -------
+        dict
+            ``{"points": [[...]], "x": [...], "y": [...]}`` with the rows
+            top-first, which is the schema's order and what the core turns
+            over again so its own row 0 is the bottom of the drawing.
+            Empty when there is nothing to bin, which leaves the figure with
+            no layer rather than an empty one (#636).
+        """
+        grid = _binned_grid(self._trace)
+        if grid is None:
+            return {}
+
+        counts, x_labels, y_labels = grid
+
+        # The schema's rows run top-first and the core reverses them, so the
+        # bottom-first grid built above turns over -- unless the y axis is
+        # drawn reversed and already counts from the top (#487). The columns
+        # start at the left and turn over only when the x axis does (#489).
+        # Both mirror `PlotlyHeatmapPlot`, whose grid this becomes.
+        if not self._axis_runs_backwards(self._yaxis_name):
+            counts.reverse()
+            y_labels = list(reversed(y_labels))
+        if self._axis_runs_backwards(self._xaxis_name):
+            counts = [list(reversed(row)) for row in counts]
+            x_labels = list(reversed(x_labels))
+
+        return {
+            MaidrKey.POINTS: counts,
+            MaidrKey.X: x_labels,
+            MaidrKey.Y: y_labels,
+        }
+
+    def _extract_axes_data(self) -> dict:
+        """Name the third axis for what the cells actually hold.
+
+        The parent emits a ``z`` only when the author titled the colour bar,
+        which is right for a heatmap: its numbers are the author's and only
+        they can say what they are. A ``histogram2d``'s numbers are computed,
+        so their name is known here -- and leaving it unsaid would announce
+        a grid of bare numbers with no word for what they count.
+
+        The author's colour bar title still wins where there is one.
+        """
+        axes = super()._extract_axes_data()
+        axes.setdefault(MaidrKey.Z, self._axis_config(label=self._cell_name()))
+        return axes
+
+    def _cell_name(self) -> str:
+        """What one cell measures: the normalisation, the aggregate, or a count."""
+        histnorm = self._trace.get("histnorm")
+        if histnorm in _HISTNORM_NAMES:
+            return _HISTNORM_NAMES[histnorm]
+        histfunc = self._trace.get("histfunc")
+        if histfunc in _HISTFUNC_NAMES and _values(self._trace) is not None:
+            return _HISTFUNC_NAMES[histfunc]
+        return "Count"
+
+
+def is_histogram2d_trace(trace: dict) -> bool:
+    """Report whether a trace is a two-dimensional histogram."""
+    return trace.get("type") == "histogram2d"
+
+
+def _binned_grid(trace: dict) -> tuple[list[list], list[str], list[str]] | None:
+    """Bin a trace's samples into the grid plotly draws.
+
+    Returns
+    -------
+    tuple or None
+        ``(counts, x_labels, y_labels)`` with ``counts`` **bottom-first**,
+        matching plotly's own ``calcdata``. None when there is nothing to
+        bin: a trace with no samples draws no grid at all -- measured, its
+        ``calcdata`` entry carries no ``z`` -- so there is nothing to read.
+    """
+    x = as_numeric(as_list(trace.get("x")))
+    y = as_numeric(as_list(trace.get("y")))
+    paired = min(x.size, y.size)
+    x, y = x[:paired], y[:paired]
+    # A sample missing either coordinate is not on the chart. Measured: one
+    # `None` among three x values drops that pair rather than placing it
+    # anywhere, so counting it would announce a cell one fuller than drawn.
+    #
+    # This is also what answers a trace with no samples at all: nothing is
+    # usable, so nothing is binned. Said once rather than twice, since an
+    # empty array and an array of nothing usable are the same chart -- one
+    # plotly draws no grid for, its `calcdata` entry carrying no `z`.
+    inside = np.isfinite(x) & np.isfinite(y)
+    if not inside.any():
+        return None
+
+    x_edges = compute_bin_edges(
+        x[inside], trace.get("xbins"), trace.get("nbinsx"), is_2d=True
+    )
+    y_edges = compute_bin_edges(
+        y[inside], trace.get("ybins"), trace.get("nbinsy"), is_2d=True
+    )
+    if len(x_edges) < 2 or len(y_edges) < 2:
+        return None
+
+    columns, rows = len(x_edges) - 1, len(y_edges) - 1
+    column_of = _bin_of(x, x_edges)
+    row_of = _bin_of(y, y_edges)
+    # A sample outside every bin is dropped rather than clipped into an edge
+    # one -- measured on an explicit `xbins` with a value past its `end`.
+    placed = inside & (column_of >= 0) & (row_of >= 0)
+
+    histfunc = trace.get("histfunc")
+    values = _values(trace)
+    if histfunc in _AGGREGATING and values is not None:
+        cells = _aggregate(row_of, column_of, placed, values[:paired], rows, columns, histfunc)
+    else:
+        # Plotly falls back to counting when an aggregating `histfunc` has no
+        # `z` to reduce -- measured, `histfunc="sum"` without one draws the
+        # same grid as the default.
+        cells = _count(row_of, column_of, placed, rows, columns)
+        histfunc = "count"
+
+    cells = _normalised(cells, trace.get("histnorm"), x_edges, y_edges)
+    counts = _as_payload(cells, histfunc)
+
+    return (
+        counts,
+        [_bin_label(x_edges, index) for index in range(columns)],
+        [_bin_label(y_edges, index) for index in range(rows)],
+    )
+
+
+def _values(trace: dict) -> np.ndarray | None:
+    """The ``z`` array an aggregating ``histfunc`` reduces, or None."""
+    declared = as_list(trace.get("z"))
+    return as_numeric(declared) if declared else None
+
+
+def _bin_of(values: np.ndarray, edges: np.ndarray) -> np.ndarray:
+    """Which bin each value falls in, or ``-1`` for one outside every bin.
+
+    Every bin is half-open, ``[lo, hi)``, **including the last** -- measured
+    rather than assumed, because the obliging thing to do is fold a value
+    sitting exactly on the final edge into the bin below it, and plotly does
+    not: with ``xbins`` running to 4, a sample at 4 is dropped, while one at
+    an interior edge of 2 counts in ``[2, 4)`` and one at the opening edge of
+    0 counts in ``[0, 2)``. Folding it in would announce a cell one fuller
+    than the chart draws.
+    """
+    with np.errstate(invalid="ignore"):
+        index = np.digitize(values, edges) - 1
+    return np.where((index < 0) | (index >= len(edges) - 1), -1, index)
+
+
+def _count(
+    row_of: np.ndarray,
+    column_of: np.ndarray,
+    placed: np.ndarray,
+    rows: int,
+    columns: int,
+) -> list[list[float | None]]:
+    """How many samples landed in each cell, bottom row first."""
+    cells: list[list[float | None]] = [[0.0] * columns for _ in range(rows)]
+    for row, column in zip(row_of[placed], column_of[placed]):
+        cells[int(row)][int(column)] += 1.0
+    return cells
+
+
+def _aggregate(
+    row_of: np.ndarray,
+    column_of: np.ndarray,
+    placed: np.ndarray,
+    values: np.ndarray,
+    rows: int,
+    columns: int,
+    histfunc: str,
+) -> list[list[float | None]]:
+    """Reduce each cell's values the way ``histfunc`` does.
+
+    A value that is not a number is not an observation rather than an
+    observation of zero, which is what :func:`~maidr.plotly.histogram.as_numeric`
+    turns it into and what is dropped here -- the same reading the
+    one-dimensional path settled (#405).
+    """
+    usable = placed & np.isfinite(values[: placed.size])
+    gathered: dict[tuple[int, int], list[float]] = {}
+    for row, column, value in zip(row_of[usable], column_of[usable], values[usable]):
+        gathered.setdefault((int(row), int(column)), []).append(float(value))
+
+    reduce = {
+        "sum": sum,
+        "avg": lambda held: sum(held) / len(held),
+        "min": min,
+        "max": max,
+    }[histfunc]
+
+    cells: list[list[float | None]] = [[None] * columns for _ in range(rows)]
+    for (row, column), held in gathered.items():
+        cells[row][column] = float(reduce(held))
+    return cells
+
+
+def _normalised(
+    cells: list[list[float | None]],
+    histnorm: str | None,
+    x_edges: np.ndarray,
+    y_edges: np.ndarray,
+) -> list[list[float | None]]:
+    """Rescale the cells the way ``histnorm`` does.
+
+    The one-dimensional rule with the bin's **area** where it uses the bin's
+    width -- measured against the browser for all four forms on a grid of
+    unequal x and y widths: ``percent`` and ``probability`` divide by the
+    grand total, ``density`` by the cell's area, and ``probability density``
+    by both.
+    """
+    if not histnorm:
+        return cells
+
+    rows, columns = len(cells), len(cells[0]) if cells else 0
+    widths = np.array(
+        [
+            [
+                (x_edges[column + 1] - x_edges[column])
+                * (y_edges[row + 1] - y_edges[row])
+                for column in range(columns)
+            ]
+            for row in range(rows)
+        ],
+        dtype=float,
+    )
+    held = np.array(
+        [[0.0 if value is None else value for value in row] for row in cells],
+        dtype=float,
+    )
+    scaled = apply_histnorm(held.reshape(-1), widths.reshape(-1), histnorm)
+    scaled = scaled.reshape(held.shape)
+
+    return [
+        [None if cells[row][column] is None else float(scaled[row][column])
+         for column in range(columns)]
+        for row in range(rows)
+    ]
+
+
+def _as_payload(
+    cells: list[list[float | None]], histfunc: str
+) -> list[list[float | None]]:
+    """Turn a cell nothing landed in into what plotly shows there.
+
+    ``count`` and ``sum`` paint a zero; ``avg``, ``min`` and ``max`` leave the
+    cell unpainted, and there is no number to announce for it.
+    """
+    empty: float | None = None if histfunc in _UNDEFINED_WHEN_EMPTY else 0.0
+    return [[empty if value is None else value for value in row] for row in cells]
+
+
+def _bin_label(edges: np.ndarray, index: int) -> str:
+    """Name one bin by the range it covers."""
+    return (
+        f"{_edge(edges[index])}{_RANGE_SEPARATOR}{_edge(edges[index + 1])}"
+    )
+
+
+def _edge(value: Any) -> str:
+    """Write one edge without the floating-point tail an exact width leaves."""
+    number = float(value)
+    if not math.isfinite(number):
+        return str(value)
+    rounded = float(f"{number:.{_EDGE_FIGURES}g}")
+    return str(int(rounded)) if rounded == int(rounded) else str(rounded)

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -17,6 +17,7 @@ from maidr.plotly.gauge import draws_a_dial
 from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
 from maidr.plotly.area import is_area_trace
 from maidr.plotly.contour import is_contour_trace
+from maidr.plotly.histogram2d import is_histogram2d_trace
 from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.trendline import is_trendline_trace
 from maidr.plotly.plotly_plot import (
@@ -1266,6 +1267,28 @@ class PlotlyMaidr:
                     plot.col_index = col
                     self._plots.append(plot)
                 merged.update(id(t) for t in waterfall_traces)
+
+            # Two-dimensional histograms, one layer each. A `histogram2d`
+            # draws a single `<image>` into the subplot's `heatmaplayer`
+            # exactly as a `go.Heatmap` does -- measured -- so it needs no
+            # position of its own and could have been left to the factory.
+            # It is built here so it sits beside the contour it shares an
+            # issue with, and so the two 2-D binning readings are found
+            # together.
+            histogram2d_traces = [
+                t for t in group_traces if is_histogram2d_trace(t)
+            ]
+            if histogram2d_traces:
+                from maidr.plotly.histogram2d import PlotlyHistogram2dPlot
+
+                for histogram2d_trace in histogram2d_traces:
+                    plot = PlotlyHistogram2dPlot(
+                        histogram2d_trace, layout, **axis_kwargs
+                    )
+                    plot.row_index = row
+                    plot.col_index = col
+                    self._plots.append(plot)
+                merged.update(id(t) for t in histogram2d_traces)
 
             # Contours, one layer each. Built here rather than left to
             # the factory for the reason the waterfalls above are: plotly

--- a/tests/plotly/test_plotly_histogram2d.py
+++ b/tests/plotly/test_plotly_histogram2d.py
@@ -1,0 +1,361 @@
+"""A plotly 2-D histogram produced a figure with no layers.
+
+`go.Histogram2d` carries raw samples and lets plotly bin them into a grid in
+the browser. `maidr/plotly/` had no handling for it, so it fell through
+`_extract_plots` to `PlotlyPlotFactory`, which returned `None` (#627).
+
+**It is a heatmap.** A rectangular grid of cells each carrying a number is
+exactly that, and plotly agrees: measured in Chromium, a `histogram2d` draws a
+single `<image>` into its subplot's `heatmaplayer`, the same element a
+`go.Heatmap` draws. So the layer extends `PlotlyHeatmapPlot` and shares its
+selector.
+
+What differs is where the grid comes from, and that turned out to be a small
+question with a measured answer. Plotly bins a 2-D axis on the rule py-maidr
+already matches for a 1-D histogram, with **one** change: the sample-size
+exponent is `0.25` rather than `0.4` -- `autoBin`'s own `is2d` flag. The same
+thirty values are binned five wide by `go.Histogram` and ten wide by
+`go.Histogram2d`, which is what `test_a_two_dimensional_axis_is_binned_more_coarsely`
+pins.
+
+Every emitted cell and bin label was then checked against `gd.calcdata` in
+Chromium across 16 figures -- auto widths, `nbins` hints, explicit bins, all
+four `histnorm` forms, three `histfunc` aggregates, a reversed x axis, a
+reversed y axis, and a subplot. 0 disagreements.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Two bins on each axis, so a grid can be read by eye. Samples at (1, 1),
+#: (1, 3) and (3, 1) fill three of the four cells and leave the fourth empty.
+BINS = {
+    "xbins": {"start": 0, "end": 4, "size": 2},
+    "ybins": {"start": 0, "end": 4, "size": 2},
+}
+CORNER = {"x": [1, 1, 3], "y": [1, 3, 1]}
+
+#: The grid those three samples make, **top row first** -- the schema's order,
+#: which the core turns over again so its own row 0 is the bottom of the
+#: drawing.
+CORNER_GRID = [[1.0, 0.0], [1.0, 1.0]]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _histogram2d(**kwargs: object) -> go.Figure:
+    """One 2-D histogram, with its colour bar out of the way."""
+    return go.Figure(go.Histogram2d(showscale=False, **kwargs))
+
+
+def test_a_histogram2d_is_read_as_a_heatmap_layer() -> None:
+    """The reproduction, and the type it becomes.
+
+    A rectangular grid of cells each carrying a number is a heatmap, and
+    plotly draws it with the same element -- measured, one `<image>` in the
+    subplot's `heatmaplayer`.
+    """
+    (layer,) = _layers(_histogram2d(**CORNER, **BINS))
+
+    assert layer["type"] is PlotType.HEAT
+    assert layer["selectors"] == ".subplot.xy .heatmaplayer image"
+
+
+def test_the_grid_is_the_counts_the_samples_make() -> None:
+    """Read top row first, which is the schema's order."""
+    (layer,) = _layers(_histogram2d(**CORNER, **BINS))
+
+    assert layer["data"]["points"] == CORNER_GRID
+
+
+def test_a_cell_is_named_by_the_range_it_covers() -> None:
+    """Not by its index and not by its centre.
+
+    "A count of 4" says nothing without "between 0 and 2", and the range is
+    what a sighted reader takes off the axis. r-maidr settled the same
+    question the same way for `geom_bin_2d` (xability/r-maidr#136).
+    """
+    (layer,) = _layers(_histogram2d(**CORNER, **BINS))
+
+    assert layer["data"]["x"] == ["0 – 2", "2 – 4"]
+    assert layer["data"]["y"] == ["2 – 4", "0 – 2"]
+
+
+def test_a_two_dimensional_axis_is_binned_more_coarsely() -> None:
+    """The one thing that differs from the 1-D rule, and the whole of it.
+
+    Plotly's `autoBin` divides by ``n ** 0.25`` for a 2-D histogram and
+    ``n ** 0.4`` for a 1-D one. Measured in Chromium on exactly these thirty
+    values: `go.Histogram` bins them **five** wide and `go.Histogram2d` bins
+    them **ten** wide, both starting at -0.5. Reusing the 1-D exponent would
+    announce six columns where the chart draws three.
+    """
+    values = list(range(30))
+
+    (layer,) = _layers(_histogram2d(x=values, y=values))
+
+    assert layer["data"]["x"] == ["-0.5 – 9.5", "9.5 – 19.5", "19.5 – 29.5"]
+
+
+def test_an_nbins_hint_is_honoured() -> None:
+    """Plotly rounds it to a nice width rather than obeying it exactly.
+
+    Which is the 1-D behaviour unchanged: only the *automatic* width differs
+    between one dimension and two, so the hint path needed nothing.
+    """
+    values = list(range(30))
+
+    (layer,) = _layers(_histogram2d(x=values, y=values, nbinsx=6, nbinsy=6))
+
+    assert layer["data"]["x"] == [
+        "-0.5 – 4.5",
+        "4.5 – 9.5",
+        "9.5 – 14.5",
+        "14.5 – 19.5",
+        "19.5 – 24.5",
+        "24.5 – 29.5",
+    ]
+
+
+def test_a_sample_missing_a_coordinate_is_not_on_the_chart() -> None:
+    """Measured: plotly drops the pair rather than placing it anywhere.
+
+    Counting it would announce a cell one fuller than the one drawn.
+    """
+    (layer,) = _layers(_histogram2d(x=[1, None, 3], y=[1, 3, 1], **BINS))
+
+    assert layer["data"]["points"] == [[0.0, 0.0], [1.0, 1.0]]
+
+
+def test_a_sample_outside_every_bin_is_dropped_rather_than_clipped() -> None:
+    """Measured on an explicit ``xbins`` with a value past its ``end``.
+
+    Folding it into the edge bin would put a sample in a cell the chart shows
+    as holding one fewer.
+    """
+    (layer,) = _layers(_histogram2d(x=[1, 9, 3], y=[1, 1, 1], **BINS))
+
+    assert layer["data"]["points"] == [[0.0, 0.0], [1.0, 1.0]]
+
+
+def test_a_histfunc_reduces_the_z_values_rather_than_counting_rows() -> None:
+    """What a cell *measures* is the author's choice, not the population.
+
+    The bottom-left cell holds **two** samples on purpose: with one apiece
+    every reduction agrees, and a sum would pass for an average.
+    """
+    (layer,) = _layers(
+        _histogram2d(
+            x=[1, 1, 1, 3],
+            y=[1, 1, 3, 1],
+            z=[10, 30, 20, 40],
+            histfunc="avg",
+            **BINS,
+        )
+    )
+
+    assert layer["data"]["points"] == [[20.0, None], [20.0, 40.0]]
+
+
+def test_a_cell_nothing_landed_in_is_a_zero_or_a_blank_by_histfunc() -> None:
+    """Measured: `count` and `sum` paint a 0 there, `avg`/`min`/`max` do not.
+
+    An average of nothing is not zero, and announcing one would put a number
+    on a cell the chart leaves unpainted.
+    """
+    counted = _layers(_histogram2d(**CORNER, **BINS))[0]
+    averaged = _layers(
+        _histogram2d(**CORNER, z=[10, 20, 30], histfunc="avg", **BINS)
+    )[0]
+
+    assert counted["data"]["points"][0][1] == 0.0
+    assert averaged["data"]["points"][0][1] is None
+
+
+def test_an_aggregating_histfunc_with_nothing_to_reduce_counts_instead() -> None:
+    """Which is what plotly does with it -- measured.
+
+    `histfunc="sum"` and no `z` draws the same grid as the default, so
+    declining it would leave a readable chart unread.
+    """
+    (layer,) = _layers(_histogram2d(**CORNER, histfunc="sum", **BINS))
+
+    assert layer["data"]["points"] == CORNER_GRID
+
+
+@pytest.mark.parametrize(
+    ("histnorm", "expected"),
+    [
+        pytest.param(None, [[1.0, 0.0], [1.0, 1.0]], id="count"),
+        pytest.param(
+            "percent",
+            [[100 / 3, 0.0], [100 / 3, 100 / 3]],
+            id="percent-of-the-grand-total",
+        ),
+        pytest.param(
+            "probability", [[1 / 3, 0.0], [1 / 3, 1 / 3]], id="share-of-the-total"
+        ),
+        pytest.param(
+            "density", [[0.25, 0.0], [0.25, 0.25]], id="per-unit-of-cell-area"
+        ),
+        pytest.param(
+            "probability density",
+            [[1 / 12, 0.0], [1 / 12, 1 / 12]],
+            id="share-per-unit-of-area",
+        ),
+    ],
+)
+def test_histnorm_rescales_a_cell_the_way_plotly_does(
+    histnorm: str | None, expected: list
+) -> None:
+    """The 1-D rule with the cell's **area** where it uses the bin's width.
+
+    Measured against the browser for all four forms on a grid of unequal x
+    and y widths. Here every cell is 2 x 2, so a density is a quarter of a
+    count.
+    """
+    figure = _histogram2d(**CORNER, **BINS)
+    if histnorm is not None:
+        figure.data[0].histnorm = histnorm
+
+    (layer,) = _layers(figure)
+
+    # Flattened because `pytest.approx` does not take a nested sequence, and
+    # the shape is already pinned by the tests above.
+    flat = [value for row in layer["data"]["points"] for value in row]
+    assert flat == pytest.approx([value for row in expected for value in row])
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        pytest.param({}, "Count", id="the-default"),
+        pytest.param({"histnorm": "percent"}, "Percent", id="a-normalisation"),
+        pytest.param(
+            {"z": [1, 2, 3], "histfunc": "max"}, "Maximum", id="an-aggregate"
+        ),
+        pytest.param(
+            {"z": [1, 2, 3], "histfunc": "sum", "histnorm": "density"},
+            "Density",
+            id="the-normalisation-wins-over-the-aggregate",
+        ),
+        pytest.param({"histfunc": "sum"}, "Count", id="an-aggregate-with-no-z"),
+    ],
+)
+def test_the_third_axis_is_named_for_what_a_cell_holds(
+    kwargs: dict, expected: str
+) -> None:
+    """A heatmap's numbers are the author's; these are computed.
+
+    So their name is known here, and leaving it unsaid would announce a grid
+    of bare numbers with no word for what they count. The normalisation wins
+    over the aggregate because it is what decides the units -- measured, a
+    ``sum`` under ``histnorm="percent"`` still totals 100.
+    """
+    (layer,) = _layers(_histogram2d(**CORNER, **BINS, **kwargs))
+
+    assert layer["axes"]["z"]["label"] == expected
+
+
+def test_a_colour_bar_the_author_titled_wins() -> None:
+    """It is the one thing they may have written about the cells."""
+    (layer,) = _layers(
+        _histogram2d(
+            **CORNER, **BINS, colorbar={"title": {"text": "Sightings"}}
+        )
+    )
+
+    assert layer["axes"]["z"]["label"] == "Sightings"
+
+
+def test_a_reversed_y_axis_already_counts_from_the_top() -> None:
+    """So the rows are not turned over again (#487).
+
+    The schema's rows run top-first and the core reverses them, which is what
+    makes ArrowUp move visually up. A y axis drawn reversed has the drawing's
+    top at its low end already.
+    """
+    figure = _histogram2d(**CORNER, **BINS)
+    figure.update_layout(yaxis={"autorange": "reversed"})
+
+    (layer,) = _layers(figure)
+
+    assert layer["data"]["points"] == [[1.0, 1.0], [1.0, 0.0]]
+    assert layer["data"]["y"] == ["0 – 2", "2 – 4"]
+
+
+def test_a_reversed_x_axis_turns_the_columns_over() -> None:
+    """The columns start at the left, so only a reversed x axis moves them."""
+    figure = _histogram2d(**CORNER, **BINS)
+    figure.update_layout(xaxis={"autorange": "reversed"})
+
+    (layer,) = _layers(figure)
+
+    assert layer["data"]["points"] == [[0.0, 1.0], [1.0, 1.0]]
+    assert layer["data"]["x"] == ["2 – 4", "0 – 2"]
+
+
+def test_a_histogram2d_on_a_second_subplot_is_scoped_to_it() -> None:
+    """Each subplot holds a `heatmaplayer` of its own."""
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(rows=1, cols=2)
+    figure.add_trace(go.Bar(x=["a"], y=[1]), row=1, col=1)
+    figure.add_trace(
+        go.Histogram2d(showscale=False, **CORNER, **BINS), row=1, col=2
+    )
+
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert [len(row) for row in grid] == [2]
+    (heat,) = grid[0][1]["layers"]
+    assert heat["selectors"] == ".subplot.x2y2 .heatmaplayer image"
+
+
+def test_a_histogram2d_with_no_samples_forms_no_layer() -> None:
+    """Nothing is binned, so nothing is drawn (#636).
+
+    Measured: plotly's `calcdata` entry for such a trace carries no `z` at
+    all, so there is no grid to read.
+    """
+    assert _layers(_histogram2d(x=[], y=[], **BINS)) == []
+
+
+def test_a_histogram2d_whose_samples_are_all_unusable_forms_no_layer() -> None:
+    """Same answer, reached with values rather than an empty array."""
+    assert _layers(_histogram2d(x=[None, None], y=[1, 2], **BINS)) == []
+
+
+@pytest.mark.parametrize(
+    ("x", "expected"),
+    [
+        pytest.param([1, 4], [[0.0, 0.0], [1.0, 0.0]], id="the-last-edge-is-outside"),
+        pytest.param([1, 2], [[0.0, 0.0], [1.0, 1.0]], id="an-interior-edge-goes-up"),
+        pytest.param([0, 1], [[0.0, 0.0], [2.0, 0.0]], id="the-opening-edge-is-inside"),
+    ],
+)
+def test_every_bin_is_half_open_including_the_last(x: list, expected: list) -> None:
+    """Measured, because the obliging answer is the wrong one.
+
+    Folding a sample that sits exactly on the closing edge into the bin below
+    it is what a reader of the code would expect, and plotly drops it: with
+    ``xbins`` running to 4, a sample at 4 is not on the chart. Announcing it
+    would make that cell one fuller than the one drawn.
+    """
+    (layer,) = _layers(_histogram2d(x=x, y=[1, 1], **BINS))
+
+    assert layer["data"]["points"] == expected

--- a/tests/plotly/test_plotly_histogram2d.py
+++ b/tests/plotly/test_plotly_histogram2d.py
@@ -359,3 +359,50 @@ def test_every_bin_is_half_open_including_the_last(x: list, expected: list) -> N
     (layer,) = _layers(_histogram2d(x=x, y=[1, 1], **BINS))
 
     assert layer["data"]["points"] == expected
+
+
+def test_a_z_shorter_than_the_samples_shortens_the_pairing() -> None:
+    """A sample is an x, a y **and** a z when a `histfunc` reduces them.
+
+    Measured: with `histfunc="avg"` and a `z` two long against four x and y,
+    plotly uses two samples and leaves the rest of the grid unpainted. Before
+    the pairing folded `z` in, this raised `ValueError: operands could not be
+    broadcast together with shapes (4,) (2,)` out of the extraction and took
+    the **whole figure** with it -- the failure `paired_arrays` documents for
+    the 1-D path, arrived at again.
+    """
+    (layer,) = _layers(
+        _histogram2d(
+            x=[1, 1, 1, 3], y=[1, 1, 3, 1], z=[10, 30], histfunc="avg", **BINS
+        )
+    )
+
+    assert layer["data"]["points"] == [[None, None], [20.0, None]]
+
+
+def test_a_short_z_leaves_a_counting_trace_alone() -> None:
+    """It shortens the pairing only where it is read.
+
+    Measured: the same two-long `z` under the default `count` changes nothing
+    and all four samples are counted, exactly as if no `z` were there. Folding
+    it into the pairing unconditionally would drop two samples the chart draws.
+    """
+    (layer,) = _layers(_histogram2d(x=[1, 1, 1, 3], y=[1, 1, 3, 1], z=[10, 30], **BINS))
+
+    assert layer["data"]["points"] == [[1.0, 0.0], [2.0, 1.0]]
+
+
+def test_a_grid_of_one_cell_is_still_a_grid() -> None:
+    """The smallest chart there is, and the one an off-by-one shows up in."""
+    (layer,) = _layers(
+        _histogram2d(
+            x=[1.0, 1.5],
+            y=[1.0, 1.5],
+            xbins={"start": 0, "end": 2, "size": 2},
+            ybins={"start": 0, "end": 2, "size": 2},
+        )
+    )
+
+    assert layer["data"]["points"] == [[2.0]]
+    assert layer["data"]["x"] == ["0 – 2"]
+    assert layer["data"]["y"] == ["0 – 2"]

--- a/tests/plotly/test_plotly_histogram2d.py
+++ b/tests/plotly/test_plotly_histogram2d.py
@@ -459,3 +459,35 @@ def test_mismatched_x_and_y_pair_down_to_the_shorter() -> None:
     (layer,) = _layers(_histogram2d(x=[1, 1], y=[1, 3, 1, 3], **BINS))
 
     assert layer["data"]["points"] == [[1.0, 0.0], [1.0, 0.0]]
+
+
+@pytest.mark.parametrize(
+    ("histnorm", "expected"),
+    [
+        pytest.param("percent", [[25.0, 0.0], [25.0, 50.0]], id="percent"),
+        pytest.param("density", [[5.0, 0.0], [5.0, 10.0]], id="per-unit-of-area"),
+    ],
+)
+def test_a_normalised_aggregate_scales_its_populated_cells_too(
+    histnorm: str, expected: list
+) -> None:
+    """The empty cell is not the only thing the pair of rules decides.
+
+    The averages are 20, 20 and 40, so a percent is of their **own** total of
+    80 rather than of the sample count -- the distinction `apply_histnorm`
+    documents -- and a density is per unit of the 2 x 2 cell. Both measured
+    against the browser; this pins the populated cells the empty-cell tests
+    above leave open.
+    """
+    (layer,) = _layers(
+        _histogram2d(
+            x=[1, 1, 1, 3],
+            y=[1, 1, 3, 1],
+            z=[10, 30, 20, 40],
+            histfunc="avg",
+            histnorm=histnorm,
+            **BINS,
+        )
+    )
+
+    assert layer["data"]["points"] == expected

--- a/tests/plotly/test_plotly_histogram2d.py
+++ b/tests/plotly/test_plotly_histogram2d.py
@@ -406,3 +406,56 @@ def test_a_grid_of_one_cell_is_still_a_grid() -> None:
     assert layer["data"]["points"] == [[2.0]]
     assert layer["data"]["x"] == ["0 – 2"]
     assert layer["data"]["y"] == ["0 – 2"]
+
+
+@pytest.mark.parametrize("histfunc", ["avg", "min", "max"])
+@pytest.mark.parametrize(
+    "histnorm", ["percent", "probability", "density", "probability density"]
+)
+def test_a_histnorm_brings_an_empty_cell_back_as_a_zero(
+    histfunc: str, histnorm: str
+) -> None:
+    """Which is not the composition of the two rules, and is what plotly does.
+
+    An `avg` of nothing has no answer, so plotly leaves that cell `NaN` --
+    until any `histnorm` is set, and then it is a **0**. Measured across all
+    three of these functions and all four norms. Rescaling evidently runs over
+    the whole grid without carrying the "no answer" marker through.
+
+    The one-dimensional path found exactly this and says so; deciding from
+    `histfunc` alone would announce "no value" on a cell the chart paints.
+    """
+    (layer,) = _layers(
+        _histogram2d(
+            x=[1, 1, 1, 3],
+            y=[1, 1, 3, 1],
+            z=[10, 30, 20, 40],
+            histfunc=histfunc,
+            histnorm=histnorm,
+            **BINS,
+        )
+    )
+
+    assert layer["data"]["points"][0][1] == 0.0
+
+
+def test_an_aggregate_without_a_histnorm_still_leaves_the_cell_unpainted() -> None:
+    """The control for the pair above: the norm is what changes it."""
+    (layer,) = _layers(
+        _histogram2d(
+            x=[1, 1, 1, 3], y=[1, 1, 3, 1], z=[10, 30, 20, 40], histfunc="avg", **BINS
+        )
+    )
+
+    assert layer["data"]["points"][0][1] is None
+
+
+def test_mismatched_x_and_y_pair_down_to_the_shorter() -> None:
+    """A sample needs both coordinates, `histfunc` or no `histfunc`.
+
+    The `z` tests above cover the aggregating path; this is the same question
+    on the counting one, where `z` is not read at all.
+    """
+    (layer,) = _layers(_histogram2d(x=[1, 1], y=[1, 3, 1, 3], **BINS))
+
+    assert layer["data"]["points"] == [[1.0, 0.0], [1.0, 0.0]]


### PR DESCRIPTION
Closes part of #627, and answers the 2-D binning half of #642's closing note.

`go.Histogram2d` produced a figure with no layers.

## It is a heatmap

A rectangular grid of cells each carrying a number is exactly that, and plotly
agrees: measured in Chromium, a `histogram2d` draws a single `<image>` into its
subplot's `heatmaplayer` — the same element a `go.Heatmap` draws. So the layer
extends `PlotlyHeatmapPlot` and shares its selector, its row/column ordering
and its axis titles.

What differs is where the grid comes from. A heatmap is handed one; a
`histogram2d` carries raw samples and lets plotly bin them in the browser.

## The 2-D binning rule is the 1-D one, minus one exponent

This is the part #642 flagged as needing "plotly's 2-D autobinning matched
first". It turned out to be a single character of difference.

`autoBin` computes its rough width as `2 * stdev(data) / n ** (is2d ? 0.25 : 0.4)`
and rounds it through the same `autoTicks`. py-maidr already matches everything
but the exponent. Measured against the browser on eight axes across four
figures — gaussian, uniform, a six-value sample, a normalised one — `0.4`
matched **none** and `0.25` matched **all eight**.

The test pins it on a deterministic sample rather than a random one. The same
thirty values `0 … 29`:

| trace | plotly's width |
|---|---|
| `go.Histogram(x=v)` | **5** |
| `go.Histogram2d(x=v, y=v)` | **10** |

Reusing the 1-D exponent would announce six columns where the chart draws
three. `nbinsx`/`nbinsy` hints and explicit `xbins`/`ybins` needed no change at
all — the difference reaches exactly the automatic branch, which is why
`compute_bin_edges` grew one keyword and nothing else.

## Reading a cell

- **Named by the range it covers**, not its index or its centre — "a count of 4"
  says nothing without "between 0 and 2", and the range is what a sighted reader
  takes off the axis. r-maidr settled the same question the same way for
  `geom_bin_2d` (xability/r-maidr#136).
- **`histfunc`** reduces `z` rather than counting rows; an aggregating
  `histfunc` with no `z` falls back to counting, which is what plotly does with
  it (measured).
- **A cell nothing landed in** is a `0` under `count`/`sum` and `None` under
  `avg`/`min`/`max` — measured, plotly paints the first and leaves the second
  unpainted. An average of nothing is not zero.
- **`histnorm`** is the 1-D rule with the cell's **area** where it uses the bin's
  width. All four forms verified on a grid of unequal x and y widths.
- **The third axis is named for what the cells hold** — `Count`, or the
  normalisation, or the aggregate. A heatmap's numbers are the author's, so the
  parent emits a `z` only when the colour bar is titled; these are computed, so
  the name is known here, and a titled colour bar still wins.

## Verified against the browser

Every emitted cell and every bin label compared with `gd.calcdata` across **18
figures**: auto widths, `nbins` hints, explicit bins, all four `histnorm`
forms, three `histfunc` aggregates, samples sitting on the bin edges, a
reversed x axis, a reversed y axis, a single-cell grid, and a subplot beside a
bar. **0 disagreements.**

## Mutation sweep — and the defect it found

18 mutations, each reverting one decision alone against a restored baseline.
**All 18 killed, no survivors** — after the sweep changed the shipped code
three times:

- **A real defect.** I had folded a sample sitting exactly on the closing edge
  into the bin below it — the obliging thing to do, and wrong. Measured: with
  `xbins` running to 4, plotly **drops** a sample at 4, while one at an interior
  edge of 2 counts in `[2, 4)` and one at the opening edge of 0 counts in
  `[0, 2)`. Every bin is half-open, including the last. The fold would have made
  that cell one fuller than the one drawn. Removed, with the three edge cases
  now parametrised.
- **A redundant guard removed.** The explicit "no samples" check was already
  answered by "nothing usable to bin" — an empty array and an array of nothing
  usable are the same chart.
- **A weak test sharpened.** The `histfunc="avg"` case had one sample per cell,
  where a sum passes for an average. It now puts two in one cell.

## Checks

- `ruff check` clean on the touched files
- `tests/core`: 1931 passed, 5 skipped
- `tests/plotly` + altair/patch/util/widget/backend: 1371 passed

## Still open under #627

`histogram2dcontour`, which bins the same way this does and then contours the
result — so it now needs only #642's auto-level rule, which is what a plotly
contour still cannot read.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_