### PR TITLE
feat(plotly): read a scatterpolargl as the radar it draws

### DIFF
--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -1011,8 +1011,16 @@ class PlotlyMaidr:
             # a `barpolar` draws into that subplot's `.barlayer` and shifts
             # nothing there, and a trace in the *next* subplot is numbered
             # from one again.
+            #
+            # `scatterpolargl` is a `scatterpolar` in every respect that
+            # matters here -- same `r`, same `theta`, same reading -- and
+            # differs only in being painted to a canvas, which costs it its
+            # selector and its place in the numbering below (#668).
             polar_traces = [
-                t for t in group_traces if t.get("type") in ("scatterpolar", "barpolar")
+                t
+                for t in group_traces
+                if t.get("type")
+                in ("scatterpolar", "scatterpolargl", "barpolar")
             ]
             if polar_traces:
                 # `PlotType` is imported here rather than at module level
@@ -1026,7 +1034,10 @@ class PlotlyMaidr:
                 scatter_positions: dict[str, int] = {}
                 for polar_trace in polar_traces:
                     name = subplot_name(polar_trace)
-                    is_scatter = polar_trace.get("type") == "scatterpolar"
+                    is_scatter = polar_trace.get("type") in (
+                        "scatterpolar",
+                        "scatterpolargl",
+                    )
                     plot = PlotlyPolarPlot(
                         polar_trace,
                         layout,
@@ -1034,7 +1045,15 @@ class PlotlyMaidr:
                         trace_position=scatter_positions.get(name, 0),
                         **axis_kwargs,
                     )
-                    if is_scatter:
+                    # A canvas trace never enters the subplot's
+                    # `.scatterlayer`, so counting it would push every SVG
+                    # sibling one `nth-child` along onto an element plotly
+                    # never drew -- the trap the cartesian numbering above
+                    # documents. Measured in Chromium on one polar subplot
+                    # holding one gl trace and one SVG trace: declared either
+                    # way round, the `.scatterlayer` holds exactly one child
+                    # and it is the SVG trace, at `nth-child(1)`.
+                    if is_scatter and not renders_through_webgl(polar_trace):
                         scatter_positions[name] = scatter_positions.get(name, 0) + 1
                     polar_row, polar_col = self._grid_position(
                         x_starts,

--- a/maidr/plotly/polar.py
+++ b/maidr/plotly/polar.py
@@ -5,10 +5,12 @@ import math
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list, subplot_block
+from maidr.plotly.step_shape import renders_through_webgl
 
 
 class PlotlyPolarPlot(PlotlyPlot):
-    """Extract data from a Plotly ``scatterpolar`` or ``barpolar`` trace.
+    """Extract data from a Plotly ``scatterpolar``, ``scatterpolargl`` or
+    ``barpolar`` trace.
 
     Both draw spokes around a circle -- one radius per angle -- and the core
     builds both on `RadarTrace`: a radar joins the spokes into an outline and
@@ -91,8 +93,20 @@ class PlotlyPolarPlot(PlotlyPlot):
 
         A ``mode="text"`` trace draws neither, and keeps no selector for the
         reason ``barpolar`` has none.
+
+        ## When there is no element at all
+
+        A ``scatterpolargl`` draws the same spokes through regl, onto a
+        ``<canvas>``, and so puts nothing in the ``.scatterlayer`` for any
+        mode. Measured in Chromium on ``r=[1, 2, 3]``: a ``scatterpolar``
+        gives one ``.trace`` there and no canvas, a ``scatterpolargl`` gives
+        no ``.trace`` and three canvases (#668). It keeps its audio, braille
+        and text and names nothing, which is what its cartesian twin already
+        does.
         """
         if self.type is not PlotType.RADAR:
+            return []
+        if renders_through_webgl(self._trace):
             return []
         drawn = self._drawn_mark()
         if drawn is None:

--- a/maidr/plotly/step_shape.py
+++ b/maidr/plotly/step_shape.py
@@ -48,7 +48,13 @@ _CONNECTED_TRACE_TYPES = ("scatter", "scattergl")
 #:
 #: These have no per-trace DOM element, so no CSS selector can address their
 #: geometry — see :func:`renders_through_webgl` for what follows from that.
-_WEBGL_TRACE_TYPES = ("scattergl",)
+#:
+#: ``scatterpolargl`` is the polar member and behaves the same way. Measured
+#: in Chromium on ``r=[1, 2, 3]``, counting inside the polar subplot: a
+#: ``scatterpolar`` puts one ``.trace`` in the ``.scatterlayer`` and no
+#: canvas, while a ``scatterpolargl`` puts **none** there and three canvases
+#: on the page (#668).
+_WEBGL_TRACE_TYPES = ("scattergl", "scatterpolargl")
 
 
 #: Point count at which plotly's default ``mode`` drops its markers.

--- a/tests/browser/test_plotly_selectors.py
+++ b/tests/browser/test_plotly_selectors.py
@@ -44,9 +44,9 @@ which is what catches a selector that has stopped matching.
 
 Several layers deliberately emit **no** selectors, each for a measured
 reason: `barpolar` (#635), `parcoords` (#637), `parcats` (#639), `choropleth`
-(#640), `scattergl` (painted to canvas), and a contour whose level holds
-islands (#643). Those are listed rather than skipped, so that a layer which
-starts declining silently fails here.
+(#640), `scattergl` and `scatterpolargl` (painted to canvas, #668), and a
+contour whose level holds islands (#643). Those are listed rather than
+skipped, so that a layer which starts declining silently fails here.
 """
 
 from __future__ import annotations
@@ -157,6 +157,9 @@ def _figure(name: str) -> go.Figure:
         "scattergl": lambda: go.Figure(
             go.Scattergl(x=[1, 2, 3], y=[2, 1, 3], mode="markers")
         ),
+        "scatterpolargl": lambda: go.Figure(
+            go.Scatterpolargl(r=[1, 2, 3], theta=[0, 120, 240])
+        ),
         "histogram2dcontour": lambda: go.Figure(
             go.Histogram2dContour(**_SAMPLES)
         ),
@@ -208,6 +211,9 @@ SHAPES: dict[str, tuple[str, ...]] = {
     "parcats": ("none",),
     # `scattergl` paints its markers to a canvas, so there is no element.
     "scattergl": ("none",),
+    # And `scatterpolargl` paints its spokes to one, so neither the outline
+    # an SVG radar names nor its markers exist (#668).
+    "scatterpolargl": ("none",),
     # Every level of this field draws a single curve, so each is addressed;
     # a level with islands declines instead, which #643 measured and
     # xability/maidr#1142 is what would let it be outlined whole.

--- a/tests/plotly/test_plotly_polar.py
+++ b/tests/plotly/test_plotly_polar.py
@@ -412,3 +412,80 @@ def test_each_polar_subplot_is_named_from_its_own_layout_block() -> None:
 
     assert first["axes"]["y"]["label"] == "Left R"
     assert second["axes"]["y"]["label"] == "Right R"
+
+
+def test_a_scatterpolargl_is_read_as_a_radar() -> None:
+    """The WebGL twin draws the same spokes and was read as nothing (#668).
+
+    `go.Scatterpolargl` carries the same `r` and `theta` as
+    `go.Scatterpolar` and differs only in being painted by regl. The polar
+    branch of `_extract_plots` listed two trace types by name and this was
+    not one of them, so the figure produced no layers at all and took the
+    static-image path.
+    """
+    (layer,) = _layers(go.Figure([go.Scatterpolargl(r=RADII, theta=SPOKES)]))
+
+    assert layer["type"] == PlotType.RADAR
+    assert _spokes(layer) == list(zip(SPOKES, RADII))
+
+
+@pytest.mark.parametrize("mode", [None, "lines", "markers", "lines+markers"])
+def test_a_scatterpolargl_is_read_but_not_addressed(mode) -> None:
+    """It is painted to a canvas, so there is no element in any mode.
+
+    Measured in Chromium on `r=[1, 2, 3]`, counting inside the polar
+    subplot: a `scatterpolar` puts one `.trace` in the `.scatterlayer` and
+    no canvas on the page, while a `scatterpolargl` puts none there and
+    three canvases -- for `mode="lines"` and `mode="markers"` alike. So
+    neither the outline nor the markers `PlotlyPolarPlot` names for an SVG
+    radar exists here, and the layer ships without a highlight, keeping its
+    audio, braille and text.
+    """
+    trace = go.Scatterpolargl(r=RADII, theta=SPOKES, mode=mode)
+    (layer,) = _layers(go.Figure([trace]))
+
+    assert layer["type"] == PlotType.RADAR
+    assert "selectors" not in layer
+    assert _spokes(layer) == list(zip(SPOKES, RADII))
+
+
+@pytest.mark.parametrize("gl_first", [True, False])
+def test_a_scatterpolargl_does_not_shift_a_radar_position(gl_first: bool) -> None:
+    """It never enters the `.scatterlayer` the `nth-child` counts over.
+
+    The trap the cartesian numbering already documents, in the polar
+    subplot: counting a canvas trace would push its SVG sibling one place
+    along, onto a selector matching nothing.
+
+    Measured in Chromium on one polar subplot holding one of each --
+    declared either way round, the `.scatterlayer` holds exactly one child
+    and it is the SVG trace, at `nth-child(1)`.
+    """
+    gl = go.Scatterpolargl(r=[3, 9, 5], theta=["N", "E", "S"], name="gl")
+    svg = go.Scatterpolar(r=[2, 6, 4], theta=["N", "E", "S"], name="svg")
+    layers = _layers(go.Figure([gl, svg] if gl_first else [svg, gl]))
+
+    named = [layer for layer in layers if "selectors" in layer]
+    assert len(layers) == 2
+    assert len(named) == 1
+    assert "nth-child(1)" in named[0]["selectors"][0]
+
+
+def test_a_scatterpolargl_still_reads_its_own_spokes_beside_an_svg_one() -> None:
+    """Losing the highlight costs it nothing else.
+
+    Both layers are emitted, in the order plotly declared them, and each
+    announces the radii it was given -- which is the whole point of reading
+    a canvas trace rather than declining it.
+    """
+    first, second = _layers(
+        go.Figure(
+            [
+                go.Scatterpolargl(r=[3, 9, 5], theta=["N", "E", "S"], name="gl"),
+                go.Scatterpolar(r=[2, 6, 4], theta=["N", "E", "S"], name="svg"),
+            ]
+        )
+    )
+
+    assert _spokes(first) == [("N", 3), ("E", 9), ("S", 5)]
+    assert _spokes(second) == [("N", 2), ("E", 6), ("S", 4)]


### PR DESCRIPTION
Closes #668.

`go.Scatterpolar` reads as a `radar`. Its WebGL twin `go.Scatterpolargl` — the same `r` and `theta`, painted by regl instead of by SVG — read as **nothing**, so the whole figure took the static-image path. The polar branch of `_extract_plots` listed two trace types by name and this was not one of them.

## The distinction already exists on the cartesian side

`renders_through_webgl()` marks a trace as canvas-painted, and a canvas trace reads exactly as its SVG twin does while declining only its *selector*. `scatterpolargl` joins `_WEBGL_TRACE_TYPES`, so it inherits both halves rather than getting a rule of its own.

## Measured

In Chromium, against plotly's own page (`include_plotlyjs=True`, no network), counting inside the polar subplot:

| trace | `.scatterlayer .trace.scatter .point` | `… path.js-line` | `.scatterlayer > .trace` | `canvas` |
| --- | --- | --- | --- | --- |
| `scatterpolar` markers | 3 | 0 | 1 | 0 |
| `scatterpolar` lines | 0 | 1 | 1 | 0 |
| `scatterpolargl` markers | 0 | 0 | **0** | 3 |
| `scatterpolargl` lines | 0 | 0 | **0** | 3 |

So neither the outline nor the markers `PlotlyPolarPlot` names for an SVG radar exists. The layer ships with audio, braille and text and no highlight — the outcome #145 established for a layer with nothing to point at, and the one `scattergl` (#412 numbering) and `barpolar` (#635) already have.

Before and after, on `go.Scatterpolargl(r=[1,2,3], theta=[0,120,240])`:

```
before   (no layers — figure falls back to a picture)
after    type=RADAR  data=[[{x:0,y:1},{x:120,y:2},{x:240,y:3}]]  selectors=None
```

## The numbering

A `scatterpolar` is numbered among *its own polar subplot's* scatter traces, because that is what one `.scatterlayer` holds. A `scatterpolargl` never enters that layer, so counting it would push its SVG sibling one `nth-child` along onto an element plotly never drew — the trap the cartesian numbering documents at length.

Measured on one polar subplot holding one of each, declared both ways round:

```
declared gl, then svg   .scatterlayer > .trace -> 1   ["trace scatter …"]
declared svg, then gl   .scatterlayer > .trace -> 1   ["trace scatter …"]
```

One element either way, and it is the SVG trace at `nth-child(1)`. The emitted payload now matches: with the gl trace declared first, the SVG one still carries `nth-child(1)`.

## Changes

| file | |
| --- | --- |
| `maidr/plotly/step_shape.py` | `_WEBGL_TRACE_TYPES` gains `scatterpolargl` |
| `maidr/plotly/plotly_maidr.py` | the polar branch accepts it, reads it as `RADAR`, and leaves it out of the subplot's scatter numbering |
| `maidr/plotly/polar.py` | `_get_selector` returns none for a WebGL trace |

## Tests

`tests/plotly/test_plotly_polar.py` — 7 new cases (31 in the file, all passing): the reproduction and its type, "read but not addressed" parametrised over all four modes, the numbering parametrised over both declaration orders, and that the gl layer still announces its own spokes beside an SVG one.

`tests/browser/test_plotly_selectors.py` — the case is added to `SHAPES` as `("none",)`, so the claim is checked against a real Chromium DOM rather than asserted. That file's design is that a layer which *starts* declining fails there too.

## Mutation sweep

| mutation | |
| --- | --- |
| a scatterpolargl is not collected as a polar trace | killed |
| a scatterpolargl is read as a polar area, not a radar | killed |
| the canvas trace is counted in the subplot numbering | killed |
| a WebGL radar names its outline anyway | killed |
| `scatterpolargl` is left out of the WebGL trace types | killed |

## Verification

- `uv run pytest -q` — 3446 passed, 72 skipped (3437 before)
- `uv run pytest tests/browser/test_plotly_selectors.py --run-browser` — the new case passes in Chromium
- `ruff check` on every touched file — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_