### PR TITLE
feat(seaborn-objects): read a Bars mark as the histogram it draws

### DIFF
--- a/maidr/core/plot/bars_histogram.py
+++ b/maidr/core/plot/bars_histogram.py
@@ -1,0 +1,269 @@
+"""BarsHistPlot — the histogram ``seaborn.objects`` draws as one collection."""
+
+from __future__ import annotations
+
+import uuid
+from typing import List, Sequence
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import PatchCollection
+
+from maidr.core.plot.histogram import HistPlot
+from maidr.exception import ExtractionError
+
+#: The keyword the drawn collection is handed over under.
+DRAWN_BINS = "bins"
+
+#: The keyword the paths of one group are handed over under.
+BIN_MEMBERS = "bin_members"
+
+
+class BarsHistPlot(HistPlot):
+    """
+    A histogram drawn as one ``PatchCollection`` rather than as a container.
+
+    ``so.Bars()`` is the continuous-x bar `seaborn.objects` draws for a
+    histogram, where ``so.Bar()`` is the categorical one. Measured on
+    ``seaborn 0.13.2``, the two leave different artists and that is the whole
+    of why one was read and the other was not::
+
+        so.Bar(), so.Count()   Rectangle patches + a BarContainer   read
+        so.Bars(), so.Hist()   one PatchCollection of rectangles    --
+
+    ``HistPlot`` looks a ``BarContainer`` up and finds none, which is the same
+    decline ``element="step"`` hit before :class:`SteppedHistPlot` (#522).
+
+    Every bin is read off its own rectangle, and nothing is reconstructed. A
+    path runs ``[left, 0] [right, 0] [right, count] [left, count]``, so the
+    edges and the count are all three in the drawing::
+
+        vertical    [[-2.83, 0], [-2.39, 0], [-2.39, 3], [-2.83, 3], ...]
+        horizontal  [[0, -2.83], [3, -2.83], [3, -2.39], [0, -2.39], ...]
+
+    Orientation is read from the drawing rather than from the caller's
+    ``orient=``, and not from one rectangle's vertices: measured, the first
+    two differ on ``x`` in **both** orientations -- they span the bin when it
+    is vertical and the count when it is not -- so the winding says nothing.
+    What does is the baseline. A histogram's bars grow from zero, so the axis
+    whose lowest point over the whole chart is zero is the count one.
+
+    ``so.Stack()`` does not disturb that: it lifts the later segments and
+    leaves the first sitting on the baseline. It does change what a bar's
+    *length* means, which is why the count is read as a span rather than as a
+    top -- see :func:`_span`.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        self._collection: PatchCollection = kwargs.pop(DRAWN_BINS, None)
+
+        # Which of the collection's paths are this layer's. A colour split
+        # overlays every group in one collection, so a layer is a slice of it
+        # rather than the whole; absent means all of them.
+        self._members: Sequence[int] | None = kwargs.pop(BIN_MEMBERS, None)
+
+        super().__init__(ax, **kwargs)
+
+    def _extract_plot_data(self) -> list[dict]:
+        paths = self._paths()
+        if not paths:
+            raise ExtractionError(self.type, self.ax)
+
+        corners = [np.asarray(path.vertices, dtype=float) for path in paths]
+        self._orientation = "vert" if self._vertical(corners) else "horz"
+        bins = 0 if self._orientation == "vert" else 1
+        counts = 1 - bins
+
+        data = []
+        for corner in corners:
+            # The rectangle's extent per axis rather than named vertices: the
+            # path's winding is not the same in both orientations -- measured,
+            # the first two vertices span the bin when it is vertical and the
+            # count when it is not -- and a bounding box does not care.
+            low, high = corner[:, bins].min(), corner[:, bins].max()
+            if low == high:
+                # A rectangle of no width spans no bin. Announcing it would
+                # put both edges of a bin at the same place and claim a
+                # boundary the chart never drew. No `so.Bars` spelling
+                # reaches this -- measured across `Hist`, `Count`, `Agg` and
+                # a raw `y`, a bin the binner produced has a width whether
+                # or not anything landed in it -- so the guard is against a
+                # collection from anywhere else, and it is tested against
+                # one built to have the case rather than left as an
+                # unreachable claim.
+                continue
+            # Plain floats, not the numpy scalars the vertices come back as:
+            # `json.dumps` cannot write one, and the payload is serialised
+            # into the SVG's `maidr` attribute (#429).
+            data.append(
+                self._bin_point(
+                    self._orientation,
+                    float(low),
+                    float(high - low),
+                    float(_span(corner[:, counts])),
+                )
+            )
+
+        if not data:
+            raise ExtractionError(self.type, self._collection)
+
+        return data
+
+    def _get_selector(self) -> List[str]:
+        """
+        One selector per bin, addressing its own path inside the group.
+
+        The collection draws one path per bin as direct children of one
+        group, and a colour split puts every group's bins in that same
+        collection -- so a layer addresses its own paths by position and
+        leaves its neighbours' alone. Numbered against the **collection**
+        rather than against this layer's bins, which is what keeps the
+        second group's selectors pointing at the second group's paths.
+
+        Setting the gid here is the whole of the tagging. ``SegmentLinePlot``
+        also puts its artist in ``_elements``, but it has stand-ins to
+        displace; there is nothing here to displace, and measured, the gid
+        written here reaches the rendered document on its own.
+
+        Returns
+        -------
+        list of str
+            One selector per bin, in the order the payload announces them.
+        """
+        gid = self._collection.get_gid()
+        if not gid or not str(gid).startswith("maidr-"):
+            gid = f"maidr-{uuid.uuid4()}"
+            self._collection.set_gid(gid)
+
+        return [
+            f"g[id='{gid}'] > path:nth-of-type({position + 1})"
+            for position in self._positions()
+        ]
+
+    def _positions(self) -> list[int]:
+        """Which of the collection's paths this layer draws, in order."""
+        count = len(self._collection.get_paths()) if self._collection else 0
+        if self._members is None:
+            return list(range(count))
+        return [index for index in self._members if 0 <= index < count]
+
+    def _paths(self) -> list:
+        """This layer's rectangles, in drawing order."""
+        if self._collection is None:
+            return []
+        paths = self._collection.get_paths()
+        return [paths[index] for index in self._positions()]
+
+    @staticmethod
+    def _vertical(corners: Sequence[np.ndarray]) -> bool:
+        """
+        Whether the bins run along the x axis.
+
+        Two rectangles say it outright: they sit at different places along
+        the bin axis and start from the same value on the count axis, so the
+        axis their lower corners differ on is the bin axis.
+
+        Parameters
+        ----------
+        corners : sequence of numpy.ndarray
+            Each rectangle's path vertices, in drawing order.
+
+        Returns
+        -------
+        bool
+            True when the bins run along x.
+        """
+        drawn = np.vstack([np.asarray(corner, dtype=float) for corner in corners])
+
+        # A histogram's bars grow from zero, so the count axis is the one
+        # whose lowest point over the whole chart is zero. True of a stack
+        # too: it lifts the later segments and leaves the first sitting on
+        # the baseline. Answered from the drawing as a whole rather than by
+        # comparing two bars, so it holds for a chart of one bin.
+        if drawn[:, 1].min() == 0:
+            return True
+        return drawn[:, 0].min() != 0
+
+
+def _span(values: np.ndarray) -> float:
+    """
+    What one bar holds: the length of the rectangle, not where its top is.
+
+    The two are the same only while every bar starts at zero. Measured, a
+    stacked histogram lifts the later ones -- ``so.Bars(), so.Hist(),
+    so.Stack()`` draws a second level's bar from 1 to 41 -- so reading the
+    top would announce 41 where that level counted 40, and every level but
+    the first would be announced with its neighbours' counts added on.
+
+    That is also what ``HistPlot`` reads on its own path: a ``BarContainer``
+    patch's ``get_height()`` is the segment, matplotlib having stacked it by
+    moving the bottom rather than by growing the bar.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        One rectangle's coordinates on the count axis.
+
+    Returns
+    -------
+    float
+        What that bar holds.
+    """
+    return float(values.max()) - float(values.min())
+
+
+def hist_groups(ax: Axes, collection: PatchCollection) -> list[tuple[str, list[int]]] | None:
+    """
+    The groups a colour-split ``so.Bars`` layer was drawn with, or ``None``.
+
+    The ``PatchCollection`` counterpart of
+    :func:`maidr.core.plot.barplot.bar_groups`, and the same question: one
+    artist carries every level, so the grouping survives only in the
+    rectangles' colours and in the legend that names them.
+
+    Needed here for the reason the bar one is needed and one more. A classic
+    ``seaborn.histplot(hue=...)`` draws a container **per level**, so each
+    layer already holds one distribution; ``so.Bars()`` overlays every level
+    in one collection, and read whole it would announce two distributions'
+    bins as one -- the same bin edge appearing twice with two different
+    counts, in no stated order.
+
+    Measured, the paths run group by group rather than interleaved, so a
+    level's bins stay in bin order inside its own layer.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes drawn on, for its legend.
+    collection : matplotlib.collections.PatchCollection
+        The drawn rectangles.
+
+    Returns
+    -------
+    list of (str, list of int) or None
+        One entry per group in legend order, naming it and listing the
+        collection positions that belong to it, or ``None`` when the layer is
+        not grouped.
+    """
+    from maidr.core.plot.scatterplot import _rgba, groups_from_colours
+
+    colours = np.asarray(collection.get_facecolors(), dtype=float)
+    if colours.ndim == 1:
+        colours = colours.reshape(1, -1)
+    count = len(collection.get_paths())
+    if len(colours) == 0:
+        return None
+
+    # Cycled rather than indexed, for the reason `SegmentLinePlot` cycles its
+    # own: `get_facecolors()` returns exactly what was set, and matplotlib
+    # cycles those over the paths at draw time -- measured, four rectangles
+    # given two colours come back as a (2, 4) array with all four drawn.
+    # Indexed straight, the third rectangle falls off the end.
+    #
+    # Measured, `so.Bars` always sets one per rectangle -- 8 for 8 bins, 16
+    # for a two-level split -- so no chart drawn by this mark reaches the
+    # cycle. It is the collection's contract rather than the mark's, and it
+    # is tested against a collection built to have it.
+    return groups_from_colours(
+        ax, [_rgba(colours[index % len(colours)][:4]) for index in range(count)]
+    )

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D
-from matplotlib.collections import LineCollection, PolyCollection
+from matplotlib.collections import LineCollection, PatchCollection, PolyCollection
 from matplotlib.patches import StepPatch
 from maidr.core.enum import PlotType
 from maidr.core.plot.areaplot import AreaPlot
@@ -10,6 +10,7 @@ from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.boxenplot import BoxenPlot
 from maidr.core.plot.boxplot import BoxPlot
 from maidr.core.plot.contour import ContourPlot
+from maidr.core.plot.bars_histogram import BarsHistPlot, DRAWN_BINS
 from maidr.core.plot.errorbar import ErrorBarPlot
 from maidr.core.plot.intervalplot import DRAWN_INTERVALS, IntervalPlot
 from maidr.core.plot.eventplot import DRAWN_EVENTS, EventPlot
@@ -120,6 +121,11 @@ class MaidrPlotFactory:
             # find and no per-bin artist to look for.
             if isinstance(kwargs.get("step_patch"), StepPatch):
                 return StairsPlot(single_ax, **kwargs)
+            # `so.Bars()` draws the same distribution as one `PatchCollection`
+            # of rectangles -- neither a container nor an outline, so neither
+            # of the two below can read it.
+            if isinstance(kwargs.get(DRAWN_BINS), PatchCollection):
+                return BarsHistPlot(single_ax, **kwargs)
             # `sns.histplot(element="step"/"poly")` draws the same
             # distribution as one closed outline, so there is no container to
             # find and the call hands its `PolyCollection` over instead.

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -8,7 +8,7 @@ from typing import Any, NamedTuple
 import numpy as np
 import wrapt
 from matplotlib.axes import Axes
-from matplotlib.collections import LineCollection, PathCollection
+from matplotlib.collections import LineCollection, PatchCollection, PathCollection
 from matplotlib.container import BarContainer
 from matplotlib.lines import Line2D
 from matplotlib.patches import Polygon
@@ -17,6 +17,7 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS, bar_groups
+from maidr.core.plot.bars_histogram import BIN_MEMBERS, DRAWN_BINS, hist_groups
 from maidr.core.plot.grouped_barplot import DRAWN_GROUPS
 from maidr.core.plot.intervalplot import DRAWN_INTERVALS
 from maidr.core.plot.maidr_plot import GROUP_NAME
@@ -123,6 +124,12 @@ _READINGS: dict[str, _Reading] = {
     # of bounds.
     "Band": _Reading(PlotType.ERRORBAR, "patches", Polygon, DRAWN_INTERVALS),
     "Range": _Reading(PlotType.ERRORBAR, "collections", LineCollection, DRAWN_INTERVALS),
+    # The continuous-x bar, which is the one seaborn draws for a histogram.
+    # `Bar` is the categorical one and leaves a `BarContainer`; measured,
+    # `Bars` leaves one `PatchCollection` of rectangles instead, which is
+    # neither a container nor the outline `element="step"` gives -- so all
+    # three of `HistPlot`'s existing ways in miss it (#670).
+    "Bars": _Reading(PlotType.HIST, "collections", PatchCollection, DRAWN_BINS, True),
 }
 
 
@@ -564,6 +571,25 @@ def _handovers(
                 (
                     reading.plot_type,
                     {reading.binding: own, HUE_GROUP: (name, [members])},
+                )
+                for name, members in groups
+            ]
+
+    if reading.plot_type is PlotType.HIST and len(own) == 1:
+        groups = hist_groups(ax, own[0])
+        if groups:
+            # One layer per level, which is what a classic
+            # `seaborn.histplot(hue=)` already gives -- it draws a container
+            # per level, and this mark overlays every level's bars in one
+            # collection instead. The members go with the name because a
+            # layer's bins are a slice of that collection rather than the
+            # whole of it, and its selectors have to number against the
+            # collection so the second level's point at the second level's
+            # paths.
+            return [
+                (
+                    reading.plot_type,
+                    {reading.binding: own[0], BIN_MEMBERS: members, GROUP_NAME: name},
                 )
                 for name, members in groups
             ]

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -273,7 +273,6 @@ def test_a_panel_the_layer_never_drew_on_registers_nothing():
 @pytest.mark.parametrize(
     "mark",
     [
-        pytest.param(so.Bars(), id="Bars"),
         pytest.param(so.Dash(), id="Dash"),
         pytest.param(so.Text(), id="Text"),
     ],
@@ -285,10 +284,12 @@ def test_a_mark_this_does_not_read_still_registers_nothing(mark):
     mark whose artists no existing plot class can read is left alone, not
     guessed at. `Dash` matters most -- see the test below.
 
-    `Lines`, `Paths`, `Area`, `Band` and `Range` each left this list when they
-    gained a reading (#670). They came off deliberately: this list is the
-    reminder that a decline was a decision, so a mark added to `_READINGS`
-    has to be taken out of it by hand rather than quietly passing both ways.
+    `Lines`, `Paths`, `Area`, `Band`, `Range` and `Bars` each left this list
+    when they gained a reading (#670), leaving `Dash` and `Text` -- the two
+    that want a judgement rather than a measurement. They came off
+    deliberately: this list is the reminder that a decline was a decision, so
+    a mark added to `_READINGS` has to be taken out of it by hand rather than
+    quietly passing both ways.
     """
     figure = _drawn(
         lambda fig: so.Plot(_frame(), x="t", y="m").add(mark).on(fig).plot()
@@ -432,7 +433,6 @@ def test_every_selector_resolves_in_the_page_it_was_built_from(mark, x, y):
 @pytest.mark.parametrize(
     "mark",
     [
-        pytest.param(so.Bars(), id="Bars"),
         pytest.param(so.Dash(), id="Dash"),
         pytest.param(so.Text(), id="Text"),
     ],

--- a/tests/core/plot/test_seaborn_objects_bars.py
+++ b/tests/core/plot/test_seaborn_objects_bars.py
@@ -1,0 +1,317 @@
+"""
+``so.Bars`` drew a histogram and registered nothing (#670).
+
+`so.Bar` is the categorical bar and `so.Bars` the continuous-x one seaborn
+draws for a histogram. They leave different artists, and that is the whole of
+why one was read and the other was not — measured on ``seaborn 0.13.2``::
+
+    so.Bar(), so.Count()   Rectangle patches + a BarContainer   read as bar
+    so.Bars(), so.Hist()   one PatchCollection of rectangles    --
+
+``HistPlot`` looks a ``BarContainer`` up and finds none, which is the same
+decline ``element="step"`` hit before ``SteppedHistPlot`` (#522).
+
+Every bin is read off its own rectangle and nothing is reconstructed: a path
+carries both edges and the count.
+
+Two things had to be measured rather than assumed.
+
+**The path winding is not the same in both orientations.** The first two
+vertices span the *bin* when the chart is vertical and the *count* when it is
+not, so no fixed pair of vertices names the edges. The reading takes the
+rectangle's extent per axis instead, and the orientation comes from the fact
+that bins advance while the baseline does not.
+
+**A colour split overlays every level in one collection**, contiguous by
+colour, where a classic ``seaborn.histplot(hue=...)`` draws a container per
+level. Read whole it would announce two distributions' bins as one — the same
+edge twice with two different counts. Split, it matches the classic reading.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn.objects as so
+
+import maidr
+from maidr.core.enum import PlotType
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Two groups over one continuous variable, far enough apart to tell."""
+    rng = np.random.default_rng(3)
+    return pd.DataFrame(
+        {
+            "v": np.concatenate([rng.normal(0, 1, 120), rng.normal(6, 1, 120)]),
+            "g": ["a"] * 120 + ["b"] * 120,
+        }
+    )
+
+
+def _layers(plot) -> list[dict]:
+    """Every layer the drawn plot registered, as schemas."""
+    return [layer.schema for layer in FigureManager.get_maidr(plot.plot()._figure).plots]
+
+
+def _only(plot) -> dict:
+    schemas = _layers(plot)
+    assert len(schemas) == 1, f"expected one layer, got {len(schemas)}"
+    return schemas[0]
+
+
+def _bars(**kwargs):
+    return so.Plot(_frame(), **kwargs).add(so.Bars(), so.Hist(bins=6))
+
+
+def test_a_bars_mark_is_read_as_a_histogram_rather_than_registering_nothing():
+    # The reproduction. Before this the mark fell through `_READINGS` and the
+    # chart was a static image with nothing to navigate.
+    schema = _only(_bars(x="v"))
+
+    assert schema["type"] is PlotType.HIST
+    assert len(schema["data"]) == 6
+
+
+def test_every_bin_carries_both_edges_and_its_count():
+    # All three are in the drawing -- a rectangle's path is
+    # `[left, 0] [right, 0] [right, count] [left, count]` -- so nothing is
+    # reconstructed from spacing the way a `poly` outline has to be.
+    bins = _only(_bars(x="v"))["data"]
+
+    assert all(point["xMin"] < point["xMax"] for point in bins)
+    assert all(point["y"] >= 0 for point in bins)
+    assert sum(point["y"] for point in bins) == 240
+
+
+def test_the_bins_are_contiguous_and_in_order():
+    # A histogram's bins abut. Reading them out of order, or dropping one,
+    # would leave a reader walking a distribution with a hole in it.
+    bins = _only(_bars(x="v"))["data"]
+
+    for earlier, later in zip(bins, bins[1:]):
+        assert earlier["xMax"] == pytest.approx(later["xMin"])
+
+
+def test_a_vertical_chart_says_so():
+    assert _only(_bars(x="v"))["orientation"] == "vert"
+
+
+def test_a_sideways_chart_puts_the_bins_on_the_axis_it_drew_them_on():
+    # The measured trap: the first two vertices differ on `x` in *both*
+    # orientations, so a reading that named them would call this vertical and
+    # put the bin edges where the counts belong.
+    schema = _only(_bars(y="v"))
+
+    assert schema["orientation"] == "horz"
+    assert all(point["yMin"] < point["yMax"] for point in schema["data"])
+    assert all(point["x"] >= 0 for point in schema["data"])
+
+
+def test_one_bin_is_still_a_histogram():
+    # No neighbour to read the advance from, so the orientation falls back to
+    # the baseline: a histogram's bars grow from zero.
+    schema = _only(so.Plot(_frame(), x="v").add(so.Bars(), so.Hist(bins=1)))
+
+    assert schema["orientation"] == "vert"
+    assert len(schema["data"]) == 1
+    assert schema["data"][0]["y"] == 240
+
+
+def test_a_colour_split_becomes_one_layer_per_level():
+    # What the classic spelling already gives: `seaborn.histplot(hue=...)`
+    # draws a container per level and reads as one layer each. This mark
+    # overlays them in one collection, so the split happens here instead.
+    schemas = _layers(_bars(x="v", color="g"))
+
+    assert len(schemas) == 2
+    assert [schema["name"] for schema in schemas] == ["a", "b"]
+
+
+def test_each_level_gets_its_own_distribution_rather_than_both():
+    # The fixture puts the groups six units apart, so a layer holding both
+    # would show it in the counts rather than only in the label.
+    first, second = _layers(_bars(x="v", color="g"))
+
+    assert sum(point["y"] for point in first["data"]) == 120
+    assert sum(point["y"] for point in second["data"]) == 120
+
+
+def test_each_level_outlines_its_own_bars_and_not_its_neighbours():
+    # Both levels' rectangles are in one collection, so a layer numbering its
+    # selectors from one would outline the first level's bins whichever level
+    # a reader was on. They are numbered against the collection instead.
+    first, second = _layers(_bars(x="v", color="g"))
+    positions = [
+        int(selector.rsplit("(", 1)[1].rstrip(")"))
+        for schema in (first, second)
+        for selector in schema["selectors"]
+    ]
+
+    assert len(set(positions)) == len(positions)
+    assert max(int(s.rsplit("(", 1)[1].rstrip(")")) for s in first["selectors"]) < min(
+        int(s.rsplit("(", 1)[1].rstrip(")")) for s in second["selectors"]
+    )
+
+
+def test_a_selector_resolves_to_exactly_one_drawn_rectangle():
+    # The half a schema cannot check: the group is really there, and it holds
+    # one path per bin across both levels.
+    import io
+
+    from lxml import etree
+
+    plot = _bars(x="v", color="g").plot()
+    figure = plot._figure
+    maidr.render(figure)._repr_html_()
+    schemas = [layer.schema for layer in FigureManager.get_maidr(figure).plots]
+
+    buffer = io.BytesIO()
+    figure.savefig(buffer, format="svg")
+    root = etree.fromstring(buffer.getvalue())
+    namespaces = {"s": "http://www.w3.org/2000/svg"}
+    gid = schemas[0]["selectors"][0].split("'")[1]
+    group = root.xpath(f"//s:g[@id='{gid}']", namespaces=namespaces)
+
+    assert len(group) == 1
+    drawn = len(group[0].xpath("./s:path", namespaces=namespaces))
+    assert drawn == sum(len(schema["selectors"]) for schema in schemas)
+
+
+def test_the_categorical_bar_is_still_read_as_a_bar():
+    # `so.Bar` and `so.Bars` are one letter apart and are different charts.
+    # Claiming the categorical one as a histogram would announce bin edges
+    # for categories that have none.
+    schema = _only(so.Plot(_frame(), x="g").add(so.Bar(), so.Count()))
+
+    assert schema["type"] is PlotType.BAR
+    assert [point["x"] for point in schema["data"]] == ["a", "b"]
+
+def test_a_stacked_level_is_announced_with_its_own_count():
+    # `so.Stack()` lifts the later segments off the baseline -- measured, a
+    # second level's bar runs from 1 to 41 -- so reading the top would
+    # announce 41 where that level counted 40, and every level but the first
+    # would carry its neighbours' counts. `HistPlot`'s own path reads the
+    # segment for the same reason: matplotlib stacks by moving the bottom.
+    schemas = _layers(
+        so.Plot(_frame(), x="v", color="g").add(so.Bars(), so.Hist(bins=4), so.Stack())
+    )
+
+    assert len(schemas) == 2
+    assert sum(point["y"] for point in schemas[0]["data"]) == 120
+    assert sum(point["y"] for point in schemas[1]["data"]) == 120
+
+
+def test_a_stack_does_not_disturb_the_orientation():
+    # The baseline rule holds through a stack because the first segment still
+    # sits on it. The sideways case is the one that would break if it did
+    # not: the bins would be read as counts.
+    upright = _layers(
+        so.Plot(_frame(), x="v", color="g").add(so.Bars(), so.Hist(bins=4), so.Stack())
+    )
+    sideways = _layers(
+        so.Plot(_frame(), y="v", color="g").add(so.Bars(), so.Hist(bins=4), so.Stack())
+    )
+
+    assert {schema["orientation"] for schema in upright} == {"vert"}
+    assert {schema["orientation"] for schema in sideways} == {"horz"}
+
+
+def test_each_selector_resolves_to_exactly_one_drawn_rectangle():
+    # Numbering, not just ordering. `nth-of-type` counts from one, and a
+    # selector numbered from zero matches nothing at all -- which a schema
+    # cannot show and an ordering assertion passes straight over.
+    import io
+
+    from lxml import etree
+
+    plot = _bars(x="v").plot()
+    figure = plot._figure
+    maidr.render(figure)._repr_html_()
+    schema = FigureManager.get_maidr(figure).plots[0].schema
+
+    buffer = io.BytesIO()
+    figure.savefig(buffer, format="svg")
+    root = etree.fromstring(buffer.getvalue())
+    namespaces = {"s": "http://www.w3.org/2000/svg"}
+    gid = schema["selectors"][0].split("'")[1]
+    group = root.xpath(f"//s:g[@id='{gid}']", namespaces=namespaces)
+    assert len(group) == 1
+
+    paths = group[0].xpath("./s:path", namespaces=namespaces)
+    for selector in schema["selectors"]:
+        position = int(selector.rsplit("(", 1)[1].rstrip(")"))
+        assert 1 <= position <= len(paths)
+
+
+
+def test_a_collection_given_fewer_colours_than_rectangles_still_splits():
+    """
+    Grouping reads a collection's colours cyclically, as matplotlib draws them.
+
+    ``PatchCollection.get_facecolors()`` returns exactly what was set, and a
+    collection given fewer colours than it has paths cycles them at draw
+    time -- measured, four rectangles and two colours come back as a ``(2, 4)``
+    array while all four are drawn. Indexed straight, the third rectangle
+    would fall off the end of the array.
+
+    No ``so.Bars`` chart is in that position: seaborn sets one colour per
+    rectangle, measured 8 for 8 bins and 16 for a two-level split. The cycle
+    is here for the collection contract rather than for a spelling of the
+    mark, so it is tested against a collection built to have it.
+    """
+    from matplotlib.patches import Patch, Rectangle
+    from matplotlib.collections import PatchCollection
+
+    from maidr.core.plot.bars_histogram import hist_groups
+
+    red, blue = (1.0, 0.0, 0.0, 1.0), (0.0, 0.0, 1.0, 1.0)
+    _, ax = plt.subplots()
+    collection = PatchCollection(
+        [Rectangle((index, 0), 1, 1) for index in range(4)],
+        facecolors=[red, blue],
+    )
+    ax.add_collection(collection)
+    ax.legend(
+        handles=[Patch(facecolor=red, label="a"), Patch(facecolor=blue, label="b")]
+    )
+
+    assert len(collection.get_facecolors()) == 2, "the fixture must be short of colours"
+    assert hist_groups(ax, collection) == [("a", [0, 2]), ("b", [1, 3])]
+
+
+def test_a_rectangle_of_no_width_is_not_announced_as_a_bin():
+    """
+    A degenerate rectangle spans no bin, so it is skipped rather than read.
+
+    No ``so.Bars`` spelling reaches this -- a bin the binner produced has a
+    width whether or not anything landed in it, measured across ``Hist``,
+    ``Count``, ``Agg`` and a raw ``y`` -- so the guard is tested against a
+    collection built to have one. Announced, it would put both edges of a
+    bin at the same place and claim a boundary the chart never drew.
+    """
+    from matplotlib.collections import PatchCollection
+    from matplotlib.patches import Rectangle
+
+    from maidr.core.plot.bars_histogram import DRAWN_BINS, BarsHistPlot
+
+    _, ax = plt.subplots()
+    collection = PatchCollection(
+        [Rectangle((0, 0), 2, 5), Rectangle((2, 0), 0, 5), Rectangle((2, 0), 2, 3)]
+    )
+    ax.add_collection(collection)
+
+    points = BarsHistPlot(ax, **{DRAWN_BINS: collection})._extract_plot_data()
+
+    assert len(points) == 2, f"the degenerate rectangle was read: {points}"
+    assert [point["xMin"] for point in points] == [0, 2]
+    assert [point["xMax"] for point in points] == [2, 4]


### PR DESCRIPTION
Part of #670.

## The decline

`so.Bar` is the categorical bar and `so.Bars` the continuous-x one seaborn draws for a histogram. Only the first was read, and what separates them is what each leaves on the axes — measured on seaborn 0.13.2:

| call | artists left | read as |
|---|---|---|
| `so.Bar(), so.Count()` | `Rectangle` patches + a `BarContainer` | `bar` |
| `so.Bars(), so.Hist()` | one `PatchCollection` of rectangles | — |

`HistPlot` looks a `BarContainer` up and finds none. That is the same third branch of the decline `element="step"` hit before `SteppedHistPlot` existed (#522).

## The reading

Every bin is read off its own rectangle and nothing is reconstructed — a path carries both edges and the count. Two things had to be measured rather than assumed.

**The path winding is not the same in both orientations.** The first two vertices span the *bin* when the chart is vertical and the *count* when it is not, so no fixed pair of vertices names the edges. The reading takes the rectangle's extent per axis instead, and the orientation comes from the baseline: the axis a bar starts from at zero is the one counts run along.

**A stacked level lifts the baseline.** Measured, a second level's bar runs 1 → 41 where the level counted 40. So the count is the rectangle's *span*, not its top — which is what `HistPlot` already reads from a `BarContainer` patch's `get_height()`.

**A colour split overlays every level in one collection**, contiguous by colour, where a classic `seaborn.histplot(hue=)` draws a container per level. Read whole it would announce two distributions' bins as one: the same edge twice with two different counts, in no stated order. Split into a layer per level it matches the classic reading, and the selectors are numbered against the **collection** so the second level's points at the second level's paths.

## Measured end to end

Five cases, through the real `maidr.render(fig)._repr_html_()` path:

```
Bars + Hist         HIST vert  bins 14  selectors 14
Bars, horizontal    HIST horz  bins 14  selectors 14
Bars, colour split  two layers named a / b; b's selectors are nth-of-type(15..27)
Bars, one bin       HIST vert  bins 1   selectors 1
Bar (categorical)   BAR — unchanged
```

The inherited `_get_selector()` default is `g[maidr='true'] > path`, which resolves to **nothing** — tagging is by `maidr-<uuid>` gid, not by attribute — so this class overrides it, verified against the rendered SVG rather than against the string.

## Verification

- `uv run pytest -q` — **3527 passed, 72 skipped**.
- `tests/core/plot/test_seaborn_objects_bars.py` — 16 tests, including the stacked-level count, a selector-numbering test that resolves against the rendered SVG, and two that pin contracts no `so.Bars` spelling reaches (a collection short of facecolours, and a degenerate rectangle).
- A 15-mutation sweep over the reading, the grouping, the selectors and the dispatch table: **0 survivors**.
- `ruff check maidr tests` reports 6 re-export errors, all of which are present on `origin/main` unchanged.

## Scope

`so.Bars` used on a *categorical* axis is read as a histogram of the unit-wide adjacent rectangles seaborn actually draws, rather than by tick label. That is off-label use of the continuous mark, and it announced nothing at all before this.

`Dash` and `Text` remain the two marks #670 asks for a judgement on and are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_