### PR TITLE
docs: add gallery examples for three experimental matplotlib plot types

### DIFF
--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -635,6 +635,54 @@ count with a reduction of the values you supply, and a numeric `bins=`
 discretises the counts so the colour shows *which interval* a bin landed in.
 Pass `z_label=` to name it yourself.
 
+### Contour Plot
+
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
+
+A contour plot draws a surface as a set of level curves, each joining the
+points where the surface has one particular height. maidr reads the **levels
+themselves**: navigation walks one curve at a time, and every point on a
+curve carries the level it belongs to, so the height is never something you
+have to infer from position.
+
+That is the difference between a contour and a heatmap of the same surface.
+A heatmap gives you one number per cell on a fixed grid; a contour gives you
+the shape of a chosen height, which is what the chart was drawn to show.
+
+```{python}
+#| fig-alt: Contour plot of a two-dimensional Gaussian surface
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import maidr #<<
+
+x = np.linspace(-3, 3, 80)
+y = np.linspace(-3, 3, 80)
+grid_x, grid_y = np.meshgrid(x, y)
+height = np.exp(-(grid_x**2 + grid_y**2) / 2)
+
+fig, ax = plt.subplots(figsize=(7, 6))
+contours = ax.contour(grid_x, grid_y, height, levels=6) #<<
+ax.clabel(contours, inline=True, fontsize=8)
+ax.set_xlabel("x")
+ax.set_ylabel("y")
+ax.set_title("A Gaussian surface, six levels")
+
+plt.show() #<<
+```
+
+`levels=` decides how many curves are drawn, and the reading follows it
+exactly — ask for six and you navigate six, because maidr reads the curves
+matplotlib actually produced rather than re-deriving its own.
+
+A bivariate `sns.kdeplot(x=..., y=...)` draws its density the same way and
+gets the same reading.
+
 ### Box Plot
 
 ```{python}
@@ -904,6 +952,51 @@ than the height of either, so announcing it as an area would report the upper
 edge as a magnitude and drop the lower one. Those charts render as a static
 image for now; see [issue #339](https://github.com/xability/py-maidr/issues/339).
 
+### Stacked Area Plot
+
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
+
+`ax.stackplot()` stacks several series so the top edge is their total and each
+band's *thickness* is that series' contribution. maidr reads one layer per
+band, so navigation walks a single series at a time and up/down moves between
+them.
+
+The thickness is the point. A stacked area is read as the value each series
+contributes, not as the cumulative height its top edge sits at — the latter is
+a drawing artefact of what happens to be stacked underneath it.
+
+```{python}
+#| fig-alt: Stacked area chart of three revenue channels across eight quarters
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import maidr #<<
+
+quarters = np.arange(1, 9)
+direct = [12, 14, 15, 19, 22, 24, 27, 31]
+partner = [8, 9, 11, 11, 13, 16, 17, 18]
+online = [3, 5, 8, 12, 17, 21, 26, 33]
+
+fig, ax = plt.subplots(figsize=(8, 5))
+ax.stackplot( #<<
+    quarters, direct, partner, online, labels=["Direct", "Partner", "Online"]
+)
+ax.set_xlabel("Quarter")
+ax.set_ylabel("Revenue (millions)")
+ax.set_title("Revenue by channel")
+ax.legend(loc="upper left")
+
+plt.show() #<<
+```
+
+Pass `labels=` and each band is announced by name. Without it the bands are
+still read, but they can only be told apart by their order in the stack.
+
 ### Point Plot
 
 `sns.pointplot()` is the same reading from the other direction: it estimates a
@@ -934,6 +1027,39 @@ sns.pointplot( #<<
 ax.set_title("Mean Body Mass by Species, with 95% Confidence Intervals")
 ax.set_xlabel("Species")
 ax.set_ylabel("Body Mass (g)")
+
+plt.show() #<<
+```
+
+### Lollipop Plot
+
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
+
+`ax.stem()` draws a stem down to each value with a marker at the top — a bar
+chart with the bars thinned to lines, which is the usual answer when there are
+too many categories for bars to stay readable. maidr reads it as a lollipop:
+one term per stem, carrying its value.
+
+```{python}
+#| fig-alt: Lollipop chart of eight measurements
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import maidr #<<
+
+positions = np.arange(1, 9)
+values = [2.1, 5.4, 3.3, 9.2, 4.0, 7.1, 6.4, 8.3]
+
+fig, ax = plt.subplots(figsize=(8, 5))
+ax.stem(positions, values) #<<
+ax.set_xlabel("Sample")
+ax.set_ylabel("Concentration (mg/L)")
+ax.set_title("Concentration by sample")
 
 plt.show() #<<
 ```
@@ -1228,6 +1354,62 @@ plt.show() #<<
 ```
 
 ## Reactive Dashboard
+
+### Gantt Chart
+
+::: {.callout-warning title="Prototype"}
+This is one of the experimental plot types. It has not been through a user
+study, and it may change without a deprecation period. See
+[Plot type stability](stability.qmd).
+:::
+
+`ax.broken_barh()` draws horizontal bars that start and stop along an axis,
+which is what a schedule looks like. maidr reads it as a gantt: every bar is a
+**span**, carrying both its start and its end rather than a single position,
+so a reader hears when a task begins, when it finishes, and therefore how long
+it runs.
+
+The whole chart is one layer, organised into **lanes**. Each `broken_barh()`
+call contributes one lane, and the spans passed in that call are the spans of
+that lane — so a phase that stops and restarts is two spans on one lane, not
+two separate rows.
+
+```{python}
+#| fig-alt: Gantt chart of three project phases across a thirteen-week schedule
+
+import matplotlib.pyplot as plt
+
+import maidr #<<
+
+fig, ax = plt.subplots(figsize=(8, 4))
+
+# One call is one lane. A lane can hold several spans: "Build" runs for four
+# weeks, pauses for one, then resumes for three.
+ax.broken_barh([(0, 3)], (10, 6)) #<<
+ax.broken_barh([(3, 4), (8, 3)], (20, 6)) #<<
+ax.broken_barh([(11, 2)], (30, 6)) #<<
+
+ax.set_xlabel("Week")
+ax.set_ylabel("Phase")
+ax.set_yticks([13, 23, 33])
+ax.set_yticklabels(["Design", "Build", "Launch"])
+ax.set_title("Project schedule")
+
+plt.show() #<<
+```
+
+Set the y tick labels and the lanes are announced by name. Without them a lane
+falls back to the centre of the row it was drawn on — the `(10, 6)` above puts
+one at 13 — which is a position rather than a name. Measured on the three lanes
+above:
+
+| y ticks | lanes announced as |
+|---|---|
+| `set_yticklabels(["Design", "Build", "Launch"])` | `Design`, `Build`, `Launch` |
+| not set | `13.0`, `23.0`, `33.0` |
+
+`label=` is the argument that looks like it should do this, and it does not —
+it adds a legend entry and leaves the lane unnamed.
 
 ### Shiny
 

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -929,6 +929,9 @@ ax.legend(loc="upper left")
 plt.show() #<<
 ```
 
+Pass `labels=` and each band is announced by name. Without it the bands are
+still read, but they can only be told apart by their order in the stack.
+
 `ax.fill_between()` reads as an area too, when it draws one: `fill_between(x,
 y)` fills from zero up to a curve, which is the same chart a single
 `stackplot` band draws. `ax.fill_betweenx()` is the same picture turned over
@@ -960,56 +963,6 @@ does not read it as an area. Its content is the gap between the edges rather
 than the height of either, so announcing it as an area would report the upper
 edge as a magnitude and drop the lower one. Those charts render as a static
 image for now; see [issue #339](https://github.com/xability/py-maidr/issues/339).
-
-### Stacked Area Plot
-
-::: {.callout-warning title="Prototype"}
-This is one of the experimental plot types. It has not been through a user
-study, and it may change without a deprecation period. See
-[Plot type stability](stability.qmd).
-:::
-
-`ax.stackplot()` stacks several series so the top edge is their total and each
-band's *thickness* is that series' contribution. maidr reads one series per
-band within a single layer, so navigation walks one band at a time and up/down
-moves between them.
-
-A stack draws **two** numbers at every point, and both are read: the band's
-own value, which is its thickness, and the running total its top edge sits at.
-That is exactly why a stacked area is its own layer type rather than a line —
-a line announces one number per point with nothing to say which of the two it
-is, so the area trace announces the value and reports the total beside it.
-
-A single band is a plain `area` instead, since nothing is stacked on it and a
-running total equal to its own value at every point would just be noise.
-
-```{python}
-#| fig-alt: Stacked area chart of three revenue channels across eight quarters
-
-import matplotlib.pyplot as plt
-import numpy as np
-
-import maidr #<<
-
-quarters = np.arange(1, 9)
-direct = [12, 14, 15, 19, 22, 24, 27, 31]
-partner = [8, 9, 11, 11, 13, 16, 17, 18]
-online = [3, 5, 8, 12, 17, 21, 26, 33]
-
-fig, ax = plt.subplots(figsize=(8, 5))
-ax.stackplot( #<<
-    quarters, direct, partner, online, labels=["Direct", "Partner", "Online"]
-)
-ax.set_xlabel("Quarter")
-ax.set_ylabel("Revenue (millions)")
-ax.set_title("Revenue by channel")
-ax.legend(loc="upper left")
-
-plt.show() #<<
-```
-
-Pass `labels=` and each band is announced by name. Without it the bands are
-still read, but they can only be told apart by their order in the stack.
 
 ### Point Plot
 

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -676,9 +676,18 @@ ax.set_title("A Gaussian surface, six levels")
 plt.show() #<<
 ```
 
-`levels=` decides how many curves are drawn, and the reading follows it
-exactly — ask for six and you navigate six, because maidr reads the curves
-matplotlib actually produced rather than re-deriving its own.
+`levels=` asks for a number of heights, not a number of curves, and the
+reading follows the curves matplotlib actually drew rather than re-deriving
+its own. On a single-peaked surface like this one the two coincide — six
+levels, six curves. On a surface where one height is crossed in more than one
+place they do not, because each closed island is its own curve to walk:
+
+| surface | `levels=` | curves read |
+|---|---|---|
+| one peak | 6 | 6 |
+| two peaks | 6 | 12 |
+
+A level that nothing on the surface reaches contributes no curve at all.
 
 A bivariate `sns.kdeplot(x=..., y=...)` draws its density the same way and
 gets the same reading.
@@ -965,9 +974,14 @@ band's *thickness* is that series' contribution. maidr reads one series per
 band within a single layer, so navigation walks one band at a time and up/down
 moves between them.
 
-The thickness is the point. A stacked area is read as the value each series
-contributes, not as the cumulative height its top edge sits at — the latter is
-a drawing artefact of what happens to be stacked underneath it.
+A stack draws **two** numbers at every point, and both are read: the band's
+own value, which is its thickness, and the running total its top edge sits at.
+That is exactly why a stacked area is its own layer type rather than a line —
+a line announces one number per point with nothing to say which of the two it
+is, so the area trace announces the value and reports the total beside it.
+
+A single band is a plain `area` instead, since nothing is stacked on it and a
+running total equal to its own value at every point would just be noise.
 
 ```{python}
 #| fig-alt: Stacked area chart of three revenue channels across eight quarters

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -961,9 +961,9 @@ study, and it may change without a deprecation period. See
 :::
 
 `ax.stackplot()` stacks several series so the top edge is their total and each
-band's *thickness* is that series' contribution. maidr reads one layer per
-band, so navigation walks a single series at a time and up/down moves between
-them.
+band's *thickness* is that series' contribution. maidr reads one series per
+band within a single layer, so navigation walks one band at a time and up/down
+moves between them.
 
 The thickness is the point. A stacked area is read as the value each series
 contributes, not as the cumulative height its top edge sits at — the latter is
@@ -1396,15 +1396,18 @@ ax.set_title("Project schedule")
 plt.show() #<<
 ```
 
-Set the y tick labels and the lanes are announced by name. Without them a lane
+Naming the lanes takes **both** `set_yticks()` and `set_yticklabels()`, as the
+example does. Labels alone are ignored, because a lane name is only trusted
+when the axis carries fixed tick positions to attach it to; otherwise a lane
 falls back to the centre of the row it was drawn on — the `(10, 6)` above puts
-one at 13 — which is a position rather than a name. Measured on the three lanes
-above:
+one at 13. Measured on the three lanes above:
 
-| y ticks | lanes announced as |
+| what the axis sets | lanes announced as |
 |---|---|
-| `set_yticklabels(["Design", "Build", "Launch"])` | `Design`, `Build`, `Launch` |
-| not set | `13.0`, `23.0`, `33.0` |
+| `set_yticks()` and `set_yticklabels()` | `Design`, `Build`, `Launch` |
+| `set_yticklabels()` alone | `13.0`, `23.0`, `33.0` |
+| `set_yticks()` alone | `13`, `23`, `33` |
+| neither | `13.0`, `23.0`, `33.0` |
 
 `label=` is the argument that looks like it should do this, and it does not —
 it adds a legend entry and leaves the lane unnamed.

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -1353,8 +1353,6 @@ fig.tight_layout()
 plt.show() #<<
 ```
 
-## Reactive Dashboard
-
 ### Gantt Chart
 
 ::: {.callout-warning title="Prototype"}
@@ -1410,6 +1408,8 @@ above:
 
 `label=` is the argument that looks like it should do this, and it does not —
 it adds a legend entry and leaves the lane unnamed.
+
+## Reactive Dashboard
 
 ### Shiny
 


### PR DESCRIPTION
## What

Adds gallery examples for three experimental plot types that py-maidr supports and that had no worked example anywhere in the docs: **contour**, **lollipop**, and **gantt**.

New sections in `docs/examples.qmd`, each placed next to the reading it relates to — Contour after Hexbin, Lollipop after Point, Gantt after Candlestick, before `## Reactive Dashboard`. Each carries the standard prototype callout the other experimental sections use.

| Section | Drawn by | Read as |
|---|---|---|
| Contour Plot | `ax.contour`, bivariate `sns.kdeplot` | `contour` |
| Lollipop Plot | `ax.stem` | `lollipop` |
| Gantt Chart | `ax.broken_barh` | `gantt` |

## Measured, not asserted

Every chunk was extracted from the committed file and executed against an installed build, and the emitted layer type, point count and axis labels recorded:

```
Contour Plot   contour    n=6                                   [x=x | y=y]
Lollipop Plot  lollipop   n=8    [x=Sample | y=Concentration (mg/L)]
Gantt Chart    gantt      lanes=['Design', 'Build', 'Launch']   [x=Week | y=Phase]
```

Two gantt claims are worth calling out because measurement corrected what I first assumed:

- **`broken_barh` is one layer, not one per call.** The chart is a single `gantt` layer whose `data` is `{"points": [...], "lanes": [...]}`. Each call contributes one *lane*; the spans in that call are that lane's spans. A phase that stops and restarts is two spans on one lane, not two rows.

- **Naming a lane takes `set_yticks()` *and* `set_yticklabels()`.** `label=` looks like the argument for it and is not — it adds a legend entry. Measured across all four combinations:

  | what the axis sets | lanes announced as |
  |---|---|
  | `set_yticks()` and `set_yticklabels()` | `Design`, `Build`, `Launch` |
  | `set_yticklabels()` alone | `13.0`, `23.0`, `33.0` |
  | `set_yticks()` alone | `13`, `23`, `33` |
  | neither | `13.0`, `23.0`, `33.0` |

For contour, `levels=` is a count of heights rather than of curves — a height crossed in two places draws one closed island per place, so a two-peaked surface gives 12 curves for `levels=6` while this section's single-peaked one gives 6. The section states the dependency rather than the coincidence.

This is a docs-only change; no package code is touched.

## Changed during review

Three review findings, all real, all fixed:

- Gantt was nested under `## Reactive Dashboard` — I anchored the insertion on `### Shiny` and missed the level-2 heading between it and Candlestick (`a6e30e5`).
- The lane table credited `set_yticklabels()` alone, and "one layer per band" for stacked area contradicted the layer/lane distinction drawn two sections down (`eaa64a2`).
- The stacked area section claimed the running total was "a drawing artefact" not part of the reading. The opposite is true and the docstrings say so — it is the stated reason `stacked_area` is distinct from `line`. I had measured the emitted payload and drawn a conclusion about the announcement that the payload does not support (`189dba8`).

**A stacked area section is no longer part of this PR** (`b7f3625`). It turned out to be redundant: the existing "Area Plot" section's example is already `ax.stackplot()` with two series, which `resolve_type()` makes a `stacked_area`, and its prose already carries the two-numbers framing. My original premise that stacked area had no example was wrong — I enumerated headings without reading them, and the heading is named for the function rather than the type. The one fact it added that the existing section lacked, what `labels=` changes about the reading, is folded into that section instead.

## Still missing

The plotly gallery (`docs/examples-plotly.qmd`) has no experimental types at all — waterfall, funnel, gauge, sankey, treemap, sunburst, icicle, parallel coordinates, alluvial, choropleth, polar area, radar, and 100% stacked bar. All measured as reachable; will follow up separately rather than grow this diff. The 100% stacked *area* is held back pending #691.