### PR TITLE
fix(plotly): name a markers-only radar's markers, not a path it has none of

### DIFF
--- a/maidr/plotly/polar.py
+++ b/maidr/plotly/polar.py
@@ -65,13 +65,62 @@ class PlotlyPolarPlot(PlotlyPlot):
         Neither says what a reader means by "where am I", so the layer ships
         without a highlight and keeps its audio, braille and text -- the
         outcome #145 established for a layer with nothing to point at.
+
+        ## When there is no outline
+
+        "Exactly one ``path.js-line`` per trace" holds for every mode that
+        draws a line and for none that does not, which is a distinction the
+        original measurement did not have to make. Measured again in
+        Chromium on ``r=[1, 2, 3]``, counting inside the trace's own ``<g>``:
+
+        .. code-block:: text
+
+            mode                 path.js-line   g.points path.point
+            unset (default)            1               3
+            "lines"                    1               3
+            "lines+markers"            1               3
+            "markers"                  0               3
+            "text"                     0               0
+
+        So a markers-only radar named an element plotly never drew and the
+        layer lost its highlight entirely (#656). Its markers are named
+        instead: one ``path.point`` per sample, which is the shape
+        `LineTrace.mapViaDomElements` already takes -- a selector whose match
+        count equals the series' point count is used element for element,
+        with no path to parse.
+
+        A ``mode="text"`` trace draws neither, and keeps no selector for the
+        reason ``barpolar`` has none.
         """
         if self.type is not PlotType.RADAR:
             return []
+        drawn = self._drawn_mark()
+        if drawn is None:
+            return []
         return [
             f".polarlayer > g.{self._subplot} .scatterlayer "
-            f".trace:nth-child({self._trace_position + 1}) path.js-line"
+            f".trace:nth-child({self._trace_position + 1}) {drawn}"
         ]
+
+    def _drawn_mark(self) -> str | None:
+        """The element this trace draws for a reader to be pointed at.
+
+        Read from ``mode`` rather than from the drawing, which is not
+        available here. An absent ``mode`` is plotly's default and always
+        includes lines -- ``"lines+markers"`` up to twenty points and
+        ``"lines"`` beyond -- so it takes the outline.
+
+        Returns
+        -------
+        str or None
+            The element to name, or None when the trace draws no mark.
+        """
+        mode = self._trace.get("mode")
+        if mode is None or "lines" in str(mode):
+            return "path.js-line"
+        if "markers" in str(mode):
+            return "g.points path.point"
+        return None
 
     def _extract_axes_data(self) -> dict:
         """Name the angle and the radius.

--- a/tests/plotly/test_plotly_polar.py
+++ b/tests/plotly/test_plotly_polar.py
@@ -150,6 +150,75 @@ def test_a_radar_addresses_its_outline() -> None:
     ]
 
 
+def test_a_markers_only_radar_addresses_its_markers() -> None:
+    """"One `path.js-line` per trace" holds only where a line is drawn.
+
+    A markers-only `scatterpolar` draws none, so the selector resolved to
+    nothing at all and the layer lost its highlight while its reading, its
+    sonification and its braille stayed correct (#656). Measured in
+    Chromium on three spokes, counting inside the trace's own `<g>`:
+
+    ```
+    mode                 path.js-line   g.points path.point
+    unset (default)            1               3
+    "lines"                    1               3
+    "lines+markers"            1               3
+    "markers"                  0               3
+    "text"                     0               0
+    ```
+
+    One `path.point` per sample is the shape `LineTrace.mapViaDomElements`
+    already takes: a selector whose match count equals the series' point
+    count is used element for element, with no path to parse.
+    """
+    (layer,) = _layers(
+        go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES, mode="markers")])
+    )
+
+    assert layer["selectors"] == [
+        ".polarlayer > g.polar .scatterlayer .trace:nth-child(1) "
+        "g.points path.point"
+    ]
+
+
+@pytest.mark.parametrize("mode", ["lines", "lines+markers", "markers+lines"])
+def test_a_radar_that_draws_a_line_still_addresses_it(mode: str) -> None:
+    """The outline is preferred wherever there is one.
+
+    It is one element for the whole series, which is what the multi-series
+    contract wants; the markers are the fallback rather than the reading.
+    """
+    (layer,) = _layers(
+        go.Figure([go.Scatterpolar(r=RADII, theta=SPOKES, mode=mode)])
+    )
+
+    assert layer["selectors"] == [
+        ".polarlayer > g.polar .scatterlayer .trace:nth-child(1) path.js-line"
+    ]
+
+
+def test_a_text_only_radar_is_read_but_not_addressed() -> None:
+    """Nothing is drawn to point at, so nothing is named.
+
+    The outcome #145 established and `barpolar` already has: the layer
+    keeps its audio, braille and text and ships without a highlight, rather
+    than naming an element the chart does not draw.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Scatterpolar(
+                    r=RADII, theta=SPOKES, mode="text", text=list("abcd")
+                )
+            ]
+        )
+    )
+
+    assert layer["type"] == PlotType.RADAR
+    assert "selectors" not in layer
+    assert _spokes(layer) == list(zip(SPOKES, RADII))
+
+
 def test_a_polar_area_is_read_but_not_addressed() -> None:
     """A stated limit, not an oversight.
 


### PR DESCRIPTION
Closes #656.

`PolarPlot._get_selector` named the trace's outline:

```python
f".polarlayer > g.{self._subplot} .scatterlayer "
f".trace:nth-child({self._trace_position + 1}) path.js-line"
```

Its docstring said, and measured correctly at the time, that "a `scatterpolar` draws exactly one `path.js-line` per trace". That holds for every mode which draws a line, and `mode="markers"` is not one of them — so the selector resolved to **nothing** and the layer shipped a highlight that finds no element, while the reading, the sonification and the braille stayed correct.

## Measured

Chromium, plotly 3.5.0, `go.Scatterpolar(r=[1, 2, 3], theta=[0, 120, 240])` with the mode varied, counting inside the trace's own `<g>`:

| `mode` | `path.js-line` | `g.points path.point` |
|---|---|---|
| unset (default) | 1 | 3 |
| `"lines"` | 1 | 3 |
| `"lines+markers"` | 1 | 3 |
| `"markers"` | **0** | 3 |
| `"text"` | 0 | 0 |
| `fill="toself"`, mode unset | 1 | 3 |

Resolving the emitted selector against the drawn chart gave `[1, 1, 1, 0, 0, 1]` before, and `[1, 1, 3, 1, —, 1]` after.

## The reading

The markers are named when there is no line: one `path.point` per sample, which is the shape `LineTrace.mapViaDomElements` already takes — a selector whose match count equals the series' point count is used element for element, with no path to parse. `RadarTrace` extends `LineTrace`, so nothing in the core moves.

The outline is still preferred wherever there is one: it is a single element for the whole series, which is what the multi-series contract wants, and the markers are the fallback rather than the reading.

A `mode="text"` trace draws neither and keeps no selector, for the reason `barpolar` has none (#635, and #145 before it): there is no mark to point at, and a highlight that outlines the whole group says the same thing at every step.

An absent `mode` is read as drawing a line, which is plotly's own default — `lines+markers` up to twenty points, `lines` beyond — and both include one.

## How it was found

By resolving every emitted plotly selector against the drawn chart in Chromium: twenty-seven figures across the plotly trace types, and this was the one selector that matched zero elements. That is the check #644 asks for and nothing in the repo does; the harness for it is the follow-up, and this is what it found first.

## Testing

- Four new tests in `tests/plotly/test_plotly_polar.py`: the markers-only selector, the three line-drawing modes still taking the outline (parametrized), and a text-only radar read but not addressed.
- Four mutations killed: always the line, never the markers, an absent `mode` not read as a line, and a text-only trace falling back to the line.
- `tests/plotly` 1279 passed; the rest 1464 passed / 13 skipped. `ruff check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_