### PR TITLE
docs: mark the roadmap's new plot types as experimental

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,11 +42,26 @@ The `maidr/patch/` modules use `wrapt` to intercept matplotlib/seaborn plot call
 
 ### Supported Plot Types
 
-Defined in `maidr/core/enum/plot_type.py`: BAR, BOX, BOXEN, CONTOUR, COUNT, DODGED, ERRORBAR, GANTT, HEAT, HEXBIN, HIST, LINE, LOLLIPOP, AREA, STACKED_AREA, NORMALIZED_AREA, PIE, SCATTER, STACKED, NORMALIZED, STEP, SMOOTH, CANDLESTICK, VIOLIN_KDE, VIOLIN_BOX.
+Defined in `maidr/core/enum/plot_type.py`, which has **37** members. They do
+not all carry the same promise -- see `docs/stability.qmd`, and keep that page
+in step when adding one (`tests/core/test_plot_type_stability.py` enforces it).
+
+**Stable** (15) -- predate the plot coverage roadmap (#345) and have been
+exercised by real readers:
+
+BAR, BOX, CANDLESTICK, COUNT, DODGED, HEAT, HIST, LINE, PIE, SCATTER,
+SMOOTH, STACKED, STEP, VIOLIN_BOX, VIOLIN_KDE
+
+**Experimental** (22) -- added by that roadmap, none validated with a reader,
+and subject to change without a deprecation period:
+
+ALLUVIAL, AREA, BOXEN, CHOROPLETH, CONTOUR, ERRORBAR, FUNNEL, GANTT, GAUGE,
+HEXBIN, ICICLE, LOLLIPOP, NORMALIZED, NORMALIZED_AREA, PARALLEL, POLAR_AREA,
+RADAR, SANKEY, STACKED_AREA, SUNBURST, TREEMAP, WATERFALL
 
 Note that `maidr/plotly/` builds its MAIDR schema in Python and therefore needs its own
 handling per plot type, whereas `maidr/altair/` delegates entirely to the upstream
-Vega-Lite JS adapter — an Altair-only plot type is implemented there, not here.
+Vega-Lite JS adapter -- an Altair-only plot type is implemented there, not here.
 
 ### Canonical `axes` Payload
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -52,6 +52,8 @@ website:
             href: examples-plotly.qmd
           - text: "Altair"
             href: examples-altair.qmd
+      - file: stability.qmd
+        text: "Plot Type Stability"
       - text: "API Reference"
         href: api/
     right:

--- a/docs/stability.qmd
+++ b/docs/stability.qmd
@@ -1,0 +1,117 @@
+---
+title: "Plot Type Stability"
+description: "Which py-maidr plot types are settled and which are experimental prototypes that may change without a deprecation period."
+html-table-processing: none
+---
+
+## Two sets, two different promises
+
+`PlotType` in `maidr/core/enum/plot_type.py` names **37** plot types. They do
+not all carry the same promise, and nothing in the enum says so — which is what
+this page is for.
+
+Fifteen of them predate the plot coverage roadmap
+([#345](https://github.com/xability/py-maidr/issues/345)). The other twenty-two
+were added by it, most inside about two weeks, and **none of the twenty-two has
+been through a user study**.
+
+## Stable
+
+| `PlotType` | emitted as | drawn by |
+|---|---|---|
+| `BAR` | `bar` | `ax.bar`, `sns.barplot` |
+| `BOX` | `box` | `ax.boxplot`, `sns.boxplot` |
+| `CANDLESTICK` | `candlestick` | `mplfinance` |
+| `COUNT` | `count` | `sns.countplot` |
+| `DODGED` | `dodged_bar` | grouped bars |
+| `HEAT` | `heat` | `ax.imshow`, `sns.heatmap` |
+| `HIST` | `hist` | `ax.hist`, `sns.histplot` |
+| `LINE` | `line` | `ax.plot`, `sns.lineplot` |
+| `PIE` | `pie` | `ax.pie` |
+| `SCATTER` | `point` | `ax.scatter`, `sns.scatterplot` |
+| `SMOOTH` | `smooth` | `sns.regplot`, `sns.lmplot` |
+| `STACKED` | `stacked_bar` | stacked bars |
+| `STEP` | `step` | `ax.step` |
+| `VIOLIN_BOX` | `violin_box` | `sns.violinplot` |
+| `VIOLIN_KDE` | `violin_kde` | `sns.violinplot` |
+
+These are what py-maidr was built around. Their extraction, their announcements
+and their keyboard model have been exercised by real users over real charts, and
+changing any of them changes behaviour people already depend on.
+
+## Experimental
+
+::: {.callout-warning title="Prototypes"}
+**These are prototypes. Treat them as prototypes.** They are under active
+development, they are unstable, and they have not been validated with the
+readers they are for.
+:::
+
+| `PlotType` | emitted as |
+|---|---|
+| `ALLUVIAL` | `alluvial` |
+| `AREA` | `area` |
+| `BOXEN` | `boxen` |
+| `CHOROPLETH` | `choropleth` |
+| `CONTOUR` | `contour` |
+| `ERRORBAR` | `error_bar` |
+| `FUNNEL` | `funnel` |
+| `GANTT` | `gantt` |
+| `GAUGE` | `gauge` |
+| `HEXBIN` | `hexbin` |
+| `ICICLE` | `icicle` |
+| `LOLLIPOP` | `lollipop` |
+| `NORMALIZED` | `stacked_normalized_bar` |
+| `NORMALIZED_AREA` | `stacked_normalized_area` |
+| `PARALLEL` | `parallel_coordinates` |
+| `POLAR_AREA` | `polar_area` |
+| `RADAR` | `radar` |
+| `SANKEY` | `sankey` |
+| `STACKED_AREA` | `stacked_area` |
+| `SUNBURST` | `sunburst` |
+| `TREEMAP` | `treemap` |
+| `WATERFALL` | `waterfall` |
+
+What that means, concretely:
+
+- **Under active development.** These are being changed as they are used, not
+  maintained against a settled specification.
+- **Unstable.** Field names, announcement wording and navigation semantics may
+  change without a deprecation period, including in a patch release. Code that
+  depends on the exact shape one of these emits is pinned to the py-maidr
+  version it was written against.
+- **Not validated.** Each was measured against the chart it reads — that is what
+  the issues and the tests record. But measuring that a reading is *faithful to
+  the drawing* is a different claim from establishing that it is *useful to a
+  reader*. Nobody has asked a blind or low-vision reader whether navigating a
+  sunburst by depth, or hearing each parallel-coordinates axis on its own scale,
+  is the right way to read one. Until that happens these are proposals about how
+  a chart could be read — implemented, and measured against the drawing — rather
+  than answers.
+- **Not a support commitment.** A bug in one of these is worth reporting, and
+  reporting it is not a promise that the current behaviour will be kept.
+
+If you are building something that has to keep working, build it on the stable
+set. If you are exploring what a chart could sound like, the experimental set is
+exactly what it is for — and feedback on it is the thing that would move a type
+out of this list.
+
+## How the split is derived
+
+It is the diff of `PlotType` against `d9f7aee`, the last commit on `main` before
+[#345](https://github.com/xability/py-maidr/issues/345) was filed:
+
+```bash
+git show d9f7aee:maidr/core/enum/plot_type.py | grep -oE '^\s+[A-Z_0-9]+ = "[a-z_0-9]+"'
+```
+
+`tests/core/test_plot_type_stability.py` fails if a member of `PlotType` appears
+in neither table or in both, so a new plot type has to be placed deliberately
+rather than inherit either promise by being forgotten.
+
+## The same split upstream
+
+The JavaScript core makes the same distinction over its own `TraceType`, with
+the same boundary and for the same reason. See
+[Trace type stability](https://maidr.ai/SCHEMA.html#trace-type-stability) in the
+core schema documentation.

--- a/docs/stability.qmd
+++ b/docs/stability.qmd
@@ -113,5 +113,5 @@ rather than inherit either promise by being forgotten.
 
 The JavaScript core makes the same distinction over its own `TraceType`, with
 the same boundary and for the same reason. See
-[Trace type stability](https://maidr.ai/SCHEMA.html#trace-type-stability) in the
+[Trace type stability](https://maidr.ai/docs/SCHEMA.html#trace-type-stability) in the
 core schema documentation.

--- a/tests/core/test_plot_type_stability.py
+++ b/tests/core/test_plot_type_stability.py
@@ -1,0 +1,115 @@
+"""The stability split in ``docs/stability.qmd`` has to cover every plot type.
+
+The page divides :class:`PlotType` into a stable set and an experimental one,
+and the split is a promise to users: the stable set is what py-maidr was built
+around and has been exercised by real readers, and the experimental set is
+prototypes that may change in a patch release.
+
+A member that is in neither table inherits whichever promise the reader
+assumes, which is the failure this guards. Twenty-two types were added in about
+two weeks; at that rate a new one reaching the enum and not the page is the
+expected outcome, not an unlikely one.
+
+A member in *both* tables is the other direction of the same drift, and is
+worse, because each table reads as complete on its own.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from maidr.core.enum.plot_type import PlotType
+
+STABILITY_PAGE = Path(__file__).parents[2] / "docs" / "stability.qmd"
+
+
+def _section(heading: str) -> str:
+    """The body of one ``##`` section of the stability page.
+
+    Parameters
+    ----------
+    heading : str
+        The section heading, without the leading hashes.
+
+    Returns
+    -------
+    str
+        Everything between that heading and the next ``##`` heading.
+
+    Raises
+    ------
+    AssertionError
+        If the page no longer has the heading, so a rename fails here rather
+        than silently emptying the set it names.
+    """
+    text = STABILITY_PAGE.read_text(encoding="utf-8")
+    marker = f"\n## {heading}\n"
+    assert marker in text, f"docs/stability.qmd no longer has a '{heading}' section"
+
+    body = text.split(marker, 1)[1]
+    return body.split("\n## ", 1)[0]
+
+
+def _members(heading: str) -> set[str]:
+    """The ``PlotType`` member names named in one section's table."""
+    rows = re.findall(r"^\| `([A-Z_0-9]+)` \|", _section(heading), re.MULTILINE)
+    return set(rows)
+
+
+def test_every_plot_type_is_classified() -> None:
+    """No member may sit outside the split and inherit a promise by default."""
+    classified = _members("Stable") | _members("Experimental")
+
+    assert classified == {member.name for member in PlotType}
+
+
+def test_no_plot_type_is_in_both_sets() -> None:
+    """Each table reads as complete, so an overlap makes both of them wrong."""
+    assert _members("Stable") & _members("Experimental") == set()
+
+
+@pytest.mark.parametrize(
+    ("heading", "member"),
+    [
+        # `VIOLIN_KDE` is the last type added before the roadmap and `AREA` the
+        # first added after, so this pair is where an off-by-one in the
+        # boundary would show.
+        ("Stable", "VIOLIN_KDE"),
+        ("Experimental", "AREA"),
+    ],
+)
+def test_the_boundary_is_where_the_page_says_it_is(heading: str, member: str) -> None:
+    """Spot-check the split against ``d9f7aee``, the commit the page names."""
+    assert member in _members(heading)
+
+
+def test_the_page_says_what_experimental_does_not_promise() -> None:
+    """The tables alone would read as a changelog.
+
+    What makes the page usable is the claim attached to it, so the claim is
+    pinned too: softening the wording without revisiting the split fails here.
+    """
+    # Normalised, because these phrases are wrapped across lines in the
+    # source and a reflow should not be what breaks this test.
+    prose = " ".join(STABILITY_PAGE.read_text(encoding="utf-8").split())
+
+    assert "These are prototypes. Treat them as prototypes." in prose
+    assert "has been through a user study" in prose
+    assert "without a deprecation period" in prose
+
+
+def test_the_emitted_values_match_the_enum() -> None:
+    """A table row names both the member and the string it emits.
+
+    The second column is what reaches the MAIDR schema, so a wrong one sends a
+    reader looking for a type that never appears in the output.
+    """
+    text = STABILITY_PAGE.read_text(encoding="utf-8")
+    rows = re.findall(r"^\| `([A-Z_0-9]+)` \| `([a-z_0-9]+)` \|", text, re.MULTILINE)
+    assert rows, "the stability tables no longer pair a member with its value"
+
+    for name, emitted in rows:
+        assert PlotType[name].value == emitted

--- a/tests/core/test_plot_type_stability.py
+++ b/tests/core/test_plot_type_stability.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import pytest
 
 from maidr.core.enum.plot_type import PlotType
 
@@ -71,19 +70,50 @@ def test_no_plot_type_is_in_both_sets() -> None:
     assert _members("Stable") & _members("Experimental") == set()
 
 
-@pytest.mark.parametrize(
-    ("heading", "member"),
-    [
-        # `VIOLIN_KDE` is the last type added before the roadmap and `AREA` the
-        # first added after, so this pair is where an off-by-one in the
-        # boundary would show.
-        ("Stable", "VIOLIN_KDE"),
-        ("Experimental", "AREA"),
-    ],
-)
-def test_the_boundary_is_where_the_page_says_it_is(heading: str, member: str) -> None:
-    """Spot-check the split against ``d9f7aee``, the commit the page names."""
-    assert member in _members(heading)
+#: The stable set as it stood at ``d9f7aee``, the last commit before #345.
+#:
+#: Written out rather than spot-checked, so the whole classification is what
+#: the suite verifies. A contributor can otherwise misfile a type into the
+#: wrong table and still leave both tables internally consistent -- the
+#: partition check above would pass, and only this would notice.
+#:
+#: Re-derive with::
+#:
+#:     git show d9f7aee:maidr/core/enum/plot_type.py \
+#:       | grep -oE '^\s+[A-Z_0-9]+ = "[a-z_0-9]+"'
+STABLE_AT_D9F7AEE = {
+    "BAR",
+    "BOX",
+    "CANDLESTICK",
+    "COUNT",
+    "DODGED",
+    "HEAT",
+    "HIST",
+    "LINE",
+    "PIE",
+    "SCATTER",
+    "SMOOTH",
+    "STACKED",
+    "STEP",
+    "VIOLIN_BOX",
+    "VIOLIN_KDE",
+}
+
+
+def test_the_stable_set_is_exactly_the_one_that_predates_the_roadmap() -> None:
+    """The whole set, not a sample.
+
+    The partition check is satisfied by any split that covers the enum,
+    including a wrong one, so the boundary needs its own assertion.
+    """
+    assert _members("Stable") == STABLE_AT_D9F7AEE
+
+
+def test_everything_else_is_experimental() -> None:
+    """The complement, so a misfiled member fails from both directions."""
+    expected = {member.name for member in PlotType} - STABLE_AT_D9F7AEE
+
+    assert _members("Experimental") == expected
 
 
 def test_the_page_says_what_experimental_does_not_promise() -> None:


### PR DESCRIPTION
## What

`PlotType` defined **15** members when the plot coverage roadmap (#345) was filed. It defines **37** now. The 22 that arrived with the roadmap are not on the same footing as the 15 that predate it — most landed inside about two weeks, and **none has been through a user study** — but nothing in the enum or the docs said so.

This adds `docs/stability.qmd`, in the navbar, splitting the enum and stating what the experimental half does not promise.

## The boundary is measured, not editorial

It is the diff of `PlotType` against `d9f7aee`, the last commit on `main` before #345 was filed:

```bash
git show d9f7aee:maidr/core/enum/plot_type.py | grep -oE '^\s+[A-Z_0-9]+ = "[a-z_0-9]+"'
```

The stable set ends at `VIOLIN_KDE` / `VIOLIN_BOX`, which matches where the pre-roadmap work actually stopped.

## What the experimental set is told not to promise

- **Under active development** — changed as they are used, not maintained against a settled specification.
- **Unstable** — field names, announcement wording and navigation semantics may change without a deprecation period, including in a patch release. Code depending on the exact shape one emits is pinned to the version it was written against.
- **Not validated** — each was measured against the chart it reads, which is what the issues and tests record. Measuring that a reading is *faithful to the drawing* is a different claim from establishing that it is *useful to a reader*, and only the first has been done.
- **Not a support commitment.**

## The drift guard

`tests/core/test_plot_type_stability.py` fails if a member lands in **neither** table or in **both**. At 22 additions in two weeks, a new type reaching the enum and not the page is the expected outcome rather than an unlikely one, so the classification has to be a deliberate step.

It also checks each row's **second column** against the enum, since that string is what reaches the MAIDR schema — a wrong one would send a reader looking for a type that never appears in the output. The prose claims are pinned too, with whitespace normalised so a reflow is not what breaks them.

## Two things caught while writing it

- The `::: {.callout-warning}` block first used a `##` heading for its title, which silently truncated the section the test parses — the Experimental table came back empty and the test said so. Switched to `title="Prototypes"`.
- The cross-link to the core's schema pointed at `/SCHEMA.html`. Building the core's docs showed it renders to `/docs/SCHEMA.html`; corrected against the built site's own canonical URL and its `id="trace-type-stability"` anchor.

## Verified

```
ruff check tests/core/test_plot_type_stability.py   All checks passed
uv run pytest -q                                    3576 passed, 72 skipped
```

(`ruff check --diff` reports 37 fixable findings repo-wide, all in `example/*.ipynb` and all pre-existing — nothing in this diff.)

## Companions

The same split, same boundary, same reasoning, in the core and the R binding: xability/maidr#1208 and xability/r-maidr#287.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_