### PR TITLE
feat(seaborn): name a strip or swarm layer by the category it holds

### DIFF
--- a/maidr/patch/stripplot.py
+++ b/maidr/patch/stripplot.py
@@ -12,6 +12,7 @@ from matplotlib.collections import PathCollection
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.core.plot.scatterplot import (
     DRAWN_POINTS,
     GROUP_LABEL,
@@ -19,6 +20,7 @@ from maidr.core.plot.scatterplot import (
     _rgba,
 )
 from maidr.patch.common import _draw_quietly, plotter_axes
+from maidr.util.mixin import LineExtractorMixin
 
 
 def _point_colours(collection: PathCollection) -> list:
@@ -173,6 +175,64 @@ def _hue_levels(
     )
 
 
+def _collection_category(ax: Axes, collection: PathCollection) -> str | None:
+    """
+    The one category a collection's points all sit in, where there is one.
+
+    A strip or swarm drawn without a hue gets a collection per category, and
+    every point in it belongs to that category -- so the name is read off the
+    points rather than matched by colour, which is what makes this different
+    from the hue path above. Both axes are asked, because ``x='g', y='v'``
+    puts the names on x and ``y='g', x='v'`` puts them on y, and asking about
+    one alone was itself the #353 defect.
+
+    The tick lookup is the same pair ``ScatterPlot`` uses for a point's own
+    ``xLabel`` -- `_category_tick_labels` is empty on a numeric axis, which is
+    what stops a measurement being renamed after whichever tick it fell
+    nearest, and `_named_coordinate` rounds, which recovers the name of a
+    group a ``dodge`` shifted aside.
+
+    More than one name means the collection is not one category's -- a hue
+    level spanning them all -- and it is left unnamed rather than named after
+    whichever it drew first.
+
+    Parameters
+    ----------
+    ax : Axes
+        The panel drawn on.
+    collection : PathCollection
+        The points.
+
+    Returns
+    -------
+    str or None
+        The category, or ``None`` when the collection spans several or the
+        axes name none.
+    """
+    # An empty collection -- the one a faceted panel gets for a category it
+    # holds none of -- comes back shaped (0, 2), measured, so the column
+    # below is an empty array rather than an index error, and the set it
+    # builds is empty. It falls out at the count check with the rest.
+    offsets = np.asarray(collection.get_offsets())
+
+    for axis, column in (("x", 0), ("y", 1)):
+        ticks = LineExtractorMixin._category_tick_labels(ax, axis)
+        names = {
+            LineExtractorMixin._named_coordinate(float(value), ticks)
+            for value in offsets[:, column]
+        }
+        if len(names) != 1:
+            continue
+        name = names.pop()
+        # A numeric axis answers with the coordinate rather than a name --
+        # `_named_coordinate` guarantees it, so that a measurement cannot be
+        # renamed after whichever tick it fell nearest -- and this is where
+        # that answer is declined.
+        if isinstance(name, str):
+            return name
+    return None
+
+
 def _added(ax: Axes, before: set) -> list:
     """
     The collections this call put on one panel, in drawing order.
@@ -282,8 +342,15 @@ def sns_categorical_points(
         levels = _hue_levels(instance, added)
         if levels is None:
             for collection in added:
+                # Named by the category it holds, which is on its own points.
+                # Without it a reader switching layers heard "point plot"
+                # three times, on a chart whose layers are the categories --
+                # while the same call with a `hue=` that changes nothing
+                # about the split named all three (#662).
+                category = _collection_category(ax, collection)
+                extra = {GROUP_NAME: category} if category else {}
                 FigureManager.create_maidr(
-                    ax, PlotType.SCATTER, **{DRAWN_POINTS: collection}
+                    ax, PlotType.SCATTER, **{DRAWN_POINTS: collection, **extra}
                 )
             continue
 

--- a/tests/core/plot/test_categorical_scatter_hue.py
+++ b/tests/core/plot/test_categorical_scatter_hue.py
@@ -154,7 +154,11 @@ class TestAHueGroupedCategoricalScatter:
         figure, ax = plt.subplots()
         getattr(sns, plot)(data=frame(), x="cat", y="val", ax=ax)
 
-        assert names(figure) == [None, None, None]
+        # The layers now carry the category each holds (#662). That is not a
+        # hue grouping and does not pretend to be one: no `z` axis, which is
+        # what a hue-read layer declares and what the declines below assert.
+        assert names(figure) == CATEGORIES
+        assert [z_label(layer) for layer in layers(figure)] == [None, None, None]
         assert [len(layer["data"]) for layer in layers(figure)] == [6, 6, 6]
         assert len(set(announced(figure))) == 18
 
@@ -208,6 +212,109 @@ class TestTheShapesTheGroupingSurvives:
         assert [z_label(layer) for layer in layers(figure)] == ["cat"] * 3
 
 
+class TestTheCategoryEachLayerHolds:
+    """
+    A layer names the category it is (#662).
+
+    The split into one layer per category is #426's, unchanged. What was
+    missing is the name on each: a reader arrowing between layers heard
+    "point plot" three times, on a chart whose layers *are* the categories --
+    while the same call with a ``hue=`` that changes nothing about the split
+    named all three. The name is read off the layer's own points, against the
+    same tick lookup ``ScatterPlot`` uses for a point's ``xLabel``, so it is
+    the word the chart prints under the strip.
+    """
+
+    @pytest.mark.parametrize("plot", ["stripplot", "swarmplot"])
+    def test_a_strip_names_the_category_it_draws(self, plot):
+        figure, ax = plt.subplots()
+        getattr(sns, plot)(data=frame(), x="cat", y="val", ax=ax)
+
+        assert names(figure) == CATEGORIES
+
+    def test_a_horizontal_strip_is_named_too(self):
+        # The names are on y here, and asking about x alone was itself the
+        # #353 defect -- so both axes are asked.
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), y="cat", x="val", ax=ax)
+
+        assert names(figure) == CATEGORIES
+
+    def test_a_numerically_grouped_strip_is_named_as_the_chart_labels_it(self):
+        # Written the other way round first, expecting no names at all, and
+        # the measurement said otherwise. `stripplot` categorises its
+        # grouping axis whatever the column's dtype -- `plotter.var_types`
+        # reports `'categorical'` for a float column exactly as for a string
+        # one -- so seaborn draws one strip per distinct value and labels
+        # each tick with the value.
+        #
+        # The name is that tick, float artefacts and all, because every
+        # *point* of these layers already carries the same string on its
+        # `xLabel` and the axis already prints it. Declining at the layer
+        # while announcing at the point would be an inconsistency, not a
+        # safeguard. It is an unlovely chart, and it is unlovely on the page
+        # too: the ticks read "0.0", "0.2", "0.6000000000000001".
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame().assign(num=[0.0, 0.5, 1.0] * 6), x="num", y="val",
+                      ax=ax)
+
+        drawn_ticks = [tick.get_text() for tick in ax.get_xticklabels()]
+        assert names(figure) == drawn_ticks
+        assert [point["xLabel"] for layer in layers(figure)
+                for point in layer["data"][:1]] == drawn_ticks
+
+    def test_a_faceted_panel_names_what_it_holds(self):
+        # A `catplot` panel gets its layers the same way, and the panels here
+        # hold different categories: "p" has every "a" row and the "b" rows
+        # that are level x, "q" has the rest.
+        #
+        # seaborn gives every panel a collection for every category, so a
+        # panel holding none of one gets an empty collection -- which is
+        # registered, and which this deliberately does not name. There is no
+        # category in it to name it after, and a name read off the axis
+        # rather than off the points would announce a strip that was not
+        # drawn.
+        grid = sns.catplot(data=frame(), x="cat", y="val", col="col", kind="strip")
+
+        emitted = names(grid.figure)
+        assert [name for name in emitted if name is not None] == ["a", "b", "b", "c"]
+        assert emitted.count(None) == 2
+        assert [len(layer["data"]) for layer in layers(grid.figure)
+                if layer.get("name") is None] == [0, 0]
+
+    def test_a_collection_spanning_categories_is_not_named_after_one(self):
+        # Asked of the reader directly, because no chart reaching this branch
+        # produces such a collection: seaborn draws a strip per category
+        # whether the hue was read, declined or absent, so every collection
+        # the ungrouped path sees holds exactly one. The guard is what keeps
+        # that a fact about seaborn rather than an assumption -- a producer
+        # that ever handed over a mixed collection would be named after
+        # whichever category it drew first.
+        from maidr.patch.stripplot import _collection_category
+
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", ax=ax)
+        # One y, deliberately. x names two categories and is declined for
+        # that; y then names exactly one thing -- the number 1.0 -- and is
+        # declined because a coordinate is not a name. Two points at
+        # different heights would fall out on the count alone and never
+        # reach the second refusal.
+        spanning = ax.scatter([0.0, 1.0], [1.0, 1.0])
+
+        assert _collection_category(ax, spanning) is None
+        assert _collection_category(ax, ax.collections[0]) == "a"
+
+    def test_a_dodged_chart_is_still_named_by_its_levels(self):
+        # A hue that reads takes the other branch, and there the name is the
+        # level -- the category travels on each point's `xLabel` instead.
+        # Two namings, and only one of them can be the layer's.
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", dodge=True, ax=ax)
+
+        assert names(figure) == LEVELS
+        assert [z_label(layer) for layer in layers(figure)] == ["hue", "hue"]
+
+
 class TestWhatIsDeclined:
     def test_a_continuous_hue_is_not_a_grouping(self):
         # seaborn gives a numeric `hue=` one "level" per distinct value --
@@ -222,7 +329,12 @@ class TestWhatIsDeclined:
             ax=ax,
         )
 
-        assert names(figure) == [None, None, None]
+        # Asserted on the `z` axis rather than on the names, because the
+        # names are the *categories* now (#662) and always were the reading
+        # this chart keeps. A hue that was read declares the variable it
+        # grouped by; a hue that was declined declares nothing.
+        assert [z_label(layer) for layer in layers(figure)] == [None, None, None]
+        assert names(figure) == CATEGORIES
         assert [len(layer["data"]) for layer in layers(figure)] == [6, 6, 6]
 
 
@@ -238,23 +350,27 @@ class TestWhatIsDeclined:
         # The levels are matched on their three colour channels, so opacity
         # alone does not separate them -- and a palette that draws two levels
         # the same colour does not separate them at all. Measured: both come
-        # out as the ungrouped reading, three unnamed layers, rather than
-        # every point of both levels handed to whichever name matched first.
+        # out as the ungrouped reading -- three layers, one per category and
+        # named for it -- rather than every point of both levels handed to
+        # whichever name matched first.
         figure, ax = plt.subplots()
         sns.stripplot(data=frame(), x="cat", y="val", hue="hue", palette=palette, ax=ax)
 
-        assert names(figure) == [None, None, None]
+        assert [z_label(layer) for layer in layers(figure)] == [None, None, None]
+        assert names(figure) == CATEGORIES
         assert len(set(announced(figure))) == 18
 
     def test_a_hue_with_one_level_is_not_a_grouping(self):
         # Nothing to tell apart. A layer named "only" over every point says
-        # no more than the unnamed one it would replace.
+        # no more than the category name it would replace -- and the category
+        # is the thing these three layers actually differ by (#662).
         figure, ax = plt.subplots()
         sns.stripplot(
             data=frame().assign(one=["only"] * 18), x="cat", y="val", hue="one", ax=ax
         )
 
-        assert names(figure) == [None, None, None]
+        assert [z_label(layer) for layer in layers(figure)] == [None, None, None]
+        assert names(figure) == CATEGORIES
 
 
 class TestTheOrderAndTheNeighbours:


### PR DESCRIPTION
Closes #662. Found while measuring every plot on #255 to check whether that roadmap could be ticked — eight of the nine read cleanly, and this is the ninth's remainder.

## Measured

seaborn 0.13.2, three categories of ten points, the same call with and without a `hue=` that changes nothing about the split:

```
sns.stripplot(data=df, x="g", y="x")
  layer 0  point  name=None  xLabel='a'
  layer 1  point  name=None  xLabel='b'
  layer 2  point  name=None  xLabel='c'

sns.stripplot(data=df, x="g", y="x", hue="g")
  layer 0  point  name='a'   xLabel='a'
  layer 1  point  name='b'   xLabel='b'
  layer 2  point  name='c'   xLabel='c'
```

A reader switching layers on the first heard "point plot" three times, on a chart whose layers **are** the categories.

The split is #426's and is not in question — what was missing is the name on each, the position `MaidrLayer.name` was added for in xability/maidr#828. The name was already in hand: every point of layer *k* carries the category on its `xLabel`, so nothing is inferred or matched by colour. It is read off the layer's own points against the same tick lookup `ScatterPlot` uses for that field, so it is the word the chart prints under the strip. Both axes are asked, because `y="g"` puts the names on y and asking about x alone was itself the #353 defect.

## Six existing tests changed, and why

Each asserted `names(figure) == [None, None, None]` — as **evidence that a hue had been declined**, not as a statement about categories:

> seaborn gives a numeric `hue=` one "level" per distinct value … One layer per point is not a reading of it, so the chart keeps the reading it had.

The names no longer show that either way, so they now assert it on the `z` axis, which is what a hue-read layer declares and a declined one does not. Their subject — that the hue was not read, and the reading the chart keeps — is unchanged and now asserted directly rather than through a side-effect.

## Two things the tests caught that I had wrong

- **A numerically grouped strip.** I wrote a test expecting no names at all, and the measurement said otherwise: `stripplot` categorises its grouping axis whatever the column's dtype — `plotter.var_types` reports `'categorical'` for a float column exactly as for a string one — so seaborn draws one strip per distinct value and labels each tick with the value. The name is that tick, float artefacts and all, because every *point* of those layers **already** carries the same string on its `xLabel` and the axis already prints it (measured: the ticks read `"0.0"`, `"0.2"`, `"0.6000000000000001"`). Declining at the layer while announcing at the point would be an inconsistency, not a safeguard.
- **A faceted panel.** I expected every layer named; seaborn gives every panel a collection for every category, so a panel holding none of one gets an **empty** collection, which registers and is deliberately left unnamed — there is no category in it to name it after.

## Falsification

4 mutations, all killed. The first sweep left four survivors and each was resolved rather than argued away — three were redundancies removed after measuring the guarantee they duplicated:

| survivor | resolution |
|---|---|
| the empty-collection guard removed | measured: an empty collection's offsets come back shaped `(0, 2)`, so the column is an empty array rather than an index error and it falls out at the count check. **Guard removed.** |
| a numeric axis not skipped early | `_named_coordinate` documents and guarantees that it answers with the coordinate when the tick map is empty, and the `isinstance(str)` check already declines that. **Branch removed.** |
| a blank tick label accepted | `_category_tick_labels` filters blank labels before they enter the map. **Check removed**, keeping the `isinstance` half, which is load-bearing. |
| a collection spanning categories named after its first | not reachable through any chart — seaborn draws a strip per category whether the hue was read, declined or absent — so it is **asserted on the helper directly**, with a collection whose x names two categories and whose y names exactly one number, so both refusals are exercised. |

## Testing

- `ruff check maidr/` clean.
- Full suite: 1,464 passed / 65 skipped, then 1,950 passed / 5 skipped. No failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_