### PR TITLE
feat(seaborn-objects): read a Text mark as the labelled scatter it draws

### DIFF
--- a/maidr/core/plot/maidr_plot_factory.py
+++ b/maidr/core/plot/maidr_plot_factory.py
@@ -11,6 +11,7 @@ from maidr.core.plot.boxenplot import BoxenPlot
 from maidr.core.plot.boxplot import BoxPlot
 from maidr.core.plot.contour import ContourPlot
 from maidr.core.plot.dashplot import DRAWN_DASHES, DashPlot
+from maidr.core.plot.textplot import DRAWN_LABELS, TextPlot
 from maidr.core.plot.bars_histogram import BarsHistPlot, DRAWN_BINS
 from maidr.core.plot.errorbar import ErrorBarPlot
 from maidr.core.plot.intervalplot import DRAWN_INTERVALS, IntervalPlot
@@ -179,6 +180,12 @@ class MaidrPlotFactory:
             # its values in the segments rather than in offsets (#670).
             if kwargs.get(DRAWN_DASHES) is not None:
                 return DashPlot(single_ax, **kwargs)
+            # `so.Text()` writes a string at each observation instead of
+            # drawing a marker, so it leaves `Text` artists and nothing in
+            # `collections` at all -- the only mark #670 read that draws into
+            # a holder no other reading names.
+            if kwargs.get(DRAWN_LABELS) is not None:
+                return TextPlot(single_ax, **kwargs)
             return ScatterPlot(single_ax, **kwargs)
         elif plot_type in (PlotType.DODGED, PlotType.STACKED, PlotType.NORMALIZED):
             # One class, three types. They differ in how the groups relate --

--- a/maidr/core/plot/textplot.py
+++ b/maidr/core/plot/textplot.py
@@ -1,0 +1,163 @@
+"""Read a ``so.Text`` mark as the labelled scatter it draws."""
+
+from __future__ import annotations
+
+import math
+import uuid
+from typing import List, Sequence
+
+from matplotlib.axes import Axes
+from matplotlib.text import Text
+
+from maidr.core.enum import MaidrKey
+from maidr.core.plot.scatterplot import ScatterPlot
+from maidr.exception import ExtractionError
+
+#: The keyword the drawn labels are handed over under.
+DRAWN_LABELS = "labels"
+
+
+class TextPlot(ScatterPlot):
+    """
+    One observation per label, read off where the label was written.
+
+    ``so.Text()`` writes a string at each observation instead of drawing a
+    marker there, which is the mark Observable's ``Plot.text`` is and the
+    shape xability/maidr#1106 added ``ScatterPoint.label`` for: a chart where
+    the point's **identity** is the payload rather than a decoration. A
+    reader told "x is 3, y is 14.1" has been given the two numbers and
+    withheld the one thing the chart was drawn to show.
+
+    It is the last mark #670 left, and the only one that draws no artist any
+    other reading's holder names. Measured on ``seaborn 0.13.2``, twelve
+    observations::
+
+        ax.lines        []
+        ax.collections  []
+        ax.patches      []
+        ax.texts        12 Text artists, 'a' at (8.0, 5.12), ...
+
+    So the layer is read from ``Axes.texts``, which ``_held`` reaches by name
+    like any other holder -- no new mechanism, one more entry in the table.
+
+    **A label with nothing in it is not a point.** ``so.Text()`` written
+    without a ``text=`` variable still draws one artist per observation, each
+    with an empty string -- measured, twelve of them. Nothing is on the page,
+    and announcing twelve positions for marks a sighted reader cannot see
+    would describe a chart that is not there. Such a layer is declined.
+
+    Parameters
+    ----------
+    ax : Axes
+        The panel drawn on.
+    **kwargs : dict
+        Carries the artists under :data:`DRAWN_LABELS`, and whatever the
+        factory forwards.
+    """
+
+    def __init__(self, ax: Axes, **kwargs) -> None:
+        self._labels: Sequence[Text] = kwargs.pop(DRAWN_LABELS)
+        # Which of the handed-over artists the payload announces, in payload
+        # order. Filled by `_extract_plot_data`; empty here so a layer asked
+        # for its selectors before its data returns none rather than raising.
+        self._drawn: List[int] = []
+        super().__init__(ax, **kwargs)
+
+    def _extract_plot_data(self) -> list[dict]:
+        """
+        One sample per written label, in the order the axes holds them.
+
+        Returns
+        -------
+        list of dict
+            One point per label, carrying its text.
+
+        Raises
+        ------
+        ExtractionError
+            When no label carries a string, which is what a ``so.Text()``
+            written with no ``text=`` variable leaves behind.
+        """
+        x_ticks = self._category_tick_labels(self.ax, "x")
+        y_ticks = self._category_tick_labels(self.ax, "y")
+
+        samples: list[dict] = []
+        self._drawn = []
+        for position, artist in enumerate(self._labels):
+            written = artist.get_text()
+            if not written:
+                continue
+            x, y = artist.get_position()
+            # A label at no coordinate has nowhere to be announced, and
+            # `json.dumps` writes `NaN` as a bare token, which is legal
+            # JavaScript and invalid JSON -- one of them stops the chart
+            # initialising at all (#427).
+            if not (math.isfinite(float(x)) and math.isfinite(float(y))):
+                continue
+            sample = self._sample(float(x), float(y), x_ticks, y_ticks)
+            sample[MaidrKey.LABEL] = written
+            samples.append(sample)
+            self._drawn.append(position)
+
+        if not samples:
+            raise ExtractionError(self.type, self.ax)
+        return samples
+
+    def _get_selector(self) -> List[str]:
+        """
+        One selector per announced label, addressing its own group.
+
+        matplotlib writes each ``Text`` as a group of its own, so a label has
+        an element to name -- unlike the outline shapes
+        :class:`~maidr.core.plot.stepped_histogram.SteppedHistPlot` declines
+        highlighting for. The gid is assigned here for the reason
+        :class:`~maidr.core.plot.intervalplot.IntervalPlot` gives: matplotlib
+        stamps one at *draw* time and the schema is built first, so reading it
+        would find ``None`` and the layer would ship with an empty list.
+
+        Numbered against the **written** labels rather than the announced
+        ones, so a layer holding a blank this declines keeps every later
+        label pointing at its own element.
+
+        Returns
+        -------
+        list of str
+            One selector per announced label, in payload order.
+        """
+        selectors: list[str] = []
+        for position in self._drawn:
+            artist = self._labels[position]
+            gid = artist.get_gid()
+            if not gid or not str(gid).startswith("maidr-"):
+                gid = f"maidr-{uuid.uuid4()}"
+                artist.set_gid(gid)
+            selectors.append(f"g[id='{gid}']")
+        return selectors
+
+
+def reads(labels: Sequence[Text]) -> bool:
+    """
+    Whether a set of labels is one this can read, asked before a layer exists.
+
+    ``so.Text()`` written without a ``text=`` variable still draws one artist
+    per observation, each holding an empty string -- measured, twelve of them
+    for twelve rows. Nothing is on the page, and a layer of twelve positions
+    would describe marks a sighted reader cannot see.
+
+    Asked here rather than left to the reading's own refusal, for the reason
+    :func:`maidr.core.plot.stepped_histogram.reads` gives: a layer registered
+    and then unable to extract raises, and an ``ExtractionError`` takes the
+    **whole figure** to a static image. Declining before registration leaves
+    every other layer on the chart readable.
+
+    Parameters
+    ----------
+    labels : sequence of Text
+        The artists the mark drew.
+
+    Returns
+    -------
+    bool
+        True when at least one label carries a string.
+    """
+    return any(artist.get_text() for artist in labels)

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -12,6 +12,7 @@ from matplotlib.collections import LineCollection, PatchCollection, PathCollecti
 from matplotlib.container import BarContainer
 from matplotlib.lines import Line2D
 from matplotlib.patches import Polygon
+from matplotlib.text import Text
 
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
@@ -19,6 +20,8 @@ from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS, bar_groups
 from maidr.core.plot.bars_histogram import BIN_MEMBERS, DRAWN_BINS, hist_groups
 from maidr.core.plot.dashplot import DRAWN_DASHES
+from maidr.core.plot.textplot import DRAWN_LABELS
+from maidr.core.plot.textplot import reads as reads_labels
 from maidr.core.plot.grouped_barplot import DRAWN_GROUPS
 from maidr.core.plot.intervalplot import DRAWN_INTERVALS
 from maidr.core.plot.maidr_plot import GROUP_NAME
@@ -132,6 +135,7 @@ _READINGS: dict[str, _Reading] = {
     # three of `HistPlot`'s existing ways in miss it (#670).
     "Bars": _Reading(PlotType.HIST, "collections", PatchCollection, DRAWN_BINS, True),
     "Dash": _Reading(PlotType.SCATTER, "collections", LineCollection, DRAWN_DASHES, True),
+    "Text": _Reading(PlotType.SCATTER, "texts", Text, DRAWN_LABELS),
 }
 
 
@@ -623,6 +627,15 @@ def _handovers(
                 (reading.plot_type, {reading.binding: container, GROUP_NAME: name})
                 for container, (name, _) in zip(containers, groups)
             ]
+
+    # A `so.Text()` written with no `text=` variable draws one artist per
+    # observation and puts an empty string in every one. Registered, the
+    # layer raises when it cannot find a label to announce, and an
+    # `ExtractionError` takes the whole figure to a static image -- the
+    # phantom-layer shape of #421 with a fatal ending. Declined here, the
+    # rest of the chart is unaffected.
+    if reading.binding == DRAWN_LABELS and not reads_labels(own):
+        return []
 
     if reading.singular:
         return [(reading.plot_type, {reading.binding: one}) for one in own]

--- a/tests/core/plot/test_seaborn_objects.py
+++ b/tests/core/plot/test_seaborn_objects.py
@@ -270,31 +270,30 @@ def test_a_panel_the_layer_never_drew_on_registers_nothing():
     assert len(_layers(figure)) == 2
 
 
-@pytest.mark.parametrize(
-    "mark",
-    [
-        pytest.param(so.Text(), id="Text"),
-    ],
-)
-def test_a_mark_this_does_not_read_still_registers_nothing(mark):
-    """The additive guarantee, asserted rather than assumed.
+def test_every_mark_seaborn_defines_is_read():
+    """The list of declines is empty, and this is what keeps it honest.
 
-    Each of these registered nothing before and must register nothing now: a
-    mark whose artists no existing plot class can read is left alone, not
-    guessed at. `Dash` matters most -- see the test below.
+    This test began as a list of marks that registered nothing, asserting
+    that each still did -- the reminder that a decline was a decision rather
+    than an oversight. `Lines`, `Paths`, `Area`, `Band`, `Range`, `Bars`,
+    `Dash` and finally `Text` each came off it as they gained readings
+    (#670), and with the last one gone the list has no subject left.
 
-    `Lines`, `Paths`, `Area`, `Band`, `Range`, `Bars` and now `Dash` each
-    left this list when they gained a reading (#670), leaving `Text` alone --
-    the one mark that draws no artist any holder in `_READINGS` names. They
-    came off deliberately: this list is the reminder that a decline was a
-    decision, so a mark added to `_READINGS` has to be taken out of it by
-    hand rather than quietly passing both ways.
+    So it inverts. Every mark `seaborn.objects` defines is in `_READINGS`,
+    and a seaborn release that adds one fails here rather than shipping a
+    mark that silently draws nothing a reader can reach.
     """
-    figure = _drawn(
-        lambda fig: so.Plot(_frame(), x="t", y="m").add(mark).on(fig).plot()
-    )
+    from maidr.patch.seaborn_objects import _READINGS
 
-    assert _registers_nothing(figure)
+    defined = {
+        name
+        for name in dir(so)
+        if isinstance(getattr(so, name), type)
+        and issubclass(getattr(so, name), so.Mark)
+        and name != "Mark"
+    }
+
+    assert defined == set(_READINGS)
 
 
 def test_the_marks_are_matched_by_name_and_not_by_ancestry():
@@ -335,10 +334,13 @@ def test_a_mark_that_is_read_still_reads_beside_one_that_is_not():
     """An unclaimed layer must not take the chart down with it.
 
     That is the whole-chart-to-a-picture failure of xability/r-maidr#225,
-    from the side where declining is the right answer: the `Text` is not
-    read, and the `Dot` beside it is unaffected. It was a `Dash` here until
-    #670 gave that one a reading, which is the churn this list exists to
-    make visible.
+    from the side where declining is the right answer.
+
+    Every mark is read now, so the unreadable companion is a mark drawn with
+    nothing to read: a `so.Text()` written with no `text=` variable draws one
+    artist per observation and puts an empty string in every one. Nothing is
+    on the page, the layer is declined before it registers, and the `Dot`
+    beside it is unaffected.
     """
     figure = _drawn(
         lambda fig: so.Plot(_frame(), x="t", y="m")
@@ -433,17 +435,20 @@ def test_every_selector_resolves_in_the_page_it_was_built_from(mark, x, y):
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "mark",
-    [
-        pytest.param(so.Text(), id="Text"),
-    ],
-)
-def test_a_mark_outside_the_table_is_declined_rather_than_defaulted(mark):
-    """The lookup returns nothing for a mark it does not name."""
+def test_a_mark_outside_the_table_is_declined_rather_than_defaulted():
+    """The lookup returns nothing for a mark it does not name.
+
+    Asked with a stand-in rather than with a real mark, because there is no
+    longer an unread one to ask with -- and that is the point: the guard has
+    to keep working for the mark a future seaborn adds, which is exactly the
+    thing that does not exist yet.
+    """
     from maidr.patch.seaborn_objects import _reading_for
 
-    assert _reading_for({"mark": mark}) is None
+    class Sparkline(so.Mark):
+        """A mark seaborn does not define and this does not read."""
+
+    assert _reading_for({"mark": Sparkline()}) is None
 
 
 def test_a_reading_takes_only_its_own_artist_class_from_a_holder():

--- a/tests/core/plot/test_seaborn_objects_text.py
+++ b/tests/core/plot/test_seaborn_objects_text.py
@@ -1,0 +1,211 @@
+"""
+``so.Text`` wrote a label at each observation and registered nothing (#670).
+
+It is the last of the thirteen marks `seaborn.objects` defines, and the only
+one that draws no artist any other reading's holder names. Measured on
+``seaborn 0.13.2``, twelve observations::
+
+    ax.lines        []
+    ax.collections  []
+    ax.patches      []
+    ax.texts        12 Text artists, 'a' at (8.0, 5.12), ...
+
+So a figure whose only layer was a `so.Text()` had no layers at all and fell
+back to a static image. The reading needs no new mechanism -- ``_held``
+reaches a holder by name, and ``Axes.texts`` is a holder like any other.
+
+**A label with nothing in it is not a point.** ``so.Text()`` written without
+a ``text=`` variable still draws one artist per observation, each holding an
+empty string. Nothing is on the page, so the layer is declined *before it
+registers* rather than by the reading refusing later: a registered layer
+that cannot extract raises, and an ``ExtractionError`` takes the whole
+figure to a static image.
+"""
+
+from __future__ import annotations
+
+import re
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+import seaborn.objects as so
+
+import maidr
+from maidr.core.enum import MaidrKey, PlotType
+from maidr.core.figure_manager import FigureManager
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _frame() -> pd.DataFrame:
+    """Twelve named observations."""
+    rng = np.random.default_rng(7)
+    return pd.DataFrame(
+        {
+            "x": rng.integers(1, 9, 12),
+            "y": rng.normal(5, 2, 12),
+            "name": list("abcdefghijkl"),
+        }
+    )
+
+
+def _layers(plot) -> list[dict]:
+    return [layer.schema for layer in FigureManager.get_maidr(plot.plot()._figure).plots]
+
+
+def _only(plot) -> dict:
+    schemas = _layers(plot)
+    assert len(schemas) == 1, f"expected one layer, got {len(schemas)}"
+    return schemas[0]
+
+
+def _labelled(**kwargs):
+    return so.Plot(_frame(), x="x", y="y", text="name", **kwargs).add(so.Text())
+
+
+def test_a_text_mark_is_read_rather_than_registering_nothing():
+    schema = _only(_labelled())
+
+    assert schema[MaidrKey.TYPE] is PlotType.SCATTER
+    assert len(schema[MaidrKey.DATA]) == 12
+
+
+def test_the_label_is_the_payload_and_not_a_decoration():
+    """A reader told "x is 8, y is 5.1" has been handed the two numbers they
+    can hear the shape of already and withheld the one thing the chart was
+    drawn to show. `ScatterPoint.label` is the field xability/maidr#1106
+    added for exactly this."""
+    frame = _frame()
+    points = _only(_labelled())[MaidrKey.DATA]
+
+    assert {point[MaidrKey.LABEL] for point in points} == set(frame["name"])
+
+
+def test_each_label_is_read_where_it_was_written():
+    frame = _frame()
+    points = _only(_labelled())[MaidrKey.DATA]
+
+    written = {
+        (float(x), round(float(y), 6)): name
+        for x, y, name in zip(frame["x"], frame["y"], frame["name"])
+    }
+    for point in points:
+        key = (point[MaidrKey.X], round(point[MaidrKey.Y], 6))
+        assert written[key] == point[MaidrKey.LABEL]
+
+
+def test_a_selector_resolves_to_the_element_the_label_was_written_as():
+    """matplotlib writes each `Text` as a group of its own, so a label has an
+    element to name — and the gid has to be assigned before the SVG is, since
+    matplotlib stamps one at draw time and the schema is built first."""
+    figure = plt.figure()
+    _labelled().on(figure).plot()
+    selectors = FigureManager.get_maidr(figure).plots[0].schema[MaidrKey.SELECTOR]
+
+    html = maidr.render(figure)._repr_html_()
+    found = [
+        selector
+        for selector in selectors
+        if re.search(
+            r"<g id=\"" + re.escape(re.search(r"id='([^']+)'", selector).group(1)) + r"\"",
+            html,
+        )
+    ]
+
+    assert len(selectors) == 12
+    assert len(found) == 12
+
+
+def test_a_text_mark_with_nothing_written_registers_nothing():
+    """Twelve empty strings are twelve marks a sighted reader cannot see.
+
+    Declined *before* registration, not by the reading refusing afterwards:
+    a registered layer that then cannot extract raises, and that takes the
+    whole figure to a static image rather than this one layer.
+    """
+    from maidr.patch.seaborn_objects import _handovers, _READINGS
+
+    figure = plt.figure()
+    so.Plot(_frame(), x="x", y="y").add(so.Text()).on(figure).plot()
+    axes = figure.axes[0]
+
+    assert len(axes.texts) == 12, "seaborn draws an artist per observation"
+    assert all(not artist.get_text() for artist in axes.texts)
+    assert _handovers(_READINGS["Text"], axes, list(axes.texts)) == []
+
+
+def test_a_text_beside_a_dot_reads_as_two_layers():
+    schemas = _layers(
+        so.Plot(_frame(), x="x", y="y", text="name").add(so.Dot()).add(so.Text())
+    )
+
+    assert [schema[MaidrKey.TYPE] for schema in schemas] == [
+        PlotType.SCATTER,
+        PlotType.SCATTER,
+    ]
+    # Only one of them carries the names: the `Dot` draws markers, which have
+    # no text to read.
+    assert MaidrKey.LABEL not in schemas[0][MaidrKey.DATA][0]
+    assert MaidrKey.LABEL in schemas[1][MaidrKey.DATA][0]
+
+
+def test_a_blank_label_among_written_ones_is_dropped():
+    """A gap in the text variable draws an artist with an empty string.
+
+    Announced it would be a point with no name at a position; dropped, the
+    selectors still point at the right elements because they are numbered
+    against the artists rather than against the announced points.
+    """
+    from maidr.core.plot.textplot import DRAWN_LABELS, TextPlot
+
+    _, axes = plt.subplots()
+    written = [
+        axes.text(0.0, 1.0, "a"),
+        axes.text(1.0, 2.0, ""),
+        axes.text(2.0, 3.0, "c"),
+    ]
+
+    plot = TextPlot(axes, **{DRAWN_LABELS: written})
+    points = plot._extract_plot_data()
+
+    assert [point[MaidrKey.LABEL] for point in points] == ["a", "c"]
+    # The middle artist keeps its place in the document, so the second
+    # announced label must address the third element rather than the second.
+    assert plot._get_selector() == [
+        f"g[id='{written[0].get_gid()}']",
+        f"g[id='{written[2].get_gid()}']",
+    ]
+    assert written[1].get_gid() is None
+
+
+def test_a_label_written_at_no_coordinate_is_dropped():
+    """`json.dumps` writes `NaN` as a bare token, which `JSON.parse` rejects.
+
+    One of them stops the chart initialising at all (#427), so the label is
+    dropped rather than announced -- and a point with no position has
+    nothing left to say, unlike a bar that keeps its category.
+
+    No `so.Text()` spelling reaches this: seaborn drops a row with a
+    non-finite coordinate before it draws, the same way it does for a
+    scatter. So the guard is tested against artists built to have the case,
+    rather than left as an unreachable claim.
+    """
+    from maidr.core.plot.textplot import DRAWN_LABELS, TextPlot
+
+    _, axes = plt.subplots()
+    written = [
+        axes.text(0.0, 1.0, "a"),
+        axes.text(float("nan"), 2.0, "b"),
+        axes.text(2.0, float("nan"), "c"),
+        axes.text(3.0, 4.0, "d"),
+    ]
+
+    points = TextPlot(axes, **{DRAWN_LABELS: written})._extract_plot_data()
+
+    assert [point[MaidrKey.LABEL] for point in points] == ["a", "d"]


### PR DESCRIPTION
Closes #670.

## The silence

`so.Text()` writes a string at each observation instead of drawing a marker there. It is the last of the thirteen marks `seaborn.objects` defines, and the only one that draws no artist any other reading's holder names — measured on seaborn 0.13.2, twelve observations:

```
ax.lines        []
ax.collections  []
ax.patches      []
ax.texts        12 Text artists, 'a' at (8.0, 5.12), ...
```

So a figure whose only layer was a `so.Text()` had **no layers at all** and fell back to a static image.

## The reading

It needs no new mechanism — `_held` reaches a holder by name and `Axes.texts` is a holder like any other, so this is one entry in the table plus a plot class.

What it needs is the reading that the point's **identity** is the payload rather than a decoration. A reader told *"x is 8, y is 5.1"* has been handed the two numbers they can hear the shape of already and withheld the one thing the chart was drawn to show. That is what `ScatterPoint.label` exists for, and it is the same call maidr#1106 made for Observable's `Plot.text`.

## A label with nothing in it is not a point

`so.Text()` written **without a `text=` variable** still draws one artist per observation and puts an empty string in every one — measured, twelve of them. Nothing is on the page, and twelve announced positions would describe a chart a sighted reader cannot see.

It is declined **before it registers**, not by the reading refusing afterwards. That distinction is the whole of it: a registered layer that then cannot extract raises, and an `ExtractionError` takes the *whole figure* to a static image rather than this one layer. I wrote it the wrong way round first and the measurement caught it. `SteppedHistPlot.reads` guards an unreadable outline the same way.

## Measured end to end

```
Text                     point n=12  {'x': 8.0, 'y': 5.12, 'label': 'a'}
                                     12/12 selectors present in the rendered SVG
                                     no longer falls back to a static image
Text with no text=       registers nothing; the rest of the chart is unaffected
Text + Dot               two layers; only the Text one carries the names
```

## Every mark is read now

With this, `_READINGS` covers the whole catalogue — `Area`, `Band`, `Bar`, `Bars`, `Dash`, `Dot`, `Dots`, `Line`, `Lines`, `Path`, `Paths`, `Range`, `Text`. The declines list has no subject left.

The test that pinned it **inverts** rather than going away: it now asserts `_READINGS` covers every mark `seaborn.objects` defines, so a seaborn release that adds one fails there rather than shipping a mark that silently draws nothing a reader can reach. The `_reading_for` guard is asked with a stand-in `so.Mark` subclass, because the thing it has to keep working for is exactly the mark that does not exist yet.

## Verification

- `uv run pytest -q` — **3545 passed, 72 skipped**.
- `tests/core/plot/test_seaborn_objects_text.py` — 8 tests, including a selector test resolved against the rendered SVG and one that pins the numbering past a declined blank.
- A 12-mutation sweep over the reading, the decline, the selectors, the holder and the dispatch: **0 survivors** (one round found the non-finite guard untested).
- `ruff check maidr tests` reports the 6 re-export errors present on `origin/main` unchanged.

## Also open

#680 — a colour-split `so.Dash` still reads as one unnamed layer, filed from #679. Unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_