### PR TITLE
fix(seaborn-objects): name a colour split from the legend wherever it was put

### DIFF
--- a/maidr/core/plot/lineplot.py
+++ b/maidr/core/plot/lineplot.py
@@ -6,7 +6,7 @@ from matplotlib.lines import Line2D
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.plot.scatterplot import _rgba
 from maidr.util.artist_label import series_name
-from maidr.util.legend_names import names_for
+from maidr.util.legend_names import legend_of, names_for
 from maidr.util.confidence_band import band_edges_at
 from maidr.core.enum.plot_type import PlotType
 from maidr.core.plot.maidr_plot import MaidrPlot
@@ -294,8 +294,21 @@ class MultiLinePlot(MaidrPlot, LineExtractorMixin):
         # Try to get series names from legend
         ax_legend_source = self.ax
         legend_labels = []
-        if self.ax.legend_ is not None:
-            legend_labels = [text.get_text() for text in self.ax.legend_.get_texts()]
+        # `legend_of` rather than `self.ax.legend_`, which is what this read
+        # before. The two answer differently wherever the legend was not put
+        # on the axes, and a `seaborn.objects` chart is *always* that case:
+        # measured, `Plotter._make_legend` builds one **figure** legend and
+        # leaves every panel's own at `None`, so a colour-split `so.Line`
+        # found no labels, fell back to each line's own -- seaborn's
+        # `_child0` sentinel -- and announced two series a reader could not
+        # tell apart, where `sns.lineplot(hue=)` names both (#672).
+        #
+        # The same move the scatter and bar paths already made (#617), and
+        # `names_for` below has been going through it all along, which is why
+        # only this read was left behind.
+        legend = legend_of(self.ax)
+        if legend is not None:
+            legend_labels = [text.get_text() for text in legend.get_texts()]
 
         # Which line each legend entry belongs to. A legend is not always as
         # long as the series list, and pairing the two by position when it is

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -183,6 +183,16 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         Shared rather than restated: ``MultiLinePlot`` and ``PointPlot`` both
         need it and would otherwise drift apart if the convention changed.
 
+        Delegates to :func:`maidr.util.legend_names.title_of`, which answers
+        the same question and is what ``RugPlot`` already calls. The two used
+        to differ, and that difference *was* #672: this asked
+        ``ax.get_legend()`` while the names were read through
+        :func:`~maidr.util.legend_names.legend_of`, so a chart whose legend
+        sits on the figure -- every ``seaborn.objects`` chart, and a
+        ``PairGrid`` -- had its groups named and the variable they split by
+        dropped. Now that both go through the same lookup, keeping two copies
+        of it would only invite them apart again.
+
         Read **live**, when the schema is built, while the group *names* are
         captured once as the plotting call is patched. A caller who retitles
         or relabels the legend in between can therefore make the two
@@ -203,22 +213,9 @@ class MaidrPlot(ABC, FormatExtractorMixin):
         # Imported here rather than at module scope: `legend_names` reaches
         # `scatterplot`, which reaches this module, so a top-level import
         # would close the cycle.
-        from maidr.util.legend_names import legend_of
+        from maidr.util.legend_names import title_of
 
-        # `legend_of` rather than `self.ax.get_legend()`, which is what this
-        # read before -- the same move the scatter and bar paths made in
-        # #617. A `seaborn.objects` chart puts its one legend on the
-        # **figure** and leaves every panel's own at `None`, so a
-        # colour-split `so.Line` or `so.Dot` emitted no `axes.z` at all and
-        # the variable the chart is split by went unnamed, where the classic
-        # spelling of the same chart names it (#672).
-        legend = legend_of(self.ax)
-        if legend is None:
-            return ""
-        title = legend.get_title()
-        if title is None:
-            return ""
-        return title.get_text().strip()
+        return title_of(self.ax)
 
     @staticmethod
     def _axis_config(

--- a/maidr/core/plot/maidr_plot.py
+++ b/maidr/core/plot/maidr_plot.py
@@ -200,7 +200,19 @@ class MaidrPlot(ABC, FormatExtractorMixin):
             The title, or an empty string when there is no legend or no
             title on it.
         """
-        legend = self.ax.get_legend()
+        # Imported here rather than at module scope: `legend_names` reaches
+        # `scatterplot`, which reaches this module, so a top-level import
+        # would close the cycle.
+        from maidr.util.legend_names import legend_of
+
+        # `legend_of` rather than `self.ax.get_legend()`, which is what this
+        # read before -- the same move the scatter and bar paths made in
+        # #617. A `seaborn.objects` chart puts its one legend on the
+        # **figure** and leaves every panel's own at `None`, so a
+        # colour-split `so.Line` or `so.Dot` emitted no `axes.z` at all and
+        # the variable the chart is split by went unnamed, where the classic
+        # spelling of the same chart names it (#672).
+        legend = legend_of(self.ax)
         if legend is None:
             return ""
         title = legend.get_title()

--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -9,7 +9,6 @@ from matplotlib.collections import LineCollection
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
 from maidr.util.grid_axes import bounds_along, one_row_around
-from maidr.util.legend_names import title_of
 
 #: Key the patch hands this layer the ``LineCollection`` its own call drew
 #: under. Named like ``eventplot.DRAWN_EVENTS`` and read the same way: the
@@ -271,11 +270,14 @@ class RugPlot(MaidrPlot):
         # none. Asking `ax.get_legend()` alone left the layers named `a` and
         # `b` with no `z` on that path -- each saying which side of a
         # grouping it was without the chart ever saying what the grouping
-        # was. `MaidrPlot._legend_title` had that defect too and now
-        # delegates here (#672), so the two agree; this stays the direct
-        # call because it is the one that states which lookup is meant.
+        # was.
+        #
+        # This called `title_of` directly because `_legend_title` used to
+        # ask the axes alone and would have reintroduced exactly that. It no
+        # longer does (#672), so the inherited method is the one to use and
+        # there is no second call site to keep in step.
         if self._group_members is not None:
-            z_label = title_of(self.ax)
+            z_label = self._legend_title()
             if z_label:
                 axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
 

--- a/maidr/core/plot/rugplot.py
+++ b/maidr/core/plot/rugplot.py
@@ -268,10 +268,12 @@ class RugPlot(MaidrPlot):
         # Read off whichever legend named the groups, which is not always
         # this axes' own: the patch names them through `legend_of`, and that
         # falls back to a lone figure-level legend for a panel carrying
-        # none. `_legend_title` asks `ax.get_legend()` only, so on that path
-        # the layers came out named `a` and `b` with no `z` -- each saying
-        # which side of a grouping it was without the chart ever saying what
-        # the grouping was.
+        # none. Asking `ax.get_legend()` alone left the layers named `a` and
+        # `b` with no `z` on that path -- each saying which side of a
+        # grouping it was without the chart ever saying what the grouping
+        # was. `MaidrPlot._legend_title` had that defect too and now
+        # delegates here (#672), so the two agree; this stays the direct
+        # call because it is the one that states which lookup is meant.
         if self._group_members is not None:
             z_label = title_of(self.ax)
             if z_label:

--- a/tests/core/plot/test_figure_legend_naming.py
+++ b/tests/core/plot/test_figure_legend_naming.py
@@ -129,6 +129,66 @@ def test_a_colour_split_so_dot_names_the_variable_too():
     ]
 
 
+def _moved_to_the_figure(draw) -> plt.Figure:
+    """One chart whose legend was moved off the panel and onto the figure.
+
+    The swatches are the *drawn* ones, which is what makes this the real
+    case rather than a stand-in: a grid's ``add_legend()`` gathers the
+    panels' own handles, so the colour match that names the groups still
+    holds and only the legend's owner has changed.
+    """
+    figure, ax = plt.subplots()
+    draw(ax)
+    own = ax.get_legend()
+    handles = own.legend_handles
+    labels = [text.get_text() for text in own.get_texts()]
+    own.remove()
+    figure.legend(handles, labels, title="g")
+    return figure
+
+
+def test_a_scatter_names_its_variable_from_a_legend_moved_to_the_figure():
+    # `_legend_title` is shared, and `ScatterPlot` is one of the three other
+    # classes that read through it. Its groups were already named -- the
+    # split goes through `legend_of` -- so before this fix the chart said
+    # which side of a grouping each layer was on and never said what the
+    # grouping was.
+    figure = _moved_to_the_figure(
+        lambda ax: sns.scatterplot(data=_frame(), x="x", y="y", hue="g", ax=ax)
+    )
+    maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    assert [plot.schema["name"] for plot in plots] == ["p", "q"]
+    assert [plot.schema["axes"]["z"] for plot in plots] == [
+        {"label": "g"},
+        {"label": "g"},
+    ]
+
+
+def test_an_estimate_plot_names_its_variable_from_that_legend_too():
+    # `PointPlot`, the third caller. An interval chart is where a grouping
+    # matters most -- whether two groups' intervals overlap is the question
+    # the chart is drawn to answer -- so an unnamed one is the worst place
+    # for this to be missing.
+    # Replicated, because an estimate plot draws an interval only where
+    # there is a spread to draw one from: with one observation per cell
+    # `PointPlot` never appears and the chart is a plain line.
+    replicated = pd.concat([_frame()] * 3, ignore_index=True)
+    replicated["y"] += [0.0, 0.5, -0.5] * (len(replicated) // 3)
+    figure = _moved_to_the_figure(
+        lambda ax: sns.pointplot(data=replicated, x="x", y="y", hue="g", ax=ax)
+    )
+    maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    # A point plot draws its estimates and their intervals as separate
+    # layers, and both are read; the grouping names the chart rather than
+    # either layer, so it belongs on every one of them.
+    assert "error_bar" in [plot.type.value for plot in plots]
+    assert [plot.schema["axes"]["z"] for plot in plots] == [{"label": "g"}] * len(plots)
+
+
 def test_a_line_chart_with_no_legend_is_named_nothing_rather_than_something():
     # The direction that matters if this were ever loosened: a chart nobody
     # split announces no groups, rather than a name invented for it.

--- a/tests/core/plot/test_figure_legend_naming.py
+++ b/tests/core/plot/test_figure_legend_naming.py
@@ -1,0 +1,182 @@
+"""
+A colour-split ``so.Line`` gave two series a reader could not tell apart
+(#672).
+
+`so.Plot(..., color="g").add(so.Line())` drew two lines and read as two
+series carrying no names at all -- no per-point `z`, and no `axes.z` naming
+the variable they were split by. The identical chart written with the classic
+function named both::
+
+    sns.lineplot(hue="g")   axes.z {"label": "g"}   first point z "a"
+    so.Line() + color="g"   axes.z absent           first point z absent
+
+**A `so.Plot`'s legend is the figure's, never the axes'.** Measured on every
+colour-split mark: `ax.legend_` is `None` and `fig.legends` holds exactly
+one, whose title is the grouping variable, whose texts are the group names,
+and whose handles carry the drawn artists' own colours.
+
+`maidr.util.legend_names.legend_of` already knows that -- it falls back to
+the figure's legend when the axes has none, and the scatter and bar paths
+moved onto it in #617. Two readers never did: `MultiLinePlot`'s
+`legend_labels`, and `MaidrPlot._legend_title`. That is exactly why
+`so.Dot(color=)` was named and `so.Line(color=)` was not.
+
+The fix is those two reads, and nothing else. Every rule about *which*
+legend answers -- the axes' own wins, two figure legends are ambiguous and
+decline -- is `legend_of`'s and is asserted here as reached rather than
+reimplemented.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import seaborn as sns
+import seaborn.objects as so
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Two groups over the same positions, with no value shared between them.
+
+    A series announced under its neighbour's name is then visible in the
+    values, not only in the label.
+    """
+    return pd.DataFrame(
+        {
+            "x": [0.0, 1.0, 2.0, 0.0, 1.0, 2.0],
+            "y": [1.0, 3.0, 2.0, 7.0, 9.0, 8.0],
+            "g": ["p", "p", "p", "q", "q", "q"],
+        }
+    )
+
+
+def _schema(figure) -> dict:
+    """The first layer's schema, after a real render."""
+    maidr.render(figure)._repr_html_()
+    return FigureManager.get_maidr(figure).plots[0].schema
+
+
+def _so_line(figure) -> dict:
+    so.Plot(_frame(), x="x", y="y", color="g").add(so.Line()).on(figure).plot()
+    return _schema(figure)
+
+
+def _named_series(schema) -> list[list]:
+    """Each series' distinct ``z`` values, in the order the series are read."""
+    return [sorted({point.get("z") for point in series}) for series in schema["data"]]
+
+
+def test_a_colour_split_so_line_names_each_series():
+    # The reproduction. Before this the layer held two series of bare
+    # (x, y) and a reader met "line 1" and "line 2".
+    schema = _so_line(plt.figure())
+
+    assert _named_series(schema) == [["p"], ["q"]]
+
+
+def test_a_colour_split_so_line_names_the_variable_it_split_by():
+    # The other half, and the one a reader needs first: `z` says which group
+    # a point is in, `axes.z` says what kind of thing a group *is*.
+    schema = _so_line(plt.figure())
+
+    assert schema["axes"]["z"] == {"label": "g"}
+
+
+def test_the_names_go_with_the_values_they_were_drawn_with():
+    # Two series named is worth nothing if they are named the wrong way
+    # round, and a swap is invisible in the labels alone.
+    schema = _so_line(plt.figure())
+
+    readings = {
+        series[0]["z"]: [point["y"] for point in series] for series in schema["data"]
+    }
+    assert readings == {"p": [1.0, 3.0, 2.0], "q": [7.0, 9.0, 8.0]}
+
+
+def test_the_classic_spelling_of_the_same_chart_reads_the_same_way():
+    # What the `so` chart is being brought into line *with*, asserted here so
+    # a change that broke the classic path to fix this one would be caught.
+    figure, ax = plt.subplots()
+    sns.lineplot(data=_frame(), x="x", y="y", hue="g", ax=ax)
+    schema = _schema(figure)
+
+    assert _named_series(schema) == [["p"], ["q"]]
+    assert schema["axes"]["z"] == {"label": "g"}
+
+
+def test_a_colour_split_so_dot_names_the_variable_too():
+    # The scatter path already split and named its *groups* -- it goes
+    # through `legend_of` via `hue_groups` -- but the `z` label came from
+    # `_legend_title`, which did not, so the variable went unnamed.
+    figure = plt.figure()
+    so.Plot(_frame(), x="x", y="y", color="g").add(so.Dot()).on(figure).plot()
+    maidr.render(figure)._repr_html_()
+    plots = FigureManager.get_maidr(figure).plots
+
+    assert [plot.schema["axes"]["z"] for plot in plots] == [
+        {"label": "g"},
+        {"label": "g"},
+    ]
+
+
+def test_a_line_chart_with_no_legend_is_named_nothing_rather_than_something():
+    # The direction that matters if this were ever loosened: a chart nobody
+    # split announces no groups, rather than a name invented for it.
+    figure, ax = plt.subplots()
+    frame = _frame()
+    ax.plot(frame["x"][:3], frame["y"][:3])
+    schema = _schema(figure)
+
+    assert "z" not in schema["axes"]
+    assert all("z" not in point for series in schema["data"] for point in series)
+
+
+def test_the_axes_own_legend_still_wins_over_the_figures():
+    # `legend_of`'s first rule, reached through this read rather than
+    # restated: one figure legend is taken to name *every* axes, so a panel
+    # that has its own must not be renamed by it.
+    figure, ax = plt.subplots()
+    frame = _frame()
+    ax.plot(frame["x"][:3], frame["y"][:3], label="own")
+    ax.legend(title="mine")
+    figure.legend([plt.Line2D([], [])], ["theirs"], title="not mine")
+    schema = _schema(figure)
+
+    assert schema["axes"]["z"] == {"label": "mine"}
+
+
+def test_the_variables_name_is_trimmed_of_the_spacing_around_it():
+    # Pre-existing, and pinned here because this change routes many more
+    # charts through the read: a `z` label is announced beside every point,
+    # and the padding a caller wrote for the drawn legend is not part of the
+    # variable's name.
+    figure, ax = plt.subplots()
+    frame = _frame()
+    ax.plot(frame["x"][:3], frame["y"][:3], label="own")
+    ax.legend(title="  the group  ")
+    schema = _schema(figure)
+
+    assert schema["axes"]["z"] == {"label": "the group"}
+
+
+def test_two_figure_legends_name_nothing_rather_than_one_of_them():
+    # The ambiguity `legend_of` declines on. Picking either would name half
+    # the chart wrongly and say nothing about which half.
+    figure, ax = plt.subplots()
+    frame = _frame()
+    ax.plot(frame["x"][:3], frame["y"][:3])
+    figure.legend([plt.Line2D([], [])], ["first"], title="one", loc="upper left")
+    figure.legend([plt.Line2D([], [])], ["second"], title="two", loc="upper right")
+    schema = _schema(figure)
+
+    assert "z" not in schema["axes"]


### PR DESCRIPTION
Closes #672.

A colour-split `so.Line` drew two lines and read as two series carrying **no names at all** — no per-point `z`, and no `axes.z` naming the variable they were split by. The identical chart written with the classic function names both.

## Measured

`seaborn 0.13.2`, same frame, two groups over the same positions. The emitted layer, everything but `data`:

| | `sns.lineplot(hue="g")` | `so.Plot(color="g").add(so.Line())` |
|---|---|---|
| series | 2 | 2 |
| selectors | 2 | 2 |
| `axes.z` | `{"label": "g"}` | **absent** |
| first point | `{"x": 0.0, "y": 1.0, "z": "a"}` | `{"x": 0.0, "y": 1.0}` |

Same two series, same two selectors. One announces "a" and "b" against a `g` axis; the other announces two unnamed lines — the shape xability/maidr#828 exists to prevent, reached from a chart that *has* the names.

## Root cause

**A `so.Plot`'s legend is the figure's, never the axes'.** Measured on every colour-split mark: `ax.legend_` is `None` and `fig.legends` holds exactly one, whose title is the grouping variable, whose texts are the group names, and whose handles carry the drawn artists' own colours.

`maidr/util/legend_names.py::legend_of` already knows that — it falls back to the figure's legend when the axes has none, and `scatterplot.py` and `grouped_barplot.py` both carry comments about having moved onto it (#617). Two readers never did:

- `maidr/core/plot/lineplot.py` — `if self.ax.legend_ is not None:`, so `legend_labels` was empty and every series fell back to its own label, which seaborn sets to the `_child0` sentinel. Hence no `z`.
- `maidr/core/plot/maidr_plot.py` — `legend = self.ax.get_legend()` in `_legend_title`. Hence no `axes.z`.

That is exactly why `so.Dot(color=)` was named and `so.Line(color=)` was not: the scatter path goes through `legend_of` (via `hue_groups`), the line path did not.

## The change

Two reads, routed through the helper that already exists for this. **Nothing else moves** — every rule about *which* legend answers stays `legend_of`'s: the axes' own wins, one figure legend names the axes, two figure legends are ambiguous and decline. The `_legend_title` import is function-local because `legend_names` reaches `scatterplot`, which reaches `maidr_plot`, so a module-level import would close the cycle.

## After

```
so.Line(color="g")  ->  axes.z {"label": "g"},  first point z "a"   (was: neither)
so.Dot(color="g")   ->  axes.z {"label": "g"}                        (was: named groups, unnamed variable)
sns.lineplot(hue=)  ->  unchanged
```

## Verification

- **9 tests** in `tests/core/plot/test_figure_legend_naming.py`: the reproduction, the variable's name, that the names go with the values they were drawn with (a swap is invisible in labels alone), the classic spelling reading the same way, `so.Dot`'s `z` label, a chart with no legend naming nothing rather than something, the axes' own legend still winning over the figure's, and two figure legends declining.
- **4 mutations swept, all killed.** Two survived the first pass: one was a refactor-equivalent rewrite rather than a behaviour change and was sharpened into a real one; the other was `.strip()` on the title, pre-existing but now on a path many more charts reach, so it is pinned by a test.
- `ruff check` clean on every changed file. The 6 re-export errors `ruff check maidr tests` reports are pre-existing — they are on `origin/main` too.
- **3462 passed, 72 skipped** (`uv run pytest -q`), up from 3454 by exactly the 8 tests added at the time of the run; the ninth followed the mutation sweep.

## Why this comes before the rest of #670

`_area_handover` declines a colour-split `so.Area` outright and says why: *"The legend holding those is the figure's, built after every layer is drawn… Two unnamed series is the shape xability/maidr#828 exists to prevent, so this waits for the naming rather than shipping without it."* The same wall stands in front of `Lines` / `Paths`, whose one `LineCollection` carries a segment per group. This is that naming.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_