### PR TITLE
feat(plotly): read the seven map traces that registered nothing

### DIFF
--- a/maidr/plotly/choropleth.py
+++ b/maidr/plotly/choropleth.py
@@ -92,6 +92,16 @@ class PlotlyChoroplethPlot(PlotlyPlot):
         ]
 
 
+#: The three names plotly gives one chart. ``choropleth`` shades regions on a
+#: geographic projection; ``choroplethmap`` and its deprecated
+#: ``choroplethmapbox`` spelling shade the same regions over a tiled base map.
+#: They carry the same ``locations`` and ``z`` and are read identically -- the
+#: base map is drawing, not data (#683).
+_CHOROPLETH_TYPES = frozenset(
+    {"choropleth", "choroplethmap", "choroplethmapbox"}
+)
+
+
 def is_choropleth_trace(trace: dict) -> bool:
     """Report whether a trace is a choropleth map."""
-    return trace.get("type") == "choropleth"
+    return trace.get("type") in _CHOROPLETH_TYPES

--- a/maidr/plotly/geo.py
+++ b/maidr/plotly/geo.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from maidr.core.enum.maidr_key import MaidrKey
+from maidr.core.enum.plot_type import PlotType
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list, colorbar_title, subplot_block
+
+#: What a map marker's own coordinates are called. A map draws no cartesian
+#: axes, so there is no author-written title to read: `layout.xaxis` holds
+#: another trace's, and the fallback `"X"`/`"Y"` would name a pair of degrees
+#: after coordinates the chart does not have.
+MAP_LONGITUDE_AXIS = "Longitude"
+MAP_LATITUDE_AXIS = "Latitude"
+
+#: What a density map's magnitude is called when the author titled no colour
+#: bar. `Density` rather than `Value`, because that is what the trace weights
+#: its kernel by and what the colour states.
+MAP_DENSITY_AXIS = "Density"
+
+#: The scatter-shaped map traces: a marker per position, and a name for it.
+_PLACED_MARKS = frozenset({"scattergeo", "scattermap", "scattermapbox"})
+
+#: The same shape carrying a magnitude per position.
+_WEIGHTED_MARKS = frozenset({"densitymap", "densitymapbox"})
+
+#: Which layout block field each family of map trace names its subplot under,
+#: and what it belongs to when it names none. Measured on plotly 6.7.0: a
+#: ``scattergeo`` writes ``geo``, while every ``*map`` and ``*mapbox`` trace
+#: writes ``subplot`` -- and the two defaults differ, because a maplibre
+#: figure's block is ``layout.map`` and a mapbox one's is ``layout.mapbox``.
+_BLOCK_FIELDS: dict[str, tuple[str, str]] = {
+    "geo": ("geo", "geo"),
+    "mapbox": ("subplot", "mapbox"),
+    "map": ("subplot", "map"),
+}
+
+
+def geo_block(trace: dict) -> str:
+    """
+    The layout block naming the map subplot a trace is drawn on.
+
+    A map trace is placed by neither an axis pair nor a ``domain`` of its
+    own, but by a rectangle plotly writes under a named block, which the
+    trace addresses by name. Which field carries that name depends on the
+    family: measured on plotly 6.7.0, ``go.Scattergeo(geo="geo2")`` writes
+    ``geo``, while ``go.Scattermap(subplot="map2")`` writes ``subplot``.
+
+    Parameters
+    ----------
+    trace : dict
+        One trace of the figure.
+
+    Returns
+    -------
+    str
+        The block name, defaulted per family when the trace names none.
+    """
+    kind = str(trace.get("type", ""))
+    if kind.endswith("mapbox"):
+        field, default = _BLOCK_FIELDS["mapbox"]
+    elif kind.endswith("map"):
+        field, default = _BLOCK_FIELDS["map"]
+    else:
+        field, default = _BLOCK_FIELDS["geo"]
+    return subplot_block(trace, field, default)
+
+
+def is_geo_scatter_trace(trace: dict) -> bool:
+    """
+    Report whether a trace is a map's markers rather than its regions.
+
+    Parameters
+    ----------
+    trace : dict
+        One trace of the figure.
+
+    Returns
+    -------
+    bool
+        True for the scatter-shaped and density map traces.
+    """
+    kind = trace.get("type")
+    return kind in _PLACED_MARKS or kind in _WEIGHTED_MARKS
+
+
+def _degrees(value: Any) -> float | None:
+    """
+    One coordinate as a finite number of degrees, or ``None``.
+
+    Parameters
+    ----------
+    value : Any
+        A raw ``lat`` or ``lon`` entry.
+
+    Returns
+    -------
+    float or None
+        The coordinate, or ``None`` when it is missing or not finite.
+    """
+    if value is None or isinstance(value, str):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+class PlotlyGeoScatterPlot(PlotlyPlot):
+    """Extract data from a plotly map trace that draws markers.
+
+    Five trace types draw the same chart: ``scattergeo`` on a geographic
+    projection, ``scattermap``/``scattermapbox`` on a tiled base map, and
+    ``densitymap``/``densitymapbox``, which add a magnitude per position.
+    All five carry ``lat`` and ``lon`` in degrees, and none of them was read
+    at all -- a figure whose only trace was one of them fell back to a
+    picture (#683).
+
+    **A scatter of degrees rather than a choropleth.** A marker has a
+    position and, usually, a name, and that is the whole of its data.
+    ``ChoroplethPoint.y`` is the value a region is shaded by and is
+    required; a placed marker has none, and the only ways to give it one are
+    to invent a constant or to promote its index, both of which announce a
+    measurement the chart never made. Read as a scatter, every number
+    announced is one the figure states, and the place name travels on
+    ``ScatterPoint.label`` -- the field whose purpose is "this point is
+    Oslo" rather than "this slot is called Oslo". The same reading the
+    Highcharts adapter gives ``mappoint`` (xability/maidr#1187).
+
+    A density trace's ``z`` is a real magnitude, so it travels on
+    ``ScatterPoint.z``, which the core sounds through its intensity mapping.
+    """
+
+    def __init__(self, trace: dict, layout: dict, **kwargs: str) -> None:
+        super().__init__(trace, layout, PlotType.SCATTER, **kwargs)
+
+    def _get_selector(self) -> str:
+        """No selector, for the reason ``PlotlyChoroplethPlot`` gives.
+
+        Plotly requests a geographic projection's land geometry, and a
+        tiled map's tiles, from the network at render time, so what a map
+        trace's markers are drawn as could not be measured here. Emitting a
+        selector that has never resolved would be guessing, and a highlight
+        that lands on the wrong marker is worse than none. The layer keeps
+        its audio, braille and text; see #640.
+
+        Returns
+        -------
+        str
+            The empty string.
+        """
+        return ""
+
+    def _extract_axes_data(self) -> dict:
+        """Name the two coordinates, and the magnitude where there is one.
+
+        A map draws no cartesian axes, so ``layout.xaxis`` holds neither
+        name -- reading it would take another trace's titles. A density
+        trace's colour bar title is the one thing the author may have
+        written about its magnitude, so it is used when it is there.
+
+        Returns
+        -------
+        dict
+            The canonical per-axis payload.
+        """
+        axes = {
+            MaidrKey.X: self._axis_config(label=MAP_LONGITUDE_AXIS),
+            MaidrKey.Y: self._axis_config(label=MAP_LATITUDE_AXIS),
+        }
+        if self._trace.get("type") in _WEIGHTED_MARKS:
+            axes[MaidrKey.Z] = self._axis_config(
+                label=colorbar_title(self._trace) or MAP_DENSITY_AXIS
+            )
+        return axes
+
+    def _extract_plot_data(self) -> list[dict]:
+        """One point per marker the trace places.
+
+        A marker whose position is not a finite pair of degrees is dropped
+        rather than announced: plotly draws nothing for it, so announcing it
+        would put a place on the map the reader cannot be told anything
+        about -- and a non-finite coordinate is the ``NaN`` that stops the
+        payload parsing at all (#427).
+
+        Returns
+        -------
+        list of dict
+            The samples, in the trace's own order.
+        """
+        lats = as_list(self._trace.get("lat"))
+        lons = as_list(self._trace.get("lon"))
+        names = as_list(self._trace.get("text"))
+        weights = as_list(self._trace.get("z"))
+
+        samples: list[dict] = []
+        for position in range(min(len(lats), len(lons))):
+            latitude = _degrees(lats[position])
+            longitude = _degrees(lons[position])
+            if latitude is None or longitude is None:
+                continue
+
+            sample = {MaidrKey.X: longitude, MaidrKey.Y: latitude}
+
+            name = names[position] if position < len(names) else None
+            if isinstance(name, str) and name.strip():
+                sample[MaidrKey.LABEL] = name
+
+            if position < len(weights):
+                weight = _degrees(weights[position])
+                if weight is not None:
+                    sample[MaidrKey.Z] = weight
+
+            samples.append(sample)
+
+        return samples

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -12,7 +12,7 @@ from htmltools import HTML, HTMLDocument, Tag, tags
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.candlestick import is_ohlc_trace, layer_position
-from maidr.plotly.plotly_plot import subplot_block
+from maidr.plotly.geo import geo_block
 from maidr.plotly.gauge import draws_a_dial
 from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
 from maidr.plotly.area import is_area_trace
@@ -66,9 +66,11 @@ from maidr.util.iframe_utils import chart_title_of, wrap_in_iframe_plotly
 #: The layout keys that hold a subplot *block* -- a rectangle plotly writes
 #: for a subplot that has no cartesian axis pair, and that a trace addresses
 #: by name. ``polar``/``polar2`` for the two polar traces, ``geo``/``geo2``
-#: for a choropleth. Collected into the figure's row and column universe
-#: exactly as ``xaxis``/``yaxis`` domains are.
-_SUBPLOT_BLOCK_PREFIXES = ("polar", "geo")
+#: for a choropleth, and ``map``/``mapbox`` for the tiled-base-map family
+#: -- one prefix covers both spellings, since ``mapbox`` starts with
+#: ``map``. Collected into the figure's row and column universe exactly as
+#: ``xaxis``/``yaxis`` domains are.
+_SUBPLOT_BLOCK_PREFIXES = ("polar", "geo", "map")
 
 
 #: Trace types placed by their own ``domain`` rectangle that maidr renders as
@@ -93,6 +95,8 @@ _PLACED_BY_DOMAIN = frozenset(
         "parcoords",
         "parcats",
         "choropleth",
+        "choroplethmap",
+        "choroplethmapbox",
     }
 )
 
@@ -1107,11 +1111,38 @@ class PlotlyMaidr:
                         x_starts,
                         y_starts,
                         self._block_domain_start(
-                            layout, subplot_block(choropleth_trace, "geo")
+                            layout, geo_block(choropleth_trace)
                         ),
                     )
                     self._plots.append(plot)
                 merged.update(id(t) for t in choropleth_traces)
+
+            # Map markers, one layer each. Placed by the same named block a
+            # choropleth is -- `geo` for a geographic projection, `map` or
+            # `mapbox` for a tiled one -- so a marker layer and a region
+            # layer drawn on the same map land in the same grid cell (#683).
+            from maidr.plotly.geo import is_geo_scatter_trace
+
+            geo_scatter_traces = [
+                t for t in group_traces if is_geo_scatter_trace(t)
+            ]
+            if geo_scatter_traces:
+                from maidr.plotly.geo import PlotlyGeoScatterPlot
+
+                for geo_trace in geo_scatter_traces:
+                    # A trace that placed no marker by `lat`/`lon` states
+                    # nothing this can announce, and the empty layer it would
+                    # form is dropped by the figure-wide `_carries_data` pass
+                    # at the end of this method -- the phantom row #421
+                    # describes, already answered once for every layer type.
+                    plot = PlotlyGeoScatterPlot(geo_trace, layout, **axis_kwargs)
+                    plot.row_index, plot.col_index = self._grid_position(
+                        x_starts,
+                        y_starts,
+                        self._block_domain_start(layout, geo_block(geo_trace)),
+                    )
+                    self._plots.append(plot)
+                merged.update(id(t) for t in geo_scatter_traces)
 
             # Parallel sets, one layer each. Placed by its own `domain`
             # rectangle like a pie, because a `parcats` names no axis pair.

--- a/maidr/plotly/plotly_plot_factory.py
+++ b/maidr/plotly/plotly_plot_factory.py
@@ -200,6 +200,26 @@ class PlotlyPlotFactory:
             # precisely because it does know, and passes real positions.
             return PlotlyWaterfallPlot(trace, layout, **axis_kwargs)
 
+        if trace_type in (
+            "choropleth",
+            "choroplethmap",
+            "choroplethmapbox",
+        ):
+            from maidr.plotly.choropleth import PlotlyChoroplethPlot
+
+            return PlotlyChoroplethPlot(trace, layout, **axis_kwargs)
+
+        if trace_type in (
+            "scattergeo",
+            "scattermap",
+            "scattermapbox",
+            "densitymap",
+            "densitymapbox",
+        ):
+            from maidr.plotly.geo import PlotlyGeoScatterPlot
+
+            return PlotlyGeoScatterPlot(trace, layout, **axis_kwargs)
+
         if trace_type == "pie":
             from maidr.plotly.pie import PlotlyPiePlot
 

--- a/tests/plotly/test_plotly_geo.py
+++ b/tests/plotly/test_plotly_geo.py
@@ -1,0 +1,289 @@
+"""Seven plotly map traces registered no layer at all (#683).
+
+`go.Choropleth` was read; every other trace plotly draws on a map was not.
+Measured through `PlotlyMaidr(fig)._flatten_maidr()` on plotly 6.7.0, counting
+the layers each figure produced::
+
+    Scattergeo             n=0
+    Scattermap             n=0
+    Scattermapbox          n=0
+    Densitymap             n=0
+    Densitymapbox          n=0
+    Choroplethmap          n=0
+    Choroplethmapbox       n=0
+    Choropleth (read)      n=1   choropleth pts=1
+
+Zero layers means the whole figure falls back to a picture: a `go.Scattergeo`
+of three cities was silent.
+
+**A scatter of degrees, not a choropleth.** A placed marker has a position and
+a name and no magnitude. `ChoroplethPoint.y` is required, and the only ways to
+supply one are to invent a constant or to promote the array index -- both
+announce a measurement the chart never made. The same reading the Highcharts
+adapter gives `mappoint` (xability/maidr#1187).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# `plotly` is an optional extra; guard it the way the rest of this directory
+# does, so a minimal install skips rather than failing at collection.
+plotly = pytest.importorskip("plotly")
+
+import plotly.graph_objects as go  # noqa: E402
+from plotly.subplots import make_subplots  # noqa: E402
+
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+LAT = [51.5, 48.9, 59.9]
+LON = [-0.13, 2.35, 10.75]
+NAMES = ["London", "Paris", "Oslo"]
+
+
+def _layers(figure: go.Figure) -> list[dict]:
+    """Every emitted layer of a figure, flattened across its subplot grid."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [layer for row in grid for cell in row for layer in cell.get("layers", [])]
+
+
+def _placed(layer: dict) -> list[tuple]:
+    """Each marker as ``(longitude, latitude)``."""
+    return [(point[MaidrKey.X], point[MaidrKey.Y]) for point in layer["data"]]
+
+
+@pytest.mark.parametrize(
+    "trace",
+    [
+        go.Scattergeo(lat=LAT, lon=LON, text=NAMES),
+        go.Scattermap(lat=LAT, lon=LON, text=NAMES),
+        go.Scattermapbox(lat=LAT, lon=LON, text=NAMES),
+    ],
+    ids=["scattergeo", "scattermap", "scattermapbox"],
+)
+def test_a_map_of_markers_is_read_rather_than_registering_nothing(trace) -> None:
+    """The reproduction, across the three spellings of one chart.
+
+    `scattermapbox` is deprecated in favour of `scattermap`, but plotly still
+    draws it and figures in the wild still use it, so it is read too.
+    """
+    (layer,) = _layers(go.Figure([trace]))
+
+    assert layer["type"] is PlotType.SCATTER
+    assert _placed(layer) == [(-0.13, 51.5), (2.35, 48.9), (10.75, 59.9)]
+
+
+def test_a_marker_is_placed_at_its_longitude_and_latitude_that_way_round() -> None:
+    """Swapped, every place is announced somewhere it is not.
+
+    London is 51.5 degrees north and 0.13 west. Read the other way it lands in
+    the Indian Ocean, and nothing in the payload would say so.
+    """
+    (layer,) = _layers(go.Figure([go.Scattergeo(lat=LAT, lon=LON, text=NAMES)]))
+    london = layer["data"][0]
+
+    assert london[MaidrKey.X] == -0.13
+    assert london[MaidrKey.Y] == 51.5
+    assert london[MaidrKey.LABEL] == "London"
+
+
+def test_the_two_coordinates_are_named_rather_than_left_as_x_and_y() -> None:
+    """A map draws no cartesian axes, so `layout.xaxis` holds neither name."""
+    (layer,) = _layers(go.Figure([go.Scattergeo(lat=LAT, lon=LON)]))
+
+    assert layer["axes"][MaidrKey.X][MaidrKey.LABEL] == "Longitude"
+    assert layer["axes"][MaidrKey.Y][MaidrKey.LABEL] == "Latitude"
+    # No `z` on a trace that carries no magnitude: an axis announced with
+    # nothing behind it is a reading of a field the chart never filled.
+    assert MaidrKey.Z not in layer["axes"]
+
+
+def test_a_marker_with_no_name_carries_no_label() -> None:
+    """`ScatterPoint.label` says "this point is Oslo". An empty one says nothing."""
+    (layer,) = _layers(go.Figure([go.Scattergeo(lat=LAT, lon=LON)]))
+
+    assert all(MaidrKey.LABEL not in point for point in layer["data"])
+
+
+def test_a_blank_name_is_not_announced_as_one() -> None:
+    """A whitespace string is a name the reader would hear as silence."""
+    (layer,) = _layers(
+        go.Figure([go.Scattergeo(lat=LAT, lon=LON, text=["London", "  ", "Oslo"])])
+    )
+
+    assert [point.get(MaidrKey.LABEL) for point in layer["data"]] == [
+        "London",
+        None,
+        "Oslo",
+    ]
+
+
+@pytest.mark.parametrize(
+    "trace",
+    [
+        go.Densitymap(lat=LAT, lon=LON, z=[5, 6, 7]),
+        go.Densitymapbox(lat=LAT, lon=LON, z=[5, 6, 7]),
+    ],
+    ids=["densitymap", "densitymapbox"],
+)
+def test_a_density_map_carries_its_magnitude(trace) -> None:
+    """`z` is a real measurement here, so it travels where the core sounds it."""
+    (layer,) = _layers(go.Figure([trace]))
+
+    assert [point[MaidrKey.Z] for point in layer["data"]] == [5.0, 6.0, 7.0]
+    assert layer["axes"][MaidrKey.Z][MaidrKey.LABEL] == "Density"
+
+
+def test_a_density_map_takes_the_colour_bar_title_for_its_magnitude() -> None:
+    """The one thing the author may have written about what the colour means."""
+    (layer,) = _layers(
+        go.Figure(
+            [
+                go.Densitymap(
+                    lat=LAT,
+                    lon=LON,
+                    z=[5, 6, 7],
+                    colorbar={"title": {"text": "Sightings"}},
+                )
+            ]
+        )
+    )
+
+    assert layer["axes"][MaidrKey.Z][MaidrKey.LABEL] == "Sightings"
+
+
+@pytest.mark.parametrize(
+    "trace",
+    [
+        go.Choroplethmap(locations=["a", "b"], z=[1, 2]),
+        go.Choroplethmapbox(locations=["a", "b"], z=[1, 2]),
+    ],
+    ids=["choroplethmap", "choroplethmapbox"],
+)
+def test_a_choropleth_on_a_tiled_map_reads_as_the_choropleth_it_is(trace) -> None:
+    """The base map is drawing, not data.
+
+    `choropleth`, `choroplethmap` and `choroplethmapbox` carry the same
+    `locations` and `z`; only what is painted underneath differs. Two of the
+    three registered nothing while the first was read.
+    """
+    (layer,) = _layers(go.Figure([trace]))
+
+    assert layer["type"] is PlotType.CHOROPLETH
+    assert [(point[MaidrKey.X], point[MaidrKey.Y]) for point in layer["data"]] == [
+        ("a", 1),
+        ("b", 2),
+    ]
+
+
+def test_a_trace_that_placed_no_marker_is_declined_rather_than_emitted_empty() -> None:
+    """A layer of no points is the phantom row #421 describes.
+
+    The reader can navigate into it and it can say nothing. Declining leaves
+    the rest of the figure readable.
+    """
+    assert _layers(go.Figure([go.Scattergeo(text=NAMES)])) == []
+
+
+def test_a_marker_with_a_non_finite_coordinate_is_dropped_not_announced() -> None:
+    """`json.dumps` writes `NaN` as a bare token, which `JSON.parse` rejects.
+
+    One such value stops the chart initialising at all (#427) -- and plotly
+    draws nothing there either, so announcing it would put a place on the map
+    the reader cannot be told anything about.
+    """
+    (layer,) = _layers(
+        go.Figure(
+            [go.Scattergeo(lat=[1, None, 3], lon=[4, 5, 6], text=["a", "b", "c"])]
+        )
+    )
+
+    assert _placed(layer) == [(4.0, 1.0), (6.0, 3.0)]
+    # The names travel with the markers that survived, not with their indices.
+    assert [point[MaidrKey.LABEL] for point in layer["data"]] == ["a", "c"]
+
+
+def test_a_map_ships_without_a_selector() -> None:
+    """The limit `PlotlyChoroplethPlot` already documents, for the same reason.
+
+    Plotly fetches a projection's land geometry, and a tiled map's tiles, from
+    the network at render time, so what the markers are drawn as could not be
+    measured here. A highlight that lands on the wrong marker is worse than
+    none; the layer keeps its audio, braille and text (#640).
+    """
+    (layer,) = _layers(go.Figure([go.Scattergeo(lat=LAT, lon=LON)]))
+
+    assert not layer.get("selectors")
+
+
+def test_a_map_takes_its_own_cell_beside_a_cartesian_subplot() -> None:
+    """Placed by the named block a choropleth is, not by an axis pair."""
+    grid = make_subplots(
+        rows=1, cols=2, specs=[[{"type": "scattergeo"}, {"type": "xy"}]]
+    )
+    grid.add_trace(go.Scattergeo(lat=LAT, lon=LON, text=NAMES), row=1, col=1)
+    grid.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+
+    cells = PlotlyMaidr(grid)._flatten_maidr()["subplots"]
+
+    assert [layer["type"] for layer in cells[0][0]["layers"]] == [PlotType.SCATTER]
+    assert [layer["type"] for layer in cells[0][1]["layers"]] == [PlotType.BAR]
+
+
+@pytest.mark.parametrize(
+    ("block", "trace"),
+    [
+        ("map", go.Scattermap(lat=LAT, lon=LON, text=NAMES)),
+        ("mapbox", go.Scattermapbox(lat=LAT, lon=LON, text=NAMES)),
+        ("map", go.Choroplethmap(locations=["a"], z=[1])),
+        ("mapbox", go.Choroplethmapbox(locations=["a"], z=[1])),
+    ],
+    ids=["scattermap", "scattermapbox", "choroplethmap", "choroplethmapbox"],
+)
+def test_a_tiled_map_takes_its_own_cell_too(block, trace) -> None:
+    """The tiled family names its block under a different field than `geo`.
+
+    Measured on plotly 6.7.0: ``go.Scattergeo(geo="geo2")`` writes ``geo``,
+    while ``go.Scattermap(subplot="map2")`` writes ``subplot`` -- and the
+    block it defaults to is ``map`` for a maplibre figure and ``mapbox`` for
+    a mapbox one. Resolving every map through ``geo`` puts the layer in
+    whichever cell ``layout.geo`` happens to describe, which on a figure with
+    no ``geo`` block at all is the first one -- on top of whatever is there.
+    """
+    # The map goes in the SECOND column deliberately. A block name that
+    # resolves to nothing lands the layer at domain start (0, 0) -- which is
+    # cell [0][0], where a map drawn first would have been anyway. Only a map
+    # that is not first can tell a resolved block from an unresolved one.
+    grid = make_subplots(rows=1, cols=2, specs=[[{"type": "xy"}, {"type": block}]])
+    grid.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=1)
+    grid.add_trace(trace, row=1, col=2)
+
+    cells = PlotlyMaidr(grid)._flatten_maidr()["subplots"]
+
+    assert len(cells[0]) == 2
+    assert [layer["type"] for layer in cells[0][0]["layers"]] == [PlotType.BAR]
+    assert [layer["type"] for layer in cells[0][1]["layers"]] in (
+        [PlotType.SCATTER],
+        [PlotType.CHOROPLETH],
+    )
+
+
+def test_markers_over_regions_land_on_the_same_map() -> None:
+    """Two layers, one cell: they are drawn on one `geo` block.
+
+    Splitting them across cells would tell the reader the capital is on a
+    different map from the country it is in.
+    """
+    figure = go.Figure()
+    figure.add_trace(go.Choropleth(locations=["USA"], z=[1]))
+    figure.add_trace(go.Scattergeo(lat=[38.9], lon=[-77.0], text=["DC"]))
+
+    cells = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+
+    assert len(cells) == 1 and len(cells[0]) == 1
+    assert [layer["type"] for layer in cells[0][0]["layers"]] == [
+        PlotType.CHOROPLETH,
+        PlotType.SCATTER,
+    ]


### PR DESCRIPTION
Closes #683.

## The defect

`go.Choropleth` reads as a `choropleth` layer. Every other trace plotly draws on a map registered **no layer at all** — including `go.Choroplethmap` and `go.Choroplethmapbox`, which are the same chart on a different base map.

Measured through `PlotlyMaidr(fig)._flatten_maidr()` on plotly 6.7.0, counting the layers each figure produced:

```
Scattergeo             n=0
Scattermap             n=0
Scattermapbox          n=0
Densitymap             n=0
Densitymapbox          n=0
Choroplethmap          n=0
Choroplethmapbox       n=0
Choropleth (read)      n=1   choropleth pts=1
```

Zero layers means the whole figure falls back to a picture. A `go.Scattergeo` of three cities was silent.

## The change

**The two tiled choropleths read through the class that already existed.** `choropleth`, `choroplethmap` and `choroplethmapbox` carry the same `locations` and `z`; only what is painted underneath differs, and that is drawing rather than data.

**The five scatter-shaped traces get a class of their own, `PlotlyGeoScatterPlot`.** A placed marker has a position and a name and *no magnitude*, and `ChoroplethPoint.y` is required — the only ways to supply one are to invent a constant or to promote the array index, both of which announce a measurement the chart never made. Read as a scatter of degrees instead, every number announced is one the figure states, and the place name travels on `ScatterPoint.label`: "this point is Oslo", not "this slot is called Oslo". The same reading the Highcharts adapter gives `mappoint` (xability/maidr#1187). A density trace's `z` *is* a real magnitude, so it travels on `ScatterPoint.z`, where the core sounds it.

**Which layout block a map names is measured, not assumed.** `go.Scattergeo(geo="geo2")` writes `geo`; `go.Scattermap(subplot="map2")` writes `subplot`, defaulting to `map` on a maplibre figure and `mapbox` on a mapbox one. Resolving all of them through `geo` put the layer in whichever cell `layout.geo` described — on a figure with no `geo` block, the first one, on top of whatever was already there.

Emitted after the change:

```
scattergeo, named    point  axes=Longitude/Latitude
                     data=[{x:-0.13, y:51.5, label:'London'}, …]
densitymap           point  axes=Longitude/Latitude/Sightings
                     data=[{x:-0.13, y:51.5, z:5.0}, …]
choroplethmap        choropleth  data=[('a',1), ('b',2)]
no lat/lon at all    (no layer)
one bad pair         data=[(4.0,1.0), (6.0,3.0)]   names ['a','c']
```

Highlighting is out of scope for the reason #640 gives for `choropleth`: plotly fetches a projection's land geometry, and a tiled map's tiles, from the network at render time, so a selector could not be measured here — and one that lands on the wrong marker is worse than none. These layers keep their audio, braille and text, as `choropleth` already does.

## Tests

21 in `tests/plotly/test_plotly_geo.py`: the reproduction across all three scatter spellings, longitude-and-latitude that way round (swapped, London lands in the Indian Ocean), the two named coordinates, an unnamed and a blank-named marker, the density magnitude and its colour-bar title, the two tiled choropleths, the decline when nothing is placed, a non-finite coordinate dropped with its neighbours' names kept, the absent selector, a geographic map beside a cartesian subplot, a tiled map in a grid's **second** column (the first would hide an unresolved block, which lands at domain start `(0, 0)`), and markers over regions sharing one cell.

## Verification

- `uv run pytest -q` → **3570 passed, 72 skipped** (3549 before; 21 new tests).
- `uv run ruff check maidr tests` → the same 6 pre-existing re-export errors `origin/main` reports.
- Mutation sweep: **11/11 caught** — unrecognised traces, swapped coordinates, an announced `NaN`, a dropped or blank name, a lost magnitude, a magnitude axis on every map, the geo-only block resolution, a narrowed choropleth set, and the missing `map` grid prefix. One further mutation was resolved rather than tested: my per-branch `_carries_data` guard turned out to be redundant with the figure-wide filter `_extract_plots` already ends on, so the guard was removed and the behaviour left pinned by the shared pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_