### PR TITLE
feat(core): read a baseline-anchored vlines as the spike chart it draws

### DIFF
--- a/maidr/core/plot/lollipop.py
+++ b/maidr/core/plot/lollipop.py
@@ -27,6 +27,12 @@ DRAWN_MARKS = "_maidr_marks"
 #: The artist carrying one element per mark, for highlighting.
 MARK_ARTIST = "_maidr_mark_artist"
 
+#: Whether the handed-over marks lie along x, so the chart is horizontal.
+#: Only the `DRAWN_MARKS` path reads it; a stem plot's container is measured
+#: instead. Defaults to vertical, which is what a correlogram can only have
+#: drawn and what `Axes.vlines` draws.
+MARKS_HORIZONTAL = "_maidr_marks_horizontal"
+
 
 def marks(container: StemContainer) -> list[tuple[int, float, float]]:
     """
@@ -174,11 +180,12 @@ class LollipopPlot(MaidrPlot):
             given = kwargs.get(DRAWN_MARKS, None)
             self._points = finite(given) if given is not None else []
             self._artist = kwargs.get(MARK_ARTIST, None)
-            # A correlogram stands its lags along x and its correlations up
-            # from zero, which is the default orientation. There is no
-            # spelling of `acorr` that turns it, so this is not read back off
-            # anything -- it is what the call can only have drawn.
-            self._horizontal = False
+            # Told rather than measured. A correlogram stands its lags along
+            # x and its correlations up from zero, and there is no spelling
+            # of `acorr` that turns it, so it says nothing and takes the
+            # default. `Axes.hlines` draws the same chart turned, and the
+            # only thing that knows which call was made is the patch (#664).
+            self._horizontal = bool(kwargs.get(MARKS_HORIZONTAL, False))
 
         # The element indices `_get_selector` addresses.
         self._drawn = [index for index, _, _ in self._points]

--- a/maidr/core/plot/spanplot.py
+++ b/maidr/core/plot/spanplot.py
@@ -125,9 +125,15 @@ def states_an_interval(spans: list) -> bool:
     reason is that nothing in the geometry separates it from a lollipop's
     stems, which are also "one shared start, differing ends" and which read
     as spans announce "0 to 8" for a chart that means "8". One of the two has
-    to lose, and announcing a measurement the chart does not make is the worse
-    outcome -- so the shared-start schedule falls back to a static image,
-    which is at least a picture.
+    to lose, and announcing a measurement the chart does not make is the
+    worse outcome.
+
+    What the loser falls back to has since improved. It used to be a static
+    image, "which is at least a picture"; :func:`reads_as_stems` now claims
+    the shape instead and it is read as the lollipop it is drawn as, whose
+    marks are the ends and whose shared start is the baseline (#664). The
+    rule here is unchanged -- it is still the schedule reading that is
+    declined -- but the cost of declining it is no longer the whole chart.
 
     Recorded here as well as in :class:`SpanPlot`'s docstring because a reader
     who arrives at this function alone would otherwise see only a rule that
@@ -144,6 +150,64 @@ def states_an_interval(spans: list) -> bool:
     # announcing "0 to 8" for a chart that means "8".
     extent = max(max(starts), max(ends)) - min(min(starts), min(ends))
     return not _same_within(starts, extent) and not _same_within(ends, extent)
+
+
+def reads_as_stems(collection, along_x: bool) -> list | None:
+    """
+    The marks a call drew, when it drew stems anchored at a baseline.
+
+    Asked only after :func:`draws_a_schedule` has said no, and for the same
+    reason it is asked in the patch rather than in the layer: a layer that
+    refuses at extraction takes the whole figure with it (#564).
+
+    A stem's value is its *free* end. Which end that is has to be read off
+    the drawing rather than assumed, because a baseline is not always zero
+    and not always the lower end -- ``vlines(x, [-3, -5], 0)`` draws stems
+    hanging from zero, whose values are the ``ymin`` argument (#664).
+
+    Parameters
+    ----------
+    collection : LineCollection or None
+        The artist the call drew.
+    along_x : bool
+        True when the intervals run along x, as ``hlines`` draws them.
+
+    Returns
+    -------
+    list of tuple or None
+        One ``(lane, tip)`` per segment in draw order, or None when the call
+        did not draw stems.
+
+    Notes
+    -----
+    Exactly one end shared is the whole of the test, and each of the other
+    three answers is somebody else's:
+
+    - **neither** shared is a schedule, which :func:`draws_a_schedule` has
+      already taken.
+    - **both** shared means every segment is the same interval, which no row
+      of the data states -- reference lines drawn across the frame, declined
+      for the reason #176 gives.
+    - a call holding **one** segment lands in the both-shared case, since a
+      single end trivially agrees with itself. That is the cost the same rule
+      pays in :class:`SpanPlot`, in xability/maidr#1100 and in #1122, and it
+      is paid here for the same reason.
+    """
+    spans = read_spans(collection, along_x)
+    if spans is None:
+        return None
+
+    starts = [start for _, start, _ in spans]
+    ends = [end for _, _, end in spans]
+    extent = max(max(starts), max(ends)) - min(min(starts), min(ends))
+
+    shared_start = _same_within(starts, extent)
+    shared_end = _same_within(ends, extent)
+    if shared_start == shared_end:
+        return None
+
+    tips = ends if shared_start else starts
+    return [(lane, tip) for (lane, _, _), tip in zip(spans, tips)]
 
 
 def draws_a_schedule(collection, along_x: bool) -> bool:
@@ -200,9 +264,12 @@ class SpanPlot(GanttPlot):
 
     - ``vlines(x, 0, y)`` is a lollipop's stems: every segment starts at the
       baseline, and read as spans they announce "0 to 8" where the chart
-      means "8" -- which the markers drawn at their tips already say.
+      means "8" -- which the markers drawn at their tips already say. Where
+      the caller drew no markers there is nothing saying it, so the patch
+      asks :func:`reads_as_stems` next and registers a ``lollipop`` (#664).
     - ``hlines(y, 0, 5)`` is a set of reference lines drawn across the frame:
       every segment is the same interval, which no row of the data states.
+      Both of its ends are shared, so the stem reading declines it too.
     - A call holding one segment cannot be told from either, since a single
       end trivially agrees with itself. That is the cost the same rule pays
       on the other two adapters, and it is paid here for the same reason.

--- a/maidr/patch/spanplot.py
+++ b/maidr/patch/spanplot.py
@@ -7,12 +7,55 @@ from matplotlib.collections import LineCollection
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
+from maidr.core.plot.lollipop import DRAWN_MARKS, MARK_ARTIST, MARKS_HORIZONTAL
 from maidr.core.plot.spanplot import (
     DRAWN_SPANS,
     SPANS_ALONG_X,
     draws_a_schedule,
+    reads_as_stems,
 )
 from maidr.patch.common import _draw_quietly
+
+
+def _register_stems(drawn: LineCollection, stems: list, along_x: bool) -> None:
+    """
+    Register a baseline-anchored call as the spike chart it draws.
+
+    The same layer ``Axes.stem`` emits, reached through the machinery
+    ``Axes.acorr`` already uses: the numbers are handed over rather than
+    recovered from the artists, because in this spelling the value lives in
+    a segment's *length* and nothing sits at it for a reader to find.
+
+    Parameters
+    ----------
+    drawn : LineCollection
+        The collection the call drew, one segment per mark.
+    stems : list of tuple
+        One ``(lane, tip)`` per segment, from
+        :func:`~maidr.core.plot.spanplot.reads_as_stems`.
+    along_x : bool
+        True for ``hlines``, whose marks lie along x.
+    """
+    # As drawn, not as measured: `marks()` reads a stem plot's markers off
+    # the artist in matplotlib's own coordinates, and `finite()` maps the
+    # pair it is handed straight onto x and y. `hlines` stands its lanes
+    # down y and its magnitudes along x, so the pair goes the other way
+    # round -- which is the bar family's contract, and declaring the
+    # orientation without swapping the payload is the defect #480 had.
+    lanes = [lane for lane, _ in stems]
+    tips = [tip for _, tip in stems]
+    marks = (tips, lanes) if along_x else (lanes, tips)
+
+    ax = FigureManager.get_axes(drawn)
+    FigureManager.create_maidr(
+        ax,
+        PlotType.LOLLIPOP,
+        **{
+            DRAWN_MARKS: marks,
+            MARK_ARTIST: drawn,
+            MARKS_HORIZONTAL: along_x,
+        },
+    )
 
 
 def _spans(wrapped, instance, args, kwargs, along_x: bool) -> LineCollection:
@@ -57,6 +100,13 @@ def _spans(wrapped, instance, args, kwargs, along_x: bool) -> LineCollection:
         return drawn
 
     if not draws_a_schedule(drawn, along_x):
+        # Not a schedule is not the same as not a chart. Every segment
+        # sharing one end is a lollipop's stems, and with no markers drawn
+        # at their tips nothing else in the figure says what they measure --
+        # which is the whole of #664, and the same gap `Axes.acorr` had.
+        stems = reads_as_stems(drawn, along_x)
+        if stems is not None:
+            _register_stems(drawn, stems, along_x)
         return drawn
 
     # Registered as its own layer every time, with no equivalent of

--- a/tests/core/plot/test_spanplot.py
+++ b/tests/core/plot/test_spanplot.py
@@ -20,6 +20,12 @@ measured. A lollipop's stems all start at zero; reference lines all span the
 same interval; and a single segment cannot be told from either, since one
 end trivially agrees with itself.
 
+Not a schedule is not the same as not a chart. Where **exactly one** end is
+shared the call drew stems from a baseline, which is a magnitude per
+position -- the `lollipop` `ax.stem` emits -- and it is registered as that
+(#664). Where **both** are shared, or there is only one segment, nothing is
+registered at all, and those cases are pinned below unchanged.
+
 The decision is made in the **patch**, before anything registers. A layer
 that refuses at extraction takes the whole figure with it, which is the
 defect #564 was about -- so a declined call registers nothing at all and the
@@ -27,6 +33,8 @@ rest of the figure reads as it always did.
 """
 
 from __future__ import annotations
+
+import re
 
 import matplotlib.pyplot as plt
 import pytest
@@ -113,15 +121,68 @@ def test_an_unlabelled_lane_keeps_its_position():
     assert _rendered(fig)["data"]["lanes"] == [1.0, 2.0, 3.0]
 
 
-def test_a_lollipops_stems_register_nothing():
+def test_a_lollipops_stems_are_not_read_as_spans():
     # Every segment starts at the baseline. Read as spans they announce
-    # "0 to 8" where the chart means "8", and the markers at their tips
-    # already carry that.
+    # "0 to 8" where the chart means "8", so the *schedule* reading is
+    # declined -- which is what this has always pinned.
     fig, ax = plt.subplots()
     ax.vlines([1, 2, 3], 0, [5, 7, 6])
 
-    assert _layers(fig) == []
+    assert _layers(fig) == ["lollipop"]
     assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_a_lollipops_stems_read_as_the_magnitudes_they_draw():
+    # What they are read as instead (#664). The decline above was written on
+    # the grounds that "the markers at their tips already carry that", and
+    # here the caller drew no markers, so nothing else in the figure does.
+    fig, ax = plt.subplots()
+    ax.vlines([1, 2, 3], 0, [5, 7, 6])
+
+    schema = _schema(fig)
+    assert schema["type"].value == "lollipop"
+    assert schema["orientation"] == "vert"
+    assert [(point["x"], point["y"]) for point in schema["data"]] == [
+        (1.0, 5.0),
+        (2.0, 7.0),
+        (3.0, 6.0),
+    ]
+
+
+def test_the_value_is_the_free_end_rather_than_the_length():
+    # A baseline is not always zero. The mark sits where the chart drew it,
+    # which is the same contract `marks()` reads a stem plot's markers under
+    # -- not the distance from the baseline, which is a different number.
+    fig, ax = plt.subplots()
+    ax.vlines([1, 2, 3], 2, [5, 7, 6])
+
+    assert [point["y"] for point in _schema(fig)["data"]] == [5.0, 7.0, 6.0]
+
+
+def test_stems_hanging_from_a_baseline_are_read_from_their_free_end():
+    # Nor is the baseline always the *lower* end. Here the shared end is the
+    # top, so the values are the `ymin` argument -- which is why the shared
+    # end is found rather than assumed.
+    fig, ax = plt.subplots()
+    ax.vlines([1, 2], [-3, -5], 0)
+
+    assert [point["y"] for point in _schema(fig)["data"]] == [-3.0, -5.0]
+
+
+def test_horizontal_stems_put_their_magnitude_in_x():
+    # `hlines` draws the same chart turned: lanes down y, magnitudes along
+    # x. Declaring the orientation without swapping the payload is the
+    # defect #480 had, so both are checked together.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], 0, [5, 3, 7])
+
+    schema = _schema(fig)
+    assert schema["orientation"] == "horz"
+    assert [(point["x"], point["y"]) for point in schema["data"]] == [
+        (5.0, 1.0),
+        (3.0, 2.0),
+        (7.0, 3.0),
+    ]
 
 
 def test_reference_lines_register_nothing():
@@ -142,14 +203,25 @@ def test_a_single_span_registers_nothing():
     assert _layers(fig) == []
 
 
-def test_a_chart_beside_a_lollipop_is_untouched():
+def test_a_chart_beside_a_declined_call_is_untouched():
     # What deciding in the patch buys: a declined call registers nothing, so
-    # it cannot refuse at extraction and take the figure with it.
+    # it cannot refuse at extraction and take the figure with it. Reference
+    # lines rather than stems, since stems are now read (#664) -- the
+    # property being pinned is what a *decline* costs the rest of the figure.
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    ax.hlines([1, 2, 3], 0, 5)
+
+    assert _layers(fig) == ["bar"]
+    assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_a_chart_beside_a_spike_chart_keeps_both():
     fig, ax = plt.subplots()
     ax.bar(["a", "b"], [1, 2])
     ax.vlines([0, 1], 0, [1, 2])
 
-    assert _layers(fig) == ["bar"]
+    assert _layers(fig) == ["bar", "lollipop"]
     assert len(maidr.render(fig)._repr_html_()) > 0
 
 
@@ -298,17 +370,20 @@ def test_two_hlines_calls_stay_two_charts():
     ]
 
 
-def test_a_schedule_whose_tasks_share_a_start_is_declined():
+def test_a_schedule_whose_tasks_share_a_start_is_read_as_a_spike_chart():
     # The cost of the shared-end rule, stated rather than left to be found.
     # These are three real tasks all beginning on day 0, and nothing in the
     # geometry separates them from a lollipop's stems -- which are also one
     # shared start and differing ends, and which read as spans would announce
-    # "0 to 8" for a chart that means "8". Declining is the side that never
-    # announces a measurement the chart does not make.
+    # "0 to 8" for a chart that means "8". The schedule reading is still the
+    # one declined; what the loser falls back to is no longer a picture, so
+    # the ends are announced and the start every row shares is the baseline.
     fig, ax = plt.subplots()
     ax.hlines([1, 2, 3], [0, 0, 0], [5, 7, 6])
 
-    assert _layers(fig) == []
+    schema = _schema(fig)
+    assert schema["type"].value == "lollipop"
+    assert [point["x"] for point in schema["data"]] == [5.0, 7.0, 6.0]
     assert len(maidr.render(fig)._repr_html_()) > 0
 
 
@@ -365,7 +440,8 @@ def test_a_computed_baseline_is_still_a_lollipop():
     fig, ax = plt.subplots()
     ax.vlines([1, 2, 3, 4], baseline, tops)
 
-    assert _layers(fig) == []
+    assert _layers(fig) == ["lollipop"]
+    assert [point["y"] for point in _schema(fig)["data"]] == list(tops)
 
 
 def test_a_schedule_laid_out_in_epoch_seconds_still_reads():
@@ -417,3 +493,57 @@ def test_a_stem_plot_is_not_claimed_by_the_span_reading():
 
     assert _layers(fig) == ["lollipop"]
     assert len(maidr.render(fig)._repr_html_()) > 0
+
+
+def test_every_stem_is_addressed_by_the_path_it_is_drawn_as():
+    """Measured by parsing the SVG: one bare `<path>` child per segment."""
+    import io
+    from xml.etree import ElementTree
+
+    svg_ns = "{http://www.w3.org/2000/svg}"
+
+    fig, ax = plt.subplots()
+    ax.vlines([1, 2, 3, 4], 0, [5, 3, 7, 2])
+
+    schema = _schema(fig)
+    selectors = schema["selectors"]
+    assert len(selectors) == len(schema["data"])
+    assert len(set(selectors)) == len(selectors)
+    assert "> path:nth-of-type(1)" in selectors[0]
+
+    gid = re.search(r"g\[id='([^']+)'\]", selectors[0]).group(1)
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="svg")
+    buffer.seek(0)
+    root = ElementTree.fromstring(buffer.read())
+
+    group = next(g for g in root.iter(f"{svg_ns}g") if g.get("id") == gid)
+    assert {child.tag for child in group} == {f"{svg_ns}path"}
+    assert len(list(group)) == 4
+
+
+def test_reference_lines_are_still_declined_by_the_stem_reading():
+    # Both ends shared. Every segment is the same interval, which no row of
+    # the data states, so there is no free end to be a magnitude.
+    fig, ax = plt.subplots()
+    ax.vlines([1, 2, 3], 0, 5)
+
+    assert _layers(fig) == []
+
+
+def test_a_single_stem_is_still_declined():
+    # One segment lands in the both-shared case, since a single end
+    # trivially agrees with itself.
+    fig, ax = plt.subplots()
+    ax.vlines([1], 0, [5])
+
+    assert _layers(fig) == []
+
+
+def test_a_real_schedule_is_still_a_schedule():
+    # The stem reading is only reached once `draws_a_schedule` has said no,
+    # so a call with neither end shared cannot be diverted into it.
+    fig, ax = plt.subplots()
+    ax.hlines([1, 2, 3], [0, 2, 4], [5, 7, 6])
+
+    assert _layers(fig) == ["gantt"]


### PR DESCRIPTION
Closes #664

## What was wrong

```python
fig, ax = plt.subplots()
ax.vlines([1, 2, 3], 0, [5, 3, 7])
```

No layers at all — the figure fell back to a static picture and the three measurements were announced nowhere. The same three values drawn any other way read fine:

| call | layer before | layer after |
|---|---|---|
| `ax.stem([1,2,3], [5,3,7])` | `lollipop` | `lollipop` |
| `ax.acorr(...)` (`usevlines=True`) | `lollipop` | `lollipop` |
| `ax.vlines([1,2,3], [1,2,0], [5,3,7])` | `gantt` | `gantt` |
| **`ax.vlines([1,2,3], 0, [5,3,7])`** | **nothing** | **`lollipop`** |

`patch/spanplot.py` asks `draws_a_schedule` before registering anything, and `states_an_interval` declines when either end is shared. That is right as far as it goes — read as spans, a lollipop's stems announce "0 to 8" for a chart that means "8". The decline was written on the grounds that "the markers drawn at their tips already say it", and with a bare `vlines` there are no markers. `patch/correlogram.py` already says exactly that about `acorr`; the general call never got the same answer.

## The change

**Not a schedule is not the same as not a chart.** Once the schedule reading has said no, the patch asks a second question:

- **exactly one end shared** → stems from a baseline. A magnitude per position, registered as the `lollipop` `ax.stem` emits, through the `DRAWN_MARKS`/`MARK_ARTIST` machinery `acorr` already uses (whose `_get_selector` already addresses a `LineCollection` per segment).
- **both ends shared** → every segment is the same interval, which no row of the data states. Reference lines across the frame, still declined for the reason #176 gives.
- **one segment** → lands in the both-shared case, since a single end trivially agrees with itself. The cost the same rule pays in xability/maidr#1100 and #1122.
- **neither shared** → a schedule, unchanged.

The value is the **free** end, found rather than assumed — a baseline is not always zero and not always the lower end. `LollipopPlot` hardcoded `self._horizontal = False` on the handed-marks path, which is right for a correlogram (no spelling of `acorr` turns it) but not for `hlines`; it is now told, and the payload is swapped to match, since declaring one without the other is the defect #480 had.

## One recorded trade-off changes sign

`states_an_interval` notes that a schedule whose tasks share a start (`hlines([1,2,3], [0,0,0], [5,7,6])`) is turned away and "falls back to a static image, which is at least a picture". It is now read as the lollipop it is drawn as — the ends announced, the shared start being the baseline. The rule itself is unchanged; the cost of applying it is smaller. Both the function's Notes and `SpanPlot`'s docstring are updated where the old claim stood.

## Measured

```
vlines stems from 0       lollipop vert  (1,5) (2,3) (3,7)
vlines stems from 2       lollipop vert  (1,5) (2,3) (3,7)     baseline ≠ 0
vlines stems downward     lollipop vert  (1,-3) (2,-5)         baseline is the top
hlines stems from 0       lollipop horz  (5,1) (3,2) (7,3)     magnitude in x
hlines reference lines    declined
vlines single segment     declined
hlines shared-start jobs  lollipop horz  (5,1) (7,2) (6,3)
hlines real schedule      gantt                                unchanged
stem                      lollipop vert                        unchanged
acorr                     lollipop vert                        unchanged
plot + axvline            line                                 unchanged
plot + 2 vlines refs      line                                 unchanged
```

Selectors verified by parsing the SVG: a bare `vlines` collection is written as one `<g>` of four bare `<path>` children and nothing else, which is what `> path:nth-of-type(n)` addresses.

## Tests

`tests/core/plot/test_spanplot.py` — 5 existing tests that pinned the old declines are rewritten to state the new outcome with their reasoning intact, and 8 new tests added (free-end value, non-zero baseline, downward stems, horizontal orientation + payload swap, per-segment selectors parsed out of the SVG, reference lines still declined, single segment still declined, real schedule still a gantt). `test_a_chart_beside_a_lollipop_is_untouched` becomes `..._beside_a_declined_call_...` and uses reference lines, so the property it was really pinning — that a decline costs the rest of the figure nothing — stays covered.

Mutation sweep, seven mutations, **all killed**:

| mutation | result |
|---|---|
| accept both-ends-shared too | KILLED (5) |
| take the shared end as the value | KILLED (6) |
| always take `ends` as the value | KILLED (1) |
| never register the stems | KILLED (9) |
| do not swap the pair for `hlines` | KILLED (2) |
| always declare vertical | KILLED (1) |
| `LollipopPlot` ignores the orientation it is told | KILLED (1) |

## Gate

`ruff check` clean on every changed file · full suite **3423 passed, 70 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_