### PR TITLE
feat(seaborn): name every panel of a pairplot and a jointplot

### DIFF
--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -6,6 +6,7 @@ from matplotlib.axes import Axes
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.util.grid_position import topmost_subplotspec
+from maidr.util.panel_title import panel_title
 from maidr.util.mixin import FormatExtractorMixin
 
 # uuid is used to generate unique identifiers for each plot layer in the MAIDR schema.
@@ -159,7 +160,9 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         maidr_schema = {
             MaidrKey.ID: str(uuid.uuid4()),
             MaidrKey.TYPE: self.type,
-            MaidrKey.TITLE: self.ax.get_title(),
+            # The caller's own title wins; the generated one names a panel
+            # of a seaborn grid, which seaborn leaves untitled (#660).
+            MaidrKey.TITLE: self.ax.get_title() or panel_title(self.ax),
             MaidrKey.AXES: axes_data,
             MaidrKey.DATA: self._extract_plot_data(),
         }

--- a/maidr/patch/__init__.py
+++ b/maidr/patch/__init__.py
@@ -19,6 +19,7 @@ from . import (  # noqa: E402, F401
     eventplot,
     fillbetween,
     gantt,
+    grid_panel,
     heatmap,
     hexbin,
     highlight,

--- a/maidr/patch/grid_panel.py
+++ b/maidr/patch/grid_panel.py
@@ -1,0 +1,182 @@
+"""
+Name the panels of a seaborn ``PairGrid`` or ``JointGrid``.
+
+seaborn titles neither grid's cells, so every panel of a pairplot announced
+as ``Subplot N`` and a reader arrowing a 3x3 grid had to enter each panel and
+read a data point to find out which pair of variables it was about (#660).
+
+Both grids declare what each panel is, so the name is looked up rather than
+guessed -- see :mod:`maidr.util.panel_title` for why that distinction is the
+whole basis for doing this at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import wrapt
+
+from maidr.util.panel_title import remember_panel_title
+
+
+def _pair_title(row_var: str, col_var: str) -> str:
+    """
+    What an off-diagonal pair panel is called.
+
+    ``"y vs x"``, in the order the panel's own axis labels announce once a
+    reader is inside it -- so the lobby and the panel agree about which
+    variable is which.
+
+    Parameters
+    ----------
+    row_var : str
+        The variable on y.
+    col_var : str
+        The variable on x.
+
+    Returns
+    -------
+    str
+        The panel's name, or ``""`` when either variable is unnamed.
+    """
+    if not row_var or not col_var:
+        return ""
+    return f"{row_var} vs {col_var}"
+
+
+def _name_pair_cells(grid: Any) -> None:
+    """
+    Name every cell of a ``PairGrid``.
+
+    Called after ``__init__``, when the grid knows its variables and its
+    cells exist but nothing has been drawn into them yet -- which is early
+    enough, because a layer's title is read at schema time rather than at
+    registration.
+
+    The diagonal is **not** named here even when a cell sits on it: with a
+    univariate diagonal the data goes on a twin axes created later, and with
+    no diagonal at all (``diag_kind=None``, or a bare ``PairGrid`` mapped
+    with ``map``) the cell really does hold one variable against itself, and
+    ``"x vs x"`` is what that draws.
+
+    Parameters
+    ----------
+    grid : Any
+        The ``PairGrid``.
+    """
+    axes = getattr(grid, "axes", None)
+    x_vars = list(getattr(grid, "x_vars", ()) or ())
+    y_vars = list(getattr(grid, "y_vars", ()) or ())
+    if axes is None or not x_vars or not y_vars:
+        return
+
+    # `corner=True` leaves the upper triangle's cells as None, which
+    # `remember_panel_title` skips -- the grid is always exactly
+    # len(y_vars) x len(x_vars), so there is no index to guard against.
+    for r, row in enumerate(axes):
+        for c, cell in enumerate(row):
+            remember_panel_title(cell, _pair_title(y_vars[r], x_vars[c]))
+
+
+def _name_diagonal(grid: Any) -> None:
+    """
+    Name the univariate panels down a ``PairGrid``'s diagonal.
+
+    ``map_diag`` is what creates them, and it creates **twin** axes rather
+    than using the grid cells: measured on seaborn 0.13.2,
+    ``diag_axes[0] is axes[0][0]`` is False, and a title set on the cell
+    never reaches the histogram drawn on the twin. So this runs after
+    ``map_diag`` and addresses the twins.
+
+    Each is one variable's distribution, so it is named by that variable --
+    the same shape the off-diagonals use, with one name instead of two.
+
+    Parameters
+    ----------
+    grid : Any
+        The ``PairGrid``, after ``map_diag``.
+    """
+    diag_axes = getattr(grid, "diag_axes", None)
+    diag_vars = list(getattr(grid, "diag_vars", ()) or ())
+    if diag_axes is None:
+        return
+    for i, ax in enumerate(diag_axes):
+        if i < len(diag_vars):
+            remember_panel_title(ax, diag_vars[i])
+
+
+def _name_joint_panels(grid: Any) -> None:
+    """
+    Name a ``JointGrid``'s three panels.
+
+    The grid names them structurally -- ``ax_joint`` is the bivariate panel,
+    ``ax_marg_x`` and ``ax_marg_y`` the two marginals -- so which variable
+    each is about is declared rather than read off the layout.
+
+    Parameters
+    ----------
+    grid : Any
+        The ``JointGrid``.
+    """
+    joint = getattr(grid, "ax_joint", None)
+    if joint is None:
+        return
+    # ``JointGrid.__init__`` labels the joint axes from the variable names it
+    # was given, so the label is the name. Measured across five spellings --
+    # ``data=`` plus column names, two named Series, both through
+    # ``jointplot``, and bare arrays -- ``grid.x.name`` and
+    # ``ax_joint.get_xlabel()`` never disagreed, including on the arrays,
+    # where both are empty. Reading the Series as well would be a second
+    # source for one fact.
+    x_name = joint.get_xlabel()
+    y_name = joint.get_ylabel()
+
+    remember_panel_title(joint, _pair_title(y_name, x_name))
+    # A marginal is one variable's distribution, named the way a pair grid's
+    # diagonal is: the top marginal draws x, the right marginal draws y.
+    remember_panel_title(getattr(grid, "ax_marg_x", None), x_name)
+    remember_panel_title(getattr(grid, "ax_marg_y", None), y_name)
+
+
+def _after(name: Callable[[Any], None]) -> Callable:
+    """
+    Build a wrapper that runs ``name`` on the grid once the wrapped call
+    returns.
+
+    Both wrapped methods are asked about state the call itself produces --
+    the cells, or the diagonal twins -- so naming has to happen afterwards.
+    A failure to name a panel must not take the chart down with it, so
+    anything raised here is swallowed: the cost is a panel announced by its
+    position, which is exactly what it did before.
+
+    Parameters
+    ----------
+    name : callable
+        Given the grid, records its panels' titles.
+
+    Returns
+    -------
+    callable
+        A ``wrapt`` wrapper.
+    """
+
+    def wrapper(wrapped, instance, args, kwargs):
+        result = wrapped(*args, **kwargs)
+        try:
+            name(instance)
+        except Exception:
+            pass
+        return result
+
+    return wrapper
+
+
+wrapt.wrap_function_wrapper(
+    "seaborn.axisgrid", "PairGrid.__init__", _after(_name_pair_cells)
+)
+wrapt.wrap_function_wrapper(
+    "seaborn.axisgrid", "PairGrid.map_diag", _after(_name_diagonal)
+)
+wrapt.wrap_function_wrapper(
+    "seaborn.axisgrid", "JointGrid.__init__", _after(_name_joint_panels)
+)

--- a/maidr/util/panel_title.py
+++ b/maidr/util/panel_title.py
@@ -1,0 +1,88 @@
+"""
+Generated titles for the panels of a seaborn grid.
+
+A layer's title is the axes title (``MaidrPlot._schema``), and it is what the
+core reads back when a reader arrows across a multi-panel figure's lobby:
+
+    Subplot 2 of 9, bill_length_mm vs bill_depth_mm: This is a point plot.
+
+seaborn's ``PairGrid`` and ``JointGrid`` set no titles on their cells -- they
+label the grid's outer edge with axis labels instead -- so every panel of a
+pairplot announced as ``Subplot N`` and nothing more, on a chart whose whole
+purpose is that its panels are comparable (#660).
+
+**The panel's identity is declared, not inferred.** ``PairGrid`` knows its
+``x_vars``, ``y_vars`` and ``diag_vars``; ``JointGrid`` names its three axes
+structurally. So a title is read off what the grid was *told*, never off
+where a panel sits or what its neighbours look like -- which is the
+distinction #516 drew when it removed the axis-label-from-position heuristic,
+and the reason this is a lookup rather than a guess.
+
+Two things follow from titles being generated:
+
+* They are a **fallback**, never an override. A caller's own ``set_title``
+  wins, because that is the panel's name and this is only a name for a panel
+  that has none.
+* They are generated the **same way every time**, so a reader who learns what
+  ``"bill_length_mm vs bill_depth_mm"`` means on one panel knows it on all of
+  them.
+"""
+
+from __future__ import annotations
+
+import weakref
+
+from matplotlib.axes import Axes
+
+#: Generated title per panel axes.
+#:
+#: Weakly keyed so a closed figure's panels are collected with it, and holding
+#: **plain strings** rather than the grid they were read from: a
+#: ``WeakKeyDictionary`` whose values reach their own keys never collects
+#: anything, which is the trap ``FigureManager`` records for its own map. A
+#: resolved string reaches nothing.
+_TITLES: weakref.WeakKeyDictionary[Axes, str] = weakref.WeakKeyDictionary()
+
+
+def remember_panel_title(ax: Axes | None, title: str) -> None:
+    """
+    Record the title generated for one panel.
+
+    Parameters
+    ----------
+    ax : Axes or None
+        The panel. ``None`` is accepted and ignored -- a ``corner=True``
+        ``PairGrid`` leaves the upper triangle's cells unfilled, and the
+        caller should not have to say so twice.
+    title : str
+        The generated title. A blank one is recorded and read back as blank,
+        which is the same answer as never recording it: a panel with nothing
+        to say falls back to its position, which is what it did before and is
+        honest about knowing no name.
+    """
+    if ax is None:
+        return
+    _TITLES[ax] = title
+
+
+def panel_title(ax: Axes) -> str:
+    """
+    The generated title for a panel, or the empty string.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes a layer was drawn on.
+
+    Returns
+    -------
+    str
+        The title generated for this panel, or ``""`` when it is not a
+        seaborn grid panel -- every ordinary chart, which is unaffected.
+    """
+    try:
+        return _TITLES.get(ax, "")
+    except TypeError:
+        # An axes stand-in that cannot be weakly referenced (a test double,
+        # a mock). Not having a generated title is the correct answer for it.
+        return ""

--- a/tests/core/plot/test_grid_panel_titles.py
+++ b/tests/core/plot/test_grid_panel_titles.py
@@ -1,0 +1,232 @@
+"""
+Every panel of a ``pairplot`` announced itself as ``Subplot N`` (#660).
+
+A layer's title is the axes title, and seaborn titles neither grid's cells --
+it labels the grid's outer edge with axis labels instead. So the figure
+lobby, which reads back the focused subplot's title, had nothing to read::
+
+    Subplot 1 of 9: This is a hist plot.  Press 'ENTER' to select this subplot.
+    Subplot 2 of 9: This is a point plot. Press 'ENTER' to select this subplot.
+    Subplot 3 of 9: This is a point plot. Press 'ENTER' to select this subplot.
+
+Six of the nine were ``point`` and three were ``hist``, and nothing told them
+apart. A reader looking for "flipper length against bill depth" had to enter
+each panel, read a data point for its axis labels, and back out -- nine
+times, on a chart whose entire purpose is that its panels are comparable.
+
+The names are **looked up, not inferred**: ``PairGrid`` declares its
+``x_vars``, ``y_vars`` and ``diag_vars``, and ``JointGrid`` names its three
+axes structurally, so nothing here reads a panel's meaning off where it sits.
+That distinction is the one #516 drew when it removed the
+axis-label-from-position heuristic.
+
+Measured on seaborn 0.13.2, and the reason the diagonal needs its own pass:
+
+    diag_axes[0] is axes[0][0]?  False
+
+``map_diag`` draws a pairplot's univariate panels on **twin** axes, so a
+title recorded against the grid cell never reaches the histogram.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn as sns
+from seaborn.axisgrid import PairGrid
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    return pd.DataFrame(
+        {
+            "alpha": rng.normal(size=30),
+            "beta": rng.normal(size=30) + 1,
+            "gamma": rng.normal(size=30) + 2,
+        }
+    )
+
+
+def _titles(fig) -> list[tuple[str, str]]:
+    """Every layer as ``(type, title)``, after a real render."""
+    maidr.render(fig)._repr_html_()
+    return [
+        (plot.type.value, plot.schema.get("title"))
+        for plot in FigureManager.get_maidr(fig).plots
+    ]
+
+
+def test_a_pairplots_panels_name_the_variables_they_draw():
+    titles = _titles(sns.pairplot(_frame(), vars=["alpha", "beta"]).figure)
+
+    # "y vs x", in the order the panel's own axis labels announce once a
+    # reader is inside it, so the lobby and the panel agree.
+    assert sorted(titles) == sorted(
+        [
+            ("hist", "alpha"),
+            ("point", "alpha vs beta"),
+            ("point", "beta vs alpha"),
+            ("hist", "beta"),
+        ]
+    )
+
+
+def test_every_panel_of_a_three_variable_pairplot_is_distinct():
+    # The cost this fixes, stated as the property that was missing: nine
+    # panels, and no two announcing the same thing.
+    titles = _titles(sns.pairplot(_frame()).figure)
+
+    assert len(titles) == 9
+    assert len({title for _, title in titles}) == 9
+    assert all(title for _, title in titles)
+
+
+def test_a_diagonal_panel_is_named_though_it_is_drawn_on_a_twin():
+    # `map_diag` puts the univariate panel on a twin of the grid cell, so a
+    # title recorded against the cell reaches nothing. Asserted directly:
+    # without the `map_diag` pass these three come back empty.
+    titles = _titles(sns.pairplot(_frame()).figure)
+
+    assert sorted(t for kind, t in titles if kind == "hist") == [
+        "alpha",
+        "beta",
+        "gamma",
+    ]
+
+
+def test_a_jointplots_three_panels_are_named():
+    # Each panel is pinned by its own axis labels rather than by a sorted bag
+    # of titles: both marginals are `hist` and both are named after one of
+    # the same two variables, so a bag cannot tell the top marginal from the
+    # right one -- and naming them after each other is exactly the mistake
+    # worth catching. The top marginal draws x against a count; the right
+    # marginal is the same figure turned on its side.
+    grid = sns.jointplot(data=_frame(), x="alpha", y="beta")
+    maidr.render(grid.figure)._repr_html_()
+    panels = [
+        (
+            plot.type.value,
+            plot.schema.get("title"),
+            plot.schema["axes"]["x"]["label"],
+            plot.schema["axes"]["y"]["label"],
+        )
+        for plot in FigureManager.get_maidr(grid.figure).plots
+    ]
+
+    assert sorted(panels) == sorted(
+        [
+            ("hist", "alpha", "alpha", "Count"),
+            ("point", "beta vs alpha", "alpha", "beta"),
+            ("hist", "beta", "Count", "beta"),
+        ]
+    )
+
+
+def test_an_authors_own_title_wins():
+    # The generated name is a fallback for a panel with none, never an
+    # override -- a caller who titled the panel has said what it is called.
+    grid = sns.pairplot(_frame(), vars=["alpha", "beta"])
+    grid.axes[0][1].set_title("author said so")
+    grid.diag_axes[0].set_title("and here too")
+
+    titles = _titles(grid.figure)
+
+    assert sorted(titles) == sorted(
+        [
+            ("hist", "and here too"),
+            ("point", "author said so"),
+            ("point", "beta vs alpha"),
+            ("hist", "beta"),
+        ]
+    )
+
+
+def test_a_corner_pairplot_names_the_half_it_draws():
+    # `corner=True` leaves the upper triangle's cells as None, which the
+    # naming pass has to walk past rather than trip over.
+    titles = _titles(sns.pairplot(_frame(), corner=True).figure)
+
+    assert sorted(titles) == sorted(
+        [
+            ("hist", "alpha"),
+            ("hist", "beta"),
+            ("hist", "gamma"),
+            ("point", "beta vs alpha"),
+            ("point", "gamma vs alpha"),
+            ("point", "gamma vs beta"),
+        ]
+    )
+
+
+def test_a_grid_with_different_row_and_column_variables_is_named():
+    # `x_vars` and `y_vars` need not match, and then there is no diagonal at
+    # all -- so the row/column lookup has to be by its own index rather than
+    # by a shared variable list.
+    grid = PairGrid(_frame(), x_vars=["alpha"], y_vars=["beta", "gamma"])
+    grid.map(sns.scatterplot)
+
+    assert sorted(_titles(grid.figure)) == sorted(
+        [
+            ("point", "beta vs alpha"),
+            ("point", "gamma vs alpha"),
+        ]
+    )
+
+
+def test_a_diagonal_cell_mapped_as_a_scatter_says_so():
+    # `PairGrid.map` draws every cell including the diagonal, and there the
+    # panel really is one variable against itself. "alpha vs alpha" is what
+    # it draws, so it is what it is called.
+    grid = PairGrid(_frame(), vars=["alpha", "beta"])
+    grid.map(sns.scatterplot)
+
+    assert ("point", "alpha vs alpha") in _titles(grid.figure)
+
+
+def test_a_jointplot_of_unnamed_vectors_keeps_its_position():
+    # Nothing named the variables, so there is no name to announce. Falling
+    # back to the bare position is what a panel that knows no name should do,
+    # rather than inventing one from the numbers.
+    rng = np.random.default_rng(1)
+    grid = sns.jointplot(x=rng.normal(size=30), y=rng.normal(size=30))
+
+    assert {title for _, title in _titles(grid.figure)} == {""}
+
+
+def test_an_ordinary_chart_is_untouched():
+    # Every chart that is not a grid panel, which is nearly all of them.
+    fig, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+
+    assert _titles(fig) == [("point", "")]
+
+
+def test_an_ordinary_chart_keeps_the_title_it_was_given():
+    fig, ax = plt.subplots()
+    ax.scatter([1, 2, 3], [4, 5, 6])
+    ax.set_title("a chart of its own")
+
+    assert _titles(fig) == [("point", "a chart of its own")]
+
+
+def test_a_facet_grids_own_titles_are_untouched():
+    # seaborn *does* title a `FacetGrid`'s panels -- "g = x", "g = y" -- and
+    # a FacetGrid is neither of the two grids named here. Asserted so that
+    # naming pair and joint panels cannot start overwriting the one grid that
+    # already says what its panels are.
+    frame = _frame()
+    frame["g"] = ["x"] * 15 + ["y"] * 15
+    grid = sns.relplot(data=frame, x="alpha", y="beta", col="g")
+
+    assert sorted(_titles(grid.figure)) == [("point", "g = x"), ("point", "g = y")]


### PR DESCRIPTION
Closes #660 — the last item of #342's "what is actually new" list.

## What a reader heard

A layer's title is the axes title, read at schema time, and a `PairGrid` cell has none: seaborn labels the grid's outer edge with axis labels and never titles the cells. Measured, `sns.pairplot(penguins, vars=[...])`:

```
axes titles: [['', '', ''], ['', '', ''], ['', '', '']]
```

so the figure lobby announced

```
Subplot 1 of 9: This is a hist plot.  Press 'ENTER' to select this subplot.
Subplot 2 of 9: This is a point plot. Press 'ENTER' to select this subplot.
Subplot 3 of 9: This is a point plot. Press 'ENTER' to select this subplot.
…
```

Six of the nine were `point`, three were `hist`, and nothing distinguished them. A reader looking for "flipper length against bill depth" had to enter each panel, read a data point for its axis labels, and back out — nine times, on a chart whose entire purpose is that its panels are comparable. The axis labels inside each panel were already right, which is why this only bit in the lobby.

Now:

```
Subplot 1 of 9, bill_length_mm: This is a hist plot.
Subplot 2 of 9, bill_length_mm vs bill_depth_mm: This is a point plot.
```

## Looked up, not inferred

`PairGrid` declares `x_vars`, `y_vars` and `diag_vars`; `JointGrid` names its three axes structurally. So the title is read off what the grid was **told**, never off where a panel sits or what its neighbours look like — the distinction #516 drew when it removed the axis-label-from-position heuristic. `maidr/util/panel_title.py` says so at the top, because the whole basis for doing this at all is that these two grids declare their panels' roles.

| panel | title |
|---|---|
| pairplot off-diagonal *(r, c)* | `"{y_vars[r]} vs {x_vars[c]}"` |
| pairplot diagonal *i* | `"{diag_vars[i]}"` |
| jointplot joint | `"{y} vs {x}"` |
| jointplot top / right marginal | `"{x}"` / `"{y}"` |

"y vs x" is the order the panel's own axis labels announce once a reader is inside it, so the lobby and the panel agree about which variable is which.

**A caller's own `set_title` wins.** The generated name is a fallback for a panel that has none, never an override.

## The thing that had to be got right

A pairplot's diagonal is drawn on a **twin** axes, not on the grid cell. Measured on seaborn 0.13.2:

```
diag_axes[0] is axes[0][0]?  False
```

and it shows from the outside — setting titles on `g.axes` alone reaches the off-diagonals and leaves the diagonals blank. So `map_diag` is wrapped separately and addresses the twins. Titles are read live at schema time rather than frozen at registration, so nothing has to run before the panels draw.

## Falsification

12 tests in `tests/core/plot/test_grid_panel_titles.py`, covering `corner=True` (the upper triangle's cells are `None`), `x_vars` ≠ `y_vars` (no diagonal at all), a bare `PairGrid(...).map(...)` (where the diagonal cell really is one variable against itself, and says so), a jointplot of unnamed arrays (which keeps its position rather than inventing a name), an ordinary chart, and a `FacetGrid` — whose own `"g = x"` panel titles must not start being overwritten.

**8 mutations, all killed.** The first sweep left four survivors and each was resolved rather than argued away:

| survivor | resolution |
|---|---|
| swapping the two marginals' names | the test compared a *sorted bag* of `(type, title)`, and both marginals are `hist` named after one of the same two variables — so the swap was invisible. Sharpened to pin each panel by its own axis labels. |
| taking the variable name from the axis label instead of the Series | measured across five spellings (`data=` plus column names, two named Series, both through `jointplot`, and bare arrays): `grid.x.name` and `ax_joint.get_xlabel()` never disagree, including on the arrays where both are empty. **Redundancy removed** — the Series read was a second source for one fact. |
| removing the row/column bounds check | `axes` is always exactly `len(y_vars) × len(x_vars)`, and a `corner=True` grid's unfilled cells are `None`, which the recorder already skips. **Dead branch removed.** |
| recording a blank title like any other | a blank recorded and a blank absent are the same answer. **Unobservable branch removed**, and the signature narrowed to `str`. |

The stacked-bar analogue of that first survivor was the same lesson in the other repo this session: a test that does not reproduce what the library actually puts on the object proves nothing.

## Testing

- `ruff check` clean on every changed file.
- Full suite: 1,464 passed / 65 skipped, then 1,943 passed / 5 skipped. No failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_