### PR TITLE
perf(highlight): look each drawn artist up in a per-render dict instead of scanning the tagged list

### DIFF
--- a/maidr/core/context_manager.py
+++ b/maidr/core/context_manager.py
@@ -108,12 +108,12 @@ class HighlightContextManager:
     )
 
     @classmethod
-    def is_maidr_element(cls, id):
-        return id in cls._elements.get({})
+    def is_maidr_element(cls, gid):
+        return gid in cls._elements.get({})
 
     @classmethod
-    def get_selector_id(cls, id):
-        return cls._elements.get({})[id]
+    def get_selector_id(cls, gid):
+        return cls._elements.get({})[gid]
 
     @classmethod
     @contextlib.contextmanager

--- a/maidr/core/context_manager.py
+++ b/maidr/core/context_manager.py
@@ -140,6 +140,14 @@ class HighlightContextManager:
         # dict installed once would still be shared across every concurrent
         # render. See the class docstring.
         #
+        # `zip` would silently drop the tail of a mismatched pair, where the
+        # old `selector_ids[index]` raised; keep the failure loud.
+        if len(elements) != len(selector_ids):
+            raise ValueError(
+                f"{len(elements)} elements to highlight but "
+                f"{len(selector_ids)} selector ids; they must pair one to one"
+            )
+
         # `setdefault` keeps the first selector for an artist listed twice,
         # which is what `list.index` gave and what #376 relies on.
         selector_by_element: dict = {}

--- a/maidr/core/context_manager.py
+++ b/maidr/core/context_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
-import threading
 
 import wrapt
 
@@ -10,17 +9,7 @@ from maidr.core.plot.boxplot import BoxPlotContainer
 
 
 class ContextManager:
-    _instance = None
-    _lock = threading.Lock()
-
     _internal_context = contextvars.ContextVar("internal_context", default=False)
-
-    def __new__(cls):
-        if not cls._instance:
-            with cls._lock:
-                if not cls._instance:
-                    cls._instance = super(ContextManager, cls).__new__()
-        return cls._instance
 
     @classmethod
     def is_internal_context(cls):
@@ -85,8 +74,8 @@ class HighlightContextManager:
     As plain class attributes it was safe only because every render ran
     serialised on one thread. It stopped being safe when the Shiny renderer
     began rendering off the event loop (#504): two **different** figures
-    drawing at once would overwrite each other's ``elements_to_highlight``,
-    and artists checked after the overwrite would match nothing, so
+    drawing at once would overwrite each other's tagged artists, and
+    artists checked after the overwrite would match nothing, so
     ``XMLWriter.start`` never injected their ``maidr`` attribute. Measured
     before the change -- four concurrent renders of distinct figures went
     from 61 selectors each to ``[7, 1, 1, 1]``. A valid SVG, with the
@@ -105,25 +94,18 @@ class HighlightContextManager:
     mapping for each render rather than mutating one in place.
     """
 
-    _instance = None
-    _lock = threading.Lock()
-
     _elements: contextvars.ContextVar[dict] = contextvars.ContextVar(
         "maidr_highlight_elements"
     )
-    _elements_to_highlight: contextvars.ContextVar[list] = contextvars.ContextVar(
-        "maidr_elements_to_highlight"
+    # Keyed by `id(artist)`, not the artist: `Artist` does not define
+    # `__eq__`, so the list `in`/`index` this replaced were identity tests
+    # already, and a dict makes each draw a lookup instead of a scan of the
+    # whole tagged list -- which made a render quadratic in its artists,
+    # 2 s of a 5 s render at 5000 bars (#695). An id cannot be reused
+    # mid-render: the figure being drawn owns every artist in the mapping.
+    _selector_by_element: contextvars.ContextVar[dict] = contextvars.ContextVar(
+        "maidr_selector_by_element"
     )
-    _selector_ids: contextvars.ContextVar[list] = contextvars.ContextVar(
-        "maidr_selector_ids"
-    )
-
-    def __new__(cls):
-        if not cls._instance:
-            with cls._lock:
-                if not cls._instance:
-                    cls._instance = super(HighlightContextManager, cls).__new__()
-        return cls._instance
 
     @classmethod
     def is_maidr_element(cls, id):
@@ -135,18 +117,20 @@ class HighlightContextManager:
 
     @classmethod
     @contextlib.contextmanager
-    def set_maidr_element(cls, element, id):
-        to_highlight = cls._elements_to_highlight.get([])
-        if element not in to_highlight:
+    def set_maidr_element(cls, element, gid):
+        # `gid`, not `id` as the neighbours have it: this one needs the
+        # builtin to key the lookup.
+        selector_id = cls._selector_by_element.get({}).get(id(element))
+        if selector_id is None:
             yield
             return
 
         elements = cls._elements.get({})
         try:
-            elements[id] = cls._selector_ids.get([])[to_highlight.index(element)]
+            elements[gid] = selector_id
             yield
         finally:
-            del elements[id]
+            del elements[gid]
 
     @classmethod
     @contextlib.contextmanager
@@ -155,12 +139,17 @@ class HighlightContextManager:
         # `copy_context()` copies the variable-to-value mapping, so a single
         # dict installed once would still be shared across every concurrent
         # render. See the class docstring.
+        #
+        # `setdefault` keeps the first selector for an artist listed twice,
+        # which is what `list.index` gave and what #376 relies on.
+        selector_by_element: dict = {}
+        for element, selector_id in zip(elements, selector_ids):
+            selector_by_element.setdefault(id(element), selector_id)
+
         token_elements = cls._elements.set({})
-        token_to_highlight = cls._elements_to_highlight.set(elements)
-        token_selectors = cls._selector_ids.set(selector_ids)
+        token_selectors = cls._selector_by_element.set(selector_by_element)
         try:
             yield
         finally:
             cls._elements.reset(token_elements)
-            cls._elements_to_highlight.reset(token_to_highlight)
-            cls._selector_ids.reset(token_selectors)
+            cls._selector_by_element.reset(token_selectors)

--- a/tests/core/test_highlight_context_manager.py
+++ b/tests/core/test_highlight_context_manager.py
@@ -1,0 +1,121 @@
+"""``HighlightContextManager`` resolves a drawn artist to its selector by lookup.
+
+Each artist ``draw`` asks the manager which selector, if any, the artist
+belongs to. That used to be a scan of the render's tagged list -- ``in``
+followed by ``index`` -- so a render with *n* tagged artists cost *n*
+squared comparisons, 2 s of a 5 s render at 5000 bars (#695). It is now a
+dict keyed by ``id(artist)``, which is what the scan was testing anyway:
+``Artist`` has no ``__eq__``.
+
+The rules the scan enforced have to survive the change, and these tests
+state them: an artist tagged twice keeps its *first* selector (#376), an
+artist never tagged is left alone, and a rendered chart carries exactly one
+``maidr`` attribute per bar, with the layer's selector on each. One test
+pins the change itself: resolving an artist no longer compares it against
+the others, which is the scan that made a render quadratic.
+"""
+
+from __future__ import annotations
+
+import re
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+from matplotlib.patches import Rectangle  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.context_manager import HighlightContextManager  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def test_resolving_an_artist_does_not_compare_it_against_the_rest():
+    """The lookup is by ``id``, so no tagged artist is ever asked ``__eq__``.
+
+    A list scan asks every earlier artist to compare itself to the one being
+    drawn -- twice, once for ``in`` and once for ``index`` -- which is the
+    quadratic cost of #695. Counting those calls fails on the scan and passes
+    on the dict, without timing anything on a shared machine.
+    """
+
+    class Counting:
+        comparisons = 0
+
+        def __eq__(self, other):
+            Counting.comparisons += 1
+            return self is other
+
+    tagged = [Counting() for _ in range(100)]
+    selectors = [f"selector-{i}" for i in range(100)]
+
+    with HighlightContextManager.set_maidr_elements(tagged, selectors):
+        with HighlightContextManager.set_maidr_element(tagged[-1], "gid-last"):
+            assert HighlightContextManager.get_selector_id("gid-last") == (
+                "selector-99"
+            )
+
+    assert Counting.comparisons == 0, (
+        f"the lookup compared the drawn artist against {Counting.comparisons} "
+        "others -- that is a list scan, not a dict lookup"
+    )
+
+
+def test_an_artist_tagged_twice_keeps_its_first_selector():
+    """``list.index`` parity: the first listing wins, which #376 relies on."""
+    shared = Rectangle((0, 0), 1, 1)
+    other = Rectangle((1, 0), 1, 1)
+
+    with HighlightContextManager.set_maidr_elements(
+        [shared, other, shared], ["first", "second", "third"]
+    ):
+        with HighlightContextManager.set_maidr_element(shared, "gid-shared"):
+            assert HighlightContextManager.get_selector_id("gid-shared") == "first"
+        with HighlightContextManager.set_maidr_element(other, "gid-other"):
+            assert HighlightContextManager.get_selector_id("gid-other") == "second"
+
+
+def test_an_artist_that_was_never_tagged_is_left_alone():
+    tagged = Rectangle((0, 0), 1, 1)
+    untagged = Rectangle((1, 0), 1, 1)
+
+    with HighlightContextManager.set_maidr_elements([tagged], ["only"]):
+        with HighlightContextManager.set_maidr_element(untagged, "gid-untagged"):
+            assert not HighlightContextManager.is_maidr_element("gid-untagged")
+        # Leaving the draw removes the entry again, so a gid is only ever
+        # resolvable while its artist is being written.
+        with HighlightContextManager.set_maidr_element(tagged, "gid-tagged"):
+            assert HighlightContextManager.is_maidr_element("gid-tagged")
+        assert not HighlightContextManager.is_maidr_element("gid-tagged")
+
+
+def test_outside_a_render_nothing_is_tagged():
+    """The class-wide ``draw`` patch runs for every figure, rendered or not."""
+    with HighlightContextManager.set_maidr_element(Rectangle((0, 0), 1, 1), "gid"):
+        assert not HighlightContextManager.is_maidr_element("gid")
+
+
+def test_a_rendered_bar_chart_carries_one_selector_per_bar():
+    """End to end: each bar's ``<g>`` gets the layer's selector, and only those."""
+    fig, ax = plt.subplots()
+    bars = ax.bar(["a", "b", "c", "d"], [1, 2, 3, 4])
+
+    chart = FigureManager.get_maidr(fig)
+    html = str(chart._create_html_tag(use_iframe=False, use_cdn=True))
+
+    (selector_id,) = chart.selector_ids
+    tagged = re.findall(r'<g id="([^"]+)" maidr="([^"]+)"', html)
+
+    assert [gid for gid, _ in tagged] == [
+        bar.get_gid() for bar in bars
+    ], "every bar, in draw order, and nothing else"
+    assert {selector for _, selector in tagged} == {selector_id}

--- a/tests/core/test_highlight_context_manager.py
+++ b/tests/core/test_highlight_context_manager.py
@@ -98,6 +98,15 @@ def test_an_artist_that_was_never_tagged_is_left_alone():
         assert not HighlightContextManager.is_maidr_element("gid-tagged")
 
 
+def test_a_mismatched_elements_and_selectors_pair_is_refused():
+    """``zip`` would drop the tail silently; the old indexing raised."""
+    elements = [Rectangle((0, 0), 1, 1), Rectangle((1, 0), 1, 1)]
+
+    with pytest.raises(ValueError, match=r"2 elements .* 1 selector"):
+        with HighlightContextManager.set_maidr_elements(elements, ["only"]):
+            pass  # pragma: no cover - never entered
+
+
 def test_outside_a_render_nothing_is_tagged():
     """The class-wide ``draw`` patch runs for every figure, rendered or not."""
     with HighlightContextManager.set_maidr_element(Rectangle((0, 0), 1, 1), "gid"):


### PR DESCRIPTION
## What

`HighlightContextManager.set_maidr_element` runs inside the patched `draw` of every `Patch`/`Line2D`/collection during the SVG `savefig`, and did `element not in to_highlight` followed by `to_highlight.index(element)` against the flat list of every tagged artist of the render. Both are linear identity scans (`Artist` has no `__eq__`), so a layer with n patches — bar, hist, pie — cost n² comparisons per render. Closes #695.

The two ContextVars are replaced by one per-render `dict` keyed by `id(artist)`, built once in `set_maidr_elements` with `setdefault` so the first occurrence still wins exactly as `list.index` did (the #376 rule), and `set_maidr_element` does a single lookup. `id()` keys are safe because the elements list keeps every artist alive for the duration of the render. The per-render `ContextVar` isolation the class docstring requires (#504) is unchanged.

Also removed: the `_instance`/`_lock`/`__new__` singleton scaffolding on both classes. Both `__new__` methods called `object.__new__()` without `cls` and would have raised `TypeError`; nothing instantiates them (every method is a classmethod), so it was dead and misleading.

## Measured

| | before | after |
|---|---|---|
| 5 000-bar `ax.bar` render, min of 3, loaded 4-CPU box | 9 247 ms | 7 161 ms |
| same, quieter box (from the audit) | 4 960 ms | 2 906 ms |
| `__eq__` calls resolving 99 tagged artists | 198 | 0 |

A 50-bar render is byte-identical before and after once the per-render uuids and `<dc:date>` are normalised, with the same 51 `maidr=` attributes.

## Tests

New `tests/core/test_highlight_context_manager.py`: a duplicated artist keeps its first selector; an untagged artist is left alone; nothing is tagged outside a render; an end-to-end bar chart carries one selector per bar in draw order; and resolving an artist no longer compares it against the rest (counts `__eq__` on the tagged objects — 198 on `main`, 0 here).

## Verified

```
uv run pytest      3609 passed, 68 skipped
ruff check         All checks passed (changed files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_