### PR TITLE
fix(plotly): scope a heatmap's selector to its own image

### DIFF
--- a/maidr/plotly/candlestick.py
+++ b/maidr/plotly/candlestick.py
@@ -33,11 +33,28 @@ _MARK_OF = {"candlestick": "path.box", "ohlc": "> path"}
 #: held two ``g.contour`` groups in declaration order, while the heatmap sat
 #: elsewhere in a ``heatmaplayer`` of its own.
 #:
+#: ``heatmap``/``histogram2d`` share ``g.heatmaplayer`` -- measured on four
+#: figures, each ``g.hm`` read back through its own ``__data__`` so the
+#: pairing is plotly's rather than inferred from where the image landed:
+#:
+#: .. code-block:: text
+#:
+#:     Heatmap, Histogram2d           hm[0] heatmap      hm[1] histogram2d
+#:     Histogram2d, Heatmap           hm[0] histogram2d  hm[1] heatmap
+#:     Heatmap, Histogram2d, Heatmap  hm[0..2] in declaration order
+#:     Histogram2d, Histogram2d       hm[0..1] in declaration order
+#:
+#: A ``contour`` under ``coloring: "heatmap"`` looks like it should join them
+#: and does not: measured, it paints inside its own ``contourlayer`` and adds
+#: no ``g.hm``. Nor does a ``go.Image``, which has an ``imagelayer`` of its
+#: own (#647).
+#:
 #: A type absent from every group is numbered among its own kind, which is
 #: what a layer with one occupant needs.
 _SHARED_LAYERS = (
     frozenset({"box", "candlestick"}),
     frozenset({"contour", "histogram2dcontour"}),
+    frozenset({"heatmap", "histogram2d"}),
 )
 
 

--- a/maidr/plotly/heatmap.py
+++ b/maidr/plotly/heatmap.py
@@ -9,11 +9,62 @@ from maidr.plotly.plotly_plot import PlotlyPlot, as_list, colorbar_title
 class PlotlyHeatmapPlot(PlotlyPlot):
     """Extract data from a Plotly heatmap trace."""
 
-    def __init__(self, trace: dict, layout: dict, **kwargs: str) -> None:
+    def __init__(
+        self,
+        trace: dict,
+        layout: dict,
+        *,
+        layer_position: int = 0,
+        **kwargs: str,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        trace : dict
+            A plotly ``heatmap`` (or ``histogram2d``) trace dictionary.
+        layout : dict
+            The figure's layout dictionary.
+        layer_position : int, optional
+            This trace's zero-based position among the traces sharing the
+            subplot's ``heatmaplayer``, from
+            :func:`~maidr.plotly.candlestick.layer_position`. Defaults to the
+            first, which is what a subplot with one image has.
+        **kwargs : str
+            Axis names and other options passed to :class:`PlotlyPlot`.
+        """
+        self._layer_position = layer_position
         super().__init__(trace, layout, PlotType.HEAT, **kwargs)
 
     def _get_selector(self) -> str:
-        return f"{self._subplot_css_prefix()}.heatmaplayer image"
+        """Return the selector for this trace's own image.
+
+        Plotly appends one ``<g class="hm">`` per image-drawing trace to the
+        subplot's ``heatmaplayer``, in declaration order, and each holds
+        exactly one ``<image>``. Until #647 this named
+        ``.heatmaplayer image`` -- the first image on the subplot rather than
+        this trace's -- so a subplot holding two of them had both layers
+        outlining the first: a highlight that resolves to a real element and
+        the wrong one.
+
+        The group is what carries the position, not the image.
+        ``image:nth-of-type(N)`` counts among an element's *siblings*, and
+        each image is the only one inside its own ``g.hm``, so measured in
+        Chromium on a subplot with two:
+        ``image:nth-of-type(1)`` matched **both** and ``:nth-of-type(2)``
+        matched none. ``g.hm:nth-of-type(N) image`` matched exactly one each.
+
+        ``:nth-of-type`` counts by tag among all siblings rather than among
+        the ones matching the class beside it, so it is exact only where the
+        siblings are homogeneous -- the caution :meth:`contour's selector
+        <maidr.plotly.contour.PlotlyContourPlot._get_selector>` spells out.
+        Measured across five configurations (two heatmaps, either order of a
+        heatmap and a ``histogram2d``, two ``histogram2d``, and a heatmap
+        beside a contour), a ``heatmaplayer`` held nothing but ``g.hm``.
+        """
+        return (
+            f"{self._subplot_css_prefix()}.heatmaplayer > "
+            f"g.hm:nth-of-type({self._layer_position + 1}) image"
+        )
 
     @staticmethod
     def _to_native(val: Any) -> Any:

--- a/maidr/plotly/histogram2d.py
+++ b/maidr/plotly/histogram2d.py
@@ -76,12 +76,12 @@ class PlotlyHistogram2dPlot(PlotlyHeatmapPlot):
     axes across four figures, ``0.4`` matched none and ``0.25`` matched all
     eight.
 
-    Sharing the selector shares its one limit: `.heatmaplayer image` names the
-    first image on the subplot rather than this trace's, so a subplot holding
-    two of them -- a `go.Heatmap` beside a `histogram2d`, or two of either --
-    has both layers pointing at the first. That predates this class and
-    applies to two heatmaps today; reading a second trace type into the same
-    layer is what makes it reachable a second way. See #647.
+    Sharing the selector shares its numbering: plotly appends one
+    ``<g class="hm">`` per image-drawing trace to the subplot's
+    ``heatmaplayer`` in declaration order, counting heatmaps and 2-D
+    histograms together, so both kinds take their position from
+    :func:`~maidr.plotly.candlestick.layer_position` over the same group
+    (#647).
     """
 
     def _extract_plot_data(self) -> dict:

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -1269,28 +1269,6 @@ class PlotlyMaidr:
                     self._plots.append(plot)
                 merged.update(id(t) for t in waterfall_traces)
 
-            # Two-dimensional histograms, one layer each. A `histogram2d`
-            # draws a single `<image>` into the subplot's `heatmaplayer`
-            # exactly as a `go.Heatmap` does -- measured -- so it needs no
-            # position of its own and could have been left to the factory.
-            # It is built here so it sits beside the contour it shares an
-            # issue with, and so the two 2-D binning readings are found
-            # together.
-            histogram2d_traces = [
-                t for t in group_traces if is_histogram2d_trace(t)
-            ]
-            if histogram2d_traces:
-                from maidr.plotly.histogram2d import PlotlyHistogram2dPlot
-
-                for histogram2d_trace in histogram2d_traces:
-                    plot = PlotlyHistogram2dPlot(
-                        histogram2d_trace, layout, **axis_kwargs
-                    )
-                    plot.row_index = row
-                    plot.col_index = col
-                    self._plots.append(plot)
-                merged.update(id(t) for t in histogram2d_traces)
-
             # Contours, one layer each. Built here rather than left to
             # the factory for the reason the waterfalls above are: plotly
             # appends one `g.contour` group per trace to the subplot's
@@ -1333,9 +1311,46 @@ class PlotlyMaidr:
             for trace in group_traces:
                 if id(trace) in merged:
                     continue
-                plot = PlotlyPlotFactory.create(
-                    trace, layout, **axis_kwargs
-                )
+                if trace.get("type") == "heatmap" or is_histogram2d_trace(
+                    trace
+                ):
+                    # The image-drawing traces. Plotly appends one
+                    # `<g class="hm">` per trace to the subplot's
+                    # `heatmaplayer`, in declaration order, counting a
+                    # `go.Heatmap` and a `histogram2d` together -- so a
+                    # selector naming an image is scoped by its trace's
+                    # position among *both* kinds (#647). The factory sees
+                    # one trace at a time and cannot know that; only this
+                    # figure-wide pass does.
+                    #
+                    # Built inside this loop rather than hoisted above it,
+                    # unlike the contours, so that neither kind's layer
+                    # moves ahead of whatever was declared before it. That
+                    # is what the hoist cost while the `histogram2d` block
+                    # lived up there: a scatter declared first was announced
+                    # second.
+                    #
+                    # A 2-D histogram is a heatmap whose grid it has to bin
+                    # for itself; from the grid onwards the two read alike,
+                    # which is why one extends the other.
+                    from maidr.plotly.heatmap import PlotlyHeatmapPlot
+                    from maidr.plotly.histogram2d import PlotlyHistogram2dPlot
+
+                    build = (
+                        PlotlyHistogram2dPlot
+                        if is_histogram2d_trace(trace)
+                        else PlotlyHeatmapPlot
+                    )
+                    plot = build(
+                        trace,
+                        layout,
+                        layer_position=layer_position(group_traces, trace),
+                        **axis_kwargs,
+                    )
+                else:
+                    plot = PlotlyPlotFactory.create(
+                        trace, layout, **axis_kwargs
+                    )
                 if plot is not None:
                     plot.row_index = row
                     plot.col_index = col

--- a/tests/plotly/test_plotly_heatmap_row_order.py
+++ b/tests/plotly/test_plotly_heatmap_row_order.py
@@ -12,7 +12,7 @@ Measured on plotly.js 3.7.0 rendered in Chromium, for
 ``c2p(2) = 53.33``, and a smaller pixel is higher on screen, so 'first' is the
 bottom row.
 
-The selector is ``.heatmaplayer image``, because plotly rasterises the grid, so
+The selector names one ``<image>``, because plotly rasterises the grid, so
 the core synthesises its own overlay rects. That code used to place its row 0
 on the top band -- an error that cancelled this one, leaving the highlight
 accidentally right while navigation ran inverted. maidr#972 corrected it, so

--- a/tests/plotly/test_plotly_histogram2d.py
+++ b/tests/plotly/test_plotly_histogram2d.py
@@ -72,7 +72,9 @@ def test_a_histogram2d_is_read_as_a_heatmap_layer() -> None:
     (layer,) = _layers(_histogram2d(**CORNER, **BINS))
 
     assert layer["type"] is PlotType.HEAT
-    assert layer["selectors"] == ".subplot.xy .heatmaplayer image"
+    assert layer["selectors"] == (
+        ".subplot.xy .heatmaplayer > g.hm:nth-of-type(1) image"
+    )
 
 
 def test_the_grid_is_the_counts_the_samples_make() -> None:
@@ -323,7 +325,9 @@ def test_a_histogram2d_on_a_second_subplot_is_scoped_to_it() -> None:
 
     assert [len(row) for row in grid] == [2]
     (heat,) = grid[0][1]["layers"]
-    assert heat["selectors"] == ".subplot.x2y2 .heatmaplayer image"
+    assert heat["selectors"] == (
+        ".subplot.x2y2 .heatmaplayer > g.hm:nth-of-type(1) image"
+    )
 
 
 def test_a_histogram2d_with_no_samples_forms_no_layer() -> None:

--- a/tests/plotly/test_plotly_image_layer_position.py
+++ b/tests/plotly/test_plotly_image_layer_position.py
@@ -1,0 +1,229 @@
+"""Two image-drawing traces on one subplot both highlighted the first (#647).
+
+`PlotlyHeatmapPlot._get_selector` returned `.heatmaplayer image`, and
+`Svg.selectElement` takes `document.querySelector`, which answers with the
+first match. So a subplot holding two images had both layers naming the same
+one: a highlight that resolves to a real element and the wrong one. The
+reading, the sonification and the braille were all correct either way.
+
+It is reachable two ways. Two `go.Heatmap` traces on one subplot always were;
+a `go.Heatmap` beside a `go.Histogram2d` became reachable with #645, which
+reads a `histogram2d` as a heatmap and inherited the selector.
+
+## What plotly actually writes
+
+Measured in Chromium, each `g.hm` read back through its own `__data__` so the
+pairing is plotly's rather than inferred from where the image landed:
+
+```
+Heatmap, Histogram2d           hm[0] heatmap      hm[1] histogram2d
+Histogram2d, Heatmap           hm[0] histogram2d  hm[1] heatmap
+Heatmap, Histogram2d, Heatmap  hm[0..2] in declaration order
+Histogram2d, Histogram2d       hm[0..1] in declaration order
+```
+
+So the two types are numbered together, in declaration order -- which is what
+`layer_position` answers once `{heatmap, histogram2d}` is declared as a shared
+DOM layer beside `{box, candlestick}` and `{contour, histogram2dcontour}`.
+
+## The group carries the position, not the image
+
+The obvious selector does not work. `image:nth-of-type(N)` counts among an
+element's *siblings*, and each image is the only one inside its own `g.hm`:
+
+```
+g.heatmaplayer image                    2 matches
+g.heatmaplayer image:nth-of-type(1)     2   <- both, being each its own first
+g.heatmaplayer image:nth-of-type(2)     0
+g.heatmaplayer g.hm:nth-of-type(1) image   1
+g.heatmaplayer g.hm:nth-of-type(2) image   1
+```
+
+Two further types look like they should join the group and do not: a
+`contour` under `coloring: "heatmap"` paints inside its own `contourlayer`
+and adds no `g.hm`, and a `go.Image` has an `imagelayer` of its own.
+
+Every selector below was resolved in Chromium and its element's `g.hm` read
+back through `__data__`: five figures, every one resolving to exactly one
+element, and to the trace its layer was built from.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+#: Samples that fall in two bins on each axis, so a `histogram2d` draws a
+#: grid rather than a single cell.
+SAMPLES = {"x": [1, 2, 2, 3], "y": [1, 2, 2, 3]}
+
+#: A 2x2 grid, and a second one holding different numbers so that a layer
+#: read from the wrong trace would be visible in the data as well.
+FIRST = [[1.0, 2.0], [3.0, 4.0]]
+SECOND = [[9.0, 8.0], [7.0, 6.0]]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell["layers"]]
+
+
+def _image_selector(position: int, prefix: str = ".subplot.xy") -> str:
+    return f"{prefix} .heatmaplayer > g.hm:nth-of-type({position}) image"
+
+
+class TestEachImageIsNamedByItsOwnGroup:
+    def test_two_heatmaps_name_different_images(self) -> None:
+        layers = _layers(
+            go.Figure([go.Heatmap(z=FIRST), go.Heatmap(z=SECOND)])
+        )
+
+        assert [layer["selectors"] for layer in layers] == [
+            _image_selector(1),
+            _image_selector(2),
+        ]
+
+    def test_a_heatmap_counts_the_histogram2d_beside_it(self) -> None:
+        """The half #645 made reachable, and the direction that was wrong.
+
+        A `histogram2d` draws into the same `heatmaplayer`, so a heatmap
+        declared after one is the *second* image on the subplot.
+        """
+        layers = _layers(
+            go.Figure([go.Histogram2d(**SAMPLES), go.Heatmap(z=FIRST)])
+        )
+
+        assert [layer["selectors"] for layer in layers] == [
+            _image_selector(1),
+            _image_selector(2),
+        ]
+
+    def test_a_histogram2d_counts_the_heatmap_beside_it(self) -> None:
+        """And the other direction, which is not the same assertion.
+
+        #395 is the reason this is written twice: counting only same-typed
+        traces was symmetric-looking and wrong one way round, with a
+        candlestick counting the boxes beside it while a box ignored the
+        candlestick and claimed the group it had already taken.
+        """
+        layers = _layers(
+            go.Figure([go.Heatmap(z=FIRST), go.Histogram2d(**SAMPLES)])
+        )
+
+        assert [layer["selectors"] for layer in layers] == [
+            _image_selector(1),
+            _image_selector(2),
+        ]
+
+    def test_three_images_run_in_declaration_order(self) -> None:
+        layers = _layers(
+            go.Figure(
+                [
+                    go.Heatmap(z=FIRST),
+                    go.Histogram2d(**SAMPLES),
+                    go.Heatmap(z=SECOND),
+                ]
+            )
+        )
+
+        assert [layer["selectors"] for layer in layers] == [
+            _image_selector(1),
+            _image_selector(2),
+            _image_selector(3),
+        ]
+
+    def test_one_image_is_still_the_first(self) -> None:
+        """The case every heatmap chart is, and the one that must not move."""
+        (layer,) = _layers(go.Figure(go.Heatmap(z=FIRST)))
+
+        assert layer["type"] is PlotType.HEAT
+        assert layer["selectors"] == _image_selector(1)
+
+
+class TestWhatDoesNotShareTheLayer:
+    def test_a_scatter_does_not_shift_the_image(self) -> None:
+        """`g.scatterlayer` is elsewhere, so it takes no `g.hm`."""
+        layers = _layers(
+            go.Figure([go.Scatter(x=[1, 2], y=[1, 2]), go.Heatmap(z=FIRST)])
+        )
+
+        assert layers[1]["selectors"] == _image_selector(1)
+
+    def test_a_heatmap_coloured_contour_does_not_shift_it_either(self) -> None:
+        """It looks like it should and it does not.
+
+        `contours.coloring = "heatmap"` fills the whole field, so the trace
+        paints a raster the way a heatmap does -- but measured in Chromium it
+        paints inside its own `contourlayer` and adds no `g.hm`. Counting it
+        would push the heatmap onto a group that does not exist, and the
+        highlight would resolve to nothing at all.
+        """
+        layers = _layers(
+            go.Figure(
+                [
+                    go.Contour(
+                        z=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                        contours={"coloring": "heatmap"},
+                    ),
+                    go.Heatmap(z=FIRST),
+                ]
+            )
+        )
+
+        assert layers[-1]["selectors"] == _image_selector(1)
+
+
+class TestTheLayersStayInTheOrderTheyWereDeclared:
+    def test_an_image_does_not_move_ahead_of_what_precedes_it(self) -> None:
+        """Reading order is what a reader walks, so it follows the figure.
+
+        Both image types are built inside `_extract_plots`, because only the
+        figure-wide pass knows a trace's position among the subplot's images.
+        Building them in a block of their own -- which is what the
+        `histogram2d` did before this change -- hoists their layers ahead of
+        every trace declared before them.
+        """
+        layers = _layers(
+            go.Figure([go.Scatter(x=[1, 2], y=[1, 2]), go.Heatmap(z=FIRST)])
+        )
+
+        assert [layer["type"] for layer in layers] == [
+            PlotType.SCATTER,
+            PlotType.HEAT,
+        ]
+
+    def test_a_histogram2d_does_not_either(self) -> None:
+        layers = _layers(
+            go.Figure([go.Scatter(x=[1, 2], y=[1, 2]), go.Histogram2d(**SAMPLES)])
+        )
+
+        assert [layer["type"] for layer in layers] == [
+            PlotType.SCATTER,
+            PlotType.HEAT,
+        ]
+
+
+class TestEachSubplotCountsItsOwn:
+    def test_an_image_on_a_second_subplot_is_its_first(self) -> None:
+        """Every subplot holds a `heatmaplayer` of its own, so the position
+        is within the subplot rather than within the figure."""
+        from plotly.subplots import make_subplots
+
+        figure = make_subplots(rows=1, cols=2)
+        figure.add_trace(go.Heatmap(z=FIRST, showscale=False), row=1, col=1)
+        figure.add_trace(go.Heatmap(z=SECOND, showscale=False), row=1, col=2)
+
+        grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+        (left,) = grid[0][0]["layers"]
+        (right,) = grid[0][1]["layers"]
+        assert left["selectors"] == _image_selector(1)
+        assert right["selectors"] == _image_selector(1, ".subplot.x2y2")


### PR DESCRIPTION
Closes #647.

`PlotlyHeatmapPlot._get_selector` returned an unindexed selector:

```python
return f"{self._subplot_css_prefix()}.heatmaplayer image"
```

`Svg.selectElement` takes `document.querySelector`, which answers with the first match, so a subplot holding two images had **both** layers naming the same one — a highlight that resolves to a real element and the wrong one. Reachable with two `go.Heatmap` traces (always was), and reachable a second way since #645 read a `histogram2d` as a heatmap and inherited the selector.

## What plotly actually writes

Measured in Chromium, each `g.hm` read back through its own `__data__` so the pairing is plotly's rather than inferred from where the image landed:

| figure | DOM |
|---|---|
| `Heatmap, Histogram2d` | `hm[0]` heatmap, `hm[1]` histogram2d |
| `Histogram2d, Heatmap` | `hm[0]` histogram2d, `hm[1]` heatmap |
| `Heatmap, Histogram2d, Heatmap` | `hm[0..2]` in declaration order |
| `Histogram2d, Histogram2d` | `hm[0..1]` in declaration order |

So the two types are numbered together, in declaration order — which is what `layer_position` answers once `{heatmap, histogram2d}` joins `_SHARED_LAYERS` beside `{box, candlestick}` (#395) and `{contour, histogram2dcontour}` (#643).

Two types that look like they should join the group and do not: a `contour` under `contours.coloring = "heatmap"` fills the whole field but paints inside its own `contourlayer` and adds no `g.hm`, and a `go.Image` has an `imagelayer` of its own. Both measured.

## The group carries the position, not the image

The selector the issue proposed does not work. `image:nth-of-type(N)` counts among an element's *siblings*, and each image is the only one inside its own `g.hm`. On a subplot with two:

```
g.heatmaplayer image                       2 matches
g.heatmaplayer image:nth-of-type(1)        2   <- both, being each its own first
g.heatmaplayer image:nth-of-type(2)        0
g.heatmaplayer g.hm:nth-of-type(1) image   1
g.heatmaplayer g.hm:nth-of-type(2) image   1
```

`:nth-of-type` counts by tag among all siblings, so it is exact only where they are homogeneous — the caution the contour selector spells out. Measured across five configurations, a `heatmaplayer` held nothing but `g.hm`.

## Declaration order, kept

Both image types are now built inside the trace loop rather than hoisted above it. The `histogram2d` block was hoisted, which cost the payload its ordering: `[Scatter, Histogram2d]` announced the histogram first. `[Scatter, Heatmap]` was correct only because the heatmap reached the factory, and moving it into a hoisted block would have broken it the same way — so neither is hoisted now, and both still get their position from the figure-wide pass.

## Verified end to end

Every emitted selector resolved in Chromium, its element's `g.hm` read back through `__data__`: five figures, every selector matching **exactly one** element, and that element's trace the one its layer was built from.

## Testing

- 10 new tests in `tests/plotly/test_plotly_image_layer_position.py`: both cross-type directions written separately (the asymmetry #395 was), three images in order, one image still first, a scatter and a heatmap-coloured contour not shifting it, the two declaration-order guards, and a second subplot counting its own.
- Four mutations killed: the shared group removed (3 fail), the position never passed (4), `image:nth-of-type` instead of the group (10), and the image block hoisted above the loop (3).
- `tests/plotly` 1274 passed; `tests/core` 1931 passed / 5 skipped; the rest 1459 passed / 13 skipped. `ruff check` clean.
- Two existing selector assertions in `test_plotly_histogram2d.py` updated, and two docstrings that quoted the old selector.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_