### PR TITLE
feat(seaborn-objects): read a Dash mark as the scatter of ticks it draws

### DIFF
--- a/maidr/core/plot/dashplot.py
+++ b/maidr/core/plot/dashplot.py
@@ -1,0 +1,219 @@
+"""Read a ``so.Dash`` mark as the scatter of ticks it draws."""
+
+from __future__ import annotations
+
+import math
+import uuid
+from typing import List
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+
+from maidr.core.plot.scatterplot import ScatterPlot
+from maidr.exception import ExtractionError
+
+#: The keyword the drawn collection is handed over under.
+DRAWN_DASHES = "dashes"
+
+
+class DashPlot(ScatterPlot):
+    """
+    One observation per tick, read off the tick's middle.
+
+    ``so.Dash()`` is ``so.Dot()``'s flat sibling: instead of a marker it
+    draws a short horizontal segment at each observation, so several
+    observations at one category stack up as a row of rules rather than as a
+    pile of overlapping circles. What it leaves behind is a
+    ``LineCollection`` and nothing else, which is the whole of why it was
+    silent -- ``ScatterPlot`` asks a ``PathCollection`` for its offsets, and
+    a line collection has none.
+
+    Measured on ``seaborn 0.13.2``, forty observations over five categories::
+
+        so.Dash()               LineCollection, 40 segments
+        first segment           [[-0.4, 3.696], [0.4, 3.696]]
+        so.Dash(), so.Dodge()   [[-0.4, 3.696], [ 0.0, 3.696]]
+
+    **The width is drawing and the middle is the datum.** A segment spans
+    ``width`` either side of the position, ``0.8`` by default and halved
+    again by a ``Dodge()``, and neither number is anything the chart
+    measured. What both spellings agree on is the segment's *centre*, which
+    is where the observation is -- so the reading takes the midpoint and
+    discards the span, rather than announcing a bar of no meaning.
+
+    That is also what makes the dodge case come out right. A dodged tick's
+    midpoint is offset from its tick, which is the shape #617 describes for
+    ``so.Bar``: read literally it announces ``-0.2`` where the axis says
+    ``a``. Here it needs no special case, because
+    :meth:`~maidr.core.plot.scatterplot.ScatterPlot._on_axis` already snaps a
+    drawn coordinate to the slot it belongs to and
+    :meth:`~maidr.core.plot.scatterplot.ScatterPlot._sample` names it -- the
+    machinery a jittered strip plot needed (#439), reused unchanged.
+
+    Read as a scatter rather than as a spike: a spike runs from a baseline to
+    its value, and measured, these do not reach one. They are marks at a
+    position, which is what a point is.
+
+    Parameters
+    ----------
+    ax : Axes
+        The panel drawn on.
+    **kwargs : dict
+        Carries the collection under :data:`DRAWN_DASHES`, and whatever the
+        factory forwards.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        self._collection: LineCollection = kwargs.pop(DRAWN_DASHES)
+        # Which of the collection's segments the payload announces, in payload
+        # order. Filled by `_extract_plot_data` and read by `_get_selector`;
+        # empty here so a layer asked for its selectors before its data
+        # returns none rather than raising.
+        self._drawn: List[int] = []
+        super().__init__(ax, **kwargs)
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        One sample per tick, in the order the collection holds them.
+
+        Returns
+        -------
+        list of dict
+            One point per drawn tick.
+
+        Raises
+        ------
+        ExtractionError
+            When the collection holds no tick this can read.
+        """
+        segments = self._collection.get_segments()
+        if not segments:
+            raise ExtractionError(self.type, self.ax)
+
+        # No `_elements.append` here. `ScatterPlot` keeps its collections so
+        # that `maidr.core.maidr` can stamp a gid on them before the SVG is
+        # written; this layer assigns its own in `_get_selector` and reads it
+        # back off `self._collection`, so appending would put an artist in a
+        # list nothing here consults. Verified against the real render rather
+        # than reasoned about: with the line gone, the collection's `<g>` is
+        # still in the emitted SVG carrying all forty paths.
+        x_ticks = self._category_tick_labels(self.ax, "x")
+        y_ticks = self._category_tick_labels(self.ax, "y")
+
+        samples: list[dict] = []
+        self._drawn = []
+        for position, segment in enumerate(segments):
+            middle = _middle(segment)
+            if middle is None:
+                continue
+            samples.append(self._sample(middle[0], middle[1], x_ticks, y_ticks))
+            self._drawn.append(position)
+
+        if not samples:
+            raise ExtractionError(self.type, self._collection)
+        return samples
+
+    def _get_selector(self) -> List[str]:
+        """
+        One selector per tick, addressing its own path inside the group.
+
+        The inherited scatter selector cannot serve: it names ``<use>``
+        elements, which is what a marker collection writes and what a line
+        collection does not -- matplotlib draws these as one ``<path>`` per
+        segment, the shape
+        :class:`~maidr.core.plot.intervalplot.IntervalPlot` already addresses
+        for ``so.Range``.
+
+        Numbered against the **drawn** ticks rather than the announced ones,
+        so a collection holding a segment this declines keeps every later
+        tick pointing at its own path.
+
+        Returns
+        -------
+        list of str
+            One selector per announced tick, in payload order.
+        """
+        gid = self._collection.get_gid()
+        if not gid or not str(gid).startswith("maidr-"):
+            gid = f"maidr-{uuid.uuid4()}"
+            self._collection.set_gid(gid)
+
+        return [
+            f"g[id='{gid}'] > path:nth-of-type({position + 1})"
+            for position in self._drawn
+        ]
+
+
+def _middle(segment) -> tuple[float, float] | None:
+    """
+    Where a tick's observation is, or ``None`` where it has none.
+
+    Parameters
+    ----------
+    segment : array_like
+        One segment's vertices, as the collection holds them.
+
+    Returns
+    -------
+    tuple of float, or None
+        The observation, or None when the segment is not a readable tick.
+
+    Notes
+    -----
+    A tick runs across the axis its category is on and sits at one value on
+    the other, and **which axis that is depends on the chart**. Measured on
+    ``seaborn 0.13.2``, the same forty observations drawn both ways::
+
+        so.Plot(x="cat", y="v")   [[-0.4, 3.696], [ 0.4, 3.696]]
+        so.Plot(y="cat", x="v")   [[3.696, -0.4], [3.696,  0.4]]
+
+    So the constant coordinate is the datum and the spanned one is the mark's
+    width. Reading only the first spelling is not a narrower reading, it is a
+    broken one: every segment of the transposed chart fails the horizontal
+    test, the layer finds nothing to announce, and the ``ExtractionError``
+    that follows takes the **whole figure** to a static image.
+
+    A segment constant on neither axis is not one of these marks and is
+    declined rather than averaged into a position the chart never drew.
+
+    The **shape** check is what keeps a non-finite tick out, and it is doing
+    more work than it looks like. matplotlib strips a non-finite vertex
+    before ``get_segments`` returns -- measured, ``[(2, nan), (2, 5)]`` comes
+    back as ``[[2.0, 5.0]]``, a single point -- so such a tick arrives with
+    the wrong shape rather than with a ``NaN`` in it. That matters because
+    ``json.dumps`` writes ``NaN`` as a bare token, which is legal JavaScript
+    and invalid JSON, and the core parses the payload with ``JSON.parse``:
+    one of them stops the chart initialising at all (#427). An explicit
+    ``isfinite`` test beside this one would be unreachable.
+    """
+    ends = np.asarray(segment, dtype=float)
+    if ends.shape != (2, 2):
+        return None
+    if _same(ends[0, 1], ends[1, 1]):
+        return float(ends[:, 0].mean()), float(ends[0, 1])
+    if _same(ends[0, 0], ends[1, 0]):
+        return float(ends[0, 0]), float(ends[:, 1].mean())
+    return None
+
+
+def _same(one: float, other: float) -> bool:
+    """
+    Whether two coordinates are the one value a tick sits at.
+
+    Exact equality would do for every chart measured -- seaborn writes the
+    same number into both ends -- but the tolerance costs nothing and keeps a
+    tick that has been through a transform from being declined over the last
+    bit of a float.
+
+    Parameters
+    ----------
+    one, other : float
+        The two ends' coordinates on one axis.
+
+    Returns
+    -------
+    bool
+        True when they are the same position.
+    """
+    return math.isclose(one, other, rel_tol=1e-12, abs_tol=1e-12)

--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -10,6 +10,7 @@ from maidr.core.plot.barplot import BarPlot
 from maidr.core.plot.boxenplot import BoxenPlot
 from maidr.core.plot.boxplot import BoxPlot
 from maidr.core.plot.contour import ContourPlot
+from maidr.core.plot.dashplot import DRAWN_DASHES, DashPlot
 from maidr.core.plot.bars_histogram import BarsHistPlot, DRAWN_BINS
 from maidr.core.plot.errorbar import ErrorBarPlot
 from maidr.core.plot.intervalplot import DRAWN_INTERVALS, IntervalPlot
@@ -173,6 +174,11 @@ class MaidrPlotFactory:
             # `EventCollection`, so `EventPlot` cannot read one (#250).
             if kwargs.get(DRAWN_RUG) is not None:
                 return RugPlot(single_ax, **kwargs)
+            # `so.Dash()` draws a horizontal tick per observation instead of a
+            # marker, so it too arrives as a plain `LineCollection` and keeps
+            # its values in the segments rather than in offsets (#670).
+            if kwargs.get(DRAWN_DASHES) is not None:
+                return DashPlot(single_ax, **kwargs)
             return ScatterPlot(single_ax, **kwargs)
         elif plot_type in (PlotType.DODGED, PlotType.STACKED, PlotType.NORMALIZED):
             # One class, three types. They differ in how the groups relate --

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -18,6 +18,7 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS, bar_groups
 from maidr.core.plot.bars_histogram import BIN_MEMBERS, DRAWN_BINS, hist_groups
+from maidr.core.plot.dashplot import DRAWN_DASHES
 from maidr.core.plot.grouped_barplot import DRAWN_GROUPS
 from maidr.core.plot.intervalplot import DRAWN_INTERVALS
 from maidr.core.plot.maidr_plot import GROUP_NAME
@@ -130,6 +131,7 @@ _READINGS: dict[str, _Reading] = {
     # neither a container nor the outline `element="step"` gives -- so all
     # three of `HistPlot`'s existing ways in miss it (#670).
     "Bars": _Reading(PlotType.HIST, "collections", PatchCollection, DRAWN_BINS, True),
+    "Dash": _Reading(PlotType.SCATTER, "collections", LineCollection, DRAWN_DASHES, True),
 }
 
 

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -273,7 +273,6 @@ def test_a_panel_the_layer_never_drew_on_registers_nothing():
 @pytest.mark.parametrize(
     "mark",
     [
-        pytest.param(so.Dash(), id="Dash"),
         pytest.param(so.Text(), id="Text"),
     ],
 )
@@ -284,12 +283,12 @@ def test_a_mark_this_does_not_read_still_registers_nothing(mark):
     mark whose artists no existing plot class can read is left alone, not
     guessed at. `Dash` matters most -- see the test below.
 
-    `Lines`, `Paths`, `Area`, `Band`, `Range` and `Bars` each left this list
-    when they gained a reading (#670), leaving `Dash` and `Text` -- the two
-    that want a judgement rather than a measurement. They came off
-    deliberately: this list is the reminder that a decline was a decision, so
-    a mark added to `_READINGS` has to be taken out of it by hand rather than
-    quietly passing both ways.
+    `Lines`, `Paths`, `Area`, `Band`, `Range`, `Bars` and now `Dash` each
+    left this list when they gained a reading (#670), leaving `Text` alone --
+    the one mark that draws no artist any holder in `_READINGS` names. They
+    came off deliberately: this list is the reminder that a decline was a
+    decision, so a mark added to `_READINGS` has to be taken out of it by
+    hand rather than quietly passing both ways.
     """
     figure = _drawn(
         lambda fig: so.Plot(_frame(), x="t", y="m").add(mark).on(fig).plot()
@@ -305,11 +304,11 @@ def test_the_marks_are_matched_by_name_and_not_by_ancestry():
         Dash  < Paths < Mark      LineCollection
         Range < Paths < Mark      LineCollection
 
-    So dispatching on ancestry would claim `Dash` as a `Paths`, which *is*
-    read -- and read it as line series, which it does not draw: a `Dash` is a
-    tick per position with no length that means anything on the value axis.
-    Since #670 that is a live hazard rather than a hypothetical one, because
-    the ancestor a wrong dispatch would land on has a reading to hand it.
+    So dispatching on ancestry would claim `Dash` as a `Paths` and read it as
+    **line series**, joining the ticks into curves the chart never drew. It is
+    read -- as a `point`, one observation per tick -- and that is the whole
+    of the difference: getting there by name gives it its own reading, while
+    getting there by ancestry would hand it its parent's.
 
     `Range` is the other half of the same trap and shows why ancestry would
     still be wrong even where it happens to claim something readable: it is
@@ -328,20 +327,23 @@ def test_the_marks_are_matched_by_name_and_not_by_ancestry():
         lambda fig: so.Plot(_frame(), x="t", y="m").add(so.Dash()).on(fig).plot()
     )
 
-    assert _registers_nothing(figure)
+    # A point, which is what it draws -- not the `line` its ancestor reads as.
+    assert _kinds(figure) == ["point"]
 
 
 def test_a_mark_that_is_read_still_reads_beside_one_that_is_not():
     """An unclaimed layer must not take the chart down with it.
 
     That is the whole-chart-to-a-picture failure of xability/r-maidr#225,
-    from the side where declining is the right answer: the `Dash` is not
-    read, and the `Dot` beside it is unaffected.
+    from the side where declining is the right answer: the `Text` is not
+    read, and the `Dot` beside it is unaffected. It was a `Dash` here until
+    #670 gave that one a reading, which is the churn this list exists to
+    make visible.
     """
     figure = _drawn(
         lambda fig: so.Plot(_frame(), x="t", y="m")
         .add(so.Dot())
-        .add(so.Dash())
+        .add(so.Text())
         .on(fig)
         .plot()
     )
@@ -418,10 +420,11 @@ def test_every_selector_resolves_in_the_page_it_was_built_from(mark, x, y):
 # `_reading_for` declines a mark that is not in the table; `_held` keeps only
 # the artist class that reading reads. Every unread mark measured draws into a
 # holder no reading reads, or draws a class the filter removes -- so dropping
-# either one alone changes nothing any chart can show. Dropping *both* reads a
-# `so.Dash`'s `LineCollection` through `ScatterPlot`, which cannot see it,
-# silently falls back to sweeping the whole axes, and announces a neighbouring
-# layer's points as this one's.
+# either one alone changes nothing any chart can show. Dropping *both* reads
+# an unclaimed mark's artists through whichever plot class the fallback lands
+# on -- for a `LineCollection` that is `ScatterPlot`, which cannot see one,
+# so it silently sweeps the whole axes and announces a neighbouring layer's
+# points as this one's.
 #
 # Measured, mutating the live code one change at a time against the tests
 # above: claiming every mark, and removing the class filter, each left all 24
@@ -433,7 +436,6 @@ def test_every_selector_resolves_in_the_page_it_was_built_from(mark, x, y):
 @pytest.mark.parametrize(
     "mark",
     [
-        pytest.param(so.Dash(), id="Dash"),
         pytest.param(so.Text(), id="Text"),
     ],
 )

--- a/tests/core/plot/test_seaborn_objects_dash.py
+++ b/tests/core/plot/test_seaborn_objects_dash.py
@@ -1,0 +1,295 @@
+"""
+``so.Dash`` drew an observation per tick and registered nothing (#670).
+
+`so.Dash()` is `so.Dot()`'s flat sibling: instead of a marker it draws a
+short horizontal segment at each observation, so several observations at one
+category stack up as a row of rules rather than as a pile of overlapping
+circles. What it leaves behind is a ``LineCollection`` and nothing else,
+which is the whole of why it was silent -- ``ScatterPlot`` asks a
+``PathCollection`` for its offsets, and a line collection has none.
+
+Two things had to be measured rather than assumed.
+
+**The width is drawing and the middle is the datum.** Measured on
+``seaborn 0.13.2``, forty observations over five categories::
+
+    so.Dash()               first segment  [[-0.4, 3.696], [0.4, 3.696]]
+    so.Dash(), so.Dodge()   first segment  [[-0.4, 3.696], [0.0, 3.696]]
+
+The span is ``0.8`` by default and halved again by a dodge, and neither
+number is anything the chart measured. What both spellings agree on is the
+segment's centre.
+
+**A dodged tick's centre is not its tick.** Read literally it announces
+``-0.2`` where the axis says ``a`` -- the shape #617 describes for
+``so.Bar``. It needs no special case here, because ``ScatterPlot._on_axis``
+already snaps a drawn coordinate to the slot it belongs to and ``_sample``
+names it: the machinery a jittered strip plot needed (#439), reused.
+"""
+
+from __future__ import annotations
+
+import re
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn.objects as so
+
+import maidr
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Forty observations over five categories, split two ways by colour."""
+    rng = np.random.default_rng(4)
+    return pd.DataFrame(
+        {
+            "x": list("abcde") * 8,
+            "v": rng.normal(5, 2, 40),
+            "g": ["p"] * 20 + ["q"] * 20,
+            "n": rng.integers(1, 9, 40),
+        }
+    )
+
+
+def _layers(plot) -> list[dict]:
+    """Every layer the drawn plot registered, as schemas."""
+    return [layer.schema for layer in FigureManager.get_maidr(plot.plot()._figure).plots]
+
+
+def _only(plot) -> dict:
+    schemas = _layers(plot)
+    assert len(schemas) == 1, f"expected one layer, got {len(schemas)}"
+    return schemas[0]
+
+
+def test_a_dash_mark_is_read_rather_than_registering_nothing():
+    schema = _only(so.Plot(_frame(), x="x", y="v").add(so.Dash()))
+
+    assert schema[MaidrKey.TYPE] is PlotType.SCATTER
+    assert len(schema[MaidrKey.DATA]) == 40
+
+
+def test_every_tick_is_read_off_its_own_middle():
+    """The centre, not either end: the span is the mark's width."""
+    frame = _frame()
+    schema = _only(so.Plot(frame, x="n", y="v").add(so.Dash()))
+
+    drawn = {(point[MaidrKey.X], round(point[MaidrKey.Y], 6))
+             for point in schema[MaidrKey.DATA]}
+    expected = {(float(n), round(float(v), 6))
+                for n, v in zip(frame["n"], frame["v"])}
+
+    assert drawn == expected
+
+
+def test_a_categorical_tick_is_named_after_its_slot():
+    """A reader is handed "a", not the slot index the position is."""
+    schema = _only(so.Plot(_frame(), x="x", y="v").add(so.Dash()))
+    points = schema[MaidrKey.DATA]
+
+    assert points[0][MaidrKey.X] == 0.0
+    assert points[0][MaidrKey.X_LABEL] == "a"
+    assert {point[MaidrKey.X_LABEL] for point in points} == set("abcde")
+
+
+def test_a_dodged_tick_announces_its_category_and_not_the_offset():
+    """A dodge moves the tick off its slot; the reading puts it back.
+
+    Measured, a dodged first segment runs `[-0.4, y]` to `[0.0, y]`, so its
+    midpoint is `-0.2` -- the offset, which is what #617 found `so.Bar`
+    announcing where the axis says `a`.
+    """
+    schema = _only(
+        so.Plot(_frame(), x="x", y="v", color="g").add(so.Dash(), so.Dodge())
+    )
+    points = schema[MaidrKey.DATA]
+
+    assert {point[MaidrKey.X] for point in points} == {0.0, 1.0, 2.0, 3.0, 4.0}
+    assert {point[MaidrKey.X_LABEL] for point in points} == set("abcde")
+
+
+def test_an_aggregated_dash_reads_one_tick_per_category():
+    schema = _only(so.Plot(_frame(), x="x", y="v").add(so.Dash(), so.Agg()))
+
+    assert len(schema[MaidrKey.DATA]) == 5
+    assert [point[MaidrKey.X_LABEL] for point in schema[MaidrKey.DATA]] == list("abcde")
+
+
+def test_a_numeric_axis_is_not_renamed_after_a_tick():
+    """No `xLabel` where the axis carries measurements rather than names."""
+    schema = _only(so.Plot(_frame(), x="n", y="v").add(so.Dash()))
+
+    assert all(MaidrKey.X_LABEL not in point for point in schema[MaidrKey.DATA])
+
+
+def test_a_selector_resolves_to_exactly_one_drawn_tick():
+    """Addressed by path inside the collection's group, not by `<use>`.
+
+    A line collection writes one `<path>` per segment where a marker
+    collection writes `<use>` elements, so the inherited scatter selector
+    would match nothing. Resolved against the SVG the render actually emits
+    rather than compared as a string.
+    """
+    figure = plt.figure()
+    so.Plot(_frame(), x="x", y="v").add(so.Dash()).on(figure).plot()
+    schema = FigureManager.get_maidr(figure).plots[0].schema
+    selectors = schema[MaidrKey.SELECTOR]
+
+    html = maidr.render(figure)._repr_html_()
+    gid = re.search(r"id='([^']+)'", selectors[0]).group(1)
+    group = re.search(
+        r"<g id=\"" + re.escape(gid) + r"\"[^>]*>(.*?)</g>", html, re.S
+    )
+
+    assert group is not None, "the collection's group is not in the rendered SVG"
+    assert len(selectors) == 40
+    assert len(re.findall(r"<path", group.group(1))) == 40
+
+
+def test_a_dash_beside_a_dot_reads_as_two_layers():
+    """Each mark its own layer, which is what `so.Plot.add()` twice means."""
+    schemas = _layers(
+        so.Plot(_frame(), x="x", y="v").add(so.Dot()).add(so.Dash())
+    )
+
+    assert [schema[MaidrKey.TYPE] for schema in schemas] == [
+        PlotType.SCATTER,
+        PlotType.SCATTER,
+    ]
+
+
+def test_a_sideways_chart_reads_the_tick_the_other_way_round():
+    """A tick runs across the axis its category is on, and either axis can be it.
+
+    Measured, the same forty observations drawn both ways::
+
+        so.Plot(x="cat", y="v")   [[-0.4, 3.696], [ 0.4, 3.696]]
+        so.Plot(y="cat", x="v")   [[3.696, -0.4], [3.696,  0.4]]
+
+    Reading only the first is not a narrower reading but a broken one: every
+    segment of the transposed chart fails the horizontal test, the layer
+    finds nothing to announce, and the `ExtractionError` that follows takes
+    the whole figure to a static image.
+    """
+    frame = _frame()
+    schema = _only(so.Plot(frame, y="x", x="v").add(so.Dash()))
+    points = schema[MaidrKey.DATA]
+
+    assert len(points) == 40
+    # The category is on y now, and so is its name.
+    assert {point[MaidrKey.Y] for point in points} == {0.0, 1.0, 2.0, 3.0, 4.0}
+    assert {point[MaidrKey.Y_LABEL] for point in points} == set("abcde")
+    assert all(MaidrKey.X_LABEL not in point for point in points)
+    # And the values are on x, unrounded.
+    assert {round(point[MaidrKey.X], 6) for point in points} == {
+        round(float(v), 6) for v in frame["v"]
+    }
+
+
+def test_a_segment_that_is_not_a_tick_is_declined():
+    """Constant on neither axis, so there is no one position it marks.
+
+    No `so.Dash` spelling draws one -- both orientations hold one coordinate
+    fixed -- so the guard is tested against a collection built to have the
+    case. Averaged into a midpoint it would announce a position the chart
+    never drew.
+    """
+    from matplotlib.collections import LineCollection
+
+    from maidr.core.plot.dashplot import DRAWN_DASHES, DashPlot
+
+    _, ax = plt.subplots()
+    collection = LineCollection(
+        [
+            [(0.0, 1.0), (1.0, 1.0)],   # a tick
+            [(2.0, 1.0), (3.0, 4.0)],   # a sloped segment
+            [(4.0, 2.0), (5.0, 2.0)],   # a tick
+        ]
+    )
+    ax.add_collection(collection)
+
+    points = DashPlot(ax, **{DRAWN_DASHES: collection})._extract_plot_data()
+
+    assert [point[MaidrKey.X] for point in points] == [0.5, 4.5]
+
+
+def test_a_tick_with_a_non_finite_end_is_dropped():
+    """`json.dumps` writes `NaN` as a bare token, which `JSON.parse` rejects.
+
+    One such value stops the chart initialising at all (#427), so the tick is
+    dropped rather than announced -- and a scatter point with no position has
+    nothing left to say, unlike a bar that keeps its category.
+
+    What drops it is the **shape** check, and this pins the matplotlib
+    behaviour that makes it sufficient: a non-finite vertex is stripped
+    before `get_segments` returns, so the tick arrives as a single point
+    rather than as a pair with a `NaN` in it. If a release stops stripping,
+    this test fails here rather than the payload failing to parse in a
+    browser.
+    """
+    from matplotlib.collections import LineCollection
+
+    from maidr.core.plot.dashplot import DRAWN_DASHES, DashPlot
+
+    _, ax = plt.subplots()
+    collection = LineCollection(
+        [
+            [(0.0, 1.0), (1.0, 1.0)],
+            # One end, not both -- the case that would reach the midpoint
+            # if the pair survived, since it is constant on x.
+            [(2.0, np.nan), (2.0, 5.0)],
+            [(4.0, 2.0), (5.0, 2.0)],
+        ]
+    )
+    ax.add_collection(collection)
+
+    # matplotlib strips the non-finite vertex, so the tick arrives with one
+    # end rather than two. That is the mechanism, asserted rather than
+    # assumed.
+    assert [len(segment) for segment in collection.get_segments()] == [2, 1, 2]
+
+    plot = DashPlot(ax, **{DRAWN_DASHES: collection})
+    points = plot._extract_plot_data()
+
+    assert [point[MaidrKey.X] for point in points] == [0.5, 4.5]
+    # The selectors follow the drawn segments, not the announced ones: the
+    # dropped tick is still a `<path>`, so numbering past it would put the
+    # second point's highlight on the tick that was declined.
+    assert [
+        int(re.search(r"nth-of-type\((\d+)\)", selector).group(1))
+        for selector in plot._get_selector()
+    ] == [1, 3]
+
+
+def test_the_nth_selector_addresses_the_nth_tick():
+    """Off by one puts every highlight on a neighbour, which is silent.
+
+    The count agreeing is not enough -- a list numbered from zero, or from
+    the announced points rather than the drawn ones, has the right length and
+    the wrong targets. This resolves the third selector against the SVG and
+    checks it reaches the third path.
+    """
+    figure = plt.figure()
+    so.Plot(_frame(), x="x", y="v").add(so.Dash()).on(figure).plot()
+    selectors = FigureManager.get_maidr(figure).plots[0].schema[MaidrKey.SELECTOR]
+
+    html = maidr.render(figure)._repr_html_()
+    gid = re.search(r"id='([^']+)'", selectors[2]).group(1)
+    group = re.search(
+        r"<g id=\"" + re.escape(gid) + r"\"[^>]*>(.*?)</g>", html, re.S
+    )
+    paths = re.findall(r"<path[^>]*>", group.group(1))
+
+    assert re.search(r"nth-of-type\((\d+)\)", selectors[0]).group(1) == "1"
+    assert re.search(r"nth-of-type\((\d+)\)", selectors[2]).group(1) == "3"
+    assert len(paths) == len(selectors)


### PR DESCRIPTION
Part of #670.

## The silence

`so.Dash()` is `so.Dot()`'s flat sibling: instead of a marker it draws a short segment at each observation, so several observations at one category stack up as a row of rules rather than as a pile of overlapping circles. What it leaves behind is a `LineCollection` and nothing else — and `ScatterPlot` asks a `PathCollection` for its offsets, which a line collection has none of.

## Read as a point, and why not the two nearby answers

- **Not a spike.** A spike runs from a baseline to its value; measured, these do not reach one. They are marks *at* a position, which is what a point is.
- **Not the line series its ancestor gets.** `Dash < Paths < Mark`, and `Paths` is read — as line series. Joining the ticks would draw curves the chart never had. This is exactly the ancestry trap `test_the_marks_are_matched_by_name_and_not_by_ancestry` pins, and #670 has made it live rather than hypothetical.

## Three things measured, not assumed

**The width is drawing; the middle is the datum.** A segment spans the mark's width either side of the position — `0.8` by default, halved again by a `Dodge()` — and neither number is anything the chart measured. Every spelling agrees on the centre.

**A tick runs across the axis its category is on, and either axis can be it.** Same forty observations, both ways:

```
so.Plot(x="cat", y="v")   [[-0.4, 3.696], [ 0.4, 3.696]]
so.Plot(y="cat", x="v")   [[3.696, -0.4], [3.696,  0.4]]
```

Reading only the first is not a narrower reading but a **broken** one — I wrote it that way first and the sweep caught it. Every segment of the transposed chart failed the horizontal test, the layer found nothing to announce, and the `ExtractionError` that followed took the **whole figure** to a static image.

**A dodged tick's centre is not its tick.** Read literally it announces `-0.2` where the axis says `a` — the shape #617 found `so.Bar` in. It needs no special case: `ScatterPlot._on_axis` already snaps a drawn coordinate to its slot and `_sample` names it, which is the machinery a jittered strip plot needed in #439.

## Measured end to end

```
Dash, categorical x   point  n=40  {'x': 0.0, 'y': 3.696, 'xLabel': 'a'}
Dash, categorical y   point  n=40  {'x': 3.696, 'y': 0.0, 'yLabel': 'a'}
Dash + Agg            point  n=5   one tick per category
Dash + Dodge          x in {0,1,2,3,4} — the categories, not the offsets
Dash, numeric x       no xLabel; a measurement is not renamed after a tick
selectors             40, resolving to the 40 <path> children of the gid group
```

## Verification

- `uv run pytest -q` — **3537 passed, 72 skipped**.
- `tests/core/plot/test_seaborn_objects_dash.py` — 12 tests, including the transposed chart, the dodge, and a selector test that resolves the **third** selector against the rendered SVG (a count that agrees is not enough — an off-by-one has the right length and the wrong targets).
- A 13-mutation sweep: **0 survivors** after three rounds. It found the transposed-chart bug above; it also showed `_elements.append` was dead here (this layer assigns its own gid and reads it back off the collection) and that an explicit `isfinite` guard was unreachable — matplotlib strips a non-finite vertex before `get_segments` returns, so such a tick arrives with the wrong *shape*. That mechanism is now pinned by a test rather than left as a guard nothing could reach.
- `ruff check maidr tests` reports the 6 re-export errors that are present on `origin/main` unchanged.

## Scope

**A colour-split `Dash` still reads as one unnamed layer.** `hue_groups` inverts a collection's *face* colours and a line collection has none — measured, 0 face colours against 40 edge colours — so the split is not seen. That is the same follow-up #672 was for `so.Line`, and it is filed separately rather than folded in here; before this change the chart announced nothing at all.

`Text` is now the only mark left on #670's declines list. It draws no artist in any holder `_READINGS` names — only `ax.texts` — so it is the next unit, not this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_