### PR TITLE
fix(plotly): round a bin width up strictly, the way plotly does

### DIFF
--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -12,9 +12,15 @@ from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 def _plotly_round_up(val: float, array: list[float], reverse: bool = False) -> float:
     """Binary search matching Plotly.js ``Lib.roundUp``.
 
-    With *reverse* False (default) returns the smallest element in *array*
-    that is >= *val*.  With *reverse* True returns the largest element <=
-    *val*.
+    With *reverse* False (default) returns the first element of *array*
+    **strictly greater** than *val*, clamped to the last element when there
+    is none. With *reverse* True it returns the largest element <= *val*.
+
+    Strictly, not "greater than or equal" -- the search advances on
+    ``array[mid] <= val``, which steps past an exact match, and that is what
+    plotly does. The distinction only shows on the boundary, and there it
+    decides a whole bin grid: see :func:`_plotly_dtick` for what an exact 2
+    costs (#646).
     """
     lo, hi = 0, len(array) - 1
     while lo < hi:
@@ -91,8 +97,30 @@ def _plotly_dtick(size0: float) -> float:
         base = 10 ** floor(log10(size0))
         dtick = base * roundUp(size0 / base, [2, 5, 10])
 
-    where ``roundUp(v, seq)`` returns the first element in *seq* that
-    is >= *v*.
+    where ``roundUp(v, seq)`` returns the first element of *seq* **strictly
+    greater** than *v*. Strictly, not "greater than or equal": ``Lib.roundUp``
+    binary-searches with ``arrayIn[mid] <= val``, which steps past an exact
+    match.
+
+    That is the whole of the difference and it is not a rounding detail. The
+    two readings agree everywhere except where ``size0 / base`` lands exactly
+    on 2, 5 or 10, and there the loose one picks the width *below* the one
+    plotly draws -- twice as many bins, half as wide, every count wrong to
+    match. Measured in Chromium, with ``nbins`` used to make the ratio exact
+    on demand:
+
+    ==========================================  =====  ==========  =========
+    trace                                       ratio  plotly      loose
+    ==========================================  =====  ==========  =========
+    ``x=linspace(0, 30, 61), nbinsx=15``        2.0    **5**       2
+    ``x=linspace(0, 75, 76), nbinsx=15``        5.0    **10**      5
+    ``x=linspace(0, 28.5, 58), nbinsx=15``      1.9    2           2
+    ``x=linspace(0, 31.5, 64), nbinsx=15``      2.1    5           5
+    ==========================================  =====  ==========  =========
+
+    The same comparison decides a contour's automatic levels, which run
+    through the same ``autoTicks``: a field spanning ``0 .. 3`` gives a rough
+    step of exactly ``0.2``, and plotly draws ``0.5`` (#642, #646).
 
     Parameters
     ----------
@@ -102,11 +130,11 @@ def _plotly_dtick(size0: float) -> float:
     if size0 <= 0:
         return 1.0
     base = 10 ** math.floor(math.log10(size0))
-    ratio = size0 / base
-    for nice in (2, 5, 10):
-        if nice >= ratio * (1 - 1e-9):  # small tolerance for FP
-            return base * nice
-    return base * 10  # fallback
+    # The same `Lib.roundUp` the bin-width floor above already goes through,
+    # rather than a second hand-rolled copy of it. The copy is where the
+    # strictness was lost: this call site read the sequence with `>=` while
+    # the helper next to it had the search right all along.
+    return base * _plotly_round_up(size0 / base, [2, 5, 10])
 
 
 def _auto_shift_bins(

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -243,3 +243,66 @@ class TestNothingToAnnounce:
         # cell the reader can tab into and find nothing in.
         fig = go.Figure([go.Histogram(x=NARROW, xbins=dict(start=20, end=24, size=1))])
         assert layers(fig) == []
+
+
+class TestTheRoundUpIsStrict:
+    """A rough width landing exactly on a nice number takes the next one up.
+
+    `Lib.roundUp` binary-searches with ``arrayIn[mid] <= val``, so it returns
+    the first element **strictly greater** than the value. py-maidr read it as
+    "greater than or equal", which agrees everywhere except on the boundary --
+    and there it picked the width *below* the one plotly draws: twice as many
+    bins, half as wide, every count wrong to match (#646).
+
+    ``nbins`` is what makes the ratio exact on demand, since the rough width
+    is then ``range / nbins`` rather than something derived from the spread.
+
+    The same comparison decides a contour's automatic levels, which run
+    through the same ``autoTicks`` -- a field spanning 0 .. 3 gives a rough
+    step of exactly 0.2 and plotly draws 0.5 (#642).
+    """
+
+    @pytest.mark.parametrize(
+        ("high", "points", "width"),
+        [
+            # 30 / 15 = 2 exactly. The loose reading gives 2; plotly gives 5.
+            pytest.param(30, 61, 5, id="exactly-two"),
+            # 75 / 15 = 5 exactly.
+            pytest.param(75, 76, 10, id="exactly-five"),
+            # Controls a hair either side, where the two readings agree.
+            pytest.param(28.5, 58, 2, id="just-below-two"),
+            pytest.param(31.5, 64, 5, id="just-above-two"),
+        ],
+    )
+    def test_the_width_is_the_one_plotly_draws(self, high, points, width):
+        values = list(np.linspace(0, high, points))
+
+        drawn = bins(go.Figure(go.Histogram(x=values, nbinsx=15)))
+
+        assert {round(hi - lo, 9) for lo, hi, _ in drawn} == {width}
+
+    def test_a_two_dimensional_histogram_rounds_the_same_way(self):
+        """It shares `_plotly_dtick`, so the boundary reaches it too.
+
+        Its automatic width divides by a different power of the sample count,
+        but the round-up afterwards is the same one -- so an `nbins` hint that
+        lands on the boundary lands there for both. Measured: plotly resolves
+        this figure to ``xbins`` of ``size 5, start -2.5, end 32.5``, where
+        the loose reading would have given a width of 2.
+        """
+        values = list(np.linspace(0, 30, 61))
+        figure = go.Figure(
+            go.Histogram2d(x=values, y=values, nbinsx=15, nbinsy=15)
+        )
+
+        layer = PlotlyMaidr(figure)._flatten_maidr()["subplots"][0][0]["layers"][0]
+
+        assert layer["data"]["x"] == [
+            "-2.5 – 2.5",
+            "2.5 – 7.5",
+            "7.5 – 12.5",
+            "12.5 – 17.5",
+            "17.5 – 22.5",
+            "22.5 – 27.5",
+            "27.5 – 32.5",
+        ]


### PR DESCRIPTION
Closes #646. Unblocks #642's automatic contour levels.

## The defect

`_plotly_dtick` rounds a rough bin width up to a 1/2/5×10ⁿ value, mirroring
plotly's `Axes.autoTicks`. It read the sequence with `>=` and a tolerance:

```python
for nice in (2, 5, 10):
    if nice >= ratio * (1 - 1e-9):  # small tolerance for FP
        return base * nice
```

Plotly's `Lib.roundUp` is **strictly greater**. Its binary search advances on
`arrayIn[mid] <= val`, which steps past an exact match.

The two agree everywhere except where `ratio` lands exactly on 2, 5 or 10 — and
there the loose reading picks the width **below** the one plotly draws: twice as
many bins, half as wide, every count wrong to match. The `* (1 - 1e-9)`
tolerance widened the wrong branch further, so a ratio a hair *under* 2 took it
as well.

## Measured

`nbins` makes the rough width exactly `range / nbins`, so the boundary is
reachable on demand. In Chromium:

| trace | ratio | plotly draws | py-maidr computed |
|---|---|---|---|
| `go.Histogram(x=linspace(0, 30, 61), nbinsx=15)` | **2.0** | **5** | 2 |
| `go.Histogram(x=linspace(0, 75, 76), nbinsx=15)` | **5.0** | **10** | 5 |
| `go.Histogram(x=linspace(0, 28.5, 58), nbinsx=15)` | 1.9 | 2 | 2 |
| `go.Histogram(x=linspace(0, 31.5, 64), nbinsx=15)` | 2.1 | 5 | 5 |

A hair either side of the boundary the two agree, which is why no existing test
caught it — and why the new ones are parametrised across both sides.

## The fix is to stop keeping a second copy

`_plotly_round_up` — the helper immediately above, already used for the
minimum-width floor — **had the search right all along**. Only `_plotly_dtick`
hand-rolled a loose loop beside it. So the loop is gone:

```python
return base * _plotly_round_up(size0 / base, [2, 5, 10])
```

One implementation of `Lib.roundUp` rather than two that can drift, which is
exactly how they had drifted. The helper's docstring said `>=` where its code
said strictly-greater; it now says what it does.

`ratio` is always in `[1, 10)` by construction of `base`, so the old loop's
`return base * 10` fallback was unreachable and goes with it.

## What it unblocks

This is the whole of what #642 was stuck on. That issue tabulated nine z ranges
for `go.Contour`'s automatic levels and found eight fit "round `(max−min)/15` up
to a 1/2/5×10ⁿ step" while `0 … 3` did not:

> `3 / 15 = 0.2`, which is already a 1/2/5 step, so the formula predicts
> `size = 0.2`. Plotly drew `size = 0.5`.

`0.2 / 0.1 = 2.0` — the same boundary. With the strict rule a sweep of **21 z
ranges**, including the three that land exactly on it (`0…3`, `0…0.3`, `0…30`),
matches plotly's resolved `contours.start`/`size`/`end` **21/21**, up from
18/21. Nothing in `autoTicks` was doing more than the round-up.

## Tests

`TestTheRoundUpIsStrict` in `tests/plotly/test_plotly_histogram_bins.py`: four
parametrised 1-D cases (both exact boundaries and a control either side), plus
one asserting a `histogram2d` rounds the same way — it shares `_plotly_dtick`,
and plotly resolves that figure to `xbins` of `size 5, start −2.5, end 32.5`
where the loose reading gave 2.

## Mutation sweep

Four mutations, each reverting one decision alone:

```
KILLED  R1 the loose round-up (with the tolerance)
KILLED  R2 the loose round-up (plain >=)
KILLED  R3 the loose loop, reintroduced
KILLED  R4 the helper's search made loose
```

## Checks

- `ruff check` clean on the touched files
- `tests/core`: 1931 passed, 5 skipped
- `tests/plotly`: 1210 passed
- The 21-range auto-contour sweep re-run against Chromium: 21/21

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_