### PR TITLE
feat(seaborn-objects): read a Band or a Range as the interval it draws

### DIFF
--- a/maidr/core/plot/intervalplot.py
+++ b/maidr/core/plot/intervalplot.py
@@ -1,0 +1,368 @@
+"""Read a band or a range of bars as the interval it draws."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, List, Sequence
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+from matplotlib.patches import Polygon
+
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.plot.maidr_plot import MaidrPlot
+from maidr.core.plot.scatterplot import _rgba
+from maidr.exception import ExtractionError
+from maidr.util.legend_names import names_for
+from maidr.util.mixin import DictMergerMixin
+
+#: The keyword the drawn artists are handed over under.
+DRAWN_INTERVALS = "intervals"
+
+
+class IntervalPlot(MaidrPlot, DictMergerMixin):
+    """
+    An interval per position, drawn either as a band or as a bar each.
+
+    ``so.Band`` and ``so.Range`` are the same reading from two drawings, which
+    is why one class serves both. Measured on ``seaborn 0.13.2`` over three
+    positions::
+
+        so.Band()   one Polygon         verts lower forward, upper backward
+        so.Range()  one LineCollection  one segment per position
+
+    Both carry **bounds and no estimate**, and that is not a gap to be filled
+    in: neither mark draws a centre of its own, and
+    :class:`~maidr.core.enum.PlotType.ERRORBAR`'s point shape declares its
+    estimate optional for exactly this -- "absent on a band that draws only
+    bounds". A chart wanting the estimate too adds ``so.Dot(), so.Agg()``
+    beside it, which registers as its own layer and is read as one.
+
+    Orientation is read from the drawing rather than from the caller's
+    spelling. The two bounds at one position share the coordinate the
+    position is on, so whichever of the pair matches is the position axis --
+    true of a polygon's paired vertices and of a segment's two endpoints
+    alike, and true whether the caller wrote ``orient="y"`` or not.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        super().__init__(ax, PlotType.ERRORBAR)
+
+        self._intervals: list = list(kwargs.pop(DRAWN_INTERVALS, None) or [])
+
+        # One per interval, filled by `_bounds` because the name belongs to
+        # the artist an interval was read off; pairing them afterwards would
+        # mean reconstructing which artist that was.
+        self._names: list = []
+
+        # Resolved from the drawing during extraction, which `render` runs
+        # before it reads this.
+        self._orientation = "vert"
+
+    def render(self) -> dict:
+        """
+        Build the layer schema, adding the orientation the intervals run in.
+
+        Returns
+        -------
+        dict
+            The MAIDR layer schema.
+        """
+        # `super().render()` runs `_extract_plot_data`, which is what resolves
+        # `self._orientation` -- so the read below has to come after it.
+        base_schema = super().render()
+        return self.merge_dict(base_schema, {MaidrKey.ORIENTATION: self._orientation})
+
+    def _extract_axes_data(self) -> dict:
+        """
+        Extend the base per-axis mapping with the legend title as ``z``.
+
+        A colour split names each series by the level it belongs to, so the
+        dimension itself needs a name for those levels to be announced
+        against. Omitted when there is no legend, which is every chart drawn
+        without a split.
+        """
+        axes_data = super()._extract_axes_data()
+
+        label = self._legend_title()
+        if label:
+            axes_data[MaidrKey.Z] = self._axis_config(label=label)
+
+        return axes_data
+
+    def _extract_plot_data(self) -> list:
+        bounds = self._bounds()
+        if not bounds:
+            raise ExtractionError(self.type, self.ax)
+
+        self._orientation = "vert" if self._vertical(bounds) else "horz"
+        # The position runs along the axis the interval does NOT span, and the
+        # magnitude along the one it does. The schema names the magnitude
+        # `y`/`yMin`/`yMax` in BOTH orientations and lets `orientation` say
+        # which is on screen where -- the convention `ErrorBarPlot` documents,
+        # and one `ErrorBarTrace` depends on: `ErrorBarPoint` declares no
+        # `xMin`/`xMax` to put a bound in, so a screen-aligned payload would
+        # leave a horizontal chart with no interval at all.
+        component = 1 if self._orientation == "vert" else 0
+        other = 1 - component
+
+        points = []
+        for index, (position, low, high) in enumerate(bounds):
+            # Ordered rather than taken as they came. Both drawings happen
+            # to give the lower bound first -- a band's fold runs the lower
+            # edge forward, and a range's segment starts at its foot -- so
+            # neither mark reaches the swap today. The fields mean the
+            # smaller and the larger, though, and a reader handed a `yMin`
+            # above its `yMax` would be told the interval runs backwards.
+            point = {
+                MaidrKey.X: _plain(position[other]),
+                MaidrKey.Y_MIN: _plain(min(low[component], high[component])),
+                MaidrKey.Y_MAX: _plain(max(low[component], high[component])),
+            }
+            name = self._names[index] if index < len(self._names) else None
+            if name:
+                point[MaidrKey.Z] = name
+            points.append(point)
+
+        return self._grouped(points)
+
+    def _grouped(self, points: list[dict]) -> list:
+        """
+        One series per level, or the flat list when nothing named them.
+
+        The grouped shape is what ``ErrorBarPoint[][]`` was added for (#942):
+        it is what lets a reader move between two levels' intervals at one
+        position, which is the comparison a grouped interval chart exists to
+        support. A chart with no split has one group and needs no name for it,
+        so it stays flat rather than becoming a list of one.
+
+        Parameters
+        ----------
+        points : list of dict
+            Every interval, in drawing order.
+
+        Returns
+        -------
+        list
+            ``ErrorBarPoint[]`` or ``ErrorBarPoint[][]``.
+        """
+        if not any(point.get(MaidrKey.Z) for point in points):
+            return points
+
+        series: dict[Any, list[dict]] = {}
+        for point in points:
+            series.setdefault(point.get(MaidrKey.Z), []).append(point)
+        return list(series.values())
+
+    def _get_selector(self) -> List[str]:
+        """
+        One selector per interval, addressing its own path inside the group.
+
+        The inherited default is ``g[maidr='true'] > path``, which resolves to
+        nothing: `maidr.patch.highlight` tags a drawn artist by giving it a
+        ``maidr-`` **gid**, not a ``maidr`` attribute, so a class that leaves
+        the default emits a selector matching no element in the document. That
+        is worse than emitting none -- the layer says its intervals can be
+        outlined and none of them can.
+
+        A range's collection draws one path per segment as direct children of
+        one group, so an interval is addressed by its position within that
+        group. This is only reached where every interval is one of that
+        collection's paths, in drawing order: :meth:`_bounds` clears the
+        elements and turns highlighting off for a band, which has no path per
+        interval, and for a split range, whose paths run in drawing order
+        while the payload is grouped by level.
+
+        Returns
+        -------
+        list of str
+            One selector per interval, in the order the payload announces them.
+        """
+        collection = self._elements[0]
+        gid = collection.get_gid()
+        if not gid or not str(gid).startswith("maidr-"):
+            gid = f"maidr-{uuid.uuid4()}"
+            collection.set_gid(gid)
+
+        return [
+            f"g[id='{gid}'] > path:nth-of-type({position + 1})"
+            for position in range(len(collection.get_segments()))
+        ]
+
+    def _bounds(self) -> list[tuple]:
+        """
+        Every interval as ``(position, lower, upper)`` points, in draw order.
+
+        Also fills ``self._names``, one per interval.
+
+        Returns
+        -------
+        list of tuple
+            One entry per drawn interval.
+        """
+        self._names = []
+        found: list[tuple] = []
+
+        polygons = [art for art in self._intervals if isinstance(art, Polygon)]
+        collections = [art for art in self._intervals if isinstance(art, LineCollection)]
+
+        if polygons:
+            named = names_for(self.ax, [_face_of(poly) for poly in polygons])
+            for poly, name in zip(polygons, named):
+                pairs = _folded(np.asarray(poly.get_path().vertices, dtype=float))
+                found.extend(pairs)
+                self._names.extend([name] * len(pairs))
+            # A band spans every position with one path, so there is no
+            # element per interval for a selector to resolve to. Announcing
+            # one would promise highlightable paths the document does not
+            # contain -- the same reason `ErrorBarPlot` clears the flag for a
+            # call that drew no bars.
+            self._support_highlighting = False
+
+        for collection in collections:
+            segments = [np.asarray(seg, dtype=float) for seg in collection.get_segments()]
+            named = names_for(self.ax, _segment_colours(collection, len(segments)))
+            for segment, name in zip(segments, named):
+                if len(segment) < 2:
+                    continue
+                found.append((segment[0], segment[0], segment[-1]))
+                self._names.append(name)
+            self._elements.append(collection)
+
+        # A split range's paths are one collection's, in drawing order, while
+        # the payload is grouped by level -- so a positional selector would
+        # pair the second level's first interval with the first level's. The
+        # grouped selector shape is a question of its own, and outlining the
+        # wrong interval is worse than outlining none (#814).
+        if collections and any(self._names):
+            self._elements.clear()
+            self._support_highlighting = False
+
+        return found
+
+    @staticmethod
+    def _vertical(bounds: Sequence[tuple]) -> bool:
+        """
+        Whether the intervals run up the page.
+
+        The two bounds at one position share the coordinate that position is
+        on. Read off the first interval that has a spread to read: a
+        degenerate one shares *both*, so it says nothing, and taking it would
+        answer from a chart's flattest point.
+
+        Parameters
+        ----------
+        bounds : sequence of tuple
+            Every interval as ``(position, lower, upper)``.
+
+        Returns
+        -------
+        bool
+            True for an interval spanning ``y``.
+        """
+        for _, low, high in bounds:
+            if low[0] != high[0]:
+                return False
+            if low[1] != high[1]:
+                return True
+        # Every interval is a point. Nothing distinguishes the axes, and
+        # vertical is what `ErrorBarPlot` also answers when its container
+        # carries no error at all.
+        return True
+
+
+def _folded(vertices: np.ndarray) -> list[tuple]:
+    """
+    A band polygon's vertices as one ``(position, lower, upper)`` per position.
+
+    Measured, the path is the lower edge forward then the upper edge
+    backward, closed by repeating the first vertex::
+
+        [[0,0.71], [1,1.78], [2,2.26], [2,2.75], [1,2.15], [0,1.19], [0,0.71]]
+         └──── lower, n ────┘ └──── upper, n, reversed ───┘ └─ close ─┘
+
+    so position ``i``'s bounds are ``verts[i]`` and ``verts[2n - 1 - i]``.
+
+    Parameters
+    ----------
+    vertices : numpy.ndarray
+        The polygon's path vertices.
+
+    Returns
+    -------
+    list of tuple
+        One entry per position, or empty when the path does not fold.
+    """
+    points = vertices
+    if len(points) > 1 and np.allclose(points[0], points[-1]):
+        points = points[:-1]
+
+    count = len(points) // 2
+    if count == 0 or len(points) != count * 2:
+        return []
+
+    return [(points[i], points[i], points[len(points) - 1 - i]) for i in range(count)]
+
+
+def _face_of(poly: Polygon):
+    """
+    One band's fill colour, as the rounded RGBA the legend is matched on.
+
+    Parameters
+    ----------
+    poly : matplotlib.patches.Polygon
+        The band.
+
+    Returns
+    -------
+    tuple of float or None
+        The rounded RGBA, or ``None`` when the patch names no single colour.
+    """
+    face = np.asarray(poly.get_facecolor(), dtype=float).ravel()
+    return _rgba(face[:4]) if len(face) >= 4 else None
+
+
+def _segment_colours(collection: LineCollection, count: int) -> list:
+    """
+    One rounded RGBA per drawn segment.
+
+    Cycled rather than indexed, for the reason ``SegmentLinePlot`` cycles its
+    own: ``get_colors()`` returns exactly what was set, which for a chart
+    drawn without a split is one colour over every segment.
+
+    Parameters
+    ----------
+    collection : matplotlib.collections.LineCollection
+        The drawn segments.
+    count : int
+        How many segments there are.
+
+    Returns
+    -------
+    list
+        One rounded RGBA per segment, or ``None`` where there is no colour.
+    """
+    colours = np.asarray(collection.get_colors(), dtype=float)
+    if colours.ndim == 1:
+        colours = colours.reshape(1, -1)
+    if len(colours) == 0:
+        return [None] * count
+    return [_rgba(colours[index % len(colours)][:4]) for index in range(count)]
+
+
+def _plain(value) -> Any:
+    """
+    A numpy scalar as the plain Python number ``json.dumps`` can write.
+
+    Parameters
+    ----------
+    value : Any
+        One coordinate.
+
+    Returns
+    -------
+    Any
+        The plain value.
+    """
+    return value.item() if hasattr(value, "item") else value

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -11,6 +11,7 @@ from maidr.core.plot.boxenplot import BoxenPlot
 from maidr.core.plot.boxplot import BoxPlot
 from maidr.core.plot.contour import ContourPlot
 from maidr.core.plot.errorbar import ErrorBarPlot
+from maidr.core.plot.intervalplot import DRAWN_INTERVALS, IntervalPlot
 from maidr.core.plot.eventplot import DRAWN_EVENTS, EventPlot
 from maidr.core.plot.gantt import GanttPlot
 from maidr.core.plot.grouped_barplot import GroupedBarPlot
@@ -102,6 +103,11 @@ class MaidrPlotFactory:
             # lines came from seaborn.
             if isinstance(kwargs.get("estimate"), Line2D) or kwargs.get("estimates"):
                 return PointPlot(single_ax, **kwargs)
+            # `so.Band` and `so.Range` draw the interval and no estimate at
+            # all, so there is no container and no estimate line to resolve --
+            # only the band or the bars themselves, which is what this names.
+            if DRAWN_INTERVALS in kwargs:
+                return IntervalPlot(single_ax, **kwargs)
             return ErrorBarPlot(single_ax, **kwargs)
         elif PlotType.HEAT == plot_type:
             return HeatPlot(single_ax, **kwargs)

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -18,6 +18,7 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS, bar_groups
 from maidr.core.plot.grouped_barplot import DRAWN_GROUPS
+from maidr.core.plot.intervalplot import DRAWN_INTERVALS
 from maidr.core.plot.maidr_plot import GROUP_NAME
 from maidr.core.plot.scatterplot import DRAWN_POINTS, HUE_GROUP, hue_groups
 from maidr.core.plot.segment_lineplot import DRAWN_SEGMENTS
@@ -110,6 +111,18 @@ _READINGS: dict[str, _Reading] = {
     # and two would be two charts (#670).
     "Lines": _Reading(PlotType.LINE, "collections", LineCollection, DRAWN_SEGMENTS, True),
     "Paths": _Reading(PlotType.LINE, "collections", LineCollection, DRAWN_SEGMENTS, True),
+    # One interval per position, drawn two ways. Measured, `so.Band()` leaves
+    # a `Polygon` folded lower-forward-then-upper-backward and `so.Range()`
+    # leaves a `LineCollection` of one segment per position -- the same
+    # reading from two drawings, which is why one class takes both and the
+    # artists are handed over as the list the layer drew (#670).
+    #
+    # A `Band` is in `patches` beside `Area`, and the two are told apart by
+    # the mark's name rather than by the artist: both are `Polygon`, and only
+    # the name says whether the fold is a series against a baseline or a pair
+    # of bounds.
+    "Band": _Reading(PlotType.ERRORBAR, "patches", Polygon, DRAWN_INTERVALS),
+    "Range": _Reading(PlotType.ERRORBAR, "collections", LineCollection, DRAWN_INTERVALS),
 }
 
 

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -285,10 +285,10 @@ def test_a_mark_this_does_not_read_still_registers_nothing(mark):
     mark whose artists no existing plot class can read is left alone, not
     guessed at. `Dash` matters most -- see the test below.
 
-    `Lines` and `Paths` left this list when they gained a reading (#670).
-    They came off deliberately: this list is the reminder that a decline was
-    a decision, so a mark added to `_READINGS` has to be taken out of it by
-    hand rather than quietly passing both ways.
+    `Lines`, `Paths`, `Area`, `Band` and `Range` each left this list when they
+    gained a reading (#670). They came off deliberately: this list is the
+    reminder that a decline was a decision, so a mark added to `_READINGS`
+    has to be taken out of it by hand rather than quietly passing both ways.
     """
     figure = _drawn(
         lambda fig: so.Plot(_frame(), x="t", y="m").add(mark).on(fig).plot()
@@ -304,11 +304,18 @@ def test_the_marks_are_matched_by_name_and_not_by_ancestry():
         Dash  < Paths < Mark      LineCollection
         Range < Paths < Mark      LineCollection
 
-    So dispatching on ancestry would claim `Dash` and `Range` as `Paths`,
-    which now *is* read -- and read them as line series, which neither
-    draws: a `Dash` is a tick per position and a `Range` is an interval.
+    So dispatching on ancestry would claim `Dash` as a `Paths`, which *is*
+    read -- and read it as line series, which it does not draw: a `Dash` is a
+    tick per position with no length that means anything on the value axis.
     Since #670 that is a live hazard rather than a hypothetical one, because
-    the ancestor a wrong dispatch would land on has a reading to hand them.
+    the ancestor a wrong dispatch would land on has a reading to hand it.
+
+    `Range` is the other half of the same trap and shows why ancestry would
+    still be wrong even where it happens to claim something readable: it is
+    read too, but as an **interval**, which is nothing like what `Paths`
+    gives. Getting there by name is what makes the two readings different;
+    getting there by ancestry would make them the same and wrong.
+
     This pins the hierarchy itself, so the seaborn release that changes it
     fails here rather than silently widening what gets claimed.
     """
@@ -317,10 +324,7 @@ def test_the_marks_are_matched_by_name_and_not_by_ancestry():
     assert issubclass(so.Range, so.Paths)
 
     figure = _drawn(
-        lambda fig: so.Plot(_frame(), x="t", ymin="val", ymax="m")
-        .add(so.Range())
-        .on(fig)
-        .plot()
+        lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Dash()).on(fig).plot()
     )
 
     assert _registers_nothing(figure)
@@ -430,7 +434,6 @@ def test_every_selector_resolves_in_the_page_it_was_built_from(mark, x, y):
     [
         pytest.param(so.Bars(), id="Bars"),
         pytest.param(so.Dash(), id="Dash"),
-        pytest.param(so.Range(), id="Range"),
         pytest.param(so.Text(), id="Text"),
     ],
 )

--- a/tests/core/plot/test_seaborn_objects_intervals.py
+++ b/tests/core/plot/test_seaborn_objects_intervals.py
@@ -1,0 +1,353 @@
+"""
+``so.Band`` and ``so.Range`` drew an interval per position and registered
+nothing (#670).
+
+Both are the same reading from two drawings, which is why one class takes
+both and one test file covers them. Measured on ``seaborn 0.13.2`` over
+three positions::
+
+    so.Band(), so.Est()    one Polygon         lower forward, upper backward
+    so.Range(), so.Est()   one LineCollection  one segment per position
+
+Neither draws a centre of its own, and that is the reading rather than a gap
+to fill in: ``ErrorBarPoint.y`` is optional precisely for "a band that draws
+only bounds". A chart wanting the estimate adds ``so.Dot(), so.Agg()``
+beside it, which registers as its own layer.
+
+Two things are read from the drawing rather than from the caller's spelling,
+and each is measured here:
+
+**Orientation.** The two bounds at one position share the coordinate the
+position sits on, so whichever of the pair matches names the position axis.
+That is true of a polygon's paired vertices and a segment's two endpoints
+alike, and it holds whether the caller wrote ``orient="y"`` or not.
+
+**The split.** A colour-split ``Band`` leaves one polygon per level; a split
+``Range`` leaves *one* collection carrying a colour per segment. Both are
+named through the legend the way every other colour split is, which is
+available here only because #672 taught the lookup to find a
+``seaborn.objects`` legend -- it is the figure's, never the axes'.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn.objects as so
+
+from maidr.core.enum import PlotType
+import maidr
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Two groups over three positions, with enough replicates to estimate.
+
+    One observation per cell would leave ``so.Est()`` with no spread, and a
+    zero-width interval is measurably not the case under test -- the band
+    collapses to a line and the bars to points.
+    """
+    rng = np.random.default_rng(7)
+    return pd.DataFrame(
+        [
+            {"x": x, "y": base + x + rng.normal(0, 0.5), "g": group}
+            for group, base in (("a", 1.0), ("b", 5.0))
+            for x in range(3)
+            for _ in range(8)
+        ]
+    )
+
+
+def _layers(plot) -> list[dict]:
+    """Every layer the drawn plot registered, as schemas."""
+    return [layer.schema for layer in FigureManager.get_maidr(plot.plot()._figure).plots]
+
+
+def _only(plot) -> dict:
+    """The one layer this plot registered."""
+    schemas = _layers(plot)
+    assert len(schemas) == 1, f"expected one layer, got {len(schemas)}"
+    return schemas[0]
+
+
+def _band(**kwargs):
+    return so.Plot(_frame(), **kwargs).add(so.Band(), so.Est())
+
+
+def _range(**kwargs):
+    return so.Plot(_frame(), **kwargs).add(so.Range(), so.Est())
+
+
+@pytest.mark.parametrize(
+    ("make", "mark"),
+    [(_band, "Band"), (_range, "Range")],
+    ids=["band", "range"],
+)
+def test_the_mark_is_read_as_an_interval_rather_than_registering_nothing(make, mark):
+    # The reproduction. Before this both marks fell through `_READINGS` and
+    # the chart was a static image with nothing to navigate.
+    schema = _only(make(x="x", y="y"))
+
+    assert schema["type"] is PlotType.ERRORBAR
+    assert len(schema["data"]) == 3
+
+
+@pytest.mark.parametrize(
+    ("make", "mark"),
+    [(_band, "Band"), (_range, "Range")],
+    ids=["band", "range"],
+)
+def test_each_position_carries_bounds_and_no_estimate(make, mark):
+    # Not an omission: neither mark draws a centre, so inventing one -- the
+    # midpoint, say -- would announce a value the chart never plotted.
+    points = _only(make(x="x", y="y"))["data"]
+
+    assert [point["x"] for point in points] == [0.0, 1.0, 2.0]
+    assert all("y" not in point for point in points)
+    assert all(point["yMin"] < point["yMax"] for point in points)
+
+
+@pytest.mark.parametrize(
+    ("make", "mark"),
+    [(_band, "Band"), (_range, "Range")],
+    ids=["band", "range"],
+)
+def test_a_vertical_chart_says_so(make, mark):
+    assert _only(make(x="x", y="y"))["orientation"] == "vert"
+
+
+@pytest.mark.parametrize(
+    ("make", "mark"),
+    [(_band, "Band"), (_range, "Range")],
+    ids=["band", "range"],
+)
+def test_a_sideways_chart_is_read_from_the_drawing(make, mark):
+    # `orient="y"` is what makes `so.Est()` aggregate down the page. The
+    # orientation is then read back off the geometry rather than off that
+    # keyword: the bounds still go in `yMin`/`yMax` and `orientation` says
+    # which axis they are on, which is the convention `ErrorBarTrace`
+    # depends on -- `ErrorBarPoint` has no `xMin`/`xMax` to put them in.
+    schema = _only(
+        so.Plot(_frame(), y="x", x="y").add(so.Band() if make is _band else so.Range(),
+                                            so.Est(), orient="y")
+    )
+
+    assert schema["orientation"] == "horz"
+    assert [point["x"] for point in schema["data"]] == [0.0, 1.0, 2.0]
+    assert all(point["yMin"] < point["yMax"] for point in schema["data"])
+
+
+@pytest.mark.parametrize(
+    ("make", "mark"),
+    [(_band, "Band"), (_range, "Range")],
+    ids=["band", "range"],
+)
+def test_a_colour_split_becomes_one_series_per_level(make, mark):
+    # The grouped shape `ErrorBarPoint[][]` exists for exactly this (#942):
+    # it is what lets a reader move between two levels' intervals at one
+    # position, which is the comparison a grouped interval chart is drawn
+    # for. Flattened, the two levels arrive as six readings in a row.
+    schema = _only(make(x="x", y="y", color="g"))
+    data = schema["data"]
+
+    assert [len(series) for series in data] == [3, 3]
+    assert [series[0]["z"] for series in data] == ["a", "b"]
+    assert schema["axes"]["z"] == {"label": "g"}
+
+
+@pytest.mark.parametrize(
+    ("make", "mark"),
+    [(_band, "Band"), (_range, "Range")],
+    ids=["band", "range"],
+)
+def test_the_levels_do_not_overlap_so_a_swap_would_show(make, mark):
+    # The fixture puts group `b` four units above group `a`, so a reading
+    # that paired a level's name with the other's bounds is visible in the
+    # numbers rather than only in the label.
+    data = _only(make(x="x", y="y", color="g"))["data"]
+    lower, upper = data
+
+    assert max(point["yMax"] for point in lower) < min(point["yMin"] for point in upper)
+
+
+def test_a_single_group_stays_flat_rather_than_becoming_a_list_of_one():
+    # One group needs no name for itself, and wrapping it would make every
+    # unsplit chart announce a grouping it does not have.
+    data = _only(_range(x="x", y="y"))["data"]
+
+    assert all(isinstance(point, dict) for point in data)
+    assert all("z" not in point for point in data)
+
+
+def test_a_band_is_told_apart_from_an_area_by_the_marks_name():
+    # Both leave a `Polygon` in `patches`, and only the mark's name says
+    # whether the fold is a series against a baseline or a pair of bounds.
+    # Read by artist class alone, an area would come out as an interval.
+    area = _only(so.Plot(_frame(), x="x", y="y").add(so.Area()))
+    band = _only(_band(x="x", y="y"))
+
+    assert area["type"] is PlotType.AREA
+    assert band["type"] is PlotType.ERRORBAR
+
+
+def test_a_range_outlines_each_interval_and_a_band_outlines_nothing():
+    # A range draws one path per position, which is what a selector resolves
+    # to. A band spans every position with a single path, so there is no
+    # element per interval -- and promising highlightable paths the document
+    # does not contain is worse than promising none.
+    assert _only(_range(x="x", y="y")).get("selectors")
+    assert not _only(_band(x="x", y="y")).get("selectors")
+
+
+def test_a_split_range_declines_to_outline_rather_than_outlining_the_wrong_one():
+    # One collection's paths run in drawing order while the payload is
+    # grouped by level, so a positional selector would pair the second
+    # level's first interval with the first level's. The grouped selector
+    # shape is a question of its own (#814).
+    assert not _only(_range(x="x", y="y", color="g")).get("selectors")
+
+
+def test_an_estimate_drawn_beside_it_is_its_own_layer():
+    # `so.Dot(), so.Agg()` is how a caller adds the centre these marks do
+    # not draw. It registers as the scatter it is rather than being folded
+    # into the interval, which is what keeps the interval honest about
+    # having no estimate of its own.
+    schemas = _layers(
+        so.Plot(_frame(), x="x", y="y").add(so.Range(), so.Est()).add(so.Dot(), so.Agg())
+    )
+
+    assert [schema["type"] for schema in schemas] == [
+        PlotType.ERRORBAR,
+        PlotType.SCATTER,
+    ]
+    assert all("y" not in point for point in schemas[0]["data"])
+    assert all("y" in point for point in schemas[1]["data"])
+
+# --------------------------------------------------------------------------
+# The guards below are asked of the helpers directly, or of the rendered SVG,
+# because a schema alone cannot see them: a mutation that removes any of them
+# leaves a schema identical to the right one and a chart that is not.
+# --------------------------------------------------------------------------
+
+
+def test_a_path_that_does_not_fold_in_half_is_declined():
+    # `_folded` pairs vertex `i` with vertex `2n - 1 - i`, which only means
+    # anything on a path with an even number of points after the closing
+    # repeat is dropped. An odd one has a vertex with no partner, and folding
+    # it anyway would pair every position with the wrong bound and report an
+    # interval the chart never drew.
+    from maidr.core.plot.intervalplot import _folded
+
+    assert _folded(np.array([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]])) == []
+
+
+def test_a_closed_path_is_folded_without_its_closing_vertex():
+    # matplotlib repeats the first vertex to close the polygon. Counting it
+    # makes the path odd, which the guard above would then decline -- so the
+    # band would read as nothing at all.
+    from maidr.core.plot.intervalplot import _folded
+
+    closed = np.array([[0.0, 1.0], [1.0, 2.0], [1.0, 4.0], [0.0, 3.0], [0.0, 1.0]])
+    folded = _folded(closed)
+
+    assert [tuple(position) for position, _, _ in folded] == [(0.0, 1.0), (1.0, 2.0)]
+    assert [tuple(high) for _, _, high in folded] == [(0.0, 3.0), (1.0, 4.0)]
+
+
+def test_one_colour_over_many_segments_is_cycled_rather_than_run_off():
+    # `get_colors()` returns exactly what was set, and a collection given one
+    # colour carries one row however many segments it draws. Indexing that
+    # would leave every segment after the first unnamed, so a split whose
+    # levels happen to share a set colour would lose its names.
+    from maidr.core.plot.intervalplot import _segment_colours
+    from matplotlib.collections import LineCollection
+
+    one = LineCollection([[(0, 0), (0, 1)]] * 3, colors="C0")
+    colours = _segment_colours(one, 3)
+
+    assert len(colours) == 3
+    assert len(set(colours)) == 1
+
+
+def test_a_collection_with_no_colours_names_nothing_rather_than_raising():
+    from maidr.core.plot.intervalplot import _segment_colours
+    from matplotlib.collections import LineCollection
+
+    bare = LineCollection([[(0, 0), (0, 1)]])
+    bare.set_color([])
+
+    assert _segment_colours(bare, 2) == [None, None]
+
+
+def test_a_degenerate_first_interval_does_not_decide_the_orientation():
+    # The two bounds at one position share the coordinate the position is on.
+    # A zero-width interval shares *both*, so it names neither axis -- and
+    # reading the orientation off it would answer from the chart's flattest
+    # point. Reachable: `so.Est()` on a position with one observation draws
+    # exactly that.
+    lopsided = pd.DataFrame(
+        [{"x": 0, "y": 1.0}]
+        + [{"x": 1, "y": 4.0 + step} for step in range(6)]
+        + [{"x": 2, "y": 9.0 + step} for step in range(6)]
+    )
+    upright = _only(so.Plot(lopsided, x="x", y="y").add(so.Range(), so.Est()))
+    # The sideways chart is what makes this test bite: reading the flat first
+    # interval says nothing, and answering from it falls back to vertical --
+    # which would put the positions in `yMin`/`yMax` and the readings in `x`.
+    sideways = _only(
+        so.Plot(lopsided, y="x", x="y").add(so.Range(), so.Est(), orient="y")
+    )
+
+    assert upright["orientation"] == "vert"
+    assert sideways["orientation"] == "horz"
+    assert upright["data"][0]["yMin"] == upright["data"][0]["yMax"]
+    assert upright["data"][1]["yMin"] < upright["data"][1]["yMax"]
+    assert [point["x"] for point in sideways["data"]] == [0.0, 1.0, 2.0]
+
+
+def test_a_range_selector_resolves_to_the_paths_it_promises():
+    # The half a schema cannot check: the selector string is the same whether
+    # or not the collection was tagged, so only the rendered document says
+    # whether it finds anything. An untagged range promises highlightable
+    # paths and outlines nothing.
+    import io
+
+    from lxml import etree
+
+    plot = _range(x="x", y="y").plot()
+    figure = plot._figure
+    maidr.render(figure)._repr_html_()
+
+    schema = FigureManager.get_maidr(figure).plots[0].schema
+    buffer = io.BytesIO()
+    figure.savefig(buffer, format="svg")
+    root = etree.fromstring(buffer.getvalue())
+    namespaces = {"s": "http://www.w3.org/2000/svg"}
+    gid = schema["selectors"][0].split("'")[1]
+    group = root.xpath(f"//s:g[@id='{gid}']", namespaces=namespaces)
+
+    assert len(schema["selectors"]) == 3
+    assert len(group) == 1
+    assert len(group[0].xpath("./s:path", namespaces=namespaces)) == 3
+
+
+def test_a_band_promises_no_selector_at_all():
+    # The other side of the same fact: a band is one path over every
+    # position, so there is nothing per-interval to address. Emitting the
+    # inherited default would promise outlining that cannot happen.
+    plot = _band(x="x", y="y").plot()
+    figure = plot._figure
+    maidr.render(figure)._repr_html_()
+
+    schema = FigureManager.get_maidr(figure).plots[0].schema
+
+    assert "selectors" not in schema
+


### PR DESCRIPTION
## The gap

`so.Band` and `so.Range` registered nothing, so a chart of estimates and their uncertainty fell back to a static image.

```python
so.Plot(df, x="x", y="y").add(so.Range(), so.Est())   # drawn, and silent
```

## One reading, two drawings

#670 records these as one unit of work, and the measurement bears it out. `seaborn 0.13.2`, three positions:

| mark | artist | shape |
|---|---|---|
| `so.Band(), so.Est()` | one `Polygon` | vertices: lower edge forward, then upper edge backward, closed |
| `so.Range(), so.Est()` | one `LineCollection` | one segment per position |

Neither draws a centre, and that is the reading rather than a gap to fill in — `ErrorBarPoint.y` is optional for exactly this case, which its own documentation calls *"absent on a band that draws only bounds"*. A chart that wants the estimate too adds `so.Dot(), so.Agg()` beside it, and that registers as the scatter it is.

## Read from the drawing, not from the spelling

**Orientation.** The two bounds at one position share the coordinate that position sits on, so whichever of the pair matches names the position axis. True of a polygon's paired vertices and a segment's two endpoints alike, and true whether the caller wrote `orient="y"` or not. A *degenerate* interval shares both and so says nothing — reachable, since `so.Est()` on a position with one observation draws exactly that — so the first interval with a spread decides rather than the first outright.

**The split.** A colour-split `Band` leaves one polygon per level; a split `Range` leaves **one** collection carrying a colour per segment. Both are named through the legend the way every other colour split is, which is available here only because #672 taught the lookup to find a `seaborn.objects` legend — it is the figure's, never the axes'. A named split becomes the grouped shape `ErrorBarPoint[][]` that xability/maidr#942 added, so a reader can move between two levels' intervals at one position, which is the comparison a grouped interval chart is drawn for. A chart with one group stays flat rather than becoming a list of one.

## Highlighting, offered only where it is real

The sweep turned up a bug worth calling out: the inherited default selector is `g[maidr='true'] > path`, and `maidr.patch.highlight` tags a drawn artist by giving it a `maidr-` **gid**, not a `maidr` attribute. A class that leaves the default emits a selector matching no element in the document — worse than emitting none, since the layer says its intervals can be outlined and none of them can. `IntervalPlot` addresses each interval by its position inside the collection's group instead, and the test verifies that against the rendered SVG rather than against the schema.

Two cases decline outright:

- a **band** is one path over every position, so there is no element per interval;
- a **split range**'s paths run in drawing order while the payload is grouped by level, so a positional selector would pair the second level's first interval with the first level's (xability/maidr#814).

## End to end

```
Band,  single         3 intervals, vert, no selectors
Range, single         3 intervals, vert, 3 selectors resolving to 3 drawn paths
Band,  colour split   [[a×3],[b×3]] with z per point, axes.z {label: 'g'}
Range, colour split   the same, selectors declined
Band,  orient="y"     horz, positions in x, bounds in yMin/yMax
Range, orient="y"     horz, likewise
Range + Dot/Agg       two layers: the interval, then the estimate
```

## Tests

`tests/core/plot/test_seaborn_objects_intervals.py` — 24 cases, most parametrised over both marks: the reading itself, bounds without an estimate, both orientations, the grouped split, non-overlapping levels so a name/bounds swap would show, the flat single-group shape, `Band` told apart from `Area` by the mark's name rather than the artist class (both are `Polygon`), and the three highlighting decisions.

Six of those are asked of the helpers or the rendered SVG directly, because a schema alone cannot see them — a path that does not fold in half, a closed path folded without its closing vertex, one colour cycled over many segments, a collection with no colours, a degenerate first interval on a *sideways* chart, and the selector resolving to real paths.

`test_seaborn_objects.py` drops `Range` from the two declines lists and rewrites the ancestry test: `Range` used to be its example of a decline, and now it is read — as an **interval**, which shows why ancestry would still be wrong even where it claims something readable.

A 21-mutation sweep killed 20. The survivor is the `min`/`max` ordering of the two bounds: both drawings happen to give the lower first, so no reachable input distinguishes it, and it is documented in place rather than tested.

## Verification

- `uv run pytest -q` → **3513 passed, 72 skipped**
- `ruff check` clean on every changed file (the 6 re-export errors ruff reports repo-wide are pre-existing and present on `origin/main`)

Part of #670.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_