### PR TITLE
feat(plotly): read a contour at the levels plotly picks for itself

### DIFF
--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -275,6 +275,14 @@ def draws_its_lines(trace: dict) -> bool:
 def levels_of(trace: dict, z: Any = None) -> list[float] | None:
     """Return the levels plotly draws: the author's, or the ones it picks.
 
+    Which route applies is asked first, rather than read off a None coming
+    back from the first one. :func:`declared_levels` answers None for two
+    unrelated reasons -- the author did not name their own levels, and the
+    author named a *billion* of them -- and only the first is a reason to
+    pick levels instead. Falling through on both would read a runaway spec at
+    nine levels of someone else's choosing, which is a chart the author did
+    not write and plotly does not draw.
+
     Parameters
     ----------
     trace : dict
@@ -286,9 +294,31 @@ def levels_of(trace: dict, z: Any = None) -> list[float] | None:
     Returns
     -------
     list of float or None
-        The levels, or None when the trace is not a set of levels at all.
+        The levels, or None when there are none to read.
     """
-    return declared_levels(trace) or automatic_levels(trace, z)
+    if declares_levels(trace):
+        return declared_levels(trace)
+    return automatic_levels(trace, z)
+
+
+def declares_levels(trace: dict) -> bool:
+    """Whether the levels are the author's rather than plotly's to pick.
+
+    **Both ends** is what makes them the author's. Plotly coerces
+    ``autocontour`` to true when either ``start`` or ``end`` is missing, so a
+    trace naming one of them, or only a ``size``, has its levels picked for
+    it -- measured, all three draw the same nine levels as a trace naming
+    nothing at all. An explicit ``autocontour: True`` overrides even a
+    complete spec, and a ``constraint`` contour is not a set of levels at
+    all (see :func:`_levels_spec`).
+    """
+    contours = _levels_spec(trace)
+    if contours is None or trace.get("autocontour") is True:
+        return False
+    return (
+        _a_number(contours.get("start")) is not None
+        and _a_number(contours.get("end")) is not None
+    )
 
 
 def declared_levels(trace: dict) -> list[float] | None:
@@ -301,12 +331,10 @@ def declared_levels(trace: dict) -> list[float] | None:
     ``start=0.2, size=0.2`` both routes agree on 0.4 and disagree on the
     third level, and the level is also what is handed to the curve tracer.
 
-    **Both ends** is what makes a spec the author's. Plotly coerces
-    ``autocontour`` to true when either ``start`` or ``end`` is missing, so a
-    trace naming one of them, or only a ``size``, has its levels picked for it
-    -- measured, all three draw the same nine levels as a trace naming nothing
-    at all. :func:`automatic_levels` takes those, and takes an explicit
-    ``autocontour: True``, which overrides a complete spec.
+    What makes a spec the author's is :func:`declares_levels`; None here
+    means either that it is not theirs or that theirs runs away (see
+    :func:`_stepped`), which is why :func:`levels_of` asks which case it is
+    before reading this.
 
     With both ends named, a missing or zero ``size`` is **not** a decline:
     plotly keeps the ends and derives a width for them, through the same
@@ -314,13 +342,13 @@ def declared_levels(trace: dict) -> list[float] | None:
     no size and a zero size both draw a width of 0.05, which is
     ``(0.8 - 0.2) / 15`` rounded up, and ``ncontours=4`` draws 0.2.
     """
-    contours = _levels_spec(trace)
-    if contours is None or trace.get("autocontour") is True:
+    if not declares_levels(trace):
         return None
 
+    contours = _levels_spec(trace) or {}
     start = _a_number(contours.get("start"))
     end = _a_number(contours.get("end"))
-    if start is None or end is None:
+    if start is None or end is None:  # pragma: no cover - `declares_levels`
         return None
 
     low, high = (start, end) if start <= end else (end, start)
@@ -341,7 +369,10 @@ def automatic_levels(trace: dict, z: Any) -> list[float] | None:
     1. A rough step of ``(zmax - zmin) / (ncontours or 15)``, rounded up to a
        1/2/5x10ⁿ value by the same ``roundUp`` a histogram's bin width goes
        through -- **strictly** greater, which is the whole of what made a
-       field spanning ``0 .. 3`` look unreproducible (#646).
+       field spanning ``0 .. 3`` look unreproducible (#646). The ``or`` reads
+       a zero ``ncontours`` as none given, which no measured figure can
+       reach: plotly's own validator rejects anything below 1, so a trace
+       built through `graph_objects` never carries one.
     2. ``start``: the first multiple of the step at or above ``zmin``, moved
        up one when it lands *on* it, so no level sits at the floor of the
        field.
@@ -375,7 +406,13 @@ def automatic_levels(trace: dict, z: Any) -> list[float] | None:
     if _levels_spec(trace) is None or z is None:
         return None
 
-    finite = np.asarray(z)[np.isfinite(np.asarray(z, dtype=float))]
+    # Through the mask rather than around it. `_grid` hands over a masked
+    # array, and reading `np.asarray` off one gives the buffer *under* the
+    # mask -- which happens to hold the NaN that caused the masking today,
+    # so the filter below would keep working by luck if a masked value were
+    # ever a finite one.
+    values = np.ma.filled(np.ma.asarray(z, dtype=float), np.nan)
+    finite = values[np.isfinite(values)]
     if finite.size == 0:
         return None
     low, high = float(np.min(finite)), float(np.max(finite))

--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.histogram import _plotly_dtick
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 _logger = logging.getLogger(__name__)
@@ -31,6 +32,18 @@ _CURVE_ALGORITHM = "mpl2014"
 #: never cost the render (#421, #636). No figure anyone draws comes near this.
 _LEVEL_LIMIT = 1000
 
+#: How many levels plotly aims for when the author names no ``ncontours``.
+#: Plotly's own default, and the divisor of the rough step an automatic
+#: contour rounds up from.
+_DEFAULT_LEVEL_COUNT = 15
+
+#: How far a multiple may miss a round number and still count as one, when
+#: locating the first and last levels inside a field's range. Only the
+#: ``ceil``/``floor`` are given this room: whether the result then *equals*
+#: the range's own end is tested exactly, because plotly tests it exactly and
+#: the difference decides a whole level (see :func:`automatic_levels`).
+_MULTIPLE_TOLERANCE = 1e-9
+
 #: How far past ``end`` plotly's level loop still steps, as a fraction of
 #: ``size``. Measured rather than assumed, across seven specs: a run at
 #: ``start=0.2, end=0.8, size=0.05`` draws a level at ``0.8000000000000002``
@@ -49,11 +62,12 @@ class PlotlyContourPlot(PlotlyPlot):
     two peaks crosses a level twice, and joining the two islands into one
     series would announce a curve running across ground the field never took.
 
-    **The curves are not in the trace.** Plotly ships a grid and a level
-    spacing and computes the curves in the browser, so reading this chart
-    means tracing the same marching squares here. That is what `contourpy`
-    does -- it is what matplotlib traces its own contours with, and it arrives
-    with matplotlib, which py-maidr already requires.
+    **Neither the curves nor, usually, the levels are in the trace.** Plotly
+    ships a grid, works out where to cut it, and traces the curves in the
+    browser. Reading this chart means doing both here: the levels by
+    :func:`levels_of`, the curves by `contourpy` -- what matplotlib traces its
+    own contours with, and what arrives with matplotlib, which py-maidr
+    already requires.
 
     Two independent implementations agreeing is not a contract, so what they
     agree about was measured rather than assumed. Across 33 fields and 207
@@ -104,18 +118,23 @@ class PlotlyContourPlot(PlotlyPlot):
         -------
         list of list of dict
             One series per curve, in plotly's own drawing order. Empty when
-            the trace declines -- see :func:`declared_levels` and
-            :func:`_grid` for the three reasons -- which leaves the figure
-            with no contour layer rather than a wrong one (#636).
+            the trace declines -- see :func:`levels_of` and :func:`_grid` for
+            the reasons -- which leaves the figure with no contour layer
+            rather than a wrong one (#636).
         """
         self._series_levels = []
 
-        levels = declared_levels(self._trace)
         grid = _grid(self._trace)
-        if levels is None or grid is None:
+        if grid is None:
             return []
 
         x, y, z = grid
+        # The field, not just the trace: an automatic contour chooses its
+        # levels from the range of what it draws.
+        levels = levels_of(self._trace, z)
+        if not levels:
+            return []
+
         # The whole of the tracing, not only the generator's construction.
         # `.lines()` is where the work happens, so it is where an unforeseen
         # grid or a stricter future contourpy would raise -- and an exception
@@ -253,6 +272,25 @@ def draws_its_lines(trace: dict) -> bool:
     return contours.get("showlines") is not False
 
 
+def levels_of(trace: dict, z: Any = None) -> list[float] | None:
+    """Return the levels plotly draws: the author's, or the ones it picks.
+
+    Parameters
+    ----------
+    trace : dict
+        One trace of the figure.
+    z : Any, optional
+        The field, needed only when the levels are automatic -- they are
+        chosen from its range. Without it an automatic trace declines.
+
+    Returns
+    -------
+    list of float or None
+        The levels, or None when the trace is not a set of levels at all.
+    """
+    return declared_levels(trace) or automatic_levels(trace, z)
+
+
 def declared_levels(trace: dict) -> list[float] | None:
     """Return the levels the author asked for, or None when plotly picks them.
 
@@ -263,40 +301,140 @@ def declared_levels(trace: dict) -> list[float] | None:
     ``start=0.2, size=0.2`` both routes agree on 0.4 and disagree on the
     third level, and the level is also what is handed to the curve tracer.
 
-    None is returned -- the layer declines -- whenever plotly would choose the
-    levels itself, because the rule it chooses them by lives in plotly.js and
-    could not be reproduced here: measured across nine fields, eight fit
-    "round ``(max - min) / 15`` up to a 1/2/5x10ⁿ step", and a field spanning
-    ``0 .. 3`` does not. So a trace that leaves any of ``start``, ``end`` or
-    ``size`` out, that sets ``size`` to zero (plotly replaces it), or that
-    sets ``autocontour: True`` (which overrides an explicit spec -- measured)
-    is left unread rather than read at levels the chart does not draw. See
-    #642.
+    **Both ends** is what makes a spec the author's. Plotly coerces
+    ``autocontour`` to true when either ``start`` or ``end`` is missing, so a
+    trace naming one of them, or only a ``size``, has its levels picked for it
+    -- measured, all three draw the same nine levels as a trace naming nothing
+    at all. :func:`automatic_levels` takes those, and takes an explicit
+    ``autocontour: True``, which overrides a complete spec.
+
+    With both ends named, a missing or zero ``size`` is **not** a decline:
+    plotly keeps the ends and derives a width for them, through the same
+    round-up an automatic contour uses. Measured on ``start=0.2, end=0.8``:
+    no size and a zero size both draw a width of 0.05, which is
+    ``(0.8 - 0.2) / 15`` rounded up, and ``ncontours=4`` draws 0.2.
     """
-    contours = trace.get("contours")
-    if not isinstance(contours, dict):
-        return None
-    if trace.get("autocontour") is True:
-        return None
-    # A constraint contour draws one curve at `value` and means "the region
-    # where z is above it", which is a different chart from a set of levels;
-    # it carries no start/end/size and so declines here anyway.
-    if contours.get("type") not in (None, "levels"):
+    contours = _levels_spec(trace)
+    if contours is None or trace.get("autocontour") is True:
         return None
 
     start = _a_number(contours.get("start"))
     end = _a_number(contours.get("end"))
-    size = _a_number(contours.get("size"))
-    if start is None or end is None or size is None or size <= 0:
+    if start is None or end is None:
         return None
 
     low, high = (start, end) if start <= end else (end, start)
-    limit = high + size / _END_TOLERANCE
-    if (high - low) / size > _LEVEL_LIMIT:
+    size = _a_number(contours.get("size"))
+    if size is None or size <= 0:
+        count = _a_number(trace.get("ncontours"))
+        size = _plotly_dtick((high - low) / (count or _DEFAULT_LEVEL_COUNT))
+    return _stepped(low, high, size)
+
+
+def automatic_levels(trace: dict, z: Any) -> list[float] | None:
+    """Return the levels plotly picks for itself, from the field's range.
+
+    The rule lives in plotly.js and is reproduced here rather than declined,
+    which is what #642 was filed for. It turned out to be four steps, each
+    measured against the browser:
+
+    1. A rough step of ``(zmax - zmin) / (ncontours or 15)``, rounded up to a
+       1/2/5x10ⁿ value by the same ``roundUp`` a histogram's bin width goes
+       through -- **strictly** greater, which is the whole of what made a
+       field spanning ``0 .. 3`` look unreproducible (#646).
+    2. ``start``: the first multiple of the step at or above ``zmin``, moved
+       up one when it lands *on* it, so no level sits at the floor of the
+       field.
+    3. ``end``: the last multiple at or below ``zmax``, moved down one when
+       it lands on it, for the same reason at the ceiling.
+    4. If those cross -- an ``ncontours`` so small that no multiple fits
+       inside at all -- both become their own midpoint, and the field gets a
+       single level. Measured: ``ncontours=2`` over ``0 .. 100`` draws one
+       level at 50, and ``ncontours=1`` over ``0 .. 10`` draws one at 10.
+
+    A field with no range at all needs no case of its own: its rough step is
+    zero, the round-up answers 1, and step 4 catches it.
+
+    Steps 2 and 3 each round twice, and all four roundings pull in opposite
+    directions on purpose. The multiple itself is taken with a tolerance,
+    because a range that divides evenly rarely says so in binary --
+    ``-0.3 / 0.05`` is -5.999999999999999, and rounding that at face value
+    starts the list a whole level late. The tests for a level landing *on* the
+    floor or the ceiling are then exact, because the value the tolerance
+    recovered is a hair off the bound rather than on it: ``0.009 / 0.0001``
+    rounds up to a top level of ``0.009000000000000001``, and a tolerant
+    comparison would read that as sitting on the ceiling and drop the level
+    plotly drew there.
+
+    Measured against plotly's drawn levels on **49 figures** -- 26 z ranges
+    from ``0 .. 0.07`` to ``0 .. 1000``, positive, negative and straddling, 8
+    explicit ``ncontours`` from 1 to 30, and 15 ranges chosen for landing on
+    exactly those ties. All 49 agree, level for level, and each of the four
+    roundings is the difference on at least one of them.
+    """
+    if _levels_spec(trace) is None or z is None:
+        return None
+
+    finite = np.asarray(z)[np.isfinite(np.asarray(z, dtype=float))]
+    if finite.size == 0:
+        return None
+    low, high = float(np.min(finite)), float(np.max(finite))
+    # A constant field needs no guard of its own. Its range is zero, so the
+    # rough step is zero and the round-up answers 1; the first multiple above
+    # the floor is then past the last below the ceiling, and the fallback in
+    # step 4 puts one level at the constant value -- which is exactly what
+    # plotly draws for it (measured: a grid of 3s gets a single level at 3).
+    # That level *is* the whole field, so it holds no curve, and #636's guard
+    # drops the empty layer.
+    count = _a_number(trace.get("ncontours"))
+    size = _plotly_dtick((high - low) / (count or _DEFAULT_LEVEL_COUNT))
+    if size <= 0:
+        return None
+
+    start = math.ceil(low / size - _MULTIPLE_TOLERANCE) * size
+    if start == low:
+        start += size
+    end = math.floor(high / size + _MULTIPLE_TOLERANCE) * size
+    if end == high:
+        end -= size
+    if start > end:
+        start = end = (start + end) / 2
+
+    return _stepped(start, end, size)
+
+
+def _levels_spec(trace: dict) -> dict | None:
+    """The trace's ``contours``, when it describes a set of levels at all.
+
+    A **constraint** contour draws one curve at ``value`` and means "the
+    region beyond it", which is a different chart -- measured, one group at
+    ``value`` however its ``start``/``end``/``size`` are written, so reading
+    those would announce levels it does not draw. A trace with no ``contours``
+    at all is a set of levels plotly picks, so it passes.
+    """
+    contours = trace.get("contours")
+    if contours is None:
+        return {}
+    if not isinstance(contours, dict):
+        return None
+    if contours.get("type") not in (None, "levels"):
+        return None
+    return contours
+
+
+def _stepped(start: float, end: float, size: float) -> list[float] | None:
+    """Step from ``start`` while the level is below ``end + size / 10``.
+
+    The one loop both paths use, because plotly uses one: the tolerance was
+    measured on an explicit spec and the automatic ``end`` is fed to the same
+    arithmetic. None when the count would run away -- see :data:`_LEVEL_LIMIT`.
+    """
+    if (end - start) / size > _LEVEL_LIMIT:
         return None
 
     levels = []
-    level = low
+    level = start
+    limit = end + size / _END_TOLERANCE
     while level < limit:
         levels.append(level)
         level += size

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -40,6 +40,7 @@ landing on a binary tie. All 49 agree, level for level.
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
@@ -646,6 +647,43 @@ def test_a_spacing_that_asks_for_a_billion_levels_is_declined() -> None:
 
     assert declared_levels(runaway) is None
     assert declared_levels(ordinary) == [0, 0.5, 1.0]
+
+
+def test_a_runaway_spec_declines_rather_than_falling_back_to_automatic() -> None:
+    """The decline has to reach the layer, not just the level list.
+
+    Reading the levels is now two routes rather than one, and the author's
+    route answers None for two unrelated reasons: they did not name their own
+    levels, and they named a billion of them. Treating both as "then pick
+    some" would read the chart above at nine levels of maidr's choosing --
+    every one of them a level plotly does not draw here, on a chart whose
+    author was explicit about which levels they wanted.
+
+    Reached through the whole layer rather than the level list, because the
+    level list is where the two reasons already look alike.
+    """
+    figure = go.Figure(_contour(ONE_PEAK, start=0, end=1, size=1e-9))
+
+    assert _layers(figure) == []
+
+
+def test_a_masked_field_picks_its_levels_from_what_is_left() -> None:
+    """The range behind automatic levels reads through the mask.
+
+    A hole is masked *and* NaN today, so filtering on `isfinite` and
+    filtering on the mask cannot be told apart -- until a masked value is a
+    finite one, which is what this arranges by masking the peak of an
+    otherwise ordinary field by hand. Reading around the mask would put the
+    range at 0 .. 1 and the levels at every tenth; reading through it puts
+    the range at 0 .. 0.5, where plotly's rule gives multiples of 0.05.
+    """
+    from maidr.plotly.contour import automatic_levels
+
+    field = np.ma.masked_values([[0.0, 0.5, 0.0], [0.5, 1.0, 0.5], [0.0, 0.5, 0.0]], 1.0)
+
+    assert automatic_levels({}, field) == pytest.approx(
+        [0.05 * step for step in range(1, 10)]
+    )
 
 
 def test_a_tracer_that_raises_costs_one_layer_and_not_the_figure(

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -5,10 +5,10 @@
 `PlotlyPlotFactory`, which returned `None` (#627). The core has had
 `TraceType.CONTOUR` for this shape since the matplotlib side was read (#539).
 
-**The curves are not in the trace.** Plotly ships a grid and a level spacing
-and traces the curves in the browser, so reading this chart means running the
-same marching squares here -- `contourpy`, which is what matplotlib traces its
-own contours with.
+**Neither the curves nor, usually, the levels are in the trace.** Plotly ships
+a grid, works out where to cut it, and traces the curves in the browser. So
+reading this chart means doing both here: the levels by the rule below, the
+curves with `contourpy` -- what matplotlib traces its own contours with.
 
 Two independent implementations agreeing is not a contract, so what they agree
 about was measured. Across 33 fields and 207 levels -- random sums of
@@ -24,6 +24,18 @@ Plotly's level list was pinned the same way: it steps `start`, `start + size`,
 ... while the level is below `end + size / 10`. Neither `<= end` (which drops
 a level plotly draws at `start=0.2, end=0.8, size=0.05`) nor `end + size / 2`
 (which adds one plotly does not draw at `start=0, end=0.9, size=0.5`) fits.
+
+**Where `start` and `end` come from** was #642's open problem, and it turned
+out to be one comparison rather than a missing formula. Plotly divides the
+field's range by `ncontours` (15 by default) and rounds that up to a 1/2/5x10ⁿ
+step -- *strictly*, which is why a field spanning `0 .. 3` looked
+unreproducible: its rough step is exactly 0.2 and plotly draws 0.5 (#646).
+`start` and `end` are then the first and last multiples strictly inside the
+range, and if those cross -- an `ncontours` too small to fit one -- plotly puts
+a single level at their midpoint. Measured against the drawn levels on **49
+figures**: 26 z ranges from `0 .. 0.07` to `0 .. 1000`, positive, negative and
+straddling, 8 explicit `ncontours` from 1 to 30, and 15 ranges picked for
+landing on a binary tie. All 49 agree, level for level.
 """
 
 from __future__ import annotations
@@ -219,7 +231,9 @@ def test_a_filled_contour_with_its_lines_off_has_nothing_to_point_at() -> None:
     outline is missing.
     """
     figure = go.Figure(
-        go.Contour(z=ONE_PEAK, contours=dict(start=0.5, end=0.5, size=0.5, showlines=False))
+        go.Contour(
+            z=ONE_PEAK, contours=dict(start=0.5, end=0.5, size=0.5, showlines=False)
+        )
     )
 
     (layer,) = _layers(figure)
@@ -248,31 +262,170 @@ def test_showlines_off_under_another_coloring_still_draws_the_curves() -> None:
     assert len(layer["selectors"]) == 1
 
 
-def test_auto_levels_are_declined() -> None:
-    """Plotly's rule for picking them lives in plotly.js and was not derivable.
-
-    Measured across nine z ranges, eight fit "round ``(max - min) / 15`` up to
-    a 1/2/5x10ⁿ step" and a field spanning 0 .. 3 does not. Reading the chart
-    at levels it does not draw would announce curves that are not there, so
-    the trace is left unread until the rule is settled (#642).
-    """
-    assert _layers(go.Figure(go.Contour(z=ONE_PEAK))) == []
+#: What plotly picks for `ONE_PEAK`, whose field runs 0 .. 1: a rough step of
+#: ``1 / 15`` rounded up to 0.1, then the multiples of it strictly inside the
+#: range. Measured -- and the same nine whichever way the author fails to name
+#: both ends.
+AUTOMATIC = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
 
 @pytest.mark.parametrize(
     ("contours", "extra"),
     [
-        pytest.param({"start": 0.5}, {}, id="start-without-end-or-size"),
-        pytest.param({"size": 0.5}, {}, id="size-alone"),
-        pytest.param({"start": 0.5, "end": 1.5}, {}, id="no-size"),
-        pytest.param({"start": 0.5, "end": 1.5, "size": 0}, {}, id="zero-size"),
+        pytest.param({}, {}, id="nothing-named-at-all"),
+        pytest.param({"start": 0.5}, {}, id="a-start-without-an-end"),
+        pytest.param({"end": 0.5}, {}, id="an-end-without-a-start"),
+        pytest.param({"size": 0.25}, {}, id="a-size-alone"),
         pytest.param(
-            {"start": 0.5, "end": 1.5, "size": 0.5},
+            {"start": 0.2, "end": 0.8, "size": 0.2},
             {"autocontour": True},
-            id="autocontour-overrides-the-spec",
+            id="autocontour-overrides-a-complete-spec",
         ),
-        pytest.param(
-            {
+    ],
+)
+def test_the_levels_plotly_picks_are_the_ones_read(
+    contours: dict, extra: dict
+) -> None:
+    """#642's open problem, and it was one comparison rather than a formula.
+
+    Plotly coerces `autocontour` to true whenever `start` or `end` is missing,
+    so each of these has its levels picked for it -- measured, all five draw
+    the same nine. The rule is a rough step of ``(zmax - zmin) / ncontours``
+    rounded up to a 1/2/5x10ⁿ value, then the multiples of it strictly inside
+    the range.
+
+    What made it look unreproducible was the round-up: a field spanning
+    ``0 .. 3`` gives a rough step of exactly ``0.2``, and plotly draws ``0.5``
+    because its `roundUp` is strictly greater (#646). With that read
+    correctly, 34 figures agree level for level.
+    """
+    figure = go.Figure(go.Contour(z=ONE_PEAK, contours=contours, **extra))
+
+    assert _levels(_layers(figure)[0]) == pytest.approx(AUTOMATIC)
+
+
+def test_two_named_ends_with_no_width_get_one_derived_for_them() -> None:
+    """Not a decline: plotly keeps the ends and rounds a width up for them.
+
+    Measured on ``start=0.2, end=0.8``: both a missing ``size`` and a zero one
+    draw a width of 0.05, which is ``(0.8 - 0.2) / 15`` rounded up by the same
+    rule an automatic contour uses.
+    """
+    figure = go.Figure(go.Contour(z=ONE_PEAK, contours={"start": 0.2, "end": 0.8}))
+    zeroed = go.Figure(
+        go.Contour(z=ONE_PEAK, contours={"start": 0.2, "end": 0.8, "size": 0})
+    )
+
+    expected = [0.2 + 0.05 * step for step in range(13)]
+    assert _levels(_layers(figure)[0]) == pytest.approx(expected)
+    assert _levels(_layers(zeroed)[0]) == pytest.approx(expected)
+
+
+def test_ncontours_is_how_many_levels_are_aimed_for() -> None:
+    """It divides the range before the round-up, rather than being obeyed.
+
+    Measured on ``start=0.2, end=0.8`` with ``ncontours=4``: a width of 0.2,
+    which is ``0.6 / 4`` rounded up, and four levels rather than the thirteen
+    the default fifteen gives.
+    """
+    figure = go.Figure(
+        go.Contour(z=ONE_PEAK, contours={"start": 0.2, "end": 0.8}, ncontours=4)
+    )
+
+    assert _levels(_layers(figure)[0]) == pytest.approx([0.2, 0.4, 0.6, 0.8])
+
+
+@pytest.mark.parametrize(
+    ("ncontours", "expected"),
+    [
+        pytest.param(2, [0.5], id="two"),
+        pytest.param(3, [0.5], id="three"),
+    ],
+)
+def test_a_step_too_wide_for_the_range_leaves_one_level_at_its_middle(
+    ncontours: int, expected: list
+) -> None:
+    """Plotly's own fallback for an `ncontours` that fits nothing inside.
+
+    With a step at least as wide as the field, the first multiple above the
+    floor is already past the last one below the ceiling -- the two cross, and
+    plotly puts a single level at their midpoint. Measured: over a field
+    running 0 .. 1, both of these draw one level at 0.5, and over ``0 .. 100``
+    an ``ncontours`` of 2 draws one at 50.
+    """
+    figure = go.Figure(go.Contour(z=ONE_PEAK, ncontours=ncontours))
+
+    assert _levels(_layers(figure)[0]) == pytest.approx(expected)
+
+
+#: Two fields whose range does not divide by its own step evenly in binary,
+#: one landing at each end of the level list. Both ramp left to right, so
+#: every level inside them draws exactly one line and the layer is
+#: addressable.
+RAMP_TO_ZERO = [[-0.3, -0.15, 0.0], [-0.3, -0.15, 0.0], [-0.3, -0.15, 0.0]]
+NARROW_RAMP = [
+    [0.008, 0.0085, 0.009],
+    [0.008, 0.0085, 0.009],
+    [0.008, 0.0085, 0.009],
+]
+
+
+def test_a_group_below_the_field_is_still_one_the_selectors_count() -> None:
+    """``-0.3 / 0.05`` is -5.999999999999999, and plotly rounds it up to -6.
+
+    So plotly's first level is ``-0.30000000000000004`` -- a hair *below* the
+    floor of the field, and holding no curve because of it -- and it still
+    gets a ``g.contourlevel`` of its own. Measured: six groups, the first with
+    no path in it, the five curves in the ones after. Which is why the
+    selectors here start at the second group rather than the first.
+
+    A ceiling taken at face value answers -5 instead, starting the list at
+    -0.25. That loses no curve, so nothing in the data would look wrong -- but
+    every group index shifts by one, and each highlight lands on the level
+    below the one being read. The test that keeps a level off the floor has to
+    be exact for the same reason: ``start`` is ``-0.30000000000000004`` and
+    the floor is -0.3, near enough that a tolerant comparison would call them
+    equal and step past the group plotly drew.
+    """
+    (layer,) = _layers(go.Figure(_contour(RAMP_TO_ZERO)))
+
+    assert _levels(layer) == pytest.approx([-0.25, -0.2, -0.15, -0.1, -0.05])
+    assert [selector.split("contourlevel:")[1] for selector in layer["selectors"]] == [
+        f"nth-of-type({group}) path:nth-of-type(1)" for group in range(2, 7)
+    ]
+
+
+def test_a_ceiling_only_exact_arithmetic_reaches_keeps_its_level() -> None:
+    """``0.009 / 0.0001`` is 89.99999999999999, and plotly rounds it down to 90.
+
+    So the top level is ``0.009000000000000001``, which sits 1.7e-18 from the
+    field's ceiling: near enough that a tolerant comparison would call it a
+    level *on* the ceiling and drop it, far enough that plotly's own exact
+    test keeps it. Measured: ten groups, each holding a curve, the last at
+    0.009.
+
+    A floor taken at face value loses that same level from the other side --
+    it answers 89, and the field ends at 0.0089 with nine levels.
+    """
+    (layer,) = _layers(go.Figure(_contour(NARROW_RAMP)))
+
+    expected = [0.008 + 0.0001 * step for step in range(1, 11)]
+    assert _levels(layer) == pytest.approx(expected)
+
+
+def test_a_constraint_is_still_a_region_rather_than_a_set_of_levels() -> None:
+    """The one spec that declines, and it declines for what it *is*.
+
+    A ``constraint`` contour draws one curve at ``value`` and means "the
+    region beyond it". It is written here *with* a full ``start``/``end``/
+    ``size`` on purpose, because plotly ignores them -- measured, one group at
+    0.5 -- while anything reading them would announce five levels the chart
+    does not draw.
+    """
+    figure = go.Figure(
+        go.Contour(
+            z=ONE_PEAK,
+            contours={
                 "type": "constraint",
                 "operation": ">",
                 "value": 0.5,
@@ -280,23 +433,21 @@ def test_auto_levels_are_declined() -> None:
                 "end": 0.9,
                 "size": 0.2,
             },
-            {},
-            id="a-constraint-is-a-region-not-a-set-of-levels",
-        ),
-    ],
-)
-def test_a_half_written_spec_is_declined(contours: dict, extra: dict) -> None:
-    """Each of these leaves plotly picking the levels, or picking a chart.
+        )
+    )
 
-    ``size: 0`` is replaced by plotly with a computed spacing, and
-    ``autocontour: True`` overrides an otherwise complete spec -- both
-    measured. A ``constraint`` contour draws one curve at ``value`` and means
-    "the region beyond it", which is a different chart from a set of levels --
-    and it is written here *with* a full ``start``/``end``/``size`` on purpose,
-    because plotly ignores them (measured: one group, at 0.5) while anything
-    reading them would announce five levels the chart does not draw.
+    assert _layers(figure) == []
+
+
+def test_a_field_with_no_range_forms_no_layer() -> None:
+    """A constant field has no step to divide out of it.
+
+    Plotly does draw one group, at the constant value itself -- measured, a
+    grid of 3s gets a single level at 3 -- but that level *is* the whole
+    field, so it holds no curve and the group carries no path. The layer comes
+    out empty either way, and #636's guard drops it.
     """
-    assert _layers(go.Figure(go.Contour(z=ONE_PEAK, contours=contours, **extra))) == []
+    assert _layers(go.Figure(go.Contour(z=[[3, 3, 3], [3, 3, 3], [3, 3, 3]]))) == []
 
 
 def test_a_grid_with_no_coordinates_is_read_at_its_indices() -> None:
@@ -340,13 +491,17 @@ def test_transpose_turns_the_grid_over_and_leaves_the_coordinates() -> None:
 
     plain = _layers(go.Figure(_contour(z, start=0.5, end=0.5, size=0.5)))
     turned = _layers(
-        go.Figure(go.Contour(z=z, transpose=True, contours=dict(start=0.5, end=0.5, size=0.5)))
+        go.Figure(
+            go.Contour(z=z, transpose=True, contours=dict(start=0.5, end=0.5, size=0.5))
+        )
     )
 
     assert plain != []
     # Transposed the grid is 3x2 with the peak on its edge, so the level
     # crosses it differently -- the point is that the two readings differ.
-    assert [_curve(s) for s in plain[0]["data"]] != [_curve(s) for s in turned[0]["data"]]
+    assert [_curve(s) for s in plain[0]["data"]] != [
+        _curve(s) for s in turned[0]["data"]
+    ]
 
 
 def test_a_hole_in_the_grid_stops_the_curves_the_way_plotly_does() -> None:


### PR DESCRIPTION
Closes #642.

`go.Contour` ships a grid, not curves, and — unless the author names both `start` and `end` — not levels either. #643 read the traces that name their own levels and declined the rest, because the rule plotly chooses levels by lives in plotly.js and nine measured fields would not fit one formula. That left every default `go.Contour(z=...)` unread.

## What the rule turned out to be

One comparison, not a missing formula. Measured step by step against the browser:

1. A rough step of `(zmax - zmin) / (ncontours or 15)`, rounded up to a 1/2/5×10ⁿ value by the same `roundUp` a histogram's bin width goes through — **strictly** greater, which is the whole of what made a field spanning `0 .. 3` look unreproducible. That was #646, fixed in #648; with it read correctly the fields stopped disagreeing.
2. `start`: the first multiple at or above `zmin`, moved up one when it lands *on* it.
3. `end`: the last multiple at or below `zmax`, moved down one when it lands on it.
4. If those cross — an `ncontours` too small to fit a multiple inside — both become their own midpoint and the field gets a single level.

Two consequences fall out and are handled rather than special-cased:

- **A trace naming both ends but no width is no longer declined.** Plotly keeps the ends and derives a width for them through the same round-up: measured on `start=0.2, end=0.8`, a missing `size` and a zero `size` both draw 0.05, and `ncontours=4` draws 0.2.
- **A constant field needs no guard of its own.** Its range is zero, so the round-up answers 1 and step 4 puts one level at the constant value — which is what plotly draws for it. That level *is* the whole field, so it holds no curve, and #636's guard drops the empty layer. The explicit guard this replaced was removed as redundant.

A `constraint` contour still declines: it draws one curve at `value` and means "the region beyond it", so reading its `start`/`end`/`size` would announce levels the chart does not draw.

## The four roundings

Steps 2 and 3 each round twice, and the four roundings pull in opposite directions on purpose:

- The multiple itself is taken **with a tolerance**, because a range that divides evenly rarely says so in binary. `-0.3 / 0.05` is `-5.999999999999999`; rounding that at face value starts the list a whole level late.
- Whether the result then lands **on** the floor or ceiling is tested **exactly**, because the value the tolerance recovered is a hair off the bound rather than on it. `0.009 / 0.0001` rounds up to a top level of `0.009000000000000001` — 1.7e-18 from the ceiling — which plotly keeps and a 1e-9 comparison would drop.

Measured against plotly's drawn levels on **49 figures**: 26 z ranges from `0 .. 0.07` to `0 .. 1000` (positive, negative and straddling), 8 explicit `ncontours` from 1 to 30, and 15 ranges picked for landing on exactly those ties. All 49 agree level for level, and **each of the four roundings is the difference on at least one of them** — none is defensive padding.

## Level groups that hold no curve still count

Plotly gives every level in its list a `g.contourlevel` of its own, drawn or not, and the selectors index that list. A field ramping `-0.3 .. 0` gets six groups, the first at `-0.30000000000000004` — below the field's own floor, holding no path — so the five curves live in groups 2–6. Resolved in Chromium: every emitted selector lands on the group at its own level.

## Testing

- `tests/plotly/test_plotly_contour.py`: 43 tests (was 31). New coverage for the five ways plotly takes the levels over, the derived width, `ncontours`, the midpoint fallback, a field with no range, and both binary ties.
- A 17-mutation sweep over the level rule, each mutation reverted alone against a restored baseline: all 17 killed. The two ties above are what kill the four rounding mutations — they were the sweep's only survivors before these tests, and two of the four were not being mutated at all until this round.
- `tests/core` 1931 passed / 5 skipped; `tests/plotly` 1216 passed; the rest 185 passed / 13 skipped. `ruff check` clean.

Follow-up already filed: #644 (no browser test resolves plotly selectors in CI — every selector in this PR was resolved by hand in Chromium instead).

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_