### PR TITLE
docs: add a word cloud example to the gallery

### DIFF
--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -299,11 +299,6 @@ cloud = WordCloud(
 ).generate_from_frequencies(mentions)
 
 fig, ax = plt.subplots(figsize=(8, 4))
-# A cloud has no x or y scale -- the glyph positions are packing, not data --
-# so the axis labels name what a point *holds* rather than where it sits.
-# Without them a term reads as "X: braille", which says nothing.
-ax.set_xlabel("Topic")
-ax.set_ylabel("Share of mentions")
 ax.set_title("What the accessibility reports talk about")
 ax.imshow(cloud) #<<
 ax.set_axis_off()
@@ -311,12 +306,18 @@ ax.set_axis_off()
 plt.show() #<<
 ```
 
-**The weights are relative, and the default axis label says so.** `WordCloud`
+A cloud has no x or y scale — the glyph positions are packing, not data —
+so maidr names the two axes after what a point *holds* rather than where it
+sits. No labels were set above, so the defaults fire and a term reads as
+"Term: braille, Relative frequency: 0.607". The generic "X"/"Y" the base
+class would otherwise give says nothing about a word.
+
+**The weights are relative, and that y axis name says so.** `WordCloud`
 divides every frequency by the largest one in `generate_from_frequencies` and
 keeps only the ratio — the raw counts are on no attribute of the object. So the
-counts above are announced as `1.0`, `0.728`, `0.607`, and the default y axis
-name is "Relative frequency" rather than "Occurrences". Naming it after counts
-would hand a reader "accessibility, 1.0" for a term that occurred 412 times.
+counts above are announced as `1.0`, `0.728`, `0.607`, and the axis is called
+"Relative frequency" rather than "Occurrences". Naming it after counts would
+hand a reader "accessibility, 1.0" for a term that occurred 412 times.
 
 That is also what the chart draws: glyph size is proportional to the ratio, so a
 reader hearing 1.0 and 0.728 hears what a sighted reader sees. (The R binding
@@ -327,6 +328,18 @@ two different honest readings.)
 `imshow` a plain RGB array, and the terms are not in it. A cloud displayed that
 way stays a picture and is not read — which is the honest answer, since the data
 never reached maidr.
+
+**Name the axes yourself if the defaults are too generic.** An authored label
+always wins, so a cloud over survey topics can say so:
+
+```python
+ax.set_xlabel("Topic")
+ax.set_ylabel("Share of mentions")
+```
+
+which reads as "Topic: braille, Share of mentions: 0.607". Keep the y name
+honest about being a ratio — "Occurrences" would be wrong for the same reason
+the default avoids it.
 
 **No highlighting.** `imshow` rasterises the whole cloud into a single image
 element, so there is no per-term element to outline. The reading ships without a

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -262,6 +262,76 @@ wedges around
 alone, so the data stays index-aligned with what is on screen.
 :::
 
+### Word Cloud
+
+A word cloud is the extreme case of a chart that carries real data while being
+readable only by eye: each term's weight is drawn as **glyph size** and written
+down nowhere on the page. Structurally it is a categorical label and a
+magnitude, so maidr reads it as a term and its number.
+
+`wordcloud` is an optional dependency — `pip install maidr[wordcloud]`.
+
+::: {.callout-warning title="Prototype"}
+`word_cloud` is one of the experimental plot types. It has not been through a
+user study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
+
+```{python}
+#| warning: false
+#| fig-alt: Word cloud of eight accessibility topics, sized by how often each was mentioned
+
+import matplotlib.pyplot as plt
+from wordcloud import WordCloud
+
+import maidr #<<
+
+mentions = {
+    "accessibility": 412, "sonification": 300, "braille": 250,
+    "screenreader": 190, "keyboard": 155, "contrast": 120,
+    "captions": 95, "semantics": 70,
+}
+
+# Pass the `WordCloud` object itself -- see the note below on `to_array()`.
+cloud = WordCloud(
+    width=800, height=400, background_color="white",
+    max_words=8, random_state=42,
+).generate_from_frequencies(mentions)
+
+fig, ax = plt.subplots(figsize=(8, 4))
+# A cloud has no x or y scale -- the glyph positions are packing, not data --
+# so the axis labels name what a point *holds* rather than where it sits.
+# Without them a term reads as "X: braille", which says nothing.
+ax.set_xlabel("Topic")
+ax.set_ylabel("Share of mentions")
+ax.set_title("What the accessibility reports talk about")
+ax.imshow(cloud) #<<
+ax.set_axis_off()
+
+plt.show() #<<
+```
+
+**The weights are relative, and the default axis label says so.** `WordCloud`
+divides every frequency by the largest one in `generate_from_frequencies` and
+keeps only the ratio — the raw counts are on no attribute of the object. So the
+counts above are announced as `1.0`, `0.728`, `0.607`, and the default y axis
+name is "Relative frequency" rather than "Occurrences". Naming it after counts
+would hand a reader "accessibility, 1.0" for a term that occurred 412 times.
+
+That is also what the chart draws: glyph size is proportional to the ratio, so a
+reader hearing 1.0 and 0.728 hears what a sighted reader sees. (The R binding
+*is* handed the raw counts, so it can honestly say "Occurrences" — same chart,
+two different honest readings.)
+
+**Show the object, not the picture.** `wc.to_array()` and `wc.to_image()` hand
+`imshow` a plain RGB array, and the terms are not in it. A cloud displayed that
+way stays a picture and is not read — which is the honest answer, since the data
+never reached maidr.
+
+**No highlighting.** `imshow` rasterises the whole cloud into a single image
+element, so there is no per-term element to outline. The reading ships without a
+visual highlight rather than pairing the terms with some other layer's marks.
+
 ### Histogram
 
 ```{python}

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -264,19 +264,18 @@ alone, so the data stays index-aligned with what is on screen.
 
 ### Word Cloud
 
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
+
 A word cloud is the extreme case of a chart that carries real data while being
 readable only by eye: each term's weight is drawn as **glyph size** and written
 down nowhere on the page. Structurally it is a categorical label and a
 magnitude, so maidr reads it as a term and its number.
 
 `wordcloud` is an optional dependency — `pip install maidr[wordcloud]`.
-
-::: {.callout-warning title="Prototype"}
-`word_cloud` is one of the experimental plot types. It has not been through a
-user study, and it may change without a deprecation period. See
-[Plot type stability](stability.qmd).
-:::
-
 ```{python}
 #| warning: false
 #| fig-alt: Word cloud of eight accessibility topics, sized by how often each was mentioned
@@ -590,6 +589,12 @@ plt.show() #<<
 
 ### Hexbin Plot
 
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
+
 A hexbin is the usual answer to a scatter plot with too many points to read:
 the points are binned into hexagons and the count is shown as fill. maidr reads
 it as a lattice of counted cells, one row at a time.
@@ -660,6 +665,12 @@ plt.show() #<<
 ```
 
 ### Boxen Plot (Letter-Value Plot)
+
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
 
 ```{python}
 #| fig-alt: Boxen plot of diamond price by cut quality, showing the letter-value ladder
@@ -774,6 +785,12 @@ plt.show() #<<
 
 ### Error Bar Plot
 
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
+
 Uncertainty is usually the finding, not the decoration: whether two group means
 differ is answered by whether their intervals overlap. `ax.errorbar()` draws
 that, and maidr reads the estimate **and** its interval, so the comparison the
@@ -813,6 +830,12 @@ plt.show() #<<
 ```
 
 ### Area Plot
+
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
 
 `ax.stackplot()` reads as an area chart rather than a line one, and the
 distinction matters: a stacked area draws **two** numbers at each point that a

--- a/example/wordcloud/matplotlib/example_mpl_wordcloud.py
+++ b/example/wordcloud/matplotlib/example_mpl_wordcloud.py
@@ -1,0 +1,51 @@
+"""Read a `wordcloud.WordCloud` shown with `imshow` as a word cloud.
+
+Requires the optional extra: `pip install maidr[wordcloud]`.
+
+A word cloud draws each term's weight as glyph size and writes it down
+nowhere, so the reading is a term and its number. `WordCloud` normalises
+every frequency by the largest one and keeps only the ratio, which is why
+the weight axis is named "Share of mentions" rather than a count.
+"""
+
+import matplotlib.pyplot as plt
+from wordcloud import WordCloud
+
+import maidr  # noqa: F401
+
+# Raw counts. `generate_from_frequencies` divides these by the largest, so
+# maidr announces 1.0, 0.728, 0.607 ... rather than 412, 300, 250.
+mentions = {
+    "accessibility": 412,
+    "sonification": 300,
+    "braille": 250,
+    "screenreader": 190,
+    "keyboard": 155,
+    "contrast": 120,
+    "captions": 95,
+    "semantics": 70,
+}
+
+# Pass the `WordCloud` object itself. `wc.to_array()` and `wc.to_image()`
+# hand `imshow` a plain RGB array with the terms nowhere in it, and such a
+# figure stays an unread picture.
+cloud = WordCloud(
+    width=800,
+    height=400,
+    background_color="white",
+    max_words=8,
+    random_state=42,
+).generate_from_frequencies(mentions)
+
+fig, ax = plt.subplots(figsize=(8, 4))
+
+# A cloud has no x or y scale -- the glyph positions are packing, not data --
+# so the axis labels name what a point holds rather than where it sits.
+ax.set_xlabel("Topic")
+ax.set_ylabel("Share of mentions")
+ax.set_title("What the accessibility reports talk about")
+
+ax.imshow(cloud)
+ax.set_axis_off()
+
+plt.show()

--- a/example/wordcloud/matplotlib/example_mpl_wordcloud.py
+++ b/example/wordcloud/matplotlib/example_mpl_wordcloud.py
@@ -4,8 +4,11 @@ Requires the optional extra: `pip install maidr[wordcloud]`.
 
 A word cloud draws each term's weight as glyph size and writes it down
 nowhere, so the reading is a term and its number. `WordCloud` normalises
-every frequency by the largest one and keeps only the ratio, which is why
-the weight axis is named "Share of mentions" rather than a count.
+every frequency by the largest one and keeps only the ratio, so the weight
+is a share rather than a count -- maidr's default axis name is "Relative
+frequency" for that reason. This script names the axes itself, since an
+authored label always wins and "Share of mentions" says the same thing in
+the language of this data.
 """
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## What this adds

A worked word cloud example in the docs gallery, plus the standalone sample under `example/wordcloud/matplotlib/`.

## Why

`word_cloud` merged in #688 with only a row in `docs/stability.qmd` naming it. A reader could learn the type exists but not how to produce one.

That was an inconsistency rather than a deliberate scope cut — four other **experimental** types already carry example sections in this same file:

| Experimental type | Example in `examples.qmd` |
|---|---|
| Hexbin | yes |
| Boxen | yes |
| Error Bar | yes |
| Area | yes |
| **Word Cloud** | **was missing** |

## What the section covers

Placed after Pie Chart — the other chart here with no positional scale — and it covers the three things that are not obvious from the API:

- **The weights are relative, and the default axis label says so.** `generate_from_frequencies` divides every frequency by the largest and keeps only the ratio, so 412 is announced as `1.0` and the y axis is named "Relative frequency". Naming it after counts would hand a reader "accessibility, 1.0" for a term that occurred 412 times. The note also says the R binding *is* handed the raw counts and can honestly say "Occurrences" — same chart, two different honest readings.
- **Show the object, not the picture.** `wc.to_array()` and `wc.to_image()` hand `imshow` a plain RGB array with the terms nowhere in it, so such a figure stays an unread picture.
- **No highlighting**, because `imshow` rasterises the cloud into a single element and there is no per-term element to outline.

A `callout-warning` marks it as a prototype and links to `stability.qmd`, matching how that page describes the experimental tier.

## Verification

The example code was **run before being written down**, not composed and hoped for:

```
type      : PlotType.WORD_CLOUD
axes      : {x: 'Topic', y: 'Share of mentions'}
n points  : 8
first 3   : accessibility 1.0 | sonification 0.728 | braille 0.607
has selector: False
```

- `ruff check` clean on the new example script.
- Word cloud and stability tests pass (18).
- The docs job runs `uv sync --locked --all-extras --dev`, and #688 put `wordcloud` in both the `wordcloud` extra and the dev group, so it is present at render time.

Quarto is not installed in this environment, so the page was not rendered locally — the substantive risk is the Python chunk, and that was executed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015TFhhzxcMetSHV7z9NCrJ8)_