### PR TITLE
fix(seaborn-objects): split a colour-split Dash into one layer per level

### DIFF
--- a/maidr/core/plot/dashplot.py
+++ b/maidr/core/plot/dashplot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 import uuid
-from typing import List
+from typing import List, Sequence
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -15,6 +15,10 @@ from maidr.exception import ExtractionError
 
 #: The keyword the drawn collection is handed over under.
 DRAWN_DASHES = "dashes"
+
+#: Which of the collection's segments one layer announces, when a colour
+#: split made the layer a slice of it rather than the whole.
+DASH_MEMBERS = "dash_members"
 
 
 class DashPlot(ScatterPlot):
@@ -66,6 +70,10 @@ class DashPlot(ScatterPlot):
 
     def __init__(self, ax: Axes, **kwargs) -> None:
         self._collection: LineCollection = kwargs.pop(DRAWN_DASHES)
+        # Which of the collection's segments are this layer's. A colour split
+        # draws every level into one collection, so a layer is a slice of it
+        # rather than the whole; absent means all of them.
+        self._members: Sequence[int] | None = kwargs.pop(DASH_MEMBERS, None)
         # Which of the collection's segments the payload announces, in payload
         # order. Filled by `_extract_plot_data` and read by `_get_selector`;
         # empty here so a layer asked for its selectors before its data
@@ -104,6 +112,8 @@ class DashPlot(ScatterPlot):
         samples: list[dict] = []
         self._drawn = []
         for position, segment in enumerate(segments):
+            if self._members is not None and position not in self._members:
+                continue
             middle = _middle(segment)
             if middle is None:
                 continue

--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -6,7 +6,7 @@ import uuid
 import numpy as np
 import numpy.ma as ma
 from matplotlib.axes import Axes
-from matplotlib.collections import PathCollection
+from matplotlib.collections import Collection, PathCollection
 from matplotlib.colors import to_rgba
 
 from maidr.core.enum import MaidrKey, PlotType
@@ -181,7 +181,7 @@ def _collections(given) -> list[PathCollection]:
 
 
 def hue_groups(
-    ax: Axes, collection: PathCollection
+    ax: Axes, collection: Collection
 ) -> list[tuple[str, list[int]]] | None:
     """
     The hue groups a scatter was drawn with, or ``None`` when it has none.
@@ -193,7 +193,9 @@ def hue_groups(
     legend's swatches, and each swatch carries its group's name.
 
     Reading those colours off the collection is the whole of what is specific
-    to the artist. Every reason to decline is
+    to the artist, and :func:`drawn_colours` is the whole of that -- a
+    ``so.Dash()`` draws the same grouping as an unfilled ``LineCollection``
+    and is read here too (#680). Every reason to decline is
     :func:`groups_from_colours`', which a bar layer reaches from a
     ``BarContainer`` and must be told the same (#599, #617).
 
@@ -201,8 +203,9 @@ def hue_groups(
     ----------
     ax : Axes
         The axes drawn on, for its legend.
-    collection : PathCollection
-        The points.
+    collection : Collection
+        The marks. A ``PathCollection`` of points, or the
+        ``LineCollection`` of ticks a dash mark draws.
 
     Returns
     -------
@@ -211,14 +214,49 @@ def hue_groups(
         collection offsets that belong to it, or ``None`` for a scatter that
         is not grouped.
     """
-    return groups_from_colours(ax, [_rgba(row) for row in collection.get_facecolors()])
+    return groups_from_colours(ax, [_rgba(row) for row in drawn_colours(collection)])
+
+
+def drawn_colours(collection: Collection) -> np.ndarray:
+    """
+    The colours a collection drew its marks in.
+
+    Face colours where the artist has them and edge colours otherwise, which
+    is a fact about the artist rather than about the chart -- and so belongs
+    beside :func:`hue_groups`, whose whole job is the part that is specific
+    to the artist.
+
+    A ``PathCollection``'s markers are filled; a ``LineCollection``'s ticks
+    are not. Measured on a colour-split ``so.Dash()`` over two levels::
+
+        get_facecolors()   (0, 4)     <- empty
+        get_edgecolors()   (40, 4)
+
+    So asking for faces alone read nothing off a chart whose colours were all
+    there, one attribute over: the split was declined and the reader was
+    handed one anonymous layer of forty ticks (#680).
+
+    Parameters
+    ----------
+    collection : Collection
+        The artist to read.
+
+    Returns
+    -------
+    ndarray
+        One RGBA row per mark, or however many the artist was given.
+    """
+    faces = np.asarray(collection.get_facecolors())
+    if len(faces):
+        return faces
+    return np.asarray(collection.get_edgecolors())
 
 
 def groups_from_colours(ax: Axes, colours: list) -> list[tuple[str, list[int]]] | None:
     """
     The groups a legend names among one layer's drawn colours.
 
-    Everything :func:`hue_groups` does after reading a collection's face
+    Everything :func:`hue_groups` does after reading a collection's drawn
     colours, which is everything that is not about the artist. A bar layer
     asks the same question of a ``BarContainer``'s patches
     (:func:`maidr.core.plot.barplot.bar_groups`) and must get the same answer,
@@ -227,8 +265,8 @@ def groups_from_colours(ax: Axes, colours: list) -> list[tuple[str, list[int]]] 
 
     Everything here is a reason to decline, and each has a chart behind it:
 
-    - **One colour for the whole layer.** ``get_facecolors()`` returns a
-      single row when every point shares a colour, which is what an ungrouped
+    - **One colour for the whole layer.** A collection reports a single
+      colour row when every mark shares one, which is what an ungrouped
       scatter and a ``style=``-only scatter both produce; a bar drawn without
       ``color=`` arrives one-long the same way.
     - **No legend.** ``legend=False`` suppresses it, and a manual

--- a/maidr/patch/seaborn_objects.py
+++ b/maidr/patch/seaborn_objects.py
@@ -19,7 +19,7 @@ from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS, bar_groups
 from maidr.core.plot.bars_histogram import BIN_MEMBERS, DRAWN_BINS, hist_groups
-from maidr.core.plot.dashplot import DRAWN_DASHES
+from maidr.core.plot.dashplot import DASH_MEMBERS, DRAWN_DASHES
 from maidr.core.plot.textplot import DRAWN_LABELS
 from maidr.core.plot.textplot import reads as reads_labels
 from maidr.core.plot.grouped_barplot import DRAWN_GROUPS
@@ -568,6 +568,21 @@ def _handovers(
 
     if reading.plot_type is PlotType.SCATTER and len(own) == 1:
         groups = hue_groups(ax, own[0])
+        # A `so.Dash()` takes the shape `so.Bars` does rather than the one
+        # `so.Dot` does: its class is handed **one** collection and reads a
+        # slice of it, where a scatter layer is handed the list and filters
+        # by offset. So the members go with the name, and the selectors keep
+        # numbering against the collection -- the second level's ticks point
+        # at the second level's paths (#680).
+        if groups and reading.binding == DRAWN_DASHES:
+            return [
+                (
+                    reading.plot_type,
+                    {reading.binding: own[0], DASH_MEMBERS: members,
+                     GROUP_NAME: name},
+                )
+                for name, members in groups
+            ]
         if groups:
             # `hue_groups` answers in the offsets of the collection it was
             # asked about, and the layer takes a list of those -- one per

--- a/tests/core/plot/test_seaborn_objects_dash.py
+++ b/tests/core/plot/test_seaborn_objects_dash.py
@@ -108,14 +108,20 @@ def test_a_dodged_tick_announces_its_category_and_not_the_offset():
     Measured, a dodged first segment runs `[-0.4, y]` to `[0.0, y]`, so its
     midpoint is `-0.2` -- the offset, which is what #617 found `so.Bar`
     announcing where the axis says `a`.
+
+    A dodge needs something to dodge by, so this chart is also colour-split
+    and reads as one layer per level (#680). The snapping is per tick, so it
+    is asserted of every layer rather than of the one this used to be.
     """
-    schema = _only(
+    schemas = _layers(
         so.Plot(_frame(), x="x", y="v", color="g").add(so.Dash(), so.Dodge())
     )
-    points = schema[MaidrKey.DATA]
 
-    assert {point[MaidrKey.X] for point in points} == {0.0, 1.0, 2.0, 3.0, 4.0}
-    assert {point[MaidrKey.X_LABEL] for point in points} == set("abcde")
+    assert len(schemas) == 2
+    for schema in schemas:
+        points = schema[MaidrKey.DATA]
+        assert {point[MaidrKey.X] for point in points} == {0.0, 1.0, 2.0, 3.0, 4.0}
+        assert {point[MaidrKey.X_LABEL] for point in points} == set("abcde")
 
 
 def test_an_aggregated_dash_reads_one_tick_per_category():
@@ -293,3 +299,70 @@ def test_the_nth_selector_addresses_the_nth_tick():
     assert re.search(r"nth-of-type\((\d+)\)", selectors[0]).group(1) == "1"
     assert re.search(r"nth-of-type\((\d+)\)", selectors[2]).group(1) == "3"
     assert len(paths) == len(selectors)
+
+
+def test_a_colour_split_becomes_one_layer_per_level():
+    """A two-level chart offered one anonymous cloud of forty ticks (#680).
+
+    `hue_groups` inverts a collection's colours against the legend that names
+    them, and it read *face* colours — which a line collection has none of.
+    Measured on this chart, 0 face colours against 40 edge colours: the
+    grouping was all there, one attribute over.
+    """
+    schemas = _layers(
+        so.Plot(_frame(), x="x", y="v", color="g").add(so.Dash(), so.Dodge())
+    )
+
+    assert [schema.get(MaidrKey.NAME) for schema in schemas] == ["p", "q"]
+    assert [len(schema[MaidrKey.DATA]) for schema in schemas] == [20, 20]
+
+
+def test_each_level_keeps_its_categories_and_its_own_values():
+    frame = _frame()
+    schemas = _layers(
+        so.Plot(frame, x="x", y="v", color="g").add(so.Dash(), so.Dodge())
+    )
+
+    for schema, level in zip(schemas, ["p", "q"]):
+        points = schema[MaidrKey.DATA]
+        # Still snapped to the ticks rather than announced at the dodge
+        # offset, and still named after them.
+        assert {point[MaidrKey.X_LABEL] for point in points} == set("abcde")
+        assert {round(point[MaidrKey.Y], 6) for point in points} == {
+            round(float(v), 6) for v in frame.loc[frame["g"] == level, "v"]
+        }
+
+
+def test_each_level_outlines_its_own_ticks_and_not_its_neighbours():
+    """Numbered against the collection, not against the layer.
+
+    Every level's ticks live in one collection, so a layer that numbered its
+    selectors from one would point the second level's announcements at the
+    first level's paths.
+    """
+    schemas = _layers(
+        so.Plot(_frame(), x="x", y="v", color="g").add(so.Dash(), so.Dodge())
+    )
+    numbers = [
+        [
+            int(re.search(r"nth-of-type\((\d+)\)", selector).group(1))
+            for selector in schema[MaidrKey.SELECTOR]
+        ]
+        for schema in schemas
+    ]
+
+    assert numbers[0] == list(range(1, 21))
+    assert numbers[1] == list(range(21, 41))
+    # And one gid between them, because it is one collection.
+    assert len({
+        re.search(r"id='([^']+)'", schema[MaidrKey.SELECTOR][0]).group(1)
+        for schema in schemas
+    }) == 1
+
+
+def test_an_ungrouped_dash_is_still_one_unnamed_layer():
+    """The split is a grouping, not a default: one colour is one layer."""
+    schema = _only(so.Plot(_frame(), x="x", y="v").add(so.Dash()))
+
+    assert MaidrKey.NAME not in schema
+    assert len(schema[MaidrKey.DATA]) == 40


### PR DESCRIPTION
Closes #680.

## The defect

`so.Dash()` given `color=` draws its levels in different colours. It was read as **one anonymous layer of forty ticks** — a reader could hear every observation but could not tell the two levels apart, and nothing named either.

The grouping was all there, one attribute over. `hue_groups` inverts a collection's colours against the legend that names them, and it asked for **face** colours. Measured on a two-level `so.Dash()`:

```
get_facecolors()   (0, 4)     <- empty
get_edgecolors()   (40, 4)
```

A `PathCollection`'s markers are filled; a `LineCollection`'s ticks are not. So the split was declined for want of colours the artist keeps under a different name.

## The change

**`drawn_colours(collection)`** — face colours where the artist has them, edge colours otherwise. That is a fact about the artist rather than about the chart, so it sits beside `hue_groups`, whose whole job is the artist-specific part. Every reason to decline stays `groups_from_colours`', unchanged and still shared with the bar and box splits.

**The split takes `so.Bars`' shape, not `so.Dot`'s.** A scatter layer is handed the *list* of collections and filters by offset; `DashPlot` is handed **one** collection and reads a slice of it. So the members travel with the name as `DASH_MEMBERS`, and the selectors keep numbering against the collection — the second level's ticks address paths 21–40 rather than restarting at one, which would point every announcement at its neighbour's tick.

Measured after the change:

```
Dash, colour+Dodge:       2 layers  name='p' n=20 nth-of-type(1..20)
                                    name='q' n=20 nth-of-type(21..40)
Dash, plain (regression): 1 layer   name absent, n=40
Dot, colour (regression): 2 layers  name='p'/'q', unchanged
```

## Tests

Four added to `tests/core/plot/test_seaborn_objects_dash.py`: the split itself, that each level keeps its own categories and values, that each level outlines its own ticks and shares one gid, and that an ungrouped `Dash` is still one unnamed layer.

`test_a_dodged_tick_announces_its_category_and_not_the_offset` moved from `_only` to `_layers`: a dodge needs something to dodge by, so its chart is colour-split too and now reads as two layers. The property it pins — a dodged tick announcing its category rather than the dodge offset — is asserted of every layer instead of the one it used to be.

## Verification

- `uv run pytest -q` → **3549 passed, 72 skipped** (3545 before; four new tests).
- `uv run ruff check maidr tests` → the same 6 pre-existing re-export errors that `origin/main` reports, no new ones.
- Mutation sweep over `drawn_colours`, the member filter and the handover branch: **10/10 caught** — including reading faces only, reading edges only, ignoring the members, reading the neighbours' ticks, dropping the name, and emitting only the first level.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_