### PR TITLE
feat(seaborn-objects): read a Lines or Paths mark as the line it draws

### DIFF
--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
-from matplotlib.collections import PolyCollection
+from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.patches import StepPatch
 from maidr.core.enum import PlotType
 from maidr.core.plot.areaplot import AreaPlot
@@ -18,6 +18,7 @@ from maidr.core.plot.heatmap import HeatPlot
 from maidr.core.plot.hexbinplot import HexbinPlot
 from maidr.core.plot.histogram import HistPlot
 from maidr.core.plot.lineplot import MultiLinePlot
+from maidr.core.plot.segment_lineplot import DRAWN_SEGMENTS, SegmentLinePlot
 from maidr.core.plot.lollipop import LollipopPlot
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.core.plot.outlined_histogram import OUTLINE_LINE, OutlinedHistPlot
@@ -132,6 +133,12 @@ class MaidrPlotFactory:
                 return StepHistPlot(single_ax, counts, edges, **kwargs)
             return HistPlot(single_ax, **kwargs)
         elif PlotType.LINE == plot_type:
+            # `so.Lines` and `so.Paths` draw every series into one
+            # `LineCollection` rather than a `Line2D` each, so the layer is
+            # handed the collection and reads its segments (#670). The same
+            # shape `SteppedHistPlot` is selected by above.
+            if isinstance(kwargs.get(DRAWN_SEGMENTS), LineCollection):
+                return SegmentLinePlot(single_ax, **kwargs)
             if PlotDetectionUtils.is_mplfinance_line_plot(single_ax, **kwargs):
                 return MplfinanceLinePlot(single_ax, **kwargs)
             else:

--- a/maidr/core/plot/segment_lineplot.py
+++ b/maidr/core/plot/segment_lineplot.py
@@ -1,0 +1,155 @@
+"""SegmentLinePlot — the series a ``LineCollection`` draws, one per segment."""
+
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+from matplotlib.lines import Line2D
+
+from maidr.core.enum.plot_type import PlotType
+from maidr.core.plot.lineplot import MultiLinePlot
+
+#: The keyword the collection is handed over under.
+#:
+#: The same one ``SteppedHistPlot`` takes, and for the same reason: the layer
+#: is told which artist it describes rather than searching the axes, so a
+#: second call on the same panel reads its own.
+DRAWN_SEGMENTS = "collection"
+
+
+class SegmentLinePlot(MultiLinePlot):
+    """
+    Several line series drawn as one ``LineCollection`` rather than as a
+    ``Line2D`` each.
+
+    ``so.Lines`` and ``so.Paths`` are the mark ``seaborn.objects`` draws when
+    the series are many: measured, a colour-split layer leaves **one**
+    collection carrying one segment per group, where ``so.Line`` leaves one
+    ``Line2D`` per group. The reading is the same multi-series line either
+    way, so everything about *what is announced* is inherited -- coordinates,
+    the gap rule, per-series naming from whichever legend named the colours,
+    the ``z`` label. Only two things differ, and both are about the artist.
+
+    **Where the series come from.** ``MultiLinePlot`` walks ``Line2D``
+    objects, so each segment is wrapped in one. They are stand-ins rather
+    than drawings: never added to the axes, carrying the segment's points and
+    the colour it was drawn in, which is all the inherited walk reads. The
+    colour matters -- it is what pairs a series with its legend entry, and
+    pairing by position gets two groups the wrong way round whenever the
+    legend is not in the drawn order (#582).
+
+    **What is outlined.** One collection is one SVG group holding one
+    ``<path>`` per segment, in segment order -- measured, three groups give
+    three paths as direct children. So a series is addressed by its position
+    within the group rather than by a group of its own, which is the one
+    thing the inherited selector cannot say.
+
+    An empty segment is not a case to handle: ``LineCollection`` refuses to
+    hold one, so every segment has at least one point and the paths and the
+    series stay one to one. A single-point group *is* drawn -- measured, it
+    leaves a segment and a degenerate path of its own -- so it keeps its
+    position in both lists.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the series were drawn on.
+    collection : LineCollection
+        The collection this call produced, handed over rather than searched
+        for.
+    **kwargs : dict
+        Forwarded to :class:`MultiLinePlot`.
+    """
+
+    def __init__(self, ax: Axes, collection: LineCollection, **kwargs) -> None:
+        super().__init__(ax, PlotType.LINE, **kwargs)
+        self._collection = collection
+
+    def _series(self) -> List[Line2D]:
+        """
+        One stand-in ``Line2D`` per drawn segment.
+
+        Rebuilt on each walk rather than kept. Nothing downstream holds one
+        by identity -- the payload reads their coordinates and colours, the
+        selectors read only how many there are, and the artist that gets
+        tagged is the collection -- so a cache would be a rule no caller
+        relies on.
+
+        The colour **is** relied on: it is what pairs a series with its
+        legend entry, which is the pairing #582 exists for. Matplotlib does
+        not expand a short colour list to match the segments -- measured, a
+        collection drawn in one colour reports exactly one however many
+        segments it holds, and that is the default -- so the reading cycles
+        it the way the drawing does rather than running off the end.
+
+        Returns
+        -------
+        list of Line2D
+            In the order the collection holds its segments, which is the
+            order it draws them.
+        """
+        colours = np.asarray(self._collection.get_colors())
+        stand_ins: List[Line2D] = []
+        for index, segment in enumerate(self._collection.get_segments()):
+            points = np.asarray(segment, dtype=float)
+            line = Line2D(points[:, 0], points[:, 1])
+            if len(colours):
+                line.set_color(colours[index % len(colours)])
+            stand_ins.append(line)
+        return stand_ins
+
+    def _extract_line_data(self):
+        """
+        The inherited reading, with the drawn artist put back.
+
+        ``MultiLinePlot`` records each series' ``Line2D`` as the element to
+        tag, which is right where the series *are* the drawing. Here they are
+        stand-ins that were never added to the axes, so tagging them would
+        write a ``maidr`` attribute onto nothing and the collection's own
+        group would carry none. The one collection is the one drawn artist.
+
+        No guard on an empty reading: the inherited ``_extract_plot_data``
+        raises rather than returning one, so a layer that read nothing never
+        reaches the tagging at all.
+
+        Returns
+        -------
+        list[list[dict]] or None
+            Whatever the inherited walk read.
+        """
+        data = super()._extract_line_data()
+        self._elements.clear()
+        self._elements.append(self._collection)
+        return data
+
+    def _get_selector(self) -> List[str]:
+        """
+        One selector per series, addressing its own path inside the group.
+
+        The inherited selector answers ``g[id=…] path`` per line, which is
+        right when each series has a group of its own and wrong here: every
+        series would outline every other one's segment too.
+
+        The gid is assigned here when the collection has none, exactly as the
+        inherited walk does for a line. ``maidr.patch.highlight`` keeps an id
+        that already begins with ``maidr-`` when the artist is drawn, so the
+        one written here is the one that reaches the SVG.
+
+        Returns
+        -------
+        list of str
+            One selector per segment, in the order the payload announces them.
+        """
+        gid = self._collection.get_gid()
+        if not gid or not str(gid).startswith("maidr-"):
+            gid = f"maidr-{uuid.uuid4()}"
+            self._collection.set_gid(gid)
+
+        return [
+            f"g[id='{gid}'] > path:nth-of-type({position + 1})"
+            for position in range(len(self._series()))
+        ]

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -8,7 +8,7 @@ from typing import Any, NamedTuple
 import numpy as np
 import wrapt
 from matplotlib.axes import Axes
-from matplotlib.collections import PathCollection
+from matplotlib.collections import LineCollection, PathCollection
 from matplotlib.container import BarContainer
 from matplotlib.lines import Line2D
 from matplotlib.patches import Polygon
@@ -20,6 +20,7 @@ from maidr.core.plot.barplot import DRAWN_BARS, bar_groups
 from maidr.core.plot.grouped_barplot import DRAWN_GROUPS
 from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.core.plot.scatterplot import DRAWN_POINTS, HUE_GROUP, hue_groups
+from maidr.core.plot.segment_lineplot import DRAWN_SEGMENTS
 from maidr.patch.common import _draw_quietly
 
 
@@ -102,6 +103,13 @@ _READINGS: dict[str, _Reading] = {
     # only where the artist itself goes and `_area_handover` supplies the
     # rest.
     "Area": _Reading(PlotType.AREA, "patches", Polygon, "collections"),
+    # The many-series spelling of `Line` and `Path`: measured, a colour split
+    # leaves **one** `LineCollection` carrying a segment per group, where the
+    # singular marks leave a `Line2D` each. `SegmentLinePlot` reads those
+    # segments, so the collection is handed over singular -- a layer draws one,
+    # and two would be two charts (#670).
+    "Lines": _Reading(PlotType.LINE, "collections", LineCollection, DRAWN_SEGMENTS, True),
+    "Paths": _Reading(PlotType.LINE, "collections", LineCollection, DRAWN_SEGMENTS, True),
 }
 
 

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -274,8 +274,6 @@ def test_a_panel_the_layer_never_drew_on_registers_nothing():
     "mark",
     [
         pytest.param(so.Bars(), id="Bars"),
-        pytest.param(so.Lines(), id="Lines"),
-        pytest.param(so.Paths(), id="Paths"),
         pytest.param(so.Dash(), id="Dash"),
         pytest.param(so.Text(), id="Text"),
     ],
@@ -285,7 +283,12 @@ def test_a_mark_this_does_not_read_still_registers_nothing(mark):
 
     Each of these registered nothing before and must register nothing now: a
     mark whose artists no existing plot class can read is left alone, not
-    guessed at. `Dash` and `Paths` matter most -- see the test below.
+    guessed at. `Dash` matters most -- see the test below.
+
+    `Lines` and `Paths` left this list when they gained a reading (#670).
+    They came off deliberately: this list is the reminder that a decline was
+    a decision, so a mark added to `_READINGS` has to be taken out of it by
+    hand rather than quietly passing both ways.
     """
     figure = _drawn(
         lambda fig: so.Plot(_frame(), x="t", y="m").add(mark).on(fig).plot()
@@ -301,10 +304,13 @@ def test_the_marks_are_matched_by_name_and_not_by_ancestry():
         Dash  < Paths < Mark      LineCollection
         Range < Paths < Mark      LineCollection
 
-    So dispatching on ancestry would claim `Dash` and `Range` as lines and
-    read a `LineCollection` through `LinePlot`, which cannot see it. This
-    pins the hierarchy itself, so the seaborn release that changes it fails
-    here rather than silently widening what gets claimed.
+    So dispatching on ancestry would claim `Dash` and `Range` as `Paths`,
+    which now *is* read -- and read them as line series, which neither
+    draws: a `Dash` is a tick per position and a `Range` is an interval.
+    Since #670 that is a live hazard rather than a hypothetical one, because
+    the ancestor a wrong dispatch would land on has a reading to hand them.
+    This pins the hierarchy itself, so the seaborn release that changes it
+    fails here rather than silently widening what gets claimed.
     """
     assert issubclass(so.Line, so.Path)
     assert issubclass(so.Dash, so.Paths)

--- a/tests/core/plot/test_seaborn_objects_lines.py
+++ b/tests/core/plot/test_seaborn_objects_lines.py
@@ -1,0 +1,253 @@
+"""
+`so.Lines` and `so.Paths` registered nothing (#670).
+
+The many-series spelling of `so.Line` and `so.Path`. Measured on
+`seaborn 0.13.2`, the difference is the artist and nothing else::
+
+    so.Line(color=)    ax.lines        one Line2D per group
+    so.Lines(color=)   ax.collections  ONE LineCollection, one segment per group
+
+`MultiLinePlot` walks `Line2D` objects, so a collection reached no reading at
+all and the whole chart fell back to a picture -- while the identical chart
+written with the singular mark was navigable.
+
+Two things follow, and each is a fact about the artist rather than a choice:
+
+  - **The segments are the series.** One collection carries one per group, in
+    the order the groups were drawn, with a colour each -- and the colour is
+    what pairs a series with its legend entry, which is the pairing #582
+    exists for.
+
+  - **A series is a path inside one group, not a group of its own.** Measured
+    against a real SVG export, a three-group collection writes three `<path>`
+    elements as direct children of its `<g>`, in segment order. The inherited
+    selector says `g[id=…] path`, which would outline every series at once.
+
+An empty segment is not a case to handle: `LineCollection` refuses to hold
+one -- matplotlib raises "'vertices' must be 2D" -- so the paths and the
+series stay one to one. A single-point group *is* drawn, and keeps its place
+in both.
+
+Related: #672, which had to land first. A `so.Plot`'s legend is the figure's,
+and until that was read a colour split arrived as unnamed series -- the shape
+xability/maidr#828 exists to prevent.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import seaborn.objects as so
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Two groups over the same positions, sharing no value between them."""
+    return pd.DataFrame(
+        {
+            "x": [0.0, 1.0, 2.0, 0.0, 1.0, 2.0],
+            "y": [1.0, 3.0, 2.0, 7.0, 9.0, 8.0],
+            "g": ["p", "p", "p", "q", "q", "q"],
+        }
+    )
+
+
+def _schema(build) -> dict:
+    """The first layer's schema, after a real render."""
+    figure = plt.figure()
+    build(figure)
+    maidr.render(figure)._repr_html_()
+    return FigureManager.get_maidr(figure).plots[0].schema
+
+
+def _split(mark, frame: pd.DataFrame | None = None) -> dict:
+    data = _frame() if frame is None else frame
+    return _schema(
+        lambda fig: so.Plot(data, x="x", y="y", color="g").add(mark).on(fig).plot()
+    )
+
+
+MARKS = [pytest.param(so.Lines(), id="Lines"), pytest.param(so.Paths(), id="Paths")]
+
+
+@pytest.mark.parametrize("mark", MARKS)
+def test_a_collection_of_segments_reads_as_the_series_it_draws(mark):
+    # The reproduction: before this the chart registered nothing at all and
+    # fell back to a static image.
+    schema = _split(mark)
+
+    assert schema["type"] == "line"
+    assert [[(point["x"], point["y"]) for point in series] for series in schema["data"]] == [
+        [(0.0, 1.0), (1.0, 3.0), (2.0, 2.0)],
+        [(0.0, 7.0), (1.0, 9.0), (2.0, 8.0)],
+    ]
+
+
+@pytest.mark.parametrize("mark", MARKS)
+def test_each_series_carries_the_group_it_was_drawn_for(mark):
+    # The colour a segment was drawn in is what pairs it with its legend
+    # entry. Pairing by position instead gets two groups the wrong way round
+    # whenever the legend is not in the drawn order (#582).
+    schema = _split(mark)
+
+    readings = {
+        series[0]["z"]: [point["y"] for point in series] for series in schema["data"]
+    }
+    assert readings == {"p": [1.0, 3.0, 2.0], "q": [7.0, 9.0, 8.0]}
+
+
+@pytest.mark.parametrize("mark", MARKS)
+def test_the_variable_the_series_are_split_by_is_named(mark):
+    schema = _split(mark)
+
+    assert schema["axes"]["z"] == {"label": "g"}
+
+
+@pytest.mark.parametrize("mark", MARKS)
+def test_each_series_addresses_its_own_path_inside_the_one_group(mark):
+    # One collection is one SVG group holding one `<path>` per segment, in
+    # segment order. The inherited selector says `g[id=…] path`, which would
+    # hand every series every other one's line.
+    schema = _split(mark)
+    selectors = schema["selectors"]
+
+    assert len(selectors) == 2
+    gid = selectors[0].split("'")[1]
+    assert gid.startswith("maidr-")
+    assert selectors == [
+        f"g[id='{gid}'] > path:nth-of-type(1)",
+        f"g[id='{gid}'] > path:nth-of-type(2)",
+    ]
+
+
+def test_a_selector_resolves_to_exactly_one_drawn_path():
+    # The half a schema cannot check on its own: that the group is really
+    # there and really holds one path per series.
+    import io
+
+    from lxml import etree
+
+    figure = plt.figure()
+    so.Plot(_frame(), x="x", y="y", color="g").add(so.Lines()).on(figure).plot()
+    maidr.render(figure)._repr_html_()
+    schema = FigureManager.get_maidr(figure).plots[0].schema
+
+    buffer = io.BytesIO()
+    figure.savefig(buffer, format="svg")
+    root = etree.fromstring(buffer.getvalue())
+    namespaces = {"s": "http://www.w3.org/2000/svg"}
+    gid = schema["selectors"][0].split("'")[1]
+    group = root.xpath(f"//s:g[@id='{gid}']", namespaces=namespaces)
+
+    assert len(group) == 1
+    assert len(group[0].xpath("./s:path", namespaces=namespaces)) == 2
+
+
+def test_an_ungrouped_collection_reads_as_the_one_series_it_draws():
+    # Nothing to split by draws a single polyline through every row, sorted
+    # along the orient axis -- one segment, and one series.
+    schema = _schema(
+        lambda fig: so.Plot(_frame(), x="x", y="y").add(so.Lines()).on(fig).plot()
+    )
+
+    assert len(schema["data"]) == 1
+    assert "z" not in schema["axes"]
+    assert len(schema["selectors"]) == 1
+
+
+def test_a_group_of_one_point_keeps_its_place_in_both_lists():
+    # Measured, a single-point group still leaves a segment and a degenerate
+    # path of its own -- so dropping it would shift every later series onto
+    # its neighbour's line.
+    lonely = pd.DataFrame(
+        {
+            "x": [0.0, 1.0, 2.0, 5.0],
+            "y": [1.0, 3.0, 2.0, 9.0],
+            "g": ["p", "p", "p", "q"],
+        }
+    )
+    schema = _split(so.Lines(), lonely)
+
+    assert [len(series) for series in schema["data"]] == [3, 1]
+    assert [series[0]["z"] for series in schema["data"]] == ["p", "q"]
+    assert len(schema["selectors"]) == 2
+
+
+def test_a_series_stands_in_for_its_segment_and_carries_its_colour():
+    # The stand-ins are what `MultiLinePlot` walks, and the colour is the
+    # half that is not obvious: it is what pairs a series with its legend
+    # entry, and pairing by position instead gets two groups the wrong way
+    # round whenever the legend is not in the drawn order (#582). Asserted
+    # directly, because a `so.Plot` always draws its groups in legend order
+    # and so cannot tell the two rules apart on its own.
+    figure = plt.figure()
+    so.Plot(_frame(), x="x", y="y", color="g").add(so.Lines()).on(figure).plot()
+    maidr.render(figure)._repr_html_()
+    plot = FigureManager.get_maidr(figure).plots[0]
+    collection = figure.axes[0].collections[0]
+
+    stand_ins = plot._series()
+    assert len(stand_ins) == len(collection.get_segments())
+    assert [line.get_xydata().tolist() for line in stand_ins] == [
+        segment.tolist() for segment in collection.get_segments()
+    ]
+    assert [tuple(line.get_color()) for line in stand_ins] == [
+        tuple(colour) for colour in collection.get_colors()
+    ]
+
+
+def test_one_colour_over_many_segments_is_cycled_the_way_it_is_drawn():
+    # Matplotlib does not expand a short colour list: measured, a collection
+    # drawn in one colour reports exactly one however many segments it
+    # holds -- and that is the *default*. Reading it by position would raise
+    # on the second segment.
+    from matplotlib.collections import LineCollection
+
+    from maidr.core.plot.segment_lineplot import SegmentLinePlot
+
+    figure, ax = plt.subplots()
+    collection = LineCollection(
+        [[(0.0, 0.0), (1.0, 1.0)], [(0.0, 1.0), (1.0, 2.0)], [(0.0, 2.0), (1.0, 3.0)]],
+        colors="red",
+    )
+    ax.add_collection(collection)
+    ax.autoscale()
+
+    stand_ins = SegmentLinePlot(ax, collection)._series()
+
+    assert len(collection.get_colors()) == 1
+    assert len(stand_ins) == 3
+    assert {tuple(line.get_color()) for line in stand_ins} == {
+        tuple(collection.get_colors()[0])
+    }
+
+
+def test_the_collection_is_what_gets_tagged_rather_than_the_stand_ins():
+    # `plot.elements` is the list the highlight machinery writes a `maidr`
+    # attribute onto. The stand-ins were never added to the axes, so tagging
+    # them would write onto nothing and the drawn group would carry none.
+    figure = plt.figure()
+    so.Plot(_frame(), x="x", y="y", color="g").add(so.Lines()).on(figure).plot()
+    maidr.render(figure)._repr_html_()
+    plot = FigureManager.get_maidr(figure).plots[0]
+
+    assert plot.elements == [figure.axes[0].collections[0]]
+
+
+def test_the_singular_mark_still_reads_the_way_it_did():
+    # What this is being brought into line *with*, asserted here so a change
+    # that broke the `Line2D` path to serve the collection is caught.
+    schema = _split(so.Line())
+
+    assert schema["type"] == "line"
+    assert [series[0]["z"] for series in schema["data"]] == ["p", "q"]
+    assert schema["axes"]["z"] == {"label": "g"}


### PR DESCRIPTION
## The gap

`so.Line` and `so.Path` were read. `so.Lines` and `so.Paths` raised nothing and registered nothing, so a plot built from them was silent — no layer, no sonification, no braille.

```python
(
    so.Plot(df, x="x", y="y", color="g")
    .add(so.Lines())      # drawn, but MAIDR saw nothing
    .plot()
)
```

## Why they fell through

The difference is what matplotlib is handed:

| mark | what lands on the axes |
|---|---|
| `so.Line` | one `Line2D` per group, in `ax.lines` |
| `so.Lines` | **one** `LineCollection`, in `ax.collections`, holding one segment per group |

`MultiLinePlot` walks `ax.lines`. For `so.Lines` that list is empty, so the mark fell through the `_READINGS` table with nothing to read.

## The reading

`SegmentLinePlot(MultiLinePlot)` reads the collection instead. It builds a `Line2D` stand-in per segment, so the existing multi-line walk — the group naming, the point extraction, the axis labels — is reused unchanged. It then swaps the tagged element back to the collection itself: the stand-ins are never drawn and have no gid to give.

Measured against a drawn figure rather than inferred from the seaborn source:

- **One `<path>` per segment, as direct children of the collection's `<g>`.** A series has no group of its own, so a selector addresses it by `nth-of-type` inside the collection's group rather than by its own id.
- **`get_colors()` returns exactly what was set** — which for the default is *one* colour over every segment, not one per segment. Indexing that off the end drops the colour on every series but the first, so it is cycled.
- **A one-point group still gets a segment and a path**, so nothing is skipped for being degenerate. An empty segment is unconstructable: matplotlib raises `'vertices' must be 2D` before the collection exists, so there is no empty case to guard.

End to end, `so.Lines` with a colour split now emits one LINE layer with two named series (`z: 'p'` / `'q'`), `axes.z = {label: 'g'}` naming the split, and two selectors that each resolve to exactly one drawn `<path>`.

## Why this waited

`_area_handover` had already recorded the blocker, and it is now cleared by #673:

> The legend holding those is the figure's, built after every layer is drawn… Two unnamed series is the shape xability/maidr#828 exists to prevent, so this waits for the naming rather than shipping without it.

With #673 merged, the figure-level legend is read, so the series come out named rather than as two anonymous lines.

## Tests

`tests/core/plot/test_seaborn_objects_lines.py` — 15 cases covering the segment walk, the colour cycling, the collection being the tagged element, the selector shape, the factory routing, and both table entries. `test_seaborn_objects.py` drops `Lines`/`Paths` from the "registers nothing" parametrisation, with a note that a mark added to `_READINGS` has to be taken off that list by hand.

A 12-mutation sweep over the new code — the segment read, the colour cycle, the element swap, the selector indexing, the factory branch, the table entries — killed all 12.

## Verification

- `uv run pytest -q` → **3475 passed, 72 skipped**
- `ruff check` clean on every changed file (the 6 re-export errors ruff reports repo-wide are pre-existing and also present on `origin/main`)

Part of #670.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_