### PR TITLE
feat(seaborn-objects): read an Area mark as the band it draws

### DIFF
--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import warnings
 from typing import Any, NamedTuple
 
+import numpy as np
 import wrapt
 from matplotlib.axes import Axes
 from matplotlib.collections import PathCollection
 from matplotlib.container import BarContainer
 from matplotlib.lines import Line2D
+from matplotlib.patches import Polygon
 
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
@@ -92,6 +94,14 @@ _READINGS: dict[str, _Reading] = {
     "Line": _Reading(PlotType.LINE, "lines", Line2D, "lines"),
     "Path": _Reading(PlotType.LINE, "lines", Line2D, "lines"),
     "Bar": _Reading(PlotType.BAR, "containers", BarContainer, DRAWN_BARS, True),
+    # An area's artists arrive in `patches` rather than in `collections`,
+    # which is the one thing separating it from `ax.fill_between`'s band
+    # (#339, #670): a `Polygon` patch instead of a `PolyCollection`, holding
+    # the same fold of baseline-then-values-reversed. `AreaPlot` takes the
+    # positions and the series rather than the artist, so `binding` names
+    # only where the artist itself goes and `_area_handover` supplies the
+    # rest.
+    "Area": _Reading(PlotType.AREA, "patches", Polygon, "collections"),
 }
 
 
@@ -350,8 +360,121 @@ def _grouped_type(move: list[Any] | None) -> PlotType | None:
     return None
 
 
+
+def _unfolded(polygon: Polygon) -> list[tuple[float, float]] | None:
+    """
+    The positions and magnitudes one area polygon was folded from.
+
+    ``so.Area`` closes its band by running the **baseline** forward and then
+    the **values** backward, so the second half of the vertex list is the
+    drawn series in reverse. Measured on ``x = 0, 1, 2`` against
+    ``y = 1, 3, 2``::
+
+        [[0,0], [1,0], [2,0], [2,2], [1,3], [0,1], [0,0]]
+         └──── baseline ────┘  └──── values, reversed ────┘
+
+    The closing repeat is not always there, and which spelling drops it is
+    narrower than it looks. Measured on the same three points: ``baseline=0``
+    and ``baseline=5`` both give **seven** vertices, while ``baseline=10`` --
+    the first drawn value -- gives **six**, because the last drawn vertex
+    already coincides with the first baseline one and matplotlib does not
+    repeat it. So the split is ``len // 2`` rather than ``(len - 1) // 2``,
+    which is 3 for both forms where the latter is 3 and 2.
+
+    Parameters
+    ----------
+    polygon : Polygon
+        The patch the mark drew.
+
+    Returns
+    -------
+    list of (float, float), or None
+        The drawn vertices, in the order the positions run; ``None`` when
+        there are too few to be a fold, which declines rather than guessing
+        at a shape.
+    """
+    vertices = np.asarray(polygon.get_xy(), dtype=float)
+    if vertices.ndim != 2 or vertices.shape[0] < 4:
+        return None
+    half = vertices.shape[0] // 2
+    values = vertices[half : half * 2][::-1]
+    if values.shape[0] != half:
+        return None
+    return [(float(point[0]), float(point[1])) for point in values]
+
+
+def _area_handover(own: list, orient: str | None) -> list[tuple[PlotType, dict]]:
+    """
+    What to register for an ``so.Area`` layer, or nothing.
+
+    **One polygon, or nothing.** A layer that drew several is a colour split,
+    and a colour split declines for a reason about names rather than numbers:
+    measured, each level's polygon spans every position, so they would fold
+    into one layer of several series -- arriving without the names that tell
+    them apart. The legend holding those is the figure's, built after every
+    layer is drawn, and `AreaPlot` takes its labels at construction. Two
+    unnamed series is the shape xability/maidr#828 exists to prevent, so this
+    waits for the naming rather than shipping without it (#670).
+
+    That one rule also covers a **position transform**, which is why there is
+    no separate guard for one. `so.Stack()` matters only where there is a
+    second band to stack on: measured on a single group, `so.Area()`,
+    `so.Area(), so.Stack()` and `so.Area(), so.Dodge()` draw byte-identical
+    polygons, and reading that polygon is right in all three. Given two
+    levels the stack draws two polygons, the second running from the first's
+    top -- so its second half is the *cumulative* top rather than that
+    group's own values -- and the count declines it before that matters.
+
+    A sideways area is read, and is the one case that moves anything: with
+    ``orient="y"`` the positions run down the page and the magnitudes out
+    along x, which is `AreaPlot`'s ``transposed`` -- the same exchange
+    ``fill_betweenx`` already gets (#566).
+
+    Parameters
+    ----------
+    own : list
+        The polygons this layer drew on one panel.
+    orient : str, optional
+        ``layer["orient"]``: ``"y"`` for a sideways band.
+
+    Returns
+    -------
+    list of (PlotType, dict)
+        One entry, or an empty list which registers nothing.
+    """
+    if len(own) != 1:
+        return []
+    drawn = _unfolded(own[0])
+    if drawn is None:
+        return []
+    # A sideways band's positions run down the page and its magnitudes out
+    # along x, so which vertex coordinate is which turns round with `orient`
+    # -- measured on `orient="y"`, the baseline runs down x = 0 and the
+    # values sit at (1, 0), (3, 1), (2, 2), which is magnitude 1, 3, 2 at
+    # positions 0, 1, 2.
+    sideways = orient == "y"
+    positions = [point[1] if sideways else point[0] for point in drawn]
+    magnitudes = [point[0] if sideways else point[1] for point in drawn]
+    return [
+        (
+            PlotType.AREA,
+            {
+                "x": positions,
+                "series": [magnitudes],
+                "labels": [],
+                "collections": own,
+                "transposed": sideways,
+            },
+        )
+    ]
+
+
 def _handovers(
-    reading: _Reading, ax: Axes, own: list, move: list[Any] | None = None
+    reading: _Reading,
+    ax: Axes,
+    own: list,
+    move: list[Any] | None = None,
+    orient: str | None = None,
 ) -> list[tuple[PlotType, dict]]:
     """
     What to register for one layer's artists: one entry per layer to make.
@@ -406,6 +529,9 @@ def _handovers(
         One (type, keyword mapping) pair per layer to register. The type is
         the mark's own except where a position transform names a richer one.
     """
+    if reading.plot_type is PlotType.AREA:
+        return _area_handover(own, orient)
+
     if reading.plot_type is PlotType.SCATTER and len(own) == 1:
         groups = hue_groups(ax, own[0])
         if groups:
@@ -523,7 +649,7 @@ def _layer(wrapped, instance, args, kwargs) -> Any:
         # `FacetGrid.add_legend()`, and a name can be deferred to render as a
         # callable -- but a *split* cannot, because it decides how many
         # layers there are. So the reading waits for `_register`.
-        pending.append((ax, reading, own, layer.get("move")))
+        pending.append((ax, reading, own, layer.get("move"), layer.get("orient")))
 
     return drawn
 
@@ -565,8 +691,8 @@ def _register(wrapped, instance, args, kwargs) -> Any:
 
     plotter = wrapped(*args, **kwargs)
 
-    for ax, reading, own, move in getattr(plotter, _PENDING, ()):
-        for plot_type, handover in _handovers(reading, ax, own, move):
+    for ax, reading, own, move, orient in getattr(plotter, _PENDING, ()):
+        for plot_type, handover in _handovers(reading, ax, own, move, orient):
             FigureManager.create_maidr(ax, plot_type, **handover)
 
     return plotter

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -273,7 +273,6 @@ def test_a_panel_the_layer_never_drew_on_registers_nothing():
 @pytest.mark.parametrize(
     "mark",
     [
-        pytest.param(so.Area(), id="Area"),
         pytest.param(so.Bars(), id="Bars"),
         pytest.param(so.Lines(), id="Lines"),
         pytest.param(so.Paths(), id="Paths"),
@@ -325,13 +324,13 @@ def test_a_mark_that_is_read_still_reads_beside_one_that_is_not():
     """An unclaimed layer must not take the chart down with it.
 
     That is the whole-chart-to-a-picture failure of xability/r-maidr#225,
-    from the side where declining is the right answer: the `Area` is not
+    from the side where declining is the right answer: the `Dash` is not
     read, and the `Dot` beside it is unaffected.
     """
     figure = _drawn(
         lambda fig: so.Plot(_frame(), x="t", y="m")
         .add(so.Dot())
-        .add(so.Area())
+        .add(so.Dash())
         .on(fig)
         .plot()
     )
@@ -423,7 +422,6 @@ def test_every_selector_resolves_in_the_page_it_was_built_from(mark, x, y):
 @pytest.mark.parametrize(
     "mark",
     [
-        pytest.param(so.Area(), id="Area"),
         pytest.param(so.Bars(), id="Bars"),
         pytest.param(so.Dash(), id="Dash"),
         pytest.param(so.Range(), id="Range"),
@@ -592,3 +590,189 @@ def test_a_layer_that_drew_several_containers_becomes_several_bar_layers():
         (PlotType.BAR, {DRAWN_BARS: first}),
         (PlotType.BAR, {DRAWN_BARS: second}),
     ]
+
+
+# --------------------------------------------------------------------------
+# `so.Area` (#670)
+#
+# The one mark whose artist arrives in `patches` rather than in `collections`
+# or `lines`, and the one that needs something extracted rather than handed
+# straight to a plot class: `AreaPlot` takes the positions and the series,
+# and the polygon carries them folded.
+#
+# Measured on `t = 1, 2, 3` against `m = 10, 30, 20`, `Polygon.get_xy()`:
+#
+#     [[1,0], [2,0], [3,0], [3,20], [2,30], [1,10], [1,0]]
+#      └──── baseline ────┘  └──── values, reversed ────┘
+#
+# and with `baseline=` set to something other than zero the closing repeat is
+# gone -- six vertices rather than seven, both folding at `len // 2`.
+# --------------------------------------------------------------------------
+
+
+def test_an_area_mark_reads_as_the_band_it_draws():
+    """The reproduction, and the values recovered from the fold."""
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Area()).on(fig).plot()
+    )
+    kinds = _kinds(figure)
+    (_, schema) = _layers(figure)[0]
+
+    assert kinds == ["area"]
+    assert schema["data"] == [
+        [{"x": 1.0, "y": 10.0}, {"x": 2.0, "y": 30.0}, {"x": 3.0, "y": 20.0}]
+    ]
+
+
+@pytest.mark.parametrize("baseline", [5.0, 10.0])
+def test_a_band_drawn_from_a_baseline_of_its_own_reads_the_same_values(baseline):
+    """`baseline=` moves the fold's other half, not the drawn series.
+
+    `10.0` is the case that pins where the fold splits, and which spelling
+    reaches it is narrower than "a baseline was given". Measured on these
+    three points, `baseline=0` and `baseline=5` both leave **seven**
+    vertices, while `baseline=10` -- the first drawn value -- leaves
+    **six**: the last drawn vertex already coincides with the first baseline
+    one, so matplotlib does not repeat it. `len // 2` is 3 for both;
+    `(len - 1) // 2` is 3 and 2, and reads the six-vertex band as two points
+    of somebody else's numbers.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m")
+        .add(so.Area(baseline=baseline))
+        .on(fig)
+        .plot()
+    )
+    (_, schema) = _layers(figure)[0]
+
+    assert schema["data"] == [
+        [{"x": 1.0, "y": 10.0}, {"x": 2.0, "y": 30.0}, {"x": 3.0, "y": 20.0}]
+    ]
+
+
+def test_a_sideways_band_keeps_its_positions_on_the_position_axis():
+    """`orient="y"` fills between vertical positions and a horizontal curve.
+
+    Measured, the baseline then runs *down* x = 0 and the values sit at
+    `(10, 1), (30, 2), (20, 3)` -- so which vertex coordinate is the position
+    turns round with the orientation. The numbers go into the fields the
+    trace reads them from and the axis titles move instead, which is what
+    `AreaPlot.transposed` does for `fill_betweenx` (#566).
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="m", y="t")
+        .add(so.Area(), orient="y")
+        .on(fig)
+        .plot()
+    )
+    (_, schema) = _layers(figure)[0]
+
+    assert schema["data"] == [
+        [{"x": 1.0, "y": 10.0}, {"x": 2.0, "y": 30.0}, {"x": 3.0, "y": 20.0}]
+    ]
+    assert schema["axes"]["x"]["label"] == "t"
+    assert schema["axes"]["y"]["label"] == "m"
+
+
+def test_an_area_addresses_the_band_it_drew():
+    """A layer that announces correctly and outlines nothing is the blind
+    spot xability/maidr#814 names.
+
+    Resolved in Chromium against a rendering of this chart: the one selector
+    matched exactly one element.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Area()).on(fig).plot()
+    )
+    html = maidr.render(figure)._repr_html_()
+    (_, schema) = _layers(figure)[0]
+
+    selectors = schema.get("selectors")
+    assert isinstance(selectors, list) and len(selectors) == 1
+    identifiers = re.findall(r"'([^']+)'", selectors[0])
+    assert identifiers
+    for identifier in identifiers:
+        assert identifier in html
+
+
+def test_a_stacked_area_registers_nothing_rather_than_the_cumulative_top():
+    """A stack of two levels is declined, and the reason is the polygon.
+
+    Measured on `so.Area(), so.Stack()`, the second group's polygon runs from
+    the first group's top rather than from the baseline, so its second half
+    is the *cumulative* top and not that group's own values. Announcing those
+    as the group's magnitudes would describe a chart nobody drew.
+    """
+    frame = pd.DataFrame(
+        {"t": [1.0, 2.0, 1.0, 2.0], "m": [1.0, 3.0, 2.0, 4.0], "g": list("aabb")}
+    )
+    figure = _drawn(
+        lambda fig: so.Plot(frame, x="t", y="m", color="g")
+        .add(so.Area(), so.Stack())
+        .on(fig)
+        .plot()
+    )
+
+    assert _registers_nothing(figure)
+
+
+@pytest.mark.parametrize(
+    "move",
+    [pytest.param(so.Stack(), id="Stack"), pytest.param(so.Dodge(), id="Dodge")],
+)
+def test_a_position_transform_with_nothing_to_move_against_still_reads(move):
+    """The declining rule is the polygon count, not the presence of a move.
+
+    A transform matters only where there is a second band to move against.
+    Measured on a single group, `so.Area()`, `so.Area(), so.Stack()` and
+    `so.Area(), so.Dodge()` draw byte-identical polygons -- so refusing on
+    the move alone would decline three charts that are the same chart, and
+    two of them read correctly.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Area(), move).on(fig).plot()
+    )
+    (_, schema) = _layers(figure)[0]
+
+    assert schema["data"] == [
+        [{"x": 1.0, "y": 10.0}, {"x": 2.0, "y": 30.0}, {"x": 3.0, "y": 20.0}]
+    ]
+
+
+def test_a_colour_split_area_registers_nothing_until_its_groups_are_named():
+    """Two unnamed series is the shape xability/maidr#828 exists to prevent.
+
+    A colour split draws one polygon per level -- measured, each spanning
+    every position, so they would fold into one layer of several series. What
+    they would arrive without is their names: the legend holding them is the
+    figure's, built after every layer is drawn, and `AreaPlot` takes its
+    labels at construction. This waits for the naming rather than shipping
+    without it.
+    """
+    frame = pd.DataFrame(
+        {"t": [1.0, 2.0, 1.0, 2.0], "m": [1.0, 3.0, 2.0, 4.0], "g": list("aabb")}
+    )
+    figure = _drawn(
+        lambda fig: so.Plot(frame, x="t", y="m", color="g")
+        .add(so.Area())
+        .on(fig)
+        .plot()
+    )
+
+    assert _registers_nothing(figure)
+
+
+def test_an_area_reads_beside_a_mark_of_another_kind():
+    """The layers stay in the order they were added, and neither eats the
+    other's artists: an `Area` leaves a patch and a `Line` leaves a `Line2D`,
+    and each reading filters its holder by its own class.
+    """
+    figure = _drawn(
+        lambda fig: so.Plot(_frame(), x="t", y="m")
+        .add(so.Area())
+        .add(so.Line())
+        .on(fig)
+        .plot()
+    )
+
+    assert _kinds(figure) == ["area", "line"]


### PR DESCRIPTION
Part of #670 — one of the eight marks it lists. The other seven are unchanged and still decline.

`so.Area` is the sixth of the thirteen `seaborn.objects` marks to be read, and the first to need something **extracted** rather than handed straight to a plot class. `ScatterPlot` already takes a collection, `LinePlot` a list of lines and `BarPlot` a container; `AreaPlot` takes the *positions* and the *series*, and the polygon carries them folded.

It is also the only mark whose artist arrives in `patches` rather than in `collections` or `lines`.

## Measured

`Polygon.get_xy()` on `t = 1, 2, 3` against `m = 10, 30, 20`:

```
[[1,0], [2,0], [3,0], [3,20], [2,30], [1,10], [1,0]]
 └──── baseline ────┘  └──── values, reversed ────┘
```

so the drawn series is the second half reversed — `(1,10) (2,30) (3,20)`, exactly the data.

**Where the fold splits is not obvious, and the obvious guess is wrong.** Measured on the same three points:

| spelling | vertices |
| --- | --- |
| `baseline=0` (the default) | 7 |
| `baseline=5` | 7 |
| `baseline=10` — the first drawn value | **6** |

The closing repeat disappears only when the last drawn vertex already coincides with the first baseline one, which is a coincidence of the *data*, not of "a baseline was given". So the split is `len // 2` and not `(len - 1) // 2`: 3 for both forms, where the latter would be 3 and 2 and would read the six-vertex band as two points of somebody else's numbers.

**A sideways band is read too.** With `orient="y"` the baseline runs down x = 0 and the values sit at `(10, 1), (30, 2), (20, 3)`, so which vertex coordinate is the position turns round. The numbers then go into the fields the trace reads them from and the axis **titles** move instead — `AreaPlot.transposed`, the same exchange `fill_betweenx` already gets (#566).

## One polygon, or nothing

A layer that drew several polygons is a colour split, and a colour split declines for a reason about **names** rather than numbers: measured, each level's polygon spans every position, so they would fold into one layer of several series — arriving without the names that tell them apart. The legend holding those is the figure's, built after every layer is drawn, and `AreaPlot` takes its labels at construction. Two unnamed series is the shape xability/maidr#828 exists to prevent.

That one rule also covers a **position transform**, which is why there is no separate guard for one — and the sweep below is what established that. Measured on a single group:

```
so.Area()                     [[1,0],[2,0],[3,0],[3,20],[2,30],[1,10],[1,0]]
so.Area(), so.Stack()         [[1,0],[2,0],[3,0],[3,20],[2,30],[1,10],[1,0]]
so.Area(), so.Dodge()         [[1,0],[2,0],[3,0],[3,20],[2,30],[1,10],[1,0]]
```

byte-identical, so refusing on the move alone would decline three charts that are the same chart and read correctly. A transform matters only where there is a second band to move against — and there the stack draws *two* polygons, the second running from the first's top, so its second half is the cumulative top rather than that group's own values, and the count declines it before that matters.

## The highlight

The one selector was resolved in Chromium against a rendering of the chart:

```
g[id='maidr-…'] path  ->  1 element
```

## Tests

`tests/core/plot/test_seaborn_objects.py` — 47 passing (40 before). Seven new: the reproduction, `baseline=` parametrised over both vertex counts, the sideways band and its exchanged titles, the selector, a two-level stack declining, a single-group transform still reading, and an Area beside a Line each keeping its own artists.

`so.Area` also comes **out** of the two lists that pinned it as unread — `test_a_mark_this_does_not_read_still_registers_nothing` and `test_a_mark_outside_the_table_is_declined_rather_than_defaulted` — which is the reminder those lists exist to give. `test_a_mark_that_is_read_still_reads_beside_one_that_is_not` needed a mark that is still declined, and now uses `so.Dash()`.

## Mutation sweep

| mutation | |
| --- | --- |
| the Area mark is not in the reading table (the reproduction) | killed |
| the fold splits one vertex earlier | killed |
| the drawn values are not reversed | killed |
| the baseline is taken as the values | killed |
| the orientation is ignored | killed |
| the layer never says it was drawn sideways | killed |
| a colour split is read as one unnamed series | killed |

Two survived the first pass, and both were the sweep doing its job:

- **the fold split** survived because the `baseline=` test used `5`, which measures seven vertices like the default and never reaches the six-vertex form. Sharpened to run both `5` and `10`, and the docstring that claimed "a baseline other than zero drops a vertex" was simply wrong and is corrected.
- **a `move` guard** survived because a stacked colour split is already declined by the polygon count. Measuring the single-group case showed the guard was over-broad rather than under-tested — it declined three identical charts — so it was **removed** and the count now carries the rule alone.

## Verification

- `uv run pytest -q` — 3454 passed, 72 skipped (3446 before)
- `ruff check` on both touched files — clean
- the selector resolved in Chromium, as above

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_