### PR TITLE
feat(plotly): read a splom as the grid of scatters it draws

### DIFF
--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -17,6 +17,7 @@ from maidr.plotly.gauge import draws_a_dial
 from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
 from maidr.plotly.area import is_area_trace
 from maidr.plotly.contour import is_contour_trace
+from maidr.plotly.splom import is_splom_trace, splom_panels
 from maidr.plotly.histogram2d import is_histogram2d_trace
 from maidr.plotly.histogram2dcontour import is_histogram2dcontour_trace
 from maidr.plotly.grouped_histogram import is_histogram_trace
@@ -896,6 +897,21 @@ class PlotlyMaidr:
                 plot.col_index = col
                 self._plots.append(plot)
                 merged.update(id(t) for t in box_traces)
+
+            # A scatterplot matrix. One trace, `n` dimensions, and an
+            # `n` by `n` grid of scatters -- which is what MAIDR's subplot
+            # grid is, so each panel becomes an ordinary scatter layer at
+            # its own position. Built here rather than in the factory
+            # because the factory returns one plot per trace and this one
+            # expands into many, each needing a grid position the factory
+            # cannot know (#666).
+            splom_traces = [t for t in group_traces if is_splom_trace(t)]
+            for splom in splom_traces:
+                for panel_row, panel_col, plot in splom_panels(splom):
+                    plot.row_index = row + panel_row
+                    plot.col_index = col + panel_col
+                    self._plots.append(plot)
+            merged.update(id(t) for t in splom_traces)
 
             # Pies, one layer each. Plotly draws them into a figure-level
             # ``pielayer`` instead of a subplot group, so a pie's selector is

--- a/maidr/plotly/splom.py
+++ b/maidr/plotly/splom.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from typing import Any
+
+from maidr.plotly.scatter import PlotlyScatterPlot
+
+
+def is_splom_trace(trace: dict) -> bool:
+    """
+    Whether a trace is a scatterplot matrix.
+
+    Parameters
+    ----------
+    trace : dict
+        The Plotly trace dictionary.
+
+    Returns
+    -------
+    bool
+        True for a ``splom`` trace.
+    """
+    return trace.get("type") == "splom"
+
+
+def _dimensions(trace: dict) -> list[dict]:
+    """
+    The dimensions a splom was given, dropped to those it can draw.
+
+    A dimension plotly is told to hide (``visible: False``) is not a panel,
+    and one carrying no values is not a variable -- both would otherwise put
+    an empty row and column in the grid, which is the phantom-layer shape of
+    #421 spread across a whole axis of the matrix.
+
+    Parameters
+    ----------
+    trace : dict
+        The Plotly trace dictionary.
+
+    Returns
+    -------
+    list of dict
+        The drawable dimensions, in the order the chart lays them out.
+    """
+    drawable = []
+    for dimension in trace.get("dimensions", []) or []:
+        if not isinstance(dimension, dict):
+            continue
+        if dimension.get("visible") is False:
+            continue
+        values = dimension.get("values")
+        if values is None or len(values) == 0:
+            continue
+        drawable.append(dimension)
+    return drawable
+
+
+def _draws_panel(trace: dict, row: int, col: int) -> bool:
+    """
+    Whether the chart draws the panel at ``(row, col)``.
+
+    Three keywords blank panels, and each is read rather than assumed --
+    emitting a panel the chart does not draw is the same defect as failing
+    to emit one it does.
+
+    - ``diagonal.visible = False`` blanks the leading diagonal. Plotly's
+      default is visible, and a diagonal panel is a variable against itself.
+    - ``showupperhalf = False`` blanks everything above it.
+    - ``showlowerhalf = False`` blanks everything below it.
+
+    Parameters
+    ----------
+    trace : dict
+        The Plotly trace dictionary.
+    row, col : int
+        The panel's position, both zero-based.
+
+    Returns
+    -------
+    bool
+        True when the panel is drawn.
+    """
+    if row == col:
+        diagonal = trace.get("diagonal") or {}
+        return diagonal.get("visible") is not False
+    if col > row:
+        return trace.get("showupperhalf") is not False
+    return trace.get("showlowerhalf") is not False
+
+
+def _axis_title(label: Any) -> dict:
+    """A layout axis carrying one title, or an empty one when unlabelled."""
+    if isinstance(label, str) and label != "":
+        return {"title": {"text": label}}
+    return {}
+
+
+class PlotlySplomPanelPlot(PlotlyScatterPlot):
+    """
+    One panel of a plotly scatterplot matrix, read as the scatter it is.
+
+    A ``splom`` is a single trace carrying ``n`` dimensions, and it draws an
+    ``n`` by ``n`` grid of scatters: panel ``(i, j)`` puts dimension ``j`` on
+    x against dimension ``i`` on y. MAIDR's schema is a grid of subplots,
+    which is that shape exactly, so each panel becomes an ordinary scatter
+    layer at its own grid position rather than the whole matrix becoming one
+    trace type of its own.
+
+    Before this, a splom produced a one-by-one grid whose only cell held **no
+    layers at all**, and `render()` succeeded on it -- so a reader was handed
+    a chart that announced itself as navigable and contained nothing (#666).
+    That is worse than the unsupported-chart path, which falls back to a
+    picture and says what it is.
+
+    The panel is handed a synthesised trace and a synthesised layout rather
+    than the splom's own, so the parent's whole axes pipeline -- labels,
+    formats, ranges and the grid-navigation preconditions -- applies to the
+    two dimensions this panel actually draws.
+
+    **No selector.** A splom's per-panel DOM has not been measured, and the
+    parent's scatter selector addresses `.trace.scatter .point` inside one
+    subplot, which a splom does not lay out that way. Returning nothing is
+    the same answer the WebGL branch gives for the same reason: a selector
+    that resolves to nothing is a highlight that silently never appears.
+    Audio, text and braille do not depend on it.
+    """
+
+    def __init__(self, trace: dict, x: dict, y: dict) -> None:
+        panel = {
+            "type": "scatter",
+            "mode": "markers",
+            "x": list(x.get("values", [])),
+            "y": list(y.get("values", [])),
+        }
+        layout = {
+            "xaxis": _axis_title(x.get("label")),
+            "yaxis": _axis_title(y.get("label")),
+        }
+        title = (trace.get("name") or "").strip()
+        if title:
+            layout["title"] = {"text": title}
+        super().__init__(panel, layout)
+
+    def _get_selector(self) -> str:
+        """No element is claimed; see the class docstring."""
+        return ""
+
+
+def splom_panels(trace: dict) -> list[tuple[int, int, PlotlySplomPanelPlot]]:
+    """
+    One plot per panel the matrix draws, with its position in the grid.
+
+    Positions are relative to the matrix's own top-left corner; the caller
+    offsets them by the subplot the splom sits in.
+
+    A panel the chart blanks is left out entirely rather than emitted empty:
+    `_flatten_maidr` fills a missing cell in with an empty one, so the grid
+    keeps its shape and the blanked panels are holes in it, which is what
+    they are on the page.
+
+    Parameters
+    ----------
+    trace : dict
+        The Plotly trace dictionary.
+
+    Returns
+    -------
+    list of (int, int, PlotlySplomPanelPlot)
+        Each drawn panel, in row-major order.
+    """
+    dimensions = _dimensions(trace)
+    panels = []
+    for row, y in enumerate(dimensions):
+        for col, x in enumerate(dimensions):
+            if not _draws_panel(trace, row, col):
+                continue
+            panels.append((row, col, PlotlySplomPanelPlot(trace, x, y)))
+    return panels

--- a/tests/plotly/test_plotly_splom.py
+++ b/tests/plotly/test_plotly_splom.py
@@ -1,0 +1,237 @@
+"""A plotly splom rendered a chart with no layers in it at all (#666).
+
+A ``splom`` is one trace carrying ``n`` dimensions, and it draws an ``n`` by
+``n`` grid of scatters. MAIDR's schema is a grid of subplots, which is that
+shape exactly -- but nothing in the plotly path read a splom, so it produced
+a one-by-one grid whose only cell held an empty layer list. `render()`
+*succeeded* on that, so a reader was handed a chart that announced itself as
+navigable and contained nothing. Worse than the unsupported-chart path,
+which falls back to a picture and says what it is.
+
+Measured before the reading:
+
+    make_subplots 2x2   grid=2x[2, 2]  layers=[[[point], [bar]], [[point], [bar]]]
+    splom (3 dims)      grid=1x[1]     layers=[[[]]]
+    px.scatter_matrix   grid=1x[1]     layers=[[[]]]
+
+So the machinery was there -- the plotly path already builds real subplot
+grids -- and only the splom converter was missing.
+
+Three keywords blank panels, and each is read rather than assumed: emitting
+a panel the chart does not draw is the same defect as failing to emit one it
+does. A blanked panel is left out entirely, and `_flatten_maidr` fills the
+missing cell with an empty one, so the grid keeps its shape and the blanks
+are holes in it -- which is what they are on the page.
+
+**No panel claims a selector.** A splom's per-panel DOM has not been
+measured, and the scatter selector addresses `.trace.scatter .point` inside
+one subplot, which a splom does not lay out that way. Returning nothing is
+what the WebGL branch already does for the same reason: a selector that
+resolves to nothing is a highlight that silently never appears. Audio, text
+and braille do not depend on it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+A = [1.0, 2.0, 3.0]
+B = [9.0, 8.0, 7.0]
+C = [4.0, 5.0, 6.0]
+
+
+def dims(*pairs):
+    """Dimensions from ``(label, values)`` pairs."""
+    return [dict(label=label, values=values) for label, values in pairs]
+
+
+def grid(trace) -> list[list[list[dict]]]:
+    """The layers of every cell, as a grid."""
+    schema = PlotlyMaidr(go.Figure(trace))._flatten_maidr()
+    return [[cell.get("layers", []) for cell in row] for row in schema["subplots"]]
+
+
+def shape(cells) -> tuple[int, list[int]]:
+    """Rows, and the width of each."""
+    return len(cells), [len(row) for row in cells]
+
+
+def drawn(cells) -> set[tuple[int, int]]:
+    """The positions holding a layer."""
+    return {
+        (r, c)
+        for r, row in enumerate(cells)
+        for c, layers in enumerate(row)
+        if layers
+    }
+
+
+def panel(cells, row, col) -> dict:
+    """The single layer at one position."""
+    layers = cells[row][col]
+    assert len(layers) == 1
+    return layers[0]
+
+
+def test_a_splom_is_read_rather_than_emitting_nothing():
+    cells = grid(go.Splom(dimensions=dims(("A", A), ("B", B))))
+
+    assert shape(cells) == (2, [2, 2])
+    assert len(drawn(cells)) == 4
+
+
+def test_every_panel_is_a_scatter():
+    cells = grid(go.Splom(dimensions=dims(("A", A), ("B", B))))
+
+    for row in cells:
+        for layers in row:
+            for layer in layers:
+                assert layer["type"].value == "point"
+
+
+def test_a_panel_puts_its_column_on_x_and_its_row_on_y():
+    # The whole layout. Panel (i, j) is dimension j against dimension i, so
+    # a reading that transposed it would announce every off-diagonal panel
+    # with its two variables the wrong way round.
+    cells = grid(go.Splom(dimensions=dims(("A", A), ("B", B))))
+    upper = panel(cells, 0, 1)
+
+    assert upper["axes"]["x"]["label"] == "B"
+    assert upper["axes"]["y"]["label"] == "A"
+    assert [point["x"] for point in upper["data"]] == B
+    assert [point["y"] for point in upper["data"]] == A
+
+
+def test_the_diagonal_is_a_dimension_against_itself():
+    cells = grid(go.Splom(dimensions=dims(("A", A), ("B", B))))
+    corner = panel(cells, 0, 0)
+
+    assert corner["axes"]["x"]["label"] == "A"
+    assert corner["axes"]["y"]["label"] == "A"
+    assert [point["x"] for point in corner["data"]] == A
+
+
+def test_a_hidden_diagonal_leaves_holes_rather_than_panels():
+    cells = grid(go.Splom(
+        dimensions=dims(("A", A), ("B", B)),
+        diagonal=dict(visible=False),
+    ))
+
+    assert shape(cells) == (2, [2, 2])
+    assert drawn(cells) == {(0, 1), (1, 0)}
+
+
+def test_a_visible_diagonal_is_the_default():
+    # Plotly's default is visible, so an absent `diagonal` must not be read
+    # as a hidden one.
+    cells = grid(go.Splom(dimensions=dims(("A", A), ("B", B))))
+
+    assert (0, 0) in drawn(cells)
+    assert (1, 1) in drawn(cells)
+
+
+def test_showupperhalf_false_keeps_the_lower_triangle():
+    cells = grid(go.Splom(
+        dimensions=dims(("A", A), ("B", B), ("C", C)),
+        showupperhalf=False,
+    ))
+
+    assert drawn(cells) == {(0, 0), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2)}
+
+
+def test_showlowerhalf_false_keeps_the_upper_triangle():
+    cells = grid(go.Splom(
+        dimensions=dims(("A", A), ("B", B), ("C", C)),
+        showlowerhalf=False,
+    ))
+
+    assert drawn(cells) == {(0, 0), (0, 1), (0, 2), (1, 1), (1, 2), (2, 2)}
+
+
+def test_a_triangle_without_its_diagonal_keeps_the_drawn_panels_in_place():
+    # Both blanking rules at once. Nothing is drawn in row 0 or in column 2,
+    # so the grid is narrower -- but every panel the chart *does* draw keeps
+    # the position it has on the page, which is what a reader navigates by.
+    cells = grid(go.Splom(
+        dimensions=dims(("A", A), ("B", B), ("C", C)),
+        showupperhalf=False,
+        diagonal=dict(visible=False),
+    ))
+
+    assert drawn(cells) == {(1, 0), (2, 0), (2, 1)}
+    assert panel(cells, 2, 1)["axes"]["x"]["label"] == "B"
+    assert panel(cells, 2, 1)["axes"]["y"]["label"] == "C"
+
+
+def test_a_dimension_the_chart_hides_is_not_a_row_or_a_column():
+    # `visible: False` on a dimension removes its panels entirely. Kept, it
+    # would put an empty row and column in the grid -- the phantom-layer
+    # shape of #421 spread across a whole axis of the matrix.
+    cells = grid(go.Splom(dimensions=[
+        dict(label="A", values=A),
+        dict(label="B", values=B, visible=False),
+    ]))
+
+    assert shape(cells) == (1, [1])
+    assert panel(cells, 0, 0)["axes"]["x"]["label"] == "A"
+
+
+@pytest.mark.parametrize(
+    "empty",
+    [
+        pytest.param({"label": "empty", "values": []}, id="empty list"),
+        pytest.param({"label": "none"}, id="no values at all"),
+    ],
+)
+def test_a_dimension_with_no_values_is_not_a_variable(empty):
+    # Asked of `splom_panels` as well as of the whole pipeline. Measured,
+    # both shapes survive `to_dict()` -- `values` comes back as `[]` and as
+    # `None` respectively -- so the guard is what drops them here. The
+    # pipeline happens to strip them a second time further up, which is why
+    # the grid alone cannot tell whether this rule is being applied.
+    from maidr.plotly.splom import splom_panels
+
+    trace = {"type": "splom", "dimensions": [{"label": "A", "values": A}, empty]}
+    panels = splom_panels(trace)
+
+    assert len(panels) == 1
+    assert (panels[0][0], panels[0][1]) == (0, 0)
+
+    cells = grid(go.Splom(dimensions=[dict(label="A", values=A), dict(**empty)]))
+    assert shape(cells) == (1, [1])
+
+
+def test_a_single_dimension_reads_as_one_panel():
+    cells = grid(go.Splom(dimensions=dims(("A", A))))
+
+    assert shape(cells) == (1, [1])
+    assert drawn(cells) == {(0, 0)}
+
+
+def test_no_panel_claims_an_element_to_highlight():
+    cells = grid(go.Splom(dimensions=dims(("A", A), ("B", B))))
+
+    for row in cells:
+        for layers in row:
+            for layer in layers:
+                assert "selector" not in layer
+                assert "selectors" not in layer
+
+
+def test_a_scatter_matrix_written_through_express_reads_the_same():
+    px = pytest.importorskip("plotly.express")
+    pd = pytest.importorskip("pandas")
+
+    frame = pd.DataFrame({"A": A, "B": B})
+    figure = px.scatter_matrix(frame, dimensions=["A", "B"])
+    schema = PlotlyMaidr(figure)._flatten_maidr()
+    cells = [[cell.get("layers", []) for cell in row] for row in schema["subplots"]]
+
+    assert shape(cells) == (2, [2, 2])
+    assert len(drawn(cells)) == 4


### PR DESCRIPTION
Closes #666.

## What was wrong

```
make_subplots 2x2   grid=2x[2, 2]  layers=[[[point], [bar]], [[point], [bar]]]
splom (3 dims)      grid=1x[1]     layers=[[[]]]
px.scatter_matrix   grid=1x[1]     layers=[[[]]]
```

A splom produced a one-by-one grid whose only cell held **no layers at all**, and `maidr.render()` *succeeded* on it — 10,392 characters of HTML carrying a maidr payload with nothing in it. So a reader was handed a chart that announced itself as navigable and contained nothing, which is worse than the unsupported-chart path: that falls back to a picture and says what it is. `px.scatter_matrix` produces the same `splom` trace type, so the commonest way to write one was affected too.

## The reading

A splom is one trace carrying `n` dimensions and drawing an `n` by `n` grid of scatters. MAIDR's schema is a grid of subplots, which is that shape exactly — and **the plotly path already builds real ones** (the `make_subplots` row above proves it). Only the converter was missing.

Panel `(i, j)` is dimension `j` on x against dimension `i` on y, and becomes an ordinary scatter layer at its own grid position. Each panel is handed a synthesised trace and layout rather than the splom's own, so the parent's whole axes pipeline — labels, formats, ranges, the grid-navigation preconditions — applies to the two dimensions the panel actually draws.

Built in `_extract_plots` rather than in the factory: the factory returns one plot per trace, and this one expands into many, each needing a grid position the factory cannot know.

## The three keywords that blank panels

Each is read rather than assumed, because emitting a panel the chart does not draw is the same defect as failing to emit one it does.

```
plain 2 dims        A/A  B/A  |  A/B  B/B
diagonal hidden      .   B/A  |  A/B   .
upper hidden        A/A   .    .   |  A/B B/B  .   |  A/C B/C C/C
lower hidden        A/A  B/A  C/A  |   .  B/B C/B  |   .   .  C/C
upper+diag hidden    .    .        |  A/B  .       |  A/C B/C
one dim             A/A
a dimension hidden  A/A
```

A blanked panel is left out entirely; `_flatten_maidr` fills the missing cell with an empty one, so the grid keeps its shape and the blanks are holes in it — which is what they are on the page. In the `upper+diag` case nothing is drawn in row 0 or column 2, so the grid is narrower, but every panel the chart *does* draw keeps the position it has on the page, which is what a reader navigates by.

A dimension the chart hides (`visible: False`) or one carrying no values is not a row or a column at all. Kept, it would put an empty row and column across the whole matrix — the phantom-layer shape of #421 spread over an axis.

## No panel claims a selector

A splom's per-panel DOM has not been measured, and the parent's scatter selector addresses `.trace.scatter .point` inside one subplot, which a splom does not lay out that way. Returning nothing is exactly what the WebGL branch already does, for the reason it already gives: *a selector that resolves to nothing is a highlight that silently never appears*. Audio, text and braille do not depend on it.

## Tests

`tests/plotly/test_plotly_splom.py`, 15 tests: read rather than emitting nothing; every panel a scatter; the column on x and the row on y; the diagonal a dimension against itself; a hidden diagonal leaving holes; a visible diagonal being the default; each triangle rule; a triangle without its diagonal keeping the drawn panels in place; a hidden dimension and a valueless one (both spellings) removed; a single dimension; no selector anywhere; and `px.scatter_matrix` reading the same.

Mutation sweep, nine mutations, **all killed**:

| mutation | result |
|---|---|
| never expand a splom (emits nothing again) | KILLED (11) |
| transpose the panel | KILLED (2) |
| draw every panel, ignoring the blanking keywords | KILLED (4) |
| treat an absent diagonal as hidden | KILLED (10) |
| swap the upper and lower half rules | KILLED (3) |
| keep a dimension the chart hides | KILLED (1) |
| keep a dimension with no values | KILLED (2) |
| claim the parent's scatter selector | KILLED (1) |
| label both axes from the x dimension | KILLED (2) |

**One survivor, and what it found.** "Keep a dimension with no values" initially survived: the pipeline strips such a dimension a second time further up, so the grid alone cannot tell whether the rule here is being applied. Measured, both spellings do reach `_dimensions` — `to_dict()` gives back `values: []` and `values: None` respectively — so the guard is real and the *test* was in the wrong place. It now asks `splom_panels` directly as well as checking the grid, and the mutation dies.

## Gate

`ruff check` clean on every changed file (the six `__init__.py` re-export findings are pre-existing on `main`, verified by stashing). Full suite **3437 passed, 70 skipped** — up from 3423, the 15 new tests less one that replaced an existing single case with a parametrised pair.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_