### PR TITLE
fix(plotly): honour a bin spec that names a start or an end but no size

### DIFF
--- a/maidr/plotly/grouped_histogram.py
+++ b/maidr/plotly/grouped_histogram.py
@@ -185,7 +185,7 @@ class PlotlyGroupedHistogramPlot(PlotlyPlot):
 
         data: list[list[dict]] = []
         for trace, sample, other in zip(self._traces, samples, values):
-            counts, _ = np.histogram(sample, bins=edges)
+            counts = _bin_counts(sample, edges)
             first, last = _occupied_span(counts)
             if first is None:
                 # A trace with nothing in the grid still holds a place in the
@@ -262,3 +262,19 @@ def _bin_assignment(arr: np.ndarray, edges: np.ndarray) -> np.ndarray:
     from maidr.plotly.histogram import PlotlyHistogramPlot
 
     return PlotlyHistogramPlot._bin_assignment(arr, edges)
+
+
+def _bin_counts(arr: np.ndarray, edges: np.ndarray) -> np.ndarray:
+    """How many observations landed in each bin.
+
+    Counted off the assignment above rather than ``np.histogram``, for the
+    reason that function exists: ``np.histogram`` closes its final bin and the
+    assignment does not, so a value sitting exactly on a shared window's
+    ``end`` was dropped by one path and folded into the last bin by the other
+    -- in the same layer, with which one applied decided by the ``histfunc``.
+    Measured on two traces sharing ``xbins=dict(start=0, end=6, size=2)``:
+    plotly draws the top bin holding two and the count path announced three.
+    """
+    from maidr.plotly.histogram import PlotlyHistogramPlot
+
+    return PlotlyHistogramPlot._bin_counts(arr, edges)

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -137,6 +137,14 @@ def _plotly_dtick(size0: float) -> float:
     return base * _plotly_round_up(size0 / base, [2, 5, 10])
 
 
+#: How far a bin count may overshoot a whole number and still be read as one.
+#: ``(end - start) / size`` decides how many bins a spec asks for, and the
+#: division rarely comes out even in binary -- ``(8 - 0) / 2`` is exact but a
+#: hair over on other spellings, and rounding that up would add a bin the
+#: chart does not draw.
+_BIN_COUNT_TOLERANCE = 1e-9
+
+
 def _auto_shift_bins(
     bin_start: float,
     data: np.ndarray,
@@ -585,21 +593,38 @@ class PlotlyHistogramPlot(PlotlyPlot):
     def _bin_assignment(arr: np.ndarray, bin_edges: np.ndarray) -> np.ndarray:
         """Which bin each observation falls in, or ``-1`` for none.
 
-        Matches how ``np.histogram`` fills the same edges, so the assignment
-        and the counts cannot disagree about which bin an observation is in:
-        half-open ``[low, high)`` throughout except the last bin, which is
-        closed so the maximum has somewhere to go.
+        Every bin is half-open, ``[low, high)``, **including the last**. That
+        is measured rather than obliging: with a window running to 6, plotly
+        drops the samples sitting exactly on it rather than folding them into
+        the bin below, and the two-dimensional reading of the same binning
+        settled it the same way (#645).
 
-        Values outside every bin get ``-1``. Plotly discards those rather than
-        clipping them into an edge bin -- an explicit window narrower than the
-        data drops what falls beyond it, both sides -- and ``np.histogram``
-        already does the same for the counts.
+        It costs nothing where the window is plotly's own, since a derived end
+        is a whole bin past the last value and no sample can sit on it. It
+        matters where the window is the author's, which is where a closed
+        final bin announced ``[4, 6)`` holding seven of a chart's five.
+
+        Values outside every bin get ``-1``: plotly discards those rather
+        than clipping them into an edge bin, both sides.
         """
         assignment = np.searchsorted(bin_edges, arr, side="right") - 1
-        assignment[arr == bin_edges[-1]] = len(bin_edges) - 2
-        outside = (arr < bin_edges[0]) | (arr > bin_edges[-1])
+        outside = (arr < bin_edges[0]) | (arr >= bin_edges[-1])
         assignment[outside] = -1
         return assignment
+
+    @staticmethod
+    def _bin_counts(arr: np.ndarray, bin_edges: np.ndarray) -> np.ndarray:
+        """How many observations landed in each bin.
+
+        Counted off :meth:`_bin_assignment` rather than ``np.histogram``, so
+        the counts and the assignment cannot disagree about which bin an
+        observation is in -- ``np.histogram`` closes its final bin and this
+        does not.
+        """
+        assignment = PlotlyHistogramPlot._bin_assignment(arr, bin_edges)
+        return np.bincount(
+            assignment[assignment >= 0], minlength=len(bin_edges) - 1
+        )
 
     def _extract_plot_data(self) -> list[dict]:
         values, _ = paired_arrays(self._trace, self._binned)
@@ -615,7 +640,9 @@ class PlotlyHistogramPlot(PlotlyPlot):
             return self._extract_categorical_data(values)
 
         bin_edges = self._compute_bin_edges(arr)
-        counts, bin_edges = np.histogram(arr, bins=bin_edges)
+        if len(bin_edges) < 2:
+            return []
+        counts = self._bin_counts(arr, bin_edges)
 
         # Trimmed on the raw counts rather than the rescaled values, because
         # that is what "a bin nothing landed in" means. Every rescaling below
@@ -803,64 +830,102 @@ def compute_bin_edges(
     np.ndarray
         Bin edges matching what Plotly renders.
     """
-    # Explicit bin size — the width is used as given, without the 'nice'
-    # rounding an `nbins` hint goes through.
-    if bins is not None and "size" in bins:
-        size = float(bins["size"])
-        data_min, data_max = float(arr.min()), float(arr.max())
-
-        # An explicit `start` is honoured verbatim. Without one, plotly
-        # still runs the same anti-clustering shift it applies when
-        # autobinning, which the round multiple of `size` alone does not
-        # reproduce: `go.Histogram(x=[0, 1, 2, 3, 4], xbins=dict(size=2))`
-        # is drawn from -0.5, not 0, because every value is an integer and
-        # they would otherwise sit on the bin edges.
-        if "start" in bins:
-            start = float(bins["start"])
-        else:
-            start = _auto_shift_bins(
-                math.floor(data_min / size) * size,
-                arr,
-                size,
-                data_min,
-                data_max,
-            )
-
-        # One bin past the last value, so a value sitting exactly on a
-        # grid multiple gets the bin starting there rather than being
-        # folded into the one below by numpy's closed final interval.
-        # Any bin this reaches past the data is empty, and `_occupied_span`
-        # trims it back off.
-        end = (
-            float(bins["end"])
-            if "end" in bins
-            else math.floor((data_max - start) / size) * size + start + size
-        )
-        return np.arange(start, end + size / 2, size)
-
+    named = bins if isinstance(bins, dict) else {}
     data_min, data_max = float(arr.min()), float(arr.max())
     data_range = data_max - data_min
-    if data_range == 0:
+    # A sample with no spread and nothing said about it: one bin around the
+    # single value, which is what plotly draws (measured -- a run of 3s is
+    # binned from 2.5 to 3.5). With something said about it there is a spec
+    # to honour, and the width below answers 1 for a zero range anyway.
+    if data_range == 0 and not named:
         return np.array([data_min - 0.5, data_max + 0.5])
 
-    # 1. Compute nice bin size (mirrors axes.autoTicks + roundDTick)
-    if nbins is not None:
-        size0 = data_range / max(1, nbins)
+    # 1. The width: the author's, the one an `nbins` hint rounds up to, or
+    #    the automatic one -- see :func:`_bin_size`.
+    size = _bin_size(arr, named, nbins, data_range, is_2d=is_2d)
+    if size <= 0:
+        # Only a *negative* explicit width reaches here -- a zero one is read
+        # as an absence above. Plotly draws something for it rather than
+        # nothing (measured: a width of -2 over twenty integers draws ten
+        # bars, one per distinct value), by a route worth neither guessing at
+        # nor reproducing for a spec that cannot be meant. Declining costs the
+        # layer; announcing one bin holding everything would misreport a chart
+        # drawing ten, which is the outcome #636 settled against.
+        return np.array([])
+
+    # 2. The start. An explicit one is honoured verbatim -- and honoured
+    #    *whether or not* a size came with it, which is what #650 was about:
+    #    reading it only alongside a size left `xbins={"start": 0.5}` binned
+    #    from the automatic -0.5, five bars announced as six and not one of
+    #    the numbers a number on the chart.
+    #
+    #    Without one, plotly runs an anti-clustering shift, which the round
+    #    multiple alone does not reproduce: `go.Histogram(x=[0, 1, 2, 3, 4],
+    #    xbins=dict(size=2))` is drawn from -0.5, not 0, because every value
+    #    is an integer and they would otherwise sit on the bin edges.
+    if "start" in named:
+        start = float(named["start"])
     else:
-        size0 = _plotly_default_size0(arr, is_2d=is_2d)
-    dtick = _plotly_dtick(size0)
+        start = _auto_shift_bins(
+            math.ceil(data_min / size) * size - size, arr, size, data_min, data_max
+        )
 
-    # 2. Initial bin start: one tick below the first tick >= data_min
-    #    (mirrors axes.tickFirst → axes.tickIncrement(reverse))
-    first_tick = math.ceil(data_min / dtick) * dtick
-    bin_start = first_tick - dtick
+    # 3. How many bins. Plotly steps from `start` while the *bin's own*
+    #    start is below `end`, so a range that is not a whole number of bins
+    #    still gets the part-bin at the top: measured on `start=0.5, end=9,
+    #    size=2`, which draws five bars and not the four that rounding the
+    #    span down gives.
+    #
+    #    Without an `end`, one bin past the last value, so a value sitting
+    #    exactly on a grid multiple has a bin of its own to land in rather
+    #    than falling outside every bin -- see
+    #    :meth:`PlotlyHistogramPlot._bin_assignment`, where the last bin is
+    #    half-open like the rest. Any bin that reaches past the data is
+    #    empty, and `_occupied_span` trims it back off.
+    if "end" in named:
+        span = (float(named["end"]) - start) / size
+        count = math.ceil(span - _BIN_COUNT_TOLERANCE)
+    else:
+        count = 1 + math.floor((data_max - start) / size)
+    # A spec that leaves no bin at all -- a `start` past the last value, or
+    # an `end` at or below it -- comes out as a count of zero or less, and
+    # `np.arange` answers that with an empty array on its own. Plotly draws
+    # nothing for such a spec (measured), and every caller reads fewer than
+    # two edges as nothing to bin, so no guard of its own is needed here.
+    return start + size * np.arange(count + 1)
 
-    # 3. Shift to avoid data clustering at bin edges
-    bin_start = _auto_shift_bins(bin_start, arr, dtick, data_min, data_max)
 
-    # 4. Compute bin count and end
-    bin_count = 1 + math.floor((data_max - bin_start) / dtick)
-    bin_end = bin_start + bin_count * dtick
+def _bin_size(
+    arr: np.ndarray,
+    named: dict,
+    nbins: int | None,
+    data_range: float,
+    *,
+    is_2d: bool,
+) -> float:
+    """The bin width plotly settles on, before any start or end is applied.
 
-    return np.arange(bin_start, bin_end + dtick / 2, dtick)
+    An explicit ``size`` is used as given, without the 'nice' rounding an
+    ``nbins`` hint goes through. A zero one is not a width but an absence:
+    measured, ``xbins=dict(size=0)`` draws the automatic bins, and plotly's
+    own test for it is falsiness.
+
+    Writing ``size`` at all -- even as that zero -- also **discards an
+    ``nbins`` hint**, which is the one place the two interact. Measured:
+    ``xbins=dict(size=0)`` with ``nbinsx`` of 4 and of 12 both draw the same
+    fully automatic bins, while ``xbins=dict(start=0)`` with ``nbinsx=4``
+    draws the width the hint asks for. So the hint is read when ``size`` is
+    absent rather than when it is unusable.
+
+    A sample with no spread gets a width of **1**, not the 2 that rounding
+    one up would give: measured, a run of 3s is binned from 2.5 to 3.5 with
+    ``size`` reported as 1, whether or not the author named a start.
+    """
+    if named.get("size"):
+        return float(named["size"])
+    if data_range == 0:
+        return 1.0
+    if nbins is not None and "size" not in named:
+        return _plotly_dtick(data_range / max(1, nbins))
+    return _plotly_dtick(_plotly_default_size0(arr, is_2d=is_2d))
 

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -608,7 +608,15 @@ class PlotlyHistogramPlot(PlotlyPlot):
         than clipping them into an edge bin, both sides.
         """
         assignment = np.searchsorted(bin_edges, arr, side="right") - 1
-        outside = (arr < bin_edges[0]) | (arr >= bin_edges[-1])
+        # A value that is not a number is not an observation rather than an
+        # observation of zero (#405), and it has to be said here rather than
+        # left to the comparisons below: NaN answers False to both of them,
+        # while `searchsorted` sorts it past the last edge -- so it would
+        # come back as a bin one past the end, and the counts below would
+        # then be one longer than the grid they belong to.
+        outside = (
+            ~np.isfinite(arr) | (arr < bin_edges[0]) | (arr >= bin_edges[-1])
+        )
         assignment[outside] = -1
         return assignment
 
@@ -925,6 +933,10 @@ def _bin_size(
         return float(named["size"])
     if data_range == 0:
         return 1.0
+    # `not in` rather than falsy: a `size` of 0 is a width plotly cannot use
+    # *and* an `nbins` it will not fall back to. The two questions have
+    # different answers for the same key, which is why they are asked
+    # differently.
     if nbins is not None and "size" not in named:
         return _plotly_dtick(data_range / max(1, nbins))
     return _plotly_dtick(_plotly_default_size0(arr, is_2d=is_2d))

--- a/tests/plotly/test_plotly_grouped_histogram.py
+++ b/tests/plotly/test_plotly_grouped_histogram.py
@@ -156,6 +156,64 @@ class TestJointBinning:
         assert layer["data"][1] == []
 
 
+class TestTheGroupCountsTheWayASingleTraceDoes:
+    """Both counting paths in this file read the bins the same way.
+
+    A grouped layer counts with `bincount` over the shared assignment rather
+    than with `np.histogram`, which closes its final bin. The two disagreed
+    about a value sitting exactly on a shared window's `end`: `np.histogram`
+    folded it into the last bin and the assignment dropped it, and which one
+    applied was decided by the `histfunc` -- the default `count` took one path
+    and an `avg` the other, in the same layer.
+    """
+
+    WINDOW = dict(start=0, end=6, size=2)
+
+    def test_a_value_on_the_shared_end_is_dropped(self):
+        """Measured: plotly draws the top bin holding two, not three.
+
+        The six samples run 1 .. 6 and the window closes at 6, so the sample
+        *at* 6 is outside every bin plotly made -- the same reading a single
+        trace has had since #650.
+        """
+        figure = go.Figure(
+            [
+                go.Histogram(x=[1, 2, 3, 4, 5, 6], xbins=self.WINDOW),
+                go.Histogram(x=[1, 2]),
+            ]
+        )
+
+        first, second = only_layer(figure)["data"]
+
+        assert [point["y"] for point in first] == [1, 2, 2]
+        assert [point["y"] for point in second] == [1, 1]
+
+    def test_an_aggregating_histfunc_agrees_with_the_count(self):
+        """The path that was already right, asserted beside the one that was not.
+
+        `avg` has always gone through the shared assignment, so it dropped the
+        boundary sample while the count folded it in. Both drop it now, and
+        this says so rather than leaving the pairing to be re-derived.
+        """
+        figure = go.Figure(
+            [
+                go.Histogram(
+                    x=[1, 2, 3, 4, 5, 6],
+                    y=[1, 1, 1, 1, 1, 99],
+                    histfunc="avg",
+                    xbins=self.WINDOW,
+                ),
+                go.Histogram(x=[1, 2], y=[1, 1], histfunc="avg"),
+            ]
+        )
+
+        first, _ = only_layer(figure)["data"]
+
+        # The 99 rides on the sample at 6, so an average that folded it in
+        # would be 50 rather than 1.
+        assert [point["y"] for point in first] == [1, 1, 1]
+
+
 class TestGroupBinSpec:
     def test_a_spec_on_any_trace_governs_the_group(self):
         # Not "the first trace's spec". Plotly resolves a `size` given on the

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -435,6 +435,27 @@ class TestABinSpecWithoutASize:
 
         assert [count for _, _, count in drawn] == [3, 2]
 
+    def test_a_value_that_is_not_a_number_is_in_no_bin(self):
+        """It is not an observation rather than an observation of zero (#405).
+
+        Said where the bins are assigned rather than left to the comparisons
+        there: NaN answers False to both of them, while ``searchsorted`` sorts
+        it past the last edge -- so it came back as a bin one past the end,
+        and the counts were then one longer than the grid they belong to.
+        """
+        from maidr.plotly.histogram import PlotlyHistogramPlot
+
+        edges = np.array([0.0, 2.0, 4.0, 6.0])
+        with_a_gap = np.array([1.0, np.nan, 3.0, 5.0])
+
+        assert list(PlotlyHistogramPlot._bin_assignment(with_a_gap, edges)) == [
+            0,
+            -1,
+            1,
+            2,
+        ]
+        assert list(PlotlyHistogramPlot._bin_counts(with_a_gap, edges)) == [1, 1, 1]
+
     def test_a_negative_width_forms_no_layer(self):
         """Not a width, and not a chart this can read.
 

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -190,16 +190,17 @@ class TestBinStartShift:
 
 
 class TestBothCallersSeedTheShiftEquivalently:
-    """``_auto_shift_bins`` has two callers that seed it differently.
+    """``_auto_shift_bins`` can be seeded two ways, and they agree.
 
-    The autobin path passes ``ceil(data_min / dtick) * dtick - dtick``; the
-    explicit-size path passes ``floor(data_min / size) * size``. Those agree
-    except when ``data_min`` is itself a multiple of the width, where they
-    differ by exactly one bin — and the branches inside then correct both to
-    the same start.
+    The seed can be written ``ceil(data_min / width) * width - width`` or
+    ``floor(data_min / width) * width``. Those differ by exactly one bin when
+    ``data_min`` is itself a multiple of the width — and the branches inside
+    then correct both to the same start.
 
-    That is a property of those branches, not of the seed arithmetic, so a
-    refactor of the shift could break the coupling with nothing failing. This
+    That agreement is what let #650 fold the explicit-size and automatic
+    paths into one, which had been the two callers seeding it differently.
+    It is a property of those branches rather than of the seed arithmetic, so
+    a refactor of the shift could break it with nothing else failing; this
     pins it instead of leaving it to be re-derived by hand.
     """
 
@@ -306,3 +307,153 @@ class TestTheRoundUpIsStrict:
             "22.5 – 27.5",
             "27.5 – 32.5",
         ]
+
+
+class TestABinSpecWithoutASize:
+    """#650: a ``start`` or an ``end`` was read only alongside a ``size``.
+
+    Every one of these was measured against plotly 6.7.0 in Chromium, on the
+    sample below -- twenty integers from 1 to 10, whose automatic bins run
+    from -0.5 in steps of 2.
+    """
+
+    SAMPLE = [1, 1, 2, 2, 2, 3, 3, 4, 5, 5, 5, 5, 6, 6, 7, 8, 8, 9, 9, 10]
+
+    def test_a_start_alone_moves_every_bin(self):
+        """The case that shows what it cost: five bars announced as six.
+
+        With the start discarded, this was binned from the automatic -0.5 and
+        announced as six bins of ``[2, 5, 5, 3, 4, 1]`` -- for a chart drawing
+        five bars of ``[5, 3, 6, 3, 3]``. Not one of the six numbers is a
+        number on the chart, and not one of the six labels names a bar.
+        """
+        drawn = bins(go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(start=0.5))))
+
+        assert [count for _, _, count in drawn] == [5, 3, 6, 3, 3]
+        assert [low for low, _, _ in drawn] == [0.5, 2.5, 4.5, 6.5, 8.5]
+
+    def test_an_end_alone_stops_the_bins_short(self):
+        """And drops the samples past it, which is what plotly draws.
+
+        Measured: three bars, holding twelve of the twenty samples. The eight
+        at 6 and above are outside every bin and are not counted anywhere --
+        the same reading an explicit window already had (#402).
+        """
+        drawn = bins(go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(end=5))))
+
+        assert drawn == [(-0.5, 1.5, 2), (1.5, 3.5, 5), (3.5, 5.5, 5)]
+
+    def test_both_ends_without_a_width_get_one_derived_for_them(self):
+        """The width is still the automatic one; only the window is theirs."""
+        drawn = bins(
+            go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(start=2, end=6)))
+        )
+
+        assert drawn == [(2.0, 4.0, 5), (4.0, 6.0, 5)]
+
+    @pytest.mark.parametrize(
+        "size",
+        [pytest.param(None, id="width-derived"), pytest.param(2, id="width-named")],
+    )
+    def test_a_window_that_is_not_whole_bins_keeps_its_part_bin(self, size):
+        """Plotly steps while the *bin's own* start is below ``end``.
+
+        ``start=0.5, end=9`` is four and a quarter bins of 2. Measured: five
+        bars, the last of them ``[8.5, 10.5)`` -- reaching past the ``end``
+        that admitted it. Rounding the span to whole bins gives four and
+        loses the three samples at 9, 9 and 10.
+
+        Written both ways round because the old code had two paths here and
+        only one of them was ever reached with a derived width.
+        """
+        spec = dict(start=0.5, end=9)
+        if size is not None:
+            spec["size"] = size
+
+        drawn = bins(go.Figure(go.Histogram(x=self.SAMPLE, xbins=spec)))
+
+        assert len(drawn) == 5
+        assert drawn[-1] == (8.5, 10.5, 3)
+
+    def test_a_width_of_zero_is_an_absence_and_takes_nbins_with_it(self):
+        """Measured, and the second half is the surprising half.
+
+        ``size=0`` is not a width plotly can use, so it bins automatically --
+        and writing ``size`` at all, even as that zero, discards an ``nbins``
+        hint too. Measured: ``nbinsx`` of 4 and of 12 both draw the same six
+        automatic bars. Reading the hint anyway would announce twelve.
+
+        This also used to be a crash rather than a reading: a zero width
+        reached a division by it.
+        """
+        for hint in (None, 4, 12):
+            extra = {} if hint is None else {"nbinsx": hint}
+            drawn = bins(
+                go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(size=0), **extra))
+            )
+
+            assert [count for _, _, count in drawn] == [2, 5, 5, 3, 4, 1]
+
+    def test_a_sample_with_no_spread_is_one_wide_wherever_it_starts(self):
+        """A width of 1, not the 2 that rounding one up gives.
+
+        Measured: a run of 3s is binned from 2.5 to 3.5, and with
+        ``start=0`` from 3 to 4 -- one wide either way. The automatic width
+        for a sample with no spread falls back to 1 *before* the round-up
+        rather than through it.
+        """
+        flat = [3, 3, 3, 3, 3]
+
+        assert bins(go.Figure(go.Histogram(x=flat))) == [(2.5, 3.5, 5)]
+        assert bins(
+            go.Figure(go.Histogram(x=flat, xbins=dict(start=0)))
+        ) == [(3.0, 4.0, 5)]
+
+    def test_a_window_a_hair_over_whole_bins_is_still_whole_bins(self):
+        """``(-2.8 - -3.0) / 0.1`` is 2.0000000000000018 in binary.
+
+        Two bins, and the arithmetic says a shade more than two -- so a
+        ceiling taken at face value adds a third, ``[-2.8, -2.7)``, and puts
+        the two samples past the author's window into it. Measured: plotly
+        draws two bars and drops those samples, which are outside every bin
+        it made.
+
+        Reached with data past the ``end`` on purpose. An empty extra bin
+        would be trimmed back off before anyone heard it, so only a bin with
+        something in it shows the difference.
+        """
+        inside_and_beyond = [-2.99, -2.95, -2.92, -2.85, -2.83, -2.75, -2.74]
+
+        drawn = bins(
+            go.Figure(
+                go.Histogram(
+                    x=inside_and_beyond,
+                    xbins=dict(start=-3.0, end=-2.8, size=0.1),
+                )
+            )
+        )
+
+        assert [count for _, _, count in drawn] == [3, 2]
+
+    def test_a_negative_width_forms_no_layer(self):
+        """Not a width, and not a chart this can read.
+
+        Plotly draws *something* for it -- measured, a width of -2 over these
+        twenty integers draws ten bars, one per distinct value -- by a route
+        worth neither guessing at nor reproducing. Declining costs the layer;
+        the one bin holding everything that the arithmetic would otherwise
+        produce would misreport a chart drawing ten (#636).
+        """
+        figure = go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(size=-2)))
+
+        assert layers(figure) == []
+
+    def test_a_start_past_the_last_value_forms_no_layer(self):
+        """There is no bin at all, which is what plotly draws: nothing.
+
+        A layer of no bins would announce a distribution the chart does not
+        draw, which is what #636 settled for every other empty reading.
+        """
+        figure = go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(start=20)))
+
+        assert layers(figure) == []


### PR DESCRIPTION
Closes #650.

`compute_bin_edges` read `xbins.start` and `xbins.end` only inside its explicit-size branch. A spec that named a window without a width fell through to the automatic path, which never looked at either — so the author's bin boundaries were discarded outright.

What that cost, measured in Chromium on twenty integers from 1 to 10 with `xbins=dict(start=0.5)`:

```
plotly draws     5 bars   [5, 3, 6, 3, 3]   from 0.5 in steps of 2
py-maidr said    6 bins   [2, 5, 5, 3, 4, 1] from -0.5
```

Not one of the six numbers is a number on the chart, and not one of the six labels names a bar.

## The shape of the fix

The two paths become one: work out the width (the author's, an `nbins` hint rounded up, or the automatic one), then apply the author's `start` and `end` over it. That fold is only safe because the two paths seeded `_auto_shift_bins` differently and the seeds converge — which `TestBothCallersSeedTheShiftEquivalently` was already pinning, for exactly this reason. Its docstring now says what it is guarding.

## Four things measured on the way, each its own test

- **A window that is not a whole number of bins keeps its part-bin.** Plotly steps while the *bin's own* start is below `end`, so `start=0.5, end=9, size=2` draws five bars, not the four that rounding the span down gives — and the four would lose the samples at 9, 9 and 10. The old `end + size/2` convention was right only when the span's fractional part was zero or at least a half.
- **The last bin is half-open like the rest.** With a window ending at 6, plotly drops the samples sitting exactly on it; numpy's closed final interval folded them in and announced `[4, 6)` holding seven of a chart's five. The two-dimensional reading of the same binning settled this the same way in #645, measured there on its own grid. Costs nothing where the window is plotly's own — a derived end is a whole bin past the last value, so nothing can sit on it.
- **A `size` of 0 is an absence, and it takes an `nbins` hint with it.** Measured: `xbins=dict(size=0)` draws the automatic bins, and `nbinsx` of 4 and of 12 both draw those same six bars — writing `size` at all discards the hint. Reading the hint anyway would announce twelve. A zero size also used to reach a division by it.
- **A sample with no spread is one bin wide.** Not the two that rounding one up gives: a run of 3s is binned 2.5 – 3.5, and with `start=0` from 3 to 4.

A **negative** width now declines rather than answering with one bin holding everything. Plotly draws ten bars for `size=-2` over those integers, one per distinct value, by a route worth neither guessing at nor reproducing for a spec that cannot be meant — and a single bin would misreport a chart drawing ten, which is what #636 settled against.

## Verification

- **168/168 emitted bins match the drawn bars.** Four samples (clustered integers, gaussian, wide uniform, constant) × 14 `xbins` shapes × 3 `nbinsx` settings, comparing py-maidr's emitted bin centres and counts against plotly's `calcdata` in Chromium. Every case, not just the edges.
- **44/44 on the 2-D path**, which shares this function through `histogram2d`.
- A 9-mutation sweep over the new code, each mutation reverted alone against a restored baseline: all 9 killed. Two survived the first pass and both were acted on — one got the test it was missing (a span landing a hair over a whole number, which needs data past the window to be observable at all, since an empty extra bin is trimmed before anyone hears it), and the other was a redundant guard `np.arange` already handled, now removed.
- `tests/core` 1931 passed / 5 skipped; `tests/plotly` 1228 passed; the rest 185 passed / 13 skipped. `ruff check` clean.

Found while reading `histogram2dcontour` for #627, where the same gap put every traced curve half a bin off the chart.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_