### PR TITLE
fix(plotly): fill a contour's holes before tracing it, the way plotly does

### DIFF
--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -9,6 +9,7 @@ import numpy as np
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.histogram import _plotly_dtick
+from maidr.plotly.holes import filled
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 _logger = logging.getLogger(__name__)
@@ -516,16 +517,15 @@ def _stepped(start: float, end: float, size: float) -> list[float] | None:
 def _grid(trace: dict) -> tuple[list[float], list[float], Any] | None:
     """Return the field as ``(x, y, z)``, or None when it cannot be traced.
 
-    ``z`` comes back masked where it is missing, which is what makes the
-    curves stop at a hole the way plotly's do -- measured on a field with the
-    peak punched out: both dropped the level the hole ate and agreed on the
-    rest.
+    ``z`` comes back with its **holes filled**, because plotly fills them
+    before tracing: a missing point in a contour's grid is averaged out of
+    its neighbours and the curves run through it. See
+    :func:`~maidr.plotly.holes.filled`, which reproduces that pass, and #651,
+    which is where reading a hole *as* a hole was measured costing up to
+    0.91 data units of curve on a grid whose cells are 0.5 across.
 
-    The mask is what ``contourpy`` documents for missing points. Passing the
-    NaN array straight through gives the same curves today -- measured, and it
-    is why removing the mask breaks no test -- but that is ``mpl2014``
-    treating NaN as missing rather than anything promised, so the documented
-    route is the one taken.
+    A field of nothing but holes has nothing to fill from and declines, which
+    is what plotly's own pass does with it (it raises rather than answers).
     """
     rows = [as_list(row) for row in as_list(trace.get("z"))]
     if not rows:
@@ -554,7 +554,11 @@ def _grid(trace: dict) -> tuple[list[float], list[float], Any] | None:
     if x is None or y is None:
         return None
 
-    return x, y, np.ma.masked_invalid(z)
+    whole = filled(z)
+    if whole is None:
+        return None
+
+    return x, y, whole
 
 
 def _has_extent(curve: Any, cell: float) -> bool:

--- a/maidr/plotly/holes.py
+++ b/maidr/plotly/holes.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+#: How small the largest fractional change has to get before the relaxation
+#: below stops, and how many passes it gets to reach it. Plotly's own
+#: ``INTERPTHRESHOLD`` and loop bound; it logs and gives up at the hundredth
+#: pass rather than iterating further.
+_THRESHOLD = 0.01
+_PASSES = 100
+
+#: The four cells a missing one takes its value from. Orthogonal only --
+#: plotly does not read the diagonals.
+_NEIGHBOURS = ((-1, 0), (1, 0), (0, -1), (0, 1))
+
+#: What the "no neighbours of my own yet" pass divides its score by, to keep a
+#: hole reached only through other holes below the ones reached directly.
+_SECOND_HAND = 20
+
+
+def filled(z: np.ndarray) -> np.ndarray | None:
+    """Return the field with its holes filled, the way plotly fills them.
+
+    A missing point in a ``contour``'s ``z`` is not a hole in the chart:
+    plotly runs ``findEmpties`` and ``interp2d`` over the grid before tracing
+    it, so the curves run *through* what was missing. Measured off
+    ``calcdata`` in Chromium -- a 5x5 field with its centre cell set to None
+    comes back with 0.6 in it, and ``_emptypoints`` counting the one it
+    filled. A ``go.Heatmap`` given the same field keeps its None, and keeps
+    it until asked for ``connectgaps``, so this is a step contours take and
+    heatmaps do not.
+
+    Reading the hole as a hole instead is not a small difference. On a 9x9
+    gaussian with one cell punched on the flank of the peak, the curve counts
+    still agree with plotly level for level -- and the curves themselves move
+    by up to 0.91 data units on a grid whose cells are 0.5 across, against a
+    0.16 sampling floor measured on the same field unpunched. A reader
+    tracing near the hole is told about ground the chart draws no curve
+    through (#651).
+
+    The rule is plotly's, transcribed rather than approximated, because a
+    near-miss puts the curves somewhere neither library draws them.
+
+    Parameters
+    ----------
+    z : numpy.ndarray
+        The field, with NaN where a point is missing. Not modified.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        A copy with the missing points filled, or None when there is nothing
+        to fill them from -- a field of nothing but holes, which plotly's own
+        pass raises on rather than answers.
+    """
+    field = np.asarray(z, dtype=float)
+    if not np.isnan(field).any():
+        return np.array(field)
+    if np.isnan(field).all():
+        return None
+
+    # The working copy, and the reason the field handed in survives: nothing
+    # below writes through to it. It is read again for the levels, which take
+    # their range from the values that were actually there.
+    grid = [list(row) for row in field]
+    empties = _find_empties(grid)
+
+    # One pass to give every hole a starting value, then the relaxation --
+    # which the holes with all four neighbours already sit still for, so
+    # plotly drops them from it. They are first in the list, since it is
+    # sorted by neighbour count.
+    _iterate(grid, empties)
+    settled = next(
+        (index for index, empty in enumerate(empties) if empty[2] < 4), len(empties)
+    )
+    unsettled = empties[settled:]
+
+    change = 1.0
+    for _ in range(_PASSES):
+        if change <= _THRESHOLD:
+            break
+        change = _iterate(grid, unsettled, _overshoot(change))
+
+    return np.array(grid, dtype=float)
+
+
+def _overshoot(change: float) -> float:
+    """How far past the neighbours' average to push, given the last pass.
+
+    Plotly's ``correctionOvershoot``: a relaxation factor that starts near a
+    half and eases off as the field settles.
+    """
+    return 0.5 - 0.25 * min(1.0, change * 0.5)
+
+
+def _iterate(
+    grid: list[list[float]], empties: list[tuple[int, int, float]], overshoot: float = 0.0
+) -> float:
+    """Move every hole to its neighbours' average, and report the largest move.
+
+    The move is reported as a fraction of the spread among those neighbours,
+    so a field of large numbers and a field of small ones settle at the same
+    point. A hole being filled for the first time has no previous value to
+    overshoot from, and answers "not settled" when it had fewer than four
+    neighbours to average.
+
+    ``overshoot`` is unused on the seeding pass and defaults accordingly:
+    every hole is still empty when that pass reaches it, so the branch that
+    reads it cannot be taken.
+    """
+    change = 0.0
+    rows = len(grid)
+    for row_index, column_index, _ in empties:
+        previous = grid[row_index][column_index]
+        total = 0.0
+        count = 0
+        low = high = 0.0
+        for row_shift, column_shift in _NEIGHBOURS:
+            row = row_index + row_shift
+            column = column_index + column_shift
+            if not 0 <= row < rows or not 0 <= column < len(grid[row]):
+                continue
+            value = grid[row][column]
+            if math.isnan(value):
+                continue
+            # Seeded off the running total rather than the count, which is
+            # what plotly does -- and it is not the same test: a first
+            # neighbour of zero leaves the pair to be seeded again by the
+            # second. Transcribed rather than corrected, because the spread
+            # it feeds only decides how quickly the relaxation stops.
+            if total == 0:
+                low = high = value
+            else:
+                low = min(low, value)
+                high = max(high, value)
+            count += 1
+            total += value
+
+        if count == 0:  # pragma: no cover - `_find_empties` orders them away
+            return change
+
+        grid[row_index][column_index] = total / count
+        if math.isnan(previous):
+            if count < 4:
+                change = 1.0
+        else:
+            grid[row_index][column_index] = (1 + overshoot) * grid[row_index][
+                column_index
+            ] - overshoot * previous
+            if high > low:
+                moved = abs(grid[row_index][column_index] - previous) / (high - low)
+                change = max(change, moved)
+    return change
+
+
+def _find_empties(grid: list[list[float]]) -> list[tuple[int, int, float]]:
+    """Every hole, with a score for how well surrounded it is, best first.
+
+    The score counts a hole's filled orthogonal neighbours and adds one for
+    each side of the grid it lies against -- an edge being as good as a
+    neighbour, since there is nothing beyond it to disagree with. Holes with
+    fewer than four then take a second pass for the sake of holes that touch
+    only *them*: those get a fraction of their neighbours' scores, which
+    keeps them behind in the ordering without ever reaching four.
+
+    Order is the whole point of the function. :func:`filled` seeds in this
+    order so that a hole is always reached after something it can average,
+    and cuts the relaxation at the first score below four.
+    """
+    rows = len(grid)
+    width = max((len(row) for row in grid), default=0)
+    empties: list[tuple[int, int, float]] = []
+    scored: dict[tuple[int, int], float] = {}
+    unreached: list[tuple[int, int]] = []
+
+    for row_index in range(rows):
+        row = grid[row_index]
+        above = grid[row_index - 1] if row_index else []
+        below = grid[row_index + 1] if row_index + 1 < rows else []
+        for column_index in range(width):
+            if not math.isnan(_at(row, column_index)):
+                continue
+            score = float(
+                (not math.isnan(_at(row, column_index - 1)))
+                + (not math.isnan(_at(row, column_index + 1)))
+                + (not math.isnan(_at(above, column_index)))
+                + (not math.isnan(_at(below, column_index)))
+            )
+            if not score:
+                unreached.append((row_index, column_index))
+                continue
+            score += float(
+                (row_index == 0)
+                + (column_index == 0)
+                + (row_index == rows - 1)
+                + (column_index == len(row) - 1)
+            )
+            if score < 4:
+                scored[(row_index, column_index)] = score
+            empties.append((row_index, column_index, score))
+
+    while unreached:
+        found: dict[tuple[int, int], float] = {}
+        # Walked backwards, because plotly walks it backwards -- it removes
+        # each match as it goes, which a forward walk cannot do safely, and
+        # the holes it finds are appended in the order the walk met them. On
+        # a square block of holes that is the difference between filling the
+        # far corner first and the near one, and the two settle a thousandth
+        # apart.
+        for row_index, column_index in reversed(unreached):
+            score = (
+                scored.get((row_index - 1, column_index), 0.0)
+                + scored.get((row_index + 1, column_index), 0.0)
+                + scored.get((row_index, column_index - 1), 0.0)
+                + scored.get((row_index, column_index + 1), 0.0)
+            ) / _SECOND_HAND
+            if score:
+                found[(row_index, column_index)] = score
+        if not found:  # pragma: no cover - `filled` declines an all-hole field
+            break
+        unreached = [cell for cell in unreached if cell not in found]
+        for (row_index, column_index), score in found.items():
+            scored[(row_index, column_index)] = score
+            empties.append((row_index, column_index, score))
+
+    # Stable, so holes of equal standing keep the order they were found in --
+    # which is the order plotly's own sort leaves them in.
+    return sorted(empties, key=lambda empty: empty[2], reverse=True)
+
+
+def _at(row: Any, index: int) -> float:
+    """One cell of a row, or NaN where there is no cell there.
+
+    Plotly reads past the ends of its rows and gets ``undefined``, which its
+    tests for a filled neighbour answer no to. Python would wrap a negative
+    index around to the far end instead, and read a neighbour from the other
+    side of the field.
+    """
+    if index < 0 or index >= len(row):
+        return math.nan
+    return float(row[index])

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -539,13 +539,32 @@ def test_transpose_turns_the_grid_over_and_leaves_the_coordinates() -> None:
     ]
 
 
-def test_a_hole_in_the_grid_stops_the_curves_the_way_plotly_does() -> None:
-    """A missing z is a hole in the field, not a reason to decline the trace.
+def test_a_hole_in_the_grid_is_filled_before_the_curves_are_traced() -> None:
+    """Plotly fills it, so the curves run through it rather than round it.
 
-    Measured on a field with its peak punched out: plotly and the tracer both
-    dropped the level the hole ate and agreed on the rest.
+    A field of zeros with its middle punched out has that middle averaged
+    back to zero -- measured, its `calcdata` comes back with the hole filled
+    -- and there is then nothing at 0.5 to draw. So this still forms no
+    layer, but for the reason plotly has rather than the one the mask had.
+
+    The reason matters where the neighbours disagree, which is what #651 was
+    filed for and what :func:`~maidr.plotly.holes.filled` reproduces. This is
+    the shape of the old reading's test kept for the boundary it still marks:
+    a missing z is not a reason to decline the trace.
     """
     z = [[0, 0, 0], [0, None, 0], [0, 0, 0]]
+
+    assert _layers(go.Figure(_contour(z, start=0.5, end=0.5, size=0.5))) == []
+
+
+def test_a_field_of_nothing_but_holes_forms_no_layer() -> None:
+    """There is nothing to fill it from, and plotly's own pass raises on it.
+
+    Declining is the answer #636 settled for every other unreadable grid: a
+    layer of curves through a field that has no values would be a chart the
+    reader is not looking at.
+    """
+    z = [[None, None, None], [None, None, None], [None, None, None]]
 
     assert _layers(go.Figure(_contour(z, start=0.5, end=0.5, size=0.5))) == []
 

--- a/tests/plotly/test_plotly_contour_holes.py
+++ b/tests/plotly/test_plotly_contour_holes.py
@@ -1,0 +1,235 @@
+"""A contour's holes were read as holes; plotly fills them before tracing.
+
+`maidr/plotly/contour.py` masked a missing point, on the reading that the
+curves should stop at it the way plotly's do. Plotly does not stop there. It
+runs `findEmpties` and `interp2d` over the grid first -- each hole becomes the
+average of its orthogonal neighbours, relaxed until the field settles -- and
+traces the curves *through* what was missing. Straight off `calcdata` in
+Chromium, on a 5x5 field with its centre set to None:
+
+```
+contour                    -> z[2][2] = 0.6    _emptypoints = 1
+heatmap                    -> z[2][2] = None   _emptypoints = null
+heatmap, connectgaps=True  -> z[2][2] = 0.6    _emptypoints = 1
+```
+
+So it is a step contours take and heatmaps do not, and it was not visible in
+the curve *counts*: on a 9x9 gaussian with one cell punched, both readings
+find nine levels of one curve each. What moved was the curves. Sampling every
+drawn path at 80 points and measuring each to the nearest segment of the
+series announced with it:
+
+```
+                       worst gap (grid cells are 0.5 across)
+whole field (control)  0.16   <- polyline against bezier, the floor
+one cell punched       0.91   <- before
+one cell punched       0.16   <- after
+```
+
+The rule is transcribed from the bundle this wheel ships rather than
+approximated, because a near-miss puts the curves where neither library draws
+them. Thirteen filled fields match plotly's own `calcdata` to 1e-9 -- single
+holes, adjacent pairs, an L, a 2x2 block, a 4x4 block, a cross, a row with
+only its ends left, holes at a corner and on an edge, and scatters of them
+through ripples and through noise. See #651.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.holes import _find_empties, filled  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+
+def _punched(rows: int, columns: int, holes: list) -> np.ndarray:
+    """A field of its own coordinates, with cells knocked out of it.
+
+    Its own coordinates rather than a constant, so a hole filled from the
+    wrong neighbours lands somewhere the assertions can see.
+    """
+    field = np.array(
+        [[float(row * 10 + column) for column in range(columns)] for row in range(rows)]
+    )
+    for row, column in holes:
+        field[row][column] = np.nan
+    return field
+
+
+class TestAHoleTakesItsNeighboursAverage:
+    def test_one_hole_is_the_mean_of_its_four(self) -> None:
+        """The plain case, and the one measured straight off `calcdata`.
+
+        A 5x5 field whose centre is punched comes back from plotly holding
+        0.6, which is what its four neighbours -- all 0.6 -- average to.
+        """
+        field = np.array(
+            [
+                [0.0, 0.1, 0.2, 0.1, 0.0],
+                [0.1, 0.4, 0.6, 0.4, 0.1],
+                [0.2, 0.6, np.nan, 0.6, 0.2],
+                [0.1, 0.4, 0.6, 0.4, 0.1],
+                [0.0, 0.1, 0.2, 0.1, 0.0],
+            ]
+        )
+
+        assert filled(field)[2][2] == pytest.approx(0.6)
+
+    def test_a_hole_reads_no_diagonals(self) -> None:
+        """Four neighbours, not eight -- which the corners here would show.
+
+        The field runs ``row * 10 + column``, so the hole at (1, 1) has
+        orthogonal neighbours 1, 10, 12 and 21 (average 11) and diagonals 0,
+        2, 20 and 22, which would pull it nowhere different on their own but
+        would change the answer if they were counted alongside.
+        """
+        assert filled(_punched(3, 3, [(1, 1)]))[1][1] == pytest.approx(11.0)
+
+    def test_a_hole_against_an_edge_averages_what_is_there(self) -> None:
+        """Three neighbours, and the missing side is simply not counted.
+
+        (0, 1) on the same ramp has 0, 2 and 11 beside it. Reading past the
+        edge would wrap round to the far side of the field in Python, where
+        plotly reads `undefined` and skips.
+        """
+        assert filled(_punched(3, 3, [(0, 1)]))[0][1] == pytest.approx(13 / 3)
+
+    def test_a_field_with_no_holes_comes_back_unchanged(self) -> None:
+        field = _punched(4, 4, [])
+
+        assert np.array_equal(filled(field), field)
+
+    def test_a_field_of_nothing_but_holes_has_nothing_to_fill_from(self) -> None:
+        """Plotly's own pass raises rather than answers, so this declines."""
+        assert filled(np.full((3, 3), np.nan)) is None
+
+    def test_the_field_handed_in_is_not_written_over(self) -> None:
+        """It is read again for the levels, and by whoever passed it."""
+        field = _punched(3, 3, [(1, 1)])
+
+        filled(field)
+
+        assert np.isnan(field[1][1])
+
+
+class TestTheOrderHolesAreFilledIn:
+    """Not an implementation detail: a block of holes settles differently.
+
+    Each hole is scored by how well surrounded it is -- filled orthogonal
+    neighbours, plus one for each side of the grid it lies against -- and they
+    are seeded best-first so that a hole is always reached after something it
+    can average. Holes that touch only other holes take a second pass and get
+    a twentieth of their neighbours' scores, which keeps them last without
+    ever reaching four.
+
+    Measured against plotly's own `_emptypoints` on a 4x4 block punched out
+    of an 8x8 field: sixteen holes, the four corners of the block scoring 2,
+    the twelve edges 1, and the four interior ones 0.1 -- in that order, and
+    with the interior four in the order below rather than its reverse. That
+    last part is not cosmetic: filling the far corner before the near one
+    settles the block a thousandth away from where plotly settles it.
+    """
+
+    def test_the_scores_and_their_order_are_plotly_s(self) -> None:
+        field = _punched(8, 8, [(row, column) for row in range(2, 6) for column in range(2, 6)])
+
+        found = _find_empties([list(row) for row in field])
+
+        assert [(row, column) for row, column, _ in found[:4]] == [
+            (2, 2),
+            (2, 5),
+            (5, 2),
+            (5, 5),
+        ]
+        assert {score for _, _, score in found[:4]} == {2.0}
+        assert {score for _, _, score in found[4:12]} == {1.0}
+        assert [(row, column) for row, column, _ in found[12:]] == [
+            (4, 4),
+            (4, 3),
+            (3, 4),
+            (3, 3),
+        ]
+
+    def test_a_hole_against_two_sides_scores_for_both(self) -> None:
+        """A corner has two neighbours and two edges, so it scores four.
+
+        Which puts it among the holes the relaxation leaves alone -- there is
+        nothing on the other side of an edge to disagree with it.
+        """
+        found = _find_empties([list(row) for row in _punched(4, 4, [(0, 0)])])
+
+        assert found == [(0, 0, 4.0)]
+
+
+class TestTheCurvesRunThroughIt:
+    """The reading, rather than the field -- which is what #651 was about."""
+
+    #: A gaussian on a 9x9 grid, its peak at the middle. Rounded, so the
+    #: numbers here are the numbers plotly is given.
+    SMOOTH = np.round(
+        np.exp(
+            -(
+                np.linspace(-2, 2, 9)[None, :] ** 2
+                + np.linspace(-2, 2, 9)[:, None] ** 2
+            )
+        ),
+        4,
+    )
+
+    def _curves(self, z: list) -> list[list[tuple[float, float]]]:
+        figure = go.Figure(go.Contour(z=z, contours=dict(coloring="lines")))
+        grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+        layers = [layer for row in grid for cell in row for layer in cell["layers"]]
+        return [
+            [(point["x"], point["y"]) for point in series]
+            for layer in layers
+            for series in layer["data"]
+        ]
+
+    def test_a_punched_field_reads_as_the_field_with_the_hole_filled(self) -> None:
+        """The point of the change, said in the emitted curves.
+
+        One cell punched on the flank of the peak, where the neighbours
+        disagree most. The hole has all four of them, so it is seeded at
+        their mean and the relaxation leaves it there -- 0.645225 where the
+        field held 0.7788. Reading the punched field is then exactly reading
+        that one, curve for curve and point for point.
+
+        Measured in the browser as well, since equality here would also hold
+        for a fill nobody draws: sampling every drawn path at 80 points and
+        measuring each to the nearest segment of the series announced with
+        it, the punched field's worst gap is 0.16 data units -- the same
+        floor the unpunched field gives, where masking gave 0.91 on a grid
+        whose cells are 0.5 across.
+        """
+        punched = self.SMOOTH.tolist()
+        punched[4][3] = None
+        by_hand = self.SMOOTH.tolist()
+        by_hand[4][3] = (
+            self.SMOOTH[3][3]
+            + self.SMOOTH[5][3]
+            + self.SMOOTH[4][2]
+            + self.SMOOTH[4][4]
+        ) / 4
+
+        assert self._curves(punched) == self._curves(by_hand)
+
+    def test_and_not_as_the_field_it_was_punched_from(self) -> None:
+        """Guards the assertion above against passing for the wrong reason.
+
+        The hole is filled with an average, not with the value that was
+        there, so the punched field is a different chart from the whole one
+        -- and if it were not, the test above would hold however the hole
+        were filled.
+        """
+        punched = self.SMOOTH.tolist()
+        punched[4][3] = None
+
+        assert self._curves(punched) != self._curves(self.SMOOTH.tolist())


### PR DESCRIPTION
Closes #651.

A missing point in a contour's `z` was masked, on the reading that the curves should stop at it the way plotly's do. Plotly does not stop there — it runs `findEmpties` and `interp2d` over the grid first and traces the curves *through* what was missing. Straight off `calcdata` in Chromium, on a 5×5 field with its centre set to None:

```
contour                    -> z[2][2] = 0.6    _emptypoints = 1
heatmap                    -> z[2][2] = None   _emptypoints = null
heatmap, connectgaps=True  -> z[2][2] = 0.6    _emptypoints = 1
```

So it is a step contours take and heatmaps do not.

## Why the old test did not catch it

It was invisible in the curve **counts**. On a 9×9 gaussian with one cell punched, both readings find nine levels of one curve each — the old `test_a_hole_in_the_grid_stops_the_curves_the_way_plotly_does` was measured on a field with its *peak* punched, where masking and interpolation both drop the top level for different reasons. What moved was the curves themselves. Sampling every drawn path at 80 points and measuring each to the nearest **segment** of the series announced with it, on a grid whose cells are 0.5 across:

| field | worst gap |
|---|---|
| whole (control) | 0.16 — polyline against bezier, the floor |
| one cell punched, **before** | **0.91** |
| one cell punched, **after** | 0.16 |

A reader tracing near the hole was told about ground the chart draws no curve through.

## Transcribed, not approximated

`maidr/plotly/holes.py` reproduces the rule from the bundle this wheel ships, including the parts that read oddly on their own, because a near-miss puts the curves where neither library draws them:

- the seeding pass runs best-surrounded-first, so a hole is always reached after something it can average;
- **an edge of the grid counts as a neighbour** — there is nothing beyond it to disagree with;
- holes that touch only *other* holes take a second pass and get a twentieth of their neighbours' scores, which keeps them last without ever reaching four;
- that second pass **walks its list backwards**, which is the difference between filling a block's far corner first and its near one — and settles a 4×4 block of holes a thousandth away from plotly if you get it the other way round. (It caught me: my first attempt was 12/13 and this was the 13th.)
- holes with all four neighbours are dropped from the relaxation after seeding, and the relaxation's overshoot eases off as the field settles.

**Thirteen filled fields match plotly's own `calcdata` to 1e-9**: single holes, adjacent pairs, an L, a 2×2 block, a 4×4 block, a cross, a row with only its ends left, holes at a corner and on an edge, and scatters of them through ripples and through noise. The empty-point ordering is checked against plotly's own `_emptypoints` array, score for score and position for position.

A field of nothing but holes has nothing to fill from and declines, which is what plotly's own pass does with it (it raises rather than answers).

## Not histogram2dcontour

Worth stating because it looks like it should be: a `histogram2dcontour`'s `_emptypoints` is empty and its `calcdata` keeps the nulls, so the tracer reads a missing cell as zero (measured in #653, on three sparse `histfunc` grids including a negative one). The two trace types genuinely want different answers for a missing cell, and this change reaches only the one that interpolates.

## Testing

- 10 new tests in `tests/plotly/test_plotly_contour_holes.py`, plus the old hole test rewritten for the reason plotly actually has and a new one for the all-holes field.
- A 9-mutation sweep: no filling, diagonals counted, a read past the edge wrapping round, edges not scoring, worst-first seeding, the second pass walking forwards, well-surrounded holes relaxed anyway, and an all-hole field not declined — all killed. One survivor was a redundant defensive copy, now removed: the working grid is a fresh list-of-lists, so the field handed in was never at risk.
- `tests/core` 1931 passed / 5 skipped; the rest 1449 passed / 13 skipped. `ruff check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_