### PR TITLE
feat(plotly): read a histogram2dcontour as the contour of its binned counts

### DIFF
--- a/maidr/plotly/choropleth.py
+++ b/maidr/plotly/choropleth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list, colorbar_title
 
 #: What the two halves of a region's reading are, when the author named
 #: neither. A choropleth has no cartesian axes to read titles off, and these
@@ -68,7 +68,7 @@ class PlotlyChoroplethPlot(PlotlyPlot):
         region, value = _AXIS_FALLBACKS
         return {
             MaidrKey.X: self._axis_config(label=region),
-            MaidrKey.Y: self._axis_config(label=self._colorbar_title() or value),
+            MaidrKey.Y: self._axis_config(label=colorbar_title(self._trace) or value),
         }
 
     def _extract_plot_data(self) -> list[dict]:
@@ -90,16 +90,6 @@ class PlotlyChoroplethPlot(PlotlyPlot):
             for location, value in zip(locations, values)
             if value is not None
         ]
-
-    def _colorbar_title(self) -> str:
-        """The title the author gave the colour bar, or an empty string."""
-        colorbar = self._trace.get("colorbar")
-        if not isinstance(colorbar, dict):
-            return ""
-        title = colorbar.get("title", "")
-        if isinstance(title, dict):
-            title = title.get("text", "")
-        return str(title) if title else ""
 
 
 def is_choropleth_trace(trace: dict) -> bool:

--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -588,8 +588,12 @@ def _has_extent(curve: Any, cell: float) -> bool:
 def _smallest_step(x: list[float], y: list[float]) -> float:
     """The narrowest cell in the grid, as the scale a curve is measured on.
 
-    The narrowest rather than the average, so an unevenly spaced grid is
-    judged by its own finest detail rather than by a figure no cell has.
+    The narrowest rather than the widest or the average, and deliberately so
+    even though no measured grid tells them apart: the fraction below is
+    small enough that any of the three separates float noise from a crossing.
+    The narrowest gives the *lowest* floor, so it is the one choice that
+    cannot drop a real curve on the fine part of an unevenly spaced grid --
+    which is the failure that would be silent.
     """
     steps = [
         abs(b - a)

--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -44,6 +44,13 @@ _DEFAULT_LEVEL_COUNT = 15
 #: the difference decides a whole level (see :func:`automatic_levels`).
 _MULTIPLE_TOLERANCE = 1e-9
 
+#: What fraction of the narrowest grid cell a traced curve must span to be a
+#: curve rather than the point where the field grazes a level. Far above the
+#: last bits that separate five copies of one vertex (1.6e-15 on a grid of 5s,
+#: measured) and far below any crossing, which is interpolated along a cell
+#: edge and so spans a real part of one.
+_POINT_FRACTION = 1e-9
+
 #: How far past ``end`` plotly's level loop still steps, as a fraction of
 #: ``size``. Measured rather than assumed, across seven specs: a run at
 #: ``start=0.2, end=0.8, size=0.05`` draws a level at ``0.8000000000000002``
@@ -124,14 +131,16 @@ class PlotlyContourPlot(PlotlyPlot):
         """
         self._series_levels = []
 
-        grid = _grid(self._trace)
+        grid = self._field()
         if grid is None:
             return []
 
         x, y, z = grid
         # The field, not just the trace: an automatic contour chooses its
-        # levels from the range of what it draws.
-        levels = levels_of(self._trace, z)
+        # levels from the range of what it draws. Asked for separately from
+        # the grid because the two are not always the same array -- see
+        # `_level_field`.
+        levels = levels_of(self._trace, self._level_field(z))
         if not levels:
             return []
 
@@ -170,9 +179,14 @@ class PlotlyContourPlot(PlotlyPlot):
         # way through leaves no half-filled `_series_levels` behind: the two
         # are read together and a mismatch would put every later series on
         # the wrong level's group.
+        # A curve counts as one when it goes somewhere, measured against the
+        # grid it was traced through -- see `_has_extent`.
+        cell = _smallest_step(x, y)
         data: list[list[dict]] = []
         for index, curves in enumerate(traced):
             for curve in curves:
+                if not _has_extent(curve, cell):
+                    continue
                 data.append(
                     [
                         {
@@ -186,6 +200,27 @@ class PlotlyContourPlot(PlotlyPlot):
                 self._series_levels.append(index)
 
         return data
+
+    def _level_field(self, z: Any) -> Any:
+        """The values an automatic level list takes its range from.
+
+        The grid itself, for a ``contour``: the numbers it draws are the
+        numbers it was given. A ``histogram2dcontour`` hands the tracer a
+        grid with zeros where a cell has no answer, and those zeros are not
+        values the chart measured -- see
+        :meth:`~maidr.plotly.histogram2dcontour.PlotlyHistogram2dContourPlot._level_field`.
+        """
+        return z
+
+    def _field(self) -> tuple[list[float], list[float], Any] | None:
+        """The grid the curves are traced through, or None when there is none.
+
+        A ``contour`` carries its field, so this is where the trace's own
+        ``z`` is read. A ``histogram2dcontour`` carries samples instead and
+        bins them into one -- which is the *only* difference between the two
+        readings, and why it overrides this and nothing else.
+        """
+        return _grid(self._trace)
 
     def _get_selector(self) -> list[str]:
         """Return one selector per emitted series, or none for the whole layer.
@@ -520,6 +555,49 @@ def _grid(trace: dict) -> tuple[list[float], list[float], Any] | None:
         return None
 
     return x, y, np.ma.masked_invalid(z)
+
+
+def _has_extent(curve: Any, cell: float) -> bool:
+    """Whether a traced curve goes anywhere, rather than touching a point.
+
+    Where the field grazes a level at exactly one grid point -- a lone cell
+    holding the level's own value -- ``contourpy`` returns a closed curve
+    whose every vertex is that point: five copies of it, spanning nothing.
+    Plotly draws no path there, measured on a ``min`` aggregate whose lowest
+    interior cell is exactly a level. Dropping it is not only agreement with
+    plotly, though: a series of one point repeated is not a curve for anyone
+    to read along, and it would take a ``g.contourlevel`` index with it that
+    a real curve in the same level needs.
+
+    "Spanning nothing" has to be measured rather than tested for zero. The
+    level that grazes a cell is rarely the cell's value written out -- an
+    automatic 0.4 arrives as ``0.39999999999999997`` -- and the five vertices
+    then differ in the last bits, 1.6e-15 apart on a grid whose cells are 5
+    wide. So the span is compared against the grid, at a fraction no curve
+    tracing a real crossing comes near: the vertices are interpolated along
+    the cell edges, so a curve that crosses at all crosses a measurable part
+    of one.
+    """
+    vertices = np.asarray(curve, dtype=float)
+    if vertices.size == 0:
+        return False
+    span = max(float(np.ptp(vertices[:, 0])), float(np.ptp(vertices[:, 1])))
+    return span > cell * _POINT_FRACTION
+
+
+def _smallest_step(x: list[float], y: list[float]) -> float:
+    """The narrowest cell in the grid, as the scale a curve is measured on.
+
+    The narrowest rather than the average, so an unevenly spaced grid is
+    judged by its own finest detail rather than by a figure no cell has.
+    """
+    steps = [
+        abs(b - a)
+        for axis in (x, y)
+        for a, b in zip(axis, axis[1:])
+        if abs(b - a) > 0
+    ]
+    return min(steps) if steps else 1.0
 
 
 def _coordinates(trace: dict, key: str, count: int) -> list[float] | None:

--- a/maidr/plotly/heatmap.py
+++ b/maidr/plotly/heatmap.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list, colorbar_title
 
 class PlotlyHeatmapPlot(PlotlyPlot):
     """Extract data from a Plotly heatmap trace."""
@@ -120,15 +120,7 @@ class PlotlyHeatmapPlot(PlotlyPlot):
         ``AxisConfig`` dict ``{"label": ...}``.
         """
         base = super()._extract_axes_data()
-        # Add z label from colorbar title if available
-        colorbar = self._trace.get("colorbar", {})
-        z_label = ""
-        if isinstance(colorbar, dict):
-            title = colorbar.get("title", "")
-            if isinstance(title, dict):
-                z_label = title.get("text", "")
-            elif title:
-                z_label = str(title)
+        z_label = colorbar_title(self._trace)
         if z_label:
             base[MaidrKey.Z] = self._axis_config(label=z_label)
         return base

--- a/maidr/plotly/histogram2d.py
+++ b/maidr/plotly/histogram2d.py
@@ -132,17 +132,23 @@ class PlotlyHistogram2dPlot(PlotlyHeatmapPlot):
         The author's colour bar title still wins where there is one.
         """
         axes = super()._extract_axes_data()
-        axes.setdefault(MaidrKey.Z, self._axis_config(label=self._cell_name()))
+        axes.setdefault(MaidrKey.Z, self._axis_config(label=cell_name(self._trace)))
         return axes
 
-    def _cell_name(self) -> str:
-        """What one cell measures: the normalisation, the aggregate, or a count."""
-        histnorm = self._trace.get("histnorm")
-        if histnorm in _HISTNORM_NAMES:
-            return _HISTNORM_NAMES[histnorm]
-        if _reduces_values(self._trace):
-            return _HISTFUNC_NAMES[str(self._trace.get("histfunc"))]
-        return "Count"
+
+def cell_name(trace: dict) -> str:
+    """What one cell measures: the normalisation, the aggregate, or a count.
+
+    Shared with the contour reading of the same binning, whose *levels* are
+    the same numbers -- see
+    :class:`~maidr.plotly.histogram2dcontour.PlotlyHistogram2dContourPlot`.
+    """
+    histnorm = trace.get("histnorm")
+    if histnorm in _HISTNORM_NAMES:
+        return _HISTNORM_NAMES[histnorm]
+    if _reduces_values(trace):
+        return _HISTFUNC_NAMES[str(trace.get("histfunc"))]
+    return "Count"
 
 
 def is_histogram2d_trace(trace: dict) -> bool:
@@ -151,12 +157,46 @@ def is_histogram2d_trace(trace: dict) -> bool:
 
 
 def _binned_grid(trace: dict) -> tuple[list[list], list[str], list[str]] | None:
-    """Bin a trace's samples into the grid plotly draws.
+    """Bin a trace's samples and name each bin by the range it covers.
 
     Returns
     -------
     tuple or None
         ``(counts, x_labels, y_labels)`` with ``counts`` **bottom-first**,
+        matching plotly's own ``calcdata``. None when there is nothing to
+        bin -- see :func:`binned_cells`.
+    """
+    binned = binned_cells(trace)
+    if binned is None:
+        return None
+
+    counts, x_edges, y_edges = binned
+    return (
+        counts,
+        [_bin_label(x_edges, index) for index in range(len(x_edges) - 1)],
+        [_bin_label(y_edges, index) for index in range(len(y_edges) - 1)],
+    )
+
+
+def binned_cells(
+    trace: dict, *, extended: bool = False
+) -> tuple[list[list], np.ndarray, np.ndarray] | None:
+    """Bin a trace's samples into the grid plotly draws.
+
+    Parameters
+    ----------
+    trace : dict
+        One ``histogram2d`` or ``histogram2dcontour`` trace.
+    extended : bool, optional
+        Whether to add the empty bin plotly puts outside each *automatic*
+        edge of a ``histogram2dcontour``, so its curves have somewhere to
+        close. See
+        :func:`~maidr.plotly.histogram2dcontour.extended_edges`.
+
+    Returns
+    -------
+    tuple or None
+        ``(cells, x_edges, y_edges)`` with ``cells`` **bottom-first**,
         matching plotly's own ``calcdata``. None when there is nothing to
         bin: a trace with no samples draws no grid at all -- measured, its
         ``calcdata`` entry carries no ``z`` -- so there is nothing to read.
@@ -202,6 +242,11 @@ def _binned_grid(trace: dict) -> tuple[list[list], list[str], list[str]] | None:
     y_edges = compute_bin_edges(
         y[inside], trace.get("ybins"), trace.get("nbinsy"), is_2d=True
     )
+    if extended:
+        from maidr.plotly.histogram2dcontour import extended_edges
+
+        x_edges = extended_edges(x_edges, trace.get("xbins"))
+        y_edges = extended_edges(y_edges, trace.get("ybins"))
     if len(x_edges) < 2 or len(y_edges) < 2:
         return None
 
@@ -226,13 +271,8 @@ def _binned_grid(trace: dict) -> tuple[list[list], list[str], list[str]] | None:
 
     histnorm = trace.get("histnorm")
     cells = _normalised(cells, histnorm, x_edges, y_edges)
-    counts = _as_payload(cells, histfunc, histnorm)
 
-    return (
-        counts,
-        [_bin_label(x_edges, index) for index in range(columns)],
-        [_bin_label(y_edges, index) for index in range(rows)],
-    )
+    return _as_payload(cells, histfunc, histnorm), x_edges, y_edges
 
 
 def _values(trace: dict) -> np.ndarray | None:

--- a/maidr/plotly/histogram2d.py
+++ b/maidr/plotly/histogram2d.py
@@ -190,8 +190,7 @@ def binned_cells(
     extended : bool, optional
         Whether to add the empty bin plotly puts outside each *automatic*
         edge of a ``histogram2dcontour``, so its curves have somewhere to
-        close. See
-        :func:`~maidr.plotly.histogram2dcontour.extended_edges`.
+        close. See :func:`extended_edges`.
 
     Returns
     -------
@@ -243,8 +242,6 @@ def binned_cells(
         y[inside], trace.get("ybins"), trace.get("nbinsy"), is_2d=True
     )
     if extended:
-        from maidr.plotly.histogram2dcontour import extended_edges
-
         x_edges = extended_edges(x_edges, trace.get("xbins"))
         y_edges = extended_edges(y_edges, trace.get("ybins"))
     if len(x_edges) < 2 or len(y_edges) < 2:
@@ -273,6 +270,56 @@ def binned_cells(
     cells = _normalised(cells, histnorm, x_edges, y_edges)
 
     return _as_payload(cells, histfunc, histnorm), x_edges, y_edges
+
+
+def extended_edges(edges: np.ndarray, bins: Any) -> np.ndarray:
+    """Add the empty bin plotly puts outside each automatic edge.
+
+    A ``histogram2dcontour`` bins its samples like a ``histogram2d`` and then
+    widens the grid, so the curves at the outermost level have somewhere to
+    close instead of running off the edge. Which edges move is not "the
+    automatic ones", though it reads that way at first -- plotly.js decides
+    it per side, and this is the line, from the bundle this wheel ships::
+
+        S && (
+          l.size || (P.start = tickIncrement(P.start, P.size, true)),
+          l.end === void 0 && (P.end = tickIncrement(P.end, P.size, false))
+        )
+
+    where ``S`` is "this group holds a ``histogram2dcontour``", ``l`` is what
+    the author wrote and ``P`` the automatic spec. So:
+
+    - the **low** edge moves down one bin unless the author gave a ``size``
+      -- not unless they gave a ``start``;
+    - the **high** edge moves up one bin unless the author gave an ``end``.
+
+    An author's own ``start`` still stands, because it overwrites ``P.start``
+    afterwards either way. Measured across nine spellings of ``xbins`` and
+    five datasets, all agreeing with those three sentences: with only a
+    ``size`` named, the low edge stays and the high edge moves; with only an
+    ``end``, the reverse.
+
+    Parameters
+    ----------
+    edges : numpy.ndarray
+        The bin edges as a ``histogram2d`` would draw them.
+    bins : Any
+        The trace's ``xbins``/``ybins``, or None when it named none.
+
+    Returns
+    -------
+    numpy.ndarray
+        The edges, with a bin added at each side that moves.
+    """
+    if len(edges) < 2:
+        return edges
+
+    named = bins if isinstance(bins, dict) else {}
+    size = float(edges[1] - edges[0])
+    moves_low = not named.get("size") and named.get("start") is None
+    low = [edges[0] - size] if moves_low else []
+    high = [edges[-1] + size] if named.get("end") is None else []
+    return np.array([*low, *edges, *high], dtype=float)
 
 
 def _values(trace: dict) -> np.ndarray | None:

--- a/maidr/plotly/histogram2dcontour.py
+++ b/maidr/plotly/histogram2dcontour.py
@@ -26,7 +26,8 @@ class PlotlyHistogram2dContourPlot(PlotlyContourPlot):
 
     - **The grid is one bin wider at each automatic edge.** A contour needs
       somewhere for its curves to close, so plotly puts an empty bin outside
-      the range it binned into. See :func:`extended_edges`.
+      the range it binned into. See
+      :func:`~maidr.plotly.histogram2d.extended_edges`.
     - **The curves run through the bin centres**, not the edges. Plotly's own
       ``calcdata`` for this trace carries centres where a ``histogram2d``
       carries edges -- 5 coordinates for 5 bins rather than 4 edges for 3.
@@ -36,6 +37,18 @@ class PlotlyHistogram2dContourPlot(PlotlyContourPlot):
     draws levels 1 .. 9, which is the automatic rule applied to that range
     (measured, and the same nine plotly draws).
     """
+
+    def _binned(self) -> tuple[list[list], Any, Any] | None:
+        """The binning, worked out once.
+
+        Both halves of the reading want it -- the curves want it with its
+        gaps at zero and the levels want it with its gaps left out -- and
+        the aggregating `histfunc`s reduce their cells in Python, so binning
+        a large sample twice is real work for no answer that differs.
+        """
+        if getattr(self, "_binned_grid", None) is None:
+            self._binned_grid = (binned_cells(self._trace, extended=True),)
+        return self._binned_grid[0]
 
     def _field(self) -> tuple[list[float], list[float], Any] | None:
         """Bin the samples, and hand the counts over as the field.
@@ -49,7 +62,7 @@ class PlotlyHistogram2dContourPlot(PlotlyContourPlot):
             when what was binned is too small to trace: marching squares
             needs a cell, which needs two rows and two columns.
         """
-        binned = binned_cells(self._trace, extended=True)
+        binned = self._binned()
         if binned is None:
             return None
 
@@ -73,7 +86,7 @@ class PlotlyHistogram2dContourPlot(PlotlyContourPlot):
         and draws 2 .. 16 -- eight levels, none of which is a level on the
         chart, on a reading whose curves would then be right.
         """
-        binned = binned_cells(self._trace, extended=True)
+        binned = self._binned()
         if binned is None:
             return z
 
@@ -106,56 +119,6 @@ class PlotlyHistogram2dContourPlot(PlotlyContourPlot):
 def is_histogram2dcontour_trace(trace: dict) -> bool:
     """Report whether a trace is a two-dimensional histogram's contour."""
     return trace.get("type") == "histogram2dcontour"
-
-
-def extended_edges(edges: np.ndarray, bins: Any) -> np.ndarray:
-    """Add the empty bin plotly puts outside each automatic edge.
-
-    A ``histogram2dcontour`` bins its samples like a ``histogram2d`` and then
-    widens the grid, so the curves at the outermost level have somewhere to
-    close instead of running off the edge. Which edges move is not "the
-    automatic ones", though it reads that way at first -- plotly.js decides
-    it per side, and this is the line, from the bundle this wheel ships::
-
-        S && (
-          l.size || (P.start = tickIncrement(P.start, P.size, true)),
-          l.end === void 0 && (P.end = tickIncrement(P.end, P.size, false))
-        )
-
-    where ``S`` is "this group holds a ``histogram2dcontour``", ``l`` is what
-    the author wrote and ``P`` the automatic spec. So:
-
-    - the **low** edge moves down one bin unless the author gave a ``size``
-      -- not unless they gave a ``start``;
-    - the **high** edge moves up one bin unless the author gave an ``end``.
-
-    An author's own ``start`` still stands, because it overwrites ``P.start``
-    afterwards either way. Measured across nine spellings of ``xbins`` and
-    five datasets, all agreeing with those three sentences: with only a
-    ``size`` named, the low edge stays and the high edge moves; with only an
-    ``end``, the reverse.
-
-    Parameters
-    ----------
-    edges : numpy.ndarray
-        The bin edges as a ``histogram2d`` would draw them.
-    bins : Any
-        The trace's ``xbins``/``ybins``, or None when it named none.
-
-    Returns
-    -------
-    numpy.ndarray
-        The edges, with a bin added at each side that moves.
-    """
-    if len(edges) < 2:
-        return edges
-
-    named = bins if isinstance(bins, dict) else {}
-    size = float(edges[1] - edges[0])
-    moves_low = not named.get("size") and named.get("start") is None
-    low = [edges[0] - size] if moves_low else []
-    high = [edges[-1] + size] if named.get("end") is None else []
-    return np.array([*low, *edges, *high], dtype=float)
 
 
 def _traced(value: Any) -> float:

--- a/maidr/plotly/histogram2dcontour.py
+++ b/maidr/plotly/histogram2dcontour.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.plotly.contour import PlotlyContourPlot
+from maidr.plotly.histogram2d import binned_cells, cell_name
+from maidr.plotly.plotly_plot import colorbar_title
+
+
+class PlotlyHistogram2dContourPlot(PlotlyContourPlot):
+    """Extract data from a Plotly ``histogram2dcontour`` trace.
+
+    The last of #627's fifteen, and the one type that is two readings at
+    once: it bins samples the way a ``histogram2d`` does and then draws the
+    curves along which the *counts* are constant, the way a ``contour`` does.
+    Both halves already exist, so this is where they meet -- the binning from
+    :func:`~maidr.plotly.histogram2d.binned_cells`, everything after it from
+    :class:`~maidr.plotly.contour.PlotlyContourPlot`, whose only overridable
+    step is which grid the curves run through.
+
+    Two things differ from a ``histogram2d`` reading the same samples, both
+    measured against the browser:
+
+    - **The grid is one bin wider at each automatic edge.** A contour needs
+      somewhere for its curves to close, so plotly puts an empty bin outside
+      the range it binned into. See :func:`extended_edges`.
+    - **The curves run through the bin centres**, not the edges. Plotly's own
+      ``calcdata`` for this trace carries centres where a ``histogram2d``
+      carries edges -- 5 coordinates for 5 bins rather than 4 edges for 3.
+
+    The levels are then whatever :func:`~maidr.plotly.contour.levels_of`
+    says, run over the binned counts: a default trace over counts of 0 .. 10
+    draws levels 1 .. 9, which is the automatic rule applied to that range
+    (measured, and the same nine plotly draws).
+    """
+
+    def _field(self) -> tuple[list[float], list[float], Any] | None:
+        """Bin the samples, and hand the counts over as the field.
+
+        Returns
+        -------
+        tuple or None
+            ``(x, y, z)`` with ``x`` and ``y`` the bin centres and ``z``
+            the counts, bottom row first and zero where a cell has no answer
+            -- see :func:`_traced`. None when there is nothing to bin, or
+            when what was binned is too small to trace: marching squares
+            needs a cell, which needs two rows and two columns.
+        """
+        binned = binned_cells(self._trace, extended=True)
+        if binned is None:
+            return None
+
+        cells, x_edges, y_edges = binned
+        z = np.array(
+            [[_traced(value) for value in row] for row in cells], dtype=float
+        )
+        if z.shape[0] < 2 or z.shape[1] < 2:
+            return None
+
+        return _centres(x_edges), _centres(y_edges), z
+
+    def _level_field(self, z: Any) -> Any:
+        """The binned cells with their gaps left out, not filled with zeros.
+
+        The tracer reads a gap as zero (see :func:`_traced`), but plotly does
+        not let those zeros decide the levels: measured on a sparse
+        ``histfunc="avg"`` grid whose four filled cells run 3.5 .. 19, plotly
+        reports a range of exactly 3.5 to 19 and draws levels 4 .. 18. Handing
+        the filled grid to the level rule instead puts the range at 0 .. 19
+        and draws 2 .. 16 -- eight levels, none of which is a level on the
+        chart, on a reading whose curves would then be right.
+        """
+        binned = binned_cells(self._trace, extended=True)
+        if binned is None:
+            return z
+
+        cells, _, _ = binned
+        return np.array(
+            [
+                [np.nan if value is None else value for value in row]
+                for row in cells
+            ],
+            dtype=float,
+        )
+
+    def _extract_axes_data(self) -> dict:
+        """Name the third axis for what the levels actually count.
+
+        A plain ``contour``'s levels are the author's own numbers, so only
+        the author can say what they are and the parent emits no ``z`` unless
+        they titled the colour bar. These levels are computed here, so their
+        name is known -- and leaving it unsaid would announce a chart of bare
+        numbers with no word for what they count. The same reading a
+        ``histogram2d`` settled for its cells, and the same order of
+        precedence: the author's colour bar title first.
+        """
+        axes = super()._extract_axes_data()
+        label = colorbar_title(self._trace) or cell_name(self._trace)
+        axes.setdefault(MaidrKey.Z, self._axis_config(label=label))
+        return axes
+
+
+def is_histogram2dcontour_trace(trace: dict) -> bool:
+    """Report whether a trace is a two-dimensional histogram's contour."""
+    return trace.get("type") == "histogram2dcontour"
+
+
+def extended_edges(edges: np.ndarray, bins: Any) -> np.ndarray:
+    """Add the empty bin plotly puts outside each automatic edge.
+
+    A ``histogram2dcontour`` bins its samples like a ``histogram2d`` and then
+    widens the grid, so the curves at the outermost level have somewhere to
+    close instead of running off the edge. Which edges move is not "the
+    automatic ones", though it reads that way at first -- plotly.js decides
+    it per side, and this is the line, from the bundle this wheel ships::
+
+        S && (
+          l.size || (P.start = tickIncrement(P.start, P.size, true)),
+          l.end === void 0 && (P.end = tickIncrement(P.end, P.size, false))
+        )
+
+    where ``S`` is "this group holds a ``histogram2dcontour``", ``l`` is what
+    the author wrote and ``P`` the automatic spec. So:
+
+    - the **low** edge moves down one bin unless the author gave a ``size``
+      -- not unless they gave a ``start``;
+    - the **high** edge moves up one bin unless the author gave an ``end``.
+
+    An author's own ``start`` still stands, because it overwrites ``P.start``
+    afterwards either way. Measured across nine spellings of ``xbins`` and
+    five datasets, all agreeing with those three sentences: with only a
+    ``size`` named, the low edge stays and the high edge moves; with only an
+    ``end``, the reverse.
+
+    Parameters
+    ----------
+    edges : numpy.ndarray
+        The bin edges as a ``histogram2d`` would draw them.
+    bins : Any
+        The trace's ``xbins``/``ybins``, or None when it named none.
+
+    Returns
+    -------
+    numpy.ndarray
+        The edges, with a bin added at each side that moves.
+    """
+    if len(edges) < 2:
+        return edges
+
+    named = bins if isinstance(bins, dict) else {}
+    size = float(edges[1] - edges[0])
+    moves_low = not named.get("size") and named.get("start") is None
+    low = [edges[0] - size] if moves_low else []
+    high = [edges[-1] + size] if named.get("end") is None else []
+    return np.array([*low, *edges, *high], dtype=float)
+
+
+def _traced(value: Any) -> float:
+    """One cell as the tracer reads it: a missing one is **zero**.
+
+    An aggregating ``histfunc`` leaves a cell nothing landed in with no
+    answer, and the heatmap reading of the same binning announces that as
+    ``None`` -- there is no average of nothing (#645). The contour reading
+    cannot: plotly hands the grid straight to a tracer written in JavaScript,
+    where a ``null`` compares as below every level and adds as zero, so the
+    curves are the curves of a field with zeros in the gaps.
+
+    Measured rather than assumed, and it is not a small difference. A sparse
+    ``histfunc="avg"`` grid whose four filled cells run 3.5 .. 19 draws ten
+    curves across eight levels in the browser; read as a field with holes in
+    it, ``contourpy`` finds five and misses the top three levels entirely.
+    With the gaps at zero the two agree, curve for curve -- on that grid, on
+    the same grid negated, and on a ``min`` of negative values, where zero is
+    *above* every level rather than below and the agreement holds anyway.
+
+    Note that this is the tracer's reading, not the chart's: plotly does
+    interpolate a hole in a ``go.Contour``'s own ``z`` before tracing it
+    (measured -- a punched cell comes back filled in ``calcdata``), but a
+    ``histogram2dcontour``'s grid never goes through that step. Its
+    ``_emptypoints`` is empty and its ``calcdata`` keeps the nulls.
+    """
+    return 0.0 if value is None or not np.isfinite(value) else float(value)
+
+
+def _centres(edges: np.ndarray) -> list[float]:
+    """The middle of each bin, which is where plotly puts the grid's points."""
+    return [
+        float((edges[index] + edges[index + 1]) / 2)
+        for index in range(len(edges) - 1)
+    ]

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -18,6 +18,7 @@ from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
 from maidr.plotly.area import is_area_trace
 from maidr.plotly.contour import is_contour_trace
 from maidr.plotly.histogram2d import is_histogram2d_trace
+from maidr.plotly.histogram2dcontour import is_histogram2dcontour_trace
 from maidr.plotly.grouped_histogram import is_histogram_trace
 from maidr.plotly.trendline import is_trendline_trace
 from maidr.plotly.plotly_plot import (
@@ -1297,12 +1298,27 @@ class PlotlyMaidr:
             # -- so a contour's selector is scoped by its position among
             # *those* traces, which the factory, seeing one trace at a time,
             # cannot know. `layer_position` knows which types share a layer.
-            contour_traces = [t for t in group_traces if is_contour_trace(t)]
+            contour_traces = [
+                t
+                for t in group_traces
+                if is_contour_trace(t) or is_histogram2dcontour_trace(t)
+            ]
             if contour_traces:
                 from maidr.plotly.contour import PlotlyContourPlot
+                from maidr.plotly.histogram2dcontour import (
+                    PlotlyHistogram2dContourPlot,
+                )
 
                 for contour_trace in contour_traces:
-                    plot = PlotlyContourPlot(
+                    # The two read alike from the grid onwards -- see
+                    # `PlotlyHistogram2dContourPlot` -- and draw into the same
+                    # `contourlayer`, so they are numbered together.
+                    build = (
+                        PlotlyHistogram2dContourPlot
+                        if is_histogram2dcontour_trace(contour_trace)
+                        else PlotlyContourPlot
+                    )
+                    plot = build(
                         contour_trace,
                         layout,
                         layer_position=layer_position(group_traces, contour_trace),

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -916,6 +916,24 @@ def subplot_css_prefix(xaxis_name: str, yaxis_name: str) -> str:
     return f".subplot.{x_ref}{y_ref} "
 
 
+def colorbar_title(trace: dict) -> str:
+    """The title the author gave the colour bar, or an empty string.
+
+    Plotly accepts the title either as a string or as a ``{"text": ...}``
+    block, and the trace may carry no ``colorbar`` at all. Read in one place
+    because three layers name their third axis from it -- a heatmap, a
+    choropleth and a two-dimensional histogram contour -- and a fourth
+    spelling of the same three cases is how they drift apart.
+    """
+    colorbar = trace.get("colorbar")
+    if not isinstance(colorbar, dict):
+        return ""
+    title = colorbar.get("title", "")
+    if isinstance(title, dict):
+        title = title.get("text", "")
+    return str(title) if title else ""
+
+
 def as_list(value: Any) -> list:
     """
     Return a plotly data array as a plain list.

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -205,6 +205,40 @@ def test_a_layer_whose_levels_each_draw_one_curve_is_addressable() -> None:
     ]
 
 
+#: A dimple: one interior cell sits on its own, everything around it above.
+#: At level 2 the field touches that one point and goes nowhere.
+DIMPLE = [
+    [4.0, 4.0, 4.0, 4.0, 4.0],
+    [4.0, 3.0, 3.0, 3.0, 4.0],
+    [4.0, 3.0, 2.0, 3.0, 4.0],
+    [4.0, 3.0, 3.0, 3.0, 4.0],
+    [4.0, 4.0, 4.0, 4.0, 4.0],
+]
+
+
+def test_a_level_the_field_only_touches_draws_no_curve() -> None:
+    """`contourpy` returns one there, and it is five copies of one point.
+
+    Measured on this field: plotly gives level 2 a ``g.contourlevel`` and
+    **no path in it**, and draws the ring at level 3. A series of one point
+    repeated is not a curve for anyone to read along, so it is not emitted --
+    and the group it would have taken an index from is still counted, which
+    is why the one curve here points at the second group rather than the
+    first.
+
+    The span is compared against the grid rather than tested for zero,
+    because the level that grazes a cell is rarely the cell's value written
+    out: an automatic 0.4 arrives as ``0.39999999999999997``, and the five
+    vertices then differ in their last bits rather than being identical.
+    """
+    figure = go.Figure(_contour(DIMPLE, start=2, end=3, size=1))
+
+    (layer,) = _layers(figure)
+
+    assert _levels(layer) == [3]
+    assert "g.contourlevel:nth-of-type(2)" in layer["selectors"][0]
+
+
 def test_a_layer_with_an_island_ships_without_a_highlight() -> None:
     """Plotly's order for a level's curves is its own, and not derivable.
 

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -574,10 +574,11 @@ def test_two_contours_on_one_subplot_address_their_own_groups() -> None:
 def test_a_histogram2dcontour_shifts_the_group_index() -> None:
     """It draws into the same `contourlayer` -- measured.
 
-    Counting only the contour traces would hand this one group 1, which is the
-    histogram's, and the highlight would land on a chart the reader is not
-    reading. maidr renders no layer for the histogram itself, so it is only
-    ever counted, never emitted.
+    Counting only the ``contour`` traces would hand the second one group 1,
+    which is the histogram's, and the highlight would land on a chart the
+    reader is not reading. The two are numbered together because plotly
+    appends both to the same layer, which is what
+    :func:`~maidr.plotly.candlestick.layer_position` is told.
     """
     figure = go.Figure(
         [
@@ -586,10 +587,10 @@ def test_a_histogram2dcontour_shifts_the_group_index() -> None:
         ]
     )
 
-    contours = [layer for layer in _layers(figure) if layer["type"] is PlotType.CONTOUR]
+    binned, declared = _layers(figure)
 
-    assert len(contours) == 1
-    assert "g.contour:nth-of-type(2)" in contours[0]["selectors"][0]
+    assert "g.contour:nth-of-type(1)" in binned["selectors"][0]
+    assert "g.contour:nth-of-type(2)" in declared["selectors"][0]
 
 
 def test_a_contour_on_a_second_subplot_is_scoped_to_it() -> None:

--- a/tests/plotly/test_plotly_histogram2dcontour.py
+++ b/tests/plotly/test_plotly_histogram2dcontour.py
@@ -10,7 +10,7 @@ in Chromium:
 
 - **The grid is one bin wider at each automatic edge**, so the curves have
   somewhere to close. Which edges move is per-side and not simply "the
-  automatic ones" -- see `extended_edges`.
+  automatic ones" -- see `histogram2d.extended_edges`.
 - **The curves run through the bin centres**, not the edges. Plotly's own
   `calcdata` for this trace carries five coordinates for five bins where a
   `histogram2d` carries four edges for three bins.
@@ -45,7 +45,7 @@ import plotly.graph_objects as go  # noqa: E402
 
 from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
-from maidr.plotly.histogram2dcontour import extended_edges  # noqa: E402
+from maidr.plotly.histogram2d import extended_edges  # noqa: E402
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 #: Twenty samples along a diagonal band. Plotly bins them into a 5x5 grid of
@@ -189,13 +189,22 @@ def test_a_normalisation_reaches_the_levels() -> None:
     """The cells are normalised before the levels are picked, as plotly does.
 
     Twenty samples under ``probability`` put the fullest cell at 0.5, and the
-    levels follow at every twentieth -- measured, nine of them.
+    levels follow at every twentieth -- measured, nine of them and twelve
+    curves.
+
+    The twelve is the sharper half. One cell here holds exactly 0.4, and the
+    level that grazes it arrives as ``0.39999999999999997`` -- so the curve
+    `contourpy` returns there is five copies of one point that differ in
+    their last bits, spanning 1.6e-15 on a grid whose cells are 5 wide.
+    Testing that span for zero rather than against the grid keeps it, and
+    announces a thirteenth curve the chart does not draw.
     """
     (layer,) = _layers(
         go.Figure(go.Histogram2dContour(x=X, y=Y, histnorm="probability"))
     )
 
     assert _levels(layer) == pytest.approx([0.05 * step for step in range(1, 10)])
+    assert len(layer["data"]) == 12
 
 
 def test_an_explicit_level_spec_is_the_author_s() -> None:

--- a/tests/plotly/test_plotly_histogram2dcontour.py
+++ b/tests/plotly/test_plotly_histogram2dcontour.py
@@ -1,0 +1,288 @@
+"""A plotly `histogram2dcontour` produced a figure with no layers.
+
+The last of #627's fifteen, and the one that is two readings at once: it bins
+samples the way a `histogram2d` does and then draws the curves along which
+those *counts* are constant, the way a `contour` does. Both halves already
+exist, so what is new here is where they meet.
+
+Three things differ from either half alone, all measured against plotly 6.7.0
+in Chromium:
+
+- **The grid is one bin wider at each automatic edge**, so the curves have
+  somewhere to close. Which edges move is per-side and not simply "the
+  automatic ones" -- see `extended_edges`.
+- **The curves run through the bin centres**, not the edges. Plotly's own
+  `calcdata` for this trace carries five coordinates for five bins where a
+  `histogram2d` carries four edges for three bins.
+- **A cell nothing landed in traces as zero.** The heatmap reading of the
+  same binning announces it as `None` -- there is no average of nothing --
+  but the contour reading cannot, because plotly hands the grid to a tracer
+  written in JavaScript where a `null` compares as below every level. The
+  *levels*, though, are still chosen from the real values: plotly reports a
+  sparse `histfunc="avg"` grid as running 3.5 to 19, not 0 to 19.
+
+Read end to end against the browser on 13 figures -- automatic bins, an
+`nbins` hint, four spellings of `xbins`, three `histfunc`s, a `histnorm`, an
+`ncontours` and an explicit level spec. Eleven agree curve for curve. The two
+that do not are levels whose curves reach the grid's own edge, where plotly's
+`<path>` elements are the outlines of the filled regions rather than the
+curves themselves; every one of those levels has more than one curve, so the
+layer declines its selectors there anyway. Measured separately: a level whose
+single curve ends on the grid edge *does* match its drawn path exactly, in
+every `coloring` mode.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.histogram2dcontour import extended_edges  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Twenty samples along a diagonal band. Plotly bins them into a 5x5 grid of
+#: counts running 0 .. 10 -- the ring of zeros being the widening -- and picks
+#: levels 1 .. 9 for it. Measured.
+X = [1, 1, 2, 2, 2, 3, 3, 4, 5, 5, 5, 5, 6, 6, 7, 8, 8, 9, 9, 10]
+Y = [1, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10]
+
+#: A value per sample, for the aggregating `histfunc`s.
+Z = list(range(20))
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _levels(layer: dict) -> list[float]:
+    """The distinct levels the layer's series run at, in order."""
+    return sorted({series[0][MaidrKey.LEVEL.value] for series in layer["data"]})
+
+
+def test_a_binned_contour_is_read_as_a_contour_layer() -> None:
+    """The counts are the field, and the curves are of the counts.
+
+    Twelve curves across nine levels, which is what plotly draws: three of the
+    levels cross the diagonal band twice and get two curves each.
+    """
+    (layer,) = _layers(go.Figure(go.Histogram2dContour(x=X, y=Y)))
+
+    assert layer["type"] is PlotType.CONTOUR
+    assert _levels(layer) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert len(layer["data"]) == 12
+
+
+def test_the_curves_run_through_the_bin_centres() -> None:
+    """Not the edges, which is where a `histogram2d` reads its grid.
+
+    Plotly bins these into five bins from -5.5 in steps of 5 and traces the
+    contour through their centres, -3 .. 17 -- measured off its own
+    `calcdata`, which carries five coordinates here where a `histogram2d`
+    carries six edges. Every vertex therefore lies within that span, and the
+    curves of the outermost level touch it.
+    """
+    (layer,) = _layers(go.Figure(go.Histogram2dContour(x=X, y=Y)))
+
+    xs = [point[MaidrKey.X.value] for series in layer["data"] for point in series]
+    ys = [point[MaidrKey.Y.value] for series in layer["data"] for point in series]
+
+    assert min(xs) >= -3.0 and max(xs) <= 17.0
+    assert min(ys) >= -3.0 and max(ys) <= 17.0
+
+
+class TestTheGridIsWidened:
+    """Which edges plotly moves, and which it leaves where the author put them.
+
+    From the bundle this wheel ships, where ``l`` is what the author wrote::
+
+        l.size || (P.start = tickIncrement(P.start, P.size, true)),
+        l.end === void 0 && (P.end = tickIncrement(P.end, P.size, false))
+
+    So the low edge moves unless a ``size`` was named -- not unless a
+    ``start`` was -- and the high edge moves unless an ``end`` was. An
+    author's own ``start`` still stands, because it replaces the automatic one
+    either way. Measured across nine spellings of ``xbins`` on five samples.
+    """
+
+    EDGES = np.array([0.0, 2.0, 4.0, 6.0])
+
+    @pytest.mark.parametrize(
+        ("bins", "expected"),
+        [
+            pytest.param(None, [-2.0, 0.0, 2.0, 4.0, 6.0, 8.0], id="nothing-named"),
+            pytest.param({}, [-2.0, 0.0, 2.0, 4.0, 6.0, 8.0], id="an-empty-block"),
+            pytest.param(
+                {"size": 2}, [0.0, 2.0, 4.0, 6.0, 8.0], id="a-size-holds-the-low-edge"
+            ),
+            pytest.param(
+                {"start": 0}, [0.0, 2.0, 4.0, 6.0, 8.0], id="a-start-holds-it-too"
+            ),
+            pytest.param(
+                {"end": 6},
+                [-2.0, 0.0, 2.0, 4.0, 6.0],
+                id="an-end-holds-the-high-edge",
+            ),
+            pytest.param(
+                {"start": 0, "end": 6},
+                [0.0, 2.0, 4.0, 6.0],
+                id="both-ends-hold-both",
+            ),
+        ],
+    )
+    def test_only_the_edges_plotly_moves_move(self, bins: dict, expected: list) -> None:
+        assert list(extended_edges(self.EDGES, bins)) == pytest.approx(expected)
+
+    def test_a_grid_of_one_edge_is_left_alone(self) -> None:
+        """There is no width to widen it by."""
+        lonely = np.array([1.0])
+
+        assert list(extended_edges(lonely, None)) == [1.0]
+
+
+class TestACellWithNoAnswer:
+    """An aggregating `histfunc` leaves gaps, and the two halves read them apart.
+
+    Measured on this grid, whose four filled cells run 3.5 .. 19: plotly draws
+    ten curves across levels 4 .. 18. Read as a field with holes in it,
+    `contourpy` finds five curves and misses the top three levels entirely --
+    the gaps are traced as zeros, not as holes.
+
+    The levels are the other half of it. They come from the values that are
+    there, so the range is 3.5 .. 19 rather than the 0 .. 19 the filled grid
+    would give. Taking the filled grid's range instead draws levels 2 .. 16,
+    none of which is a level on the chart.
+    """
+
+    def test_the_gaps_trace_as_zeros(self) -> None:
+        (layer,) = _layers(
+            go.Figure(go.Histogram2dContour(x=X, y=Y, z=Z, histfunc="avg"))
+        )
+
+        assert _levels(layer) == [4, 6, 8, 10, 12, 14, 16, 18]
+        assert len(layer["data"]) == 10
+
+    def test_a_histfunc_that_fills_every_cell_needs_none_of_that(self) -> None:
+        """`sum` puts a 0 in an empty cell rather than leaving it empty.
+
+        The same twenty values, summed instead of averaged: thirteen levels,
+        one curve each, and a highlight for every one of them.
+        """
+        (layer,) = _layers(
+            go.Figure(go.Histogram2dContour(x=X, y=Y, z=Z, histfunc="sum"))
+        )
+
+        assert _levels(layer) == [10 * step for step in range(1, 14)]
+        assert len(layer["selectors"]) == 13
+
+
+def test_a_normalisation_reaches_the_levels() -> None:
+    """The cells are normalised before the levels are picked, as plotly does.
+
+    Twenty samples under ``probability`` put the fullest cell at 0.5, and the
+    levels follow at every twentieth -- measured, nine of them.
+    """
+    (layer,) = _layers(
+        go.Figure(go.Histogram2dContour(x=X, y=Y, histnorm="probability"))
+    )
+
+    assert _levels(layer) == pytest.approx([0.05 * step for step in range(1, 10)])
+
+
+def test_an_explicit_level_spec_is_the_author_s() -> None:
+    """The binning is plotly's, the levels are theirs, and both are read.
+
+    Four levels, each drawing a single ring around the band, so the layer
+    keeps its highlight and each series points at its own group.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            go.Histogram2dContour(x=X, y=Y, contours=dict(start=1, end=4, size=1))
+        )
+    )
+
+    assert _levels(layer) == [1, 2, 3, 4]
+    assert [selector.split("contourlevel:")[1] for selector in layer["selectors"]] == [
+        f"nth-of-type({group}) path:nth-of-type(1)" for group in range(1, 5)
+    ]
+
+
+def test_ncontours_reaches_the_binned_counts() -> None:
+    """The level rule runs over the counts, so `ncontours` divides their range.
+
+    Measured: over counts of 0 .. 10, an `ncontours` of 4 rounds a step of 2.5
+    up to 5, and the first multiple above the floor is already past the last
+    below the ceiling -- so plotly draws one level, at their midpoint.
+    """
+    (layer,) = _layers(go.Figure(go.Histogram2dContour(x=X, y=Y, ncontours=4)))
+
+    assert _levels(layer) == [5]
+
+
+class TestTheThirdAxisIsNamed:
+    """A `contour`'s levels are the author's numbers; these are computed here.
+
+    So their name is known, and leaving it unsaid would announce a chart of
+    bare numbers with no word for what they count. The same reading a
+    `histogram2d` settled for its cells, and the same order of precedence.
+    """
+
+    @pytest.mark.parametrize(
+        ("extra", "expected"),
+        [
+            pytest.param({}, "Count", id="counted"),
+            pytest.param({"z": Z, "histfunc": "avg"}, "Average", id="averaged"),
+            pytest.param({"z": Z, "histfunc": "max"}, "Maximum", id="reduced"),
+            pytest.param(
+                {"histnorm": "percent"}, "Percent", id="normalised-wins-over-the-rest"
+            ),
+        ],
+    )
+    def test_the_levels_are_named_for_what_they_measure(
+        self, extra: dict, expected: str
+    ) -> None:
+        (layer,) = _layers(go.Figure(go.Histogram2dContour(x=X, y=Y, **extra)))
+
+        assert layer["axes"][MaidrKey.Z][MaidrKey.LABEL] == expected
+
+    def test_the_author_s_colour_bar_title_wins(self) -> None:
+        (layer,) = _layers(
+            go.Figure(
+                go.Histogram2dContour(x=X, y=Y, colorbar=dict(title="Sightings"))
+            )
+        )
+
+        assert layer["axes"][MaidrKey.Z][MaidrKey.LABEL] == "Sightings"
+
+
+class TestNothingToRead:
+    """Declining, rather than emitting a layer for a chart with nothing in it."""
+
+    def test_a_trace_with_no_samples_forms_no_layer(self) -> None:
+        assert _layers(go.Figure(go.Histogram2dContour(x=[], y=[]))) == []
+
+    def test_one_sample_is_still_a_chart(self) -> None:
+        """And the widening is what makes it one.
+
+        A single sample bins to one cell, which on its own is a grid too small
+        to trace -- marching squares needs a cell, which needs two rows and
+        two columns. The empty bin plotly puts outside each edge makes it a
+        3x3, and the field then runs 0 to 1 with nine levels across it.
+
+        Measured: plotly draws exactly that -- nine groups at 0.1 .. 0.9, one
+        ring each around the one filled cell -- so every one of them is
+        addressable.
+        """
+        (layer,) = _layers(go.Figure(go.Histogram2dContour(x=[3], y=[4])))
+
+        assert _levels(layer) == pytest.approx([0.1 * step for step in range(1, 10)])
+        assert len(layer["selectors"]) == 9


### PR DESCRIPTION
Closes #627 — the fifteenth and last of its declined trace types.

`histogram2dcontour` is the only one that is two readings at once: it bins samples the way a `histogram2d` does and then draws the curves along which those *counts* are constant, the way a `contour` does. Both halves already exist (#645 and #643/#649), so this is where they meet. `PlotlyHistogram2dContourPlot` extends `PlotlyContourPlot` and overrides exactly two things — which grid the curves run through, and which values the levels come from.

## What differs from either half alone

**The grid is one bin wider at each automatic edge**, so the curves have somewhere to close. Which edges move is per-side, and not simply "the automatic ones" — it reads that way at first and it is wrong. From the plotly bundle this wheel ships, where `l` is what the author wrote:

```js
l.size || (P.start = tickIncrement(P.start, P.size, true)),
l.end === void 0 && (P.end = tickIncrement(P.end, P.size, false))
```

So the **low** edge moves unless a `size` was named — not unless a `start` was — and the **high** edge moves unless an `end` was. Confirmed across nine spellings of `xbins` on five samples: with only a `size`, the low edge stays and the high edge moves; with only an `end`, the reverse.

**The curves run through the bin centres**, not the edges. Plotly's own `calcdata` for this trace carries five coordinates for five bins where a `histogram2d` carries four edges for three.

**A cell nothing landed in traces as zero.** The heatmap reading of the same binning announces it as `None` — there is no average of nothing — but the contour reading cannot: plotly hands the grid to a tracer written in JavaScript, where a `null` compares as below every level. Not a small difference. A sparse `histfunc="avg"` grid whose four filled cells run 3.5 .. 19 draws ten curves in the browser; read as a field with holes in it, `contourpy` finds five and misses the top three levels entirely. With the gaps at zero the two agree curve for curve — on that grid, on it negated, and on a `min` of negative values where zero is *above* every level.

The **levels**, though, still come from the values that are there: plotly reports that grid's range as 3.5 to 19 and draws levels 4 .. 18. Handing the zero-filled grid to the level rule instead draws 2 .. 16, none of which is a level on the chart.

(Worth stating because it looks like it should be otherwise: plotly *does* interpolate a hole in a `go.Contour`'s own `z` before tracing it — measured, a punched cell comes back filled in `calcdata` — but a `histogram2dcontour`'s grid never goes through that step. That divergence for the plain contour is filed as #651.)

## Verification

Read end to end against the browser on 13 figures — automatic bins, an `nbins` hint, four spellings of `xbins`, three `histfunc`s, a `histnorm`, an `ncontours` and an explicit level spec. **Eleven agree curve for curve.** The two that do not are levels whose curves reach the grid's own edge, where plotly's `<path>` elements are the outlines of the filled regions rather than the curves themselves. Every one of those levels has more than one curve, so the layer declines its selectors there anyway — and measured separately, a level whose *single* curve ends on the grid edge does match its drawn path exactly, in all three `coloring` modes. So the selector guard needs no new case.

A 9-mutation sweep over the new module — no widening, widening both sides, each edge rule inverted, edges instead of centres, gaps as holes, levels from the filled grid, the third axis unnamed, the colour bar title ignored: all 9 killed.

`tests/core` 1931 passed / 5 skipped; the rest 1437 passed / 13 skipped, including 21 new tests. `ruff check` clean.

## Two changes that reach the plain contour

- **A curve that spans nothing is no longer a series.** Where the field grazes a level at exactly one grid point, `contourpy` returns a closed curve whose every vertex is that point — and the level that grazes it is rarely the cell's value written out, so those vertices differ in the last bits rather than being identical. The span is now compared against the narrowest grid cell, at a fraction no real crossing comes near. Plotly draws no path there either.
- **The colour bar title is read in one place.** Three layers now name their third axis from it — a heatmap, a choropleth and this — and a third spelling of the same three cases is how they drift apart.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_