### PR TITLE
docs: tell deck authors how to keep off-slide charts out of the tab order

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -470,7 +470,7 @@ A chart on a `revealjs` slide is keyboard reachable on its own: **Tab** moves
 into it, the arrow keys explore it, and **Shift+Tab** hands focus back to the
 slide, so **Space** advances the deck again. None of that needs configuring.
 
-What does need attention is a reveal.js behaviour that has nothing to do with
+What does need attention is a reveal.js behavior that has nothing to do with
 MAIDR. reveal.js keeps the slides on either side of the current one rendered so
 that transitions stay smooth, and marking them `hidden` does not take them out
 of the tab order — reveal's own inline style overrides the attribute. On a
@@ -493,13 +493,13 @@ Until then,
 [quarto-revealjs-a11y](https://github.com/mcanouil/quarto-revealjs-a11y) does
 the same thing for a Quarto deck. Add it once per project:
 
-``` bash
+```{.bash}
 quarto add mcanouil/quarto-revealjs-a11y
 ```
 
 and enable it in the deck's front matter:
 
-``` yaml
+```{.yaml}
 format:
   revealjs:
     revealjs-plugins:

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -464,7 +464,7 @@ Below is a detailed list of keyboard shortcuts for various functions:
 
 Table: Keyboard Shortcuts {#tbl-shortcuts}
 
-## Quarto revealjs Slides
+## Quarto Reveal.js Slides
 
 A chart on a `revealjs` slide is keyboard reachable on its own: **Tab** moves
 into it, the arrow keys explore it, and **Shift+Tab** hands focus back to the
@@ -473,17 +473,21 @@ slide, so **Space** advances the deck again. None of that needs configuring.
 What does need attention is a reveal.js behaviour that has nothing to do with
 MAIDR. reveal.js keeps the slides on either side of the current one rendered so
 that transitions stay smooth, and marking them `hidden` does not take them out
-of the tab order --- reveal's own inline style overrides the attribute. On a
+of the tab order — reveal's own inline style overrides the attribute. On a
 deck with a chart on every slide, a single **Tab** can therefore land on an
 off-screen slide's chart rather than the one in front of the reader. This is
 [hakimel/reveal.js#1587](https://github.com/hakimel/reveal.js/issues/1587),
 open since 2016.
 
+::: {.callout-note}
+## The workaround below is temporary
+
 The fix is now on reveal.js `master`, which marks every slide but the current
 one `inert`. It has not reached a published release yet, and Quarto carries its
-own copy of reveal.js --- Quarto 1.10 ships 5.1.0 --- so it will arrive in a
-Quarto release some time after reveal.js cuts one. Nothing will need to change
-in your deck when it does.
+own copy of reveal.js — Quarto 1.10 ships 5.1.0 — so it will arrive in a Quarto
+release some time after reveal.js cuts one. Nothing will need to change in your
+deck when it does.
+:::
 
 Until then,
 [quarto-revealjs-a11y](https://github.com/mcanouil/quarto-revealjs-a11y) does
@@ -502,15 +506,18 @@ format:
       - a11y
 ```
 
-Use **0.2.3 or newer**. Earlier versions took off-slide elements out of the tab
-order by setting `tabindex="-1"` on them and could not find them again to put
-them back, which left the chart on the *current* slide unreachable as well.
+::: {.callout-warning}
+## Use quarto-revealjs-a11y 0.2.3 or newer
+
+Earlier versions took off-slide elements out of the tab order by setting
+`tabindex="-1"` on them and could not find them again to put them back, which
+left the chart on the *current* slide unreachable as well.
+:::
 
 With the extension enabled, each slide gives one **Tab** to its own chart and
 **Shift+Tab** back out. The extension also adds a skip link ahead of the
 slides, so Shift+Tab lands there rather than on the slide element itself;
 either way **Space** still moves to the next slide.
-
 
 ## Braille Generation
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -464,6 +464,54 @@ Below is a detailed list of keyboard shortcuts for various functions:
 
 Table: Keyboard Shortcuts {#tbl-shortcuts}
 
+## Quarto revealjs Slides
+
+A chart on a `revealjs` slide is keyboard reachable on its own: **Tab** moves
+into it, the arrow keys explore it, and **Shift+Tab** hands focus back to the
+slide, so **Space** advances the deck again. None of that needs configuring.
+
+What does need attention is a reveal.js behaviour that has nothing to do with
+MAIDR. reveal.js keeps the slides on either side of the current one rendered so
+that transitions stay smooth, and marking them `hidden` does not take them out
+of the tab order --- reveal's own inline style overrides the attribute. On a
+deck with a chart on every slide, a single **Tab** can therefore land on an
+off-screen slide's chart rather than the one in front of the reader. This is
+[hakimel/reveal.js#1587](https://github.com/hakimel/reveal.js/issues/1587),
+open since 2016.
+
+The fix is now on reveal.js `master`, which marks every slide but the current
+one `inert`. It has not reached a published release yet, and Quarto carries its
+own copy of reveal.js --- Quarto 1.10 ships 5.1.0 --- so it will arrive in a
+Quarto release some time after reveal.js cuts one. Nothing will need to change
+in your deck when it does.
+
+Until then,
+[quarto-revealjs-a11y](https://github.com/mcanouil/quarto-revealjs-a11y) does
+the same thing for a Quarto deck. Add it once per project:
+
+``` bash
+quarto add mcanouil/quarto-revealjs-a11y
+```
+
+and enable it in the deck's front matter:
+
+``` yaml
+format:
+  revealjs:
+    revealjs-plugins:
+      - a11y
+```
+
+Use **0.2.3 or newer**. Earlier versions took off-slide elements out of the tab
+order by setting `tabindex="-1"` on them and could not find them again to put
+them back, which left the chart on the *current* slide unreachable as well.
+
+With the extension enabled, each slide gives one **Tab** to its own chart and
+**Shift+Tab** back out. The extension also adds a skip link ahead of the
+slides, so Shift+Tab lands there rather than on the slide element itself;
+either way **Space** still moves to the next slide.
+
+
 ## Braille Generation
 
 maidr incorporates a Braille mode that represents the plot using Braille symbols. This allows users with visual impairments to explore and interact with the plot using a refreshable Braille display. To achieve this, our system translates the plot's visual elements and data points into a corresponding tactile representation using Braille patterns. For different plot types, such as barplot, boxplot, heatmap, and scatterplot, maidr employs unique encoding strategies tailored to effectively convey the data distribution, patterns, and trends. These tactile encodings range from using distinct Braille characters to represent value ranges, to employing characters that visually resemble the corresponding sections of a plot. By providing a comprehensive Braille representation for various plot types, maidr enables users with visual impairments to gain a deeper understanding of the underlying data and its insights.

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -464,7 +464,7 @@ Below is a detailed list of keyboard shortcuts for various functions:
 
 Table: Keyboard Shortcuts {#tbl-shortcuts}
 
-## Quarto Reveal.js Slides
+## Quarto reveal.js Slides
 
 A chart on a `revealjs` slide is keyboard reachable on its own: **Tab** moves
 into it, the arrow keys explore it, and **Shift+Tab** hands focus back to the


### PR DESCRIPTION
## Description

Adds a `## Quarto revealjs Slides` section to `docs/index.qmd`, between the keyboard shortcuts table and the braille reference.

A chart on a slide is already keyboard reachable on its own — Tab moves into it, the arrows explore it, Shift+Tab hands focus back to the slide, and Space advances the deck. That half needs no configuration. What does need attention is a reveal.js behaviour that has nothing to do with MAIDR: reveal.js keeps the slides on either side of the current one rendered so transitions stay smooth, and marking them `hidden` does not take them out of the tab order, because reveal's own inline style overrides the attribute. On a deck with a chart on every slide, one Tab therefore lands on an off-screen slide's chart rather than the one in front of the reader.

Upstream this is hakimel/reveal.js#1587, open since 2016. The fix has since landed on reveal.js `master`, which marks every slide but the current one `inert`. It is not in a published release yet, and Quarto carries its own copy — Quarto 1.10 ships reveal.js 5.1.0 — so it will reach decks in some Quarto release after reveal.js cuts one. The section says so, and says that nothing in the deck will need to change when it does.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas — not applicable, no code changed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Changes Made

`docs/index.qmd`, 48 lines added, no other file touched:

- what the keyboard already does in a deck, and that it needs no configuration
- why one Tab can land on an off-screen slide's chart, with the upstream issue
- that reveal.js `master` fixes it and the deck will not need to change when Quarto ships it
- until then, `quarto add mcanouil/quarto-revealjs-a11y` plus the YAML to enable it
- that 0.2.3 or newer is required: earlier versions parked off-slide elements at `tabindex="-1"` and could not find them again to restore them, which left the chart on the *current* slide unreachable too

## Additional Notes

Checked in Chromium against a Quarto `revealjs` deck of matplotlib charts rendered by this package, not reasoned about. Without the extension, Tab from slide 2 or 3 lands on slide 1's chart:

```
slide 2 -> iframe @slide-1-bar
slide 3 -> iframe @slide-1-bar
```

With quarto-revealjs-a11y 0.2.3, each slide gives one path in and out, and Space still advances:

```
slide 2: chart after 2 Tab(s) -> iframe @slide-2-line*    | Shift+Tab -> skip-link | Space 2->3
slide 3: chart after 2 Tab(s) -> iframe @slide-3-scatter* | Shift+Tab -> skip-link | Space 3->4
```

The 0.2.2 warning is from a measured regression, not caution. Its restore query was `[tabindex]:not([tabindex="-1"])`, which cannot match anything it had itself set to `-1`; 0.2.3 replaced that mechanism with `inert` on the slide.

The section was rendered on its own with `quarto render` to confirm the code blocks and links come out right. No executable cell was added — a chunk shown inside a fenced block is still executed by the engine, so the section sticks to YAML and shell blocks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eadkcqpkod61zhhbfy8Wj8)_