### PR TITLE
fix(seaborn): read a box or boxen chart's grouping from the legend that names it

### DIFF
--- a/maidr/core/plot/boxenplot.py
+++ b/maidr/core/plot/boxenplot.py
@@ -11,6 +11,7 @@ from matplotlib.lines import Line2D
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.exception import ExtractionError
+from maidr.util.legend_names import legend_of
 
 #: Tail probability of the widest rung, which every letter-value ladder starts
 #: from: the box spanning the middle half of the data. Successive rungs halve
@@ -173,16 +174,17 @@ class BoxenPlot(MaidrPlot):
         A hue split names each ladder by the level it belongs to, so the
         dimension itself needs a name for those levels to be announced against.
         Omitted when there is no legend.
+
+        Through :meth:`~maidr.core.plot.maidr_plot.MaidrPlot._legend_title`,
+        which reads whichever legend :func:`~maidr.util.legend_names.legend_of`
+        chose -- the same one :meth:`_hue_levels` names the ladders from, so
+        the label and the levels cannot come from two different legends.
         """
         axes_data = super()._extract_axes_data()
 
-        legend = self.ax.get_legend()
-        if legend is not None:
-            title = legend.get_title()
-            if title is not None:
-                label = title.get_text().strip()
-                if label:
-                    axes_data[MaidrKey.Z] = self._axis_config(label=label)
+        label = self._legend_title()
+        if label:
+            axes_data[MaidrKey.Z] = self._axis_config(label=label)
 
         return axes_data
 
@@ -395,7 +397,7 @@ class BoxenPlot(MaidrPlot):
         which is why ``test_a_reordered_hue_keeps_each_ladder_with_its_level``
         exists rather than the assumption being left implicit.
         """
-        legend = self.ax.get_legend()
+        legend = legend_of(self.ax)
         return [text.get_text() for text in legend.get_texts()] if legend else []
 
     def _tick_labels(self, vertical: bool) -> list[tuple[float, str]]:

--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -268,16 +268,21 @@ class BoxPlot(
         Extend the base per-axis ``AxisConfig`` mapping with a ``z`` axis whose
         label is sourced from the legend title when a hue dimension is
         present. Omitted otherwise (per-box ``z`` values remain in data).
+
+        Read through :meth:`~maidr.core.plot.maidr_plot.MaidrPlot._legend_title`
+        rather than off ``ax.get_legend()``, so it is the legend
+        :func:`~maidr.util.legend_names.legend_of` chose -- the same one
+        :meth:`_named_boxes` matched the swatches against. Asking a different
+        question of a different legend is what #674 was: a chart whose legend
+        sits on the figure had every box named ``"a, p"`` and no ``z`` at all,
+        so a reader was told which side of a grouping each box was on and
+        never told what the grouping was.
         """
         axes_data = super()._extract_axes_data()
 
-        legend = self.ax.get_legend()
-        if legend is not None:
-            title = legend.get_title()
-            if title is not None:
-                z_label = title.get_text().strip()
-                if z_label:
-                    axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
+        z_label = self._legend_title()
+        if z_label:
+            axes_data[MaidrKey.Z] = self._axis_config(label=z_label)
 
         return axes_data
 

--- a/tests/core/plot/test_box_figure_legend_naming.py
+++ b/tests/core/plot/test_box_figure_legend_naming.py
@@ -1,0 +1,206 @@
+"""
+A box or boxen chart lost its grouping when the legend sat on the figure
+(#674).
+
+Three readers still asked ``ax.get_legend()`` directly after #672 and #617
+had moved everything else onto
+:func:`maidr.util.legend_names.legend_of`, which finds the legend wherever
+it was put. Measured on ``seaborn 0.13.2``, the same chart drawn twice --
+once with the legend seaborn leaves on the axes, once with the *drawn*
+handles moved onto the figure, which is what a grid's ``add_legend()``
+does:
+
+===========  ==============  =====================  ==========================
+chart        legend          ``axes.z``             per-box ``z``
+===========  ==============  =====================  ==========================
+boxplot      on the axes     ``{"label": "g"}``     ``"a, p"``  ``"b, p"`` ...
+boxplot      on the figure   **absent**             ``"a, p"``  ``"b, p"`` ...
+boxenplot    on the axes     ``{"label": "g"}``     ``"a, p"``  ``"a, q"`` ...
+boxenplot    on the figure   **absent**             ``"a"``  ``"a"``  ...
+===========  ==============  =====================  ==========================
+
+So the two halves fail differently, and the boxen half is the worse one.
+
+``BoxPlot`` names each box by matching its drawn colour against a swatch,
+through :func:`~maidr.util.legend_names.names_for`, which already reads the
+chosen legend -- so only the *variable*'s name was dropped. A reader was
+told which side of a grouping each box was on and never told what the
+grouping was.
+
+``BoxenPlot`` cannot match on colour: a ladder is many boxes shading from
+dark to light, so its level comes from its rank in the dodge lattice looked
+up in the legend's own list of names. With no axes legend that list was
+empty, and **every ladder in a category was announced identically** -- two
+ladders both called ``"a"``, which is the shape ``xability/maidr#828``
+exists to prevent.
+
+Both are one lookup. What is asserted here is that the label and the levels
+now come from the *same* legend: reading them off two different ones is
+what the defect was.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import seaborn as sns
+
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Two categories split two ways, with enough spread to draw a box."""
+    return pd.DataFrame(
+        {
+            "cat": ["a", "a", "a", "a", "b", "b", "b", "b"] * 3,
+            "g": ["p", "q"] * 12,
+            "val": [
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+                2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0,
+                3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+            ],
+        }
+    )
+
+
+def _moved_to_the_figure(draw, title: str = "g") -> plt.Figure:
+    """One chart whose legend was moved off the panel and onto the figure.
+
+    The swatches are the *drawn* ones. That is what makes this the real case
+    rather than a stand-in: a grid's ``add_legend()`` gathers the panels' own
+    handles, so the colour match that names a box still holds and only the
+    legend's owner has changed. Handing it fresh patches instead would break
+    the match for a reason that has nothing to do with where the legend is --
+    seaborn desaturates a box's face, so a stand-in swatch in the palette
+    colour names nothing.
+    """
+    figure, ax = plt.subplots()
+    draw(ax)
+    own = ax.get_legend()
+    handles = own.legend_handles
+    labels = [text.get_text() for text in own.get_texts()]
+    own.remove()
+    figure.legend(handles, labels, title=title)
+    return figure
+
+
+def _schema(figure: plt.Figure) -> dict:
+    """The one layer's schema, rendered the way a caller gets it."""
+    maidr.render(figure)._repr_html_()
+    return FigureManager.get_maidr(figure).plots[0].schema
+
+
+def _boxes(figure: plt.Figure) -> list[str]:
+    """Each drawn box's own name, in drawing order."""
+    return [str(entry["z"]) for entry in _schema(figure)["data"]]
+
+
+def _box(ax, **kwargs) -> None:
+    sns.boxplot(data=_frame(), x="cat", y="val", hue="g", ax=ax, **kwargs)
+
+
+def _boxen(ax, **kwargs) -> None:
+    sns.boxenplot(data=_frame(), x="cat", y="val", hue="g", ax=ax, **kwargs)
+
+
+def test_a_box_chart_names_its_variable_from_a_legend_moved_to_the_figure():
+    # The boxes were already named -- `names_for` reads the chosen legend --
+    # so this is the half that was only ever a missing label.
+    schema = _schema(_moved_to_the_figure(_box))
+
+    assert schema["axes"]["z"] == {"label": "g"}
+
+
+def test_a_box_chart_still_names_each_box_from_that_same_legend():
+    # Asserted beside the label rather than assumed: the point of the fix is
+    # that both now come from one legend, and a change that moved only the
+    # title would pass the test above while leaving them on two.
+    assert _boxes(_moved_to_the_figure(_box)) == ["a, p", "b, p", "a, q", "b, q"]
+
+
+def test_a_boxen_chart_names_its_variable_from_a_legend_moved_to_the_figure():
+    schema = _schema(_moved_to_the_figure(_boxen))
+
+    assert schema["axes"]["z"] == {"label": "g"}
+
+
+def test_a_boxen_ladder_keeps_its_level_when_the_legend_is_the_figures():
+    # The worse half. A ladder's level is its rank in the dodge lattice
+    # looked up in the legend's list of names; with no axes legend that list
+    # was empty, so both ladders in a category came out as the category
+    # alone -- two identical announcements for two different distributions.
+    assert _boxes(_moved_to_the_figure(_boxen)) == ["a, p", "a, q", "b, p", "b, q"]
+
+
+@pytest.mark.parametrize("order", [["p", "q"], ["q", "p"]])
+def test_a_reordered_hue_keeps_each_boxen_ladder_with_its_level(order):
+    # The coupling `_hue_levels` documents -- seaborn lays the dodge out in
+    # legend order -- has to survive the legend moving. `hue_order` moves
+    # both together, and nothing would raise if they ever came apart: every
+    # level would simply be announced as its neighbour.
+    figure = _moved_to_the_figure(lambda ax: _boxen(ax, hue_order=order))
+
+    assert _boxes(figure) == [
+        f"{category}, {level}" for category in ("a", "b") for level in order
+    ]
+
+
+@pytest.mark.parametrize("draw", [_box, _boxen], ids=["box", "boxen"])
+def test_the_axes_own_legend_still_wins_over_the_figures(draw):
+    # `legend_of`'s rule, asserted as reached rather than reimplemented. A
+    # panel that kept its own legend is named by it and never consults the
+    # figure's, which is the mitigation for one figure legend being read as
+    # naming every axes.
+    figure, ax = plt.subplots()
+    draw(ax)
+    ax.get_legend().set_title("on the axes")
+    figure.legend(
+        ax.get_legend().legend_handles, ["p", "q"], title="on the figure"
+    )
+
+    assert _schema(figure)["axes"]["z"] == {"label": "on the axes"}
+
+
+@pytest.mark.parametrize(
+    ("draw", "categories"),
+    # The two classes walk their boxes in different orders -- `BoxPlot` reads
+    # matplotlib's `bxp` output, level by level, and `BoxenPlot` reads the
+    # dodge lattice, category by category -- so the expected order is named
+    # per class rather than accepted either way.
+    [(_box, ["a", "b", "a", "b"]), (_boxen, ["a", "a", "b", "b"])],
+    ids=["box", "boxen"],
+)
+def test_a_chart_with_no_legend_names_nothing_rather_than_something(draw, categories):
+    # Drawn `legend=False` and left that way. There is nothing to read, and
+    # the categories still come back -- answering one of the two questions is
+    # an improvement on answering neither.
+    figure, ax = plt.subplots()
+    draw(ax, legend=False)
+    schema = _schema(figure)
+
+    assert "z" not in schema["axes"]
+    assert [str(entry["z"]) for entry in schema["data"]] == categories
+
+
+@pytest.mark.parametrize("draw", [_box, _boxen], ids=["box", "boxen"])
+def test_two_figure_legends_name_nothing_rather_than_one_of_them(draw):
+    # Also `legend_of`'s: two figure legends cannot say which names this
+    # axes' colours, and a confident wrong name is worse than none. Asserted
+    # for both classes because both now route through it.
+    figure, ax = plt.subplots()
+    draw(ax)
+    own = ax.get_legend()
+    handles = own.legend_handles
+    own.remove()
+    figure.legend(handles, ["p", "q"], title="g", loc="upper left")
+    figure.legend(handles, ["p", "q"], title="h", loc="upper right")
+
+    assert "z" not in _schema(figure)["axes"]


### PR DESCRIPTION
## Measured

Three readers still asked `ax.get_legend()` directly after #672 and #617 had moved everything else onto `legend_of`, which finds the legend wherever it was put. `seaborn 0.13.2`, the same chart drawn twice — once with the legend seaborn leaves on the axes, once with the **drawn** handles moved onto the figure, which is what a grid's `add_legend()` does:

| chart | legend | `axes.z` | per-box `z` |
|---|---|---|---|
| `boxplot` | on the axes | `{"label": "g"}` | `"a, p"` `"b, p"` `"a, q"` `"b, q"` |
| `boxplot` | on the figure | **absent** | `"a, p"` `"b, p"` `"a, q"` `"b, q"` |
| `boxenplot` | on the axes | `{"label": "g"}` | `"a, p"` `"a, q"` `"b, p"` `"b, q"` |
| `boxenplot` | on the figure | **absent** | `"a"` `"a"` `"b"` `"b"` |

The two halves fail differently, and **the boxen half is worse than the issue recorded**.

`BoxPlot` names each box by matching its drawn colour against a swatch, through `names_for`, which already reads the chosen legend — so only the *variable*'s name was dropped. A reader was told which side of a grouping each box was on and never told what the grouping was. That is what #674 describes.

`BoxenPlot` cannot match on colour: a ladder is many boxes shading from dark to light, so its level comes from its rank in the dodge lattice looked up in the legend's own list of names (`_hue_levels`). With no axes legend that list was empty, and **every ladder in a category was announced identically** — two ladders both called `"a"`. That is the shape xability/maidr#828 exists to prevent, and it is a missing distinction rather than a missing label.

## The change

Three one-line reads:

- `boxplot.py` `_extract_axes_data` → `self._legend_title()`
- `boxenplot.py` `_extract_axes_data` → `self._legend_title()`
- `boxenplot.py` `_hue_levels` → `legend_of(self.ax)`

`_legend_title` already delegates to `legend_names.title_of`, which reads whichever legend `legend_of` chose — so after this the **label and the levels come from the same legend**. Reading them off two different ones is what the defect was, and that is what the tests assert rather than just "the title is present".

Every rule about *which* legend answers stays `legend_of`'s: the axes' own wins, one figure legend applies, two are ambiguous and decline.

Both boxen sites want the same legend, which the issue flagged as needing checking rather than assuming. `_hue_levels`'s docstring records that a ladder's level is its rank in the dodge lattice looked up in the legend's list, and that this holds because seaborn lays the dodge out in legend order. Moving the legend does not disturb that — `add_legend()` gathers the panels' own handles in `hue_order` — and `test_a_reordered_hue_keeps_each_boxen_ladder_with_its_level` pins it against a moved legend, mirroring the existing `test_a_reordered_hue_keeps_each_ladder_with_its_level`.

## Tests

`tests/core/plot/test_box_figure_legend_naming.py` — 12 cases, in the shape of `test_figure_legend_naming.py` but its own file, since that one's docstring is scoped to #672's line path:

- box: names its variable from a legend moved to the figure
- box: still names each box from that same legend (asserted beside the label — a change that moved only the title would pass the first and leave them on two legends)
- boxen: names its variable from a legend moved to the figure
- boxen: **a ladder keeps its level** when the legend is the figure's
- boxen: a reordered hue keeps each ladder with its level (×2 orders)
- both: the axes' own legend still wins over the figure's
- both: no legend at all names nothing rather than something, and the categories still come back
- both: two figure legends name nothing rather than one of them

The relocation helper reuses the **drawn** handles rather than fresh patches — seaborn desaturates a box's face, so a stand-in swatch in the palette colour matches nothing and the test would fail for a reason unrelated to where the legend is. That bit me while measuring, so it is written down in the helper's docstring.

## Verification

- `uv run pytest -q` → **3490 passed, 72 skipped**
- `ruff check` clean on all three changed files

Closes #674.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_