### PR TITLE
fix(plotly): compute box statistics the way plotly draws them and bound the violin kernel's memory

### DIFF
--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -8,7 +8,7 @@ import numpy as np
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
-from maidr.plotly.violin_stats import _QUANTILE_METHOD
+from maidr.plotly.violin_stats import QUANTILE_METHOD
 
 _logger = logging.getLogger(__name__)
 
@@ -310,7 +310,7 @@ class PlotlyBoxPlot(PlotlyPlot):
         # numpy's default `linear` disagrees in the third significant figure,
         # and the fences and outliers all follow from q1/q3.
         q1, q2, q3 = (
-            float(q) for q in np.percentile(arr, [25, 50, 75], method=_QUANTILE_METHOD)
+            float(q) for q in np.percentile(arr, [25, 50, 75], method=QUANTILE_METHOD)
         )
         # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
         # answer for an odd sample size: the median is left out of, or shared

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -315,7 +315,10 @@ class PlotlyBoxPlot(PlotlyPlot):
         # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
         # answer for an odd sample size: the median is left out of, or shared
         # by, the two halves whose medians become q1 and q3. An even sample
-        # is Hazen whatever the method says.
+        # is Hazen whatever the method says. So is a single sample under
+        # `exclusive`: its halves are empty, and plotly's `Lib.interp` on an
+        # empty array answers `undefined` -- there is no drawn quartile to
+        # match, and a NaN in the schema is worse than the value itself.
         if arr.size % 2 and quartilemethod in ("exclusive", "inclusive"):
             middle = arr.size // 2
             ordered = np.sort(arr)
@@ -323,8 +326,9 @@ class PlotlyBoxPlot(PlotlyPlot):
                 lower_half, upper_half = ordered[:middle], ordered[middle + 1 :]
             else:
                 lower_half, upper_half = ordered[: middle + 1], ordered[middle:]
-            q1 = float(np.median(lower_half))
-            q3 = float(np.median(upper_half))
+            if lower_half.size and upper_half.size:
+                q1 = float(np.median(lower_half))
+                q3 = float(np.median(upper_half))
         iqr = q3 - q1
         lower_fence = q1 - 1.5 * iqr
         upper_fence = q3 + 1.5 * iqr

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -89,6 +89,105 @@ def _build_box_selector(
     }
 
 
+def _compute_stats(
+    arr: np.ndarray,
+    label: str = "",
+    quartilemethod: str | None = None,
+) -> dict | None:
+    """
+    Compute box plot statistics for a numeric array.
+
+    The statistics are the ones plotly draws, not a textbook's: non-finite
+    samples are skipped, and the quartiles follow the trace's
+    ``quartilemethod`` the way plotly's box calc reads it. Shared by
+    ``PlotlyBoxPlot`` and ``PlotlyMultiBoxPlot``, which describe the same
+    boxes and must not describe them two different ways.
+
+    Answers None for an array with no finite samples. Every quartile of a
+    box with no samples is undefined -- `np.percentile` raises rather than
+    inventing one -- and an array arrives empty when the samples behind it
+    could not be read, a corrupt typed-array spec being the way that
+    happens. The caller drops the box; letting the raise through would take
+    the whole figure with it, including the layers that read perfectly
+    well. The precomputed path bounds its loop for the same reason.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+        The box's samples, as floats.
+    label : str
+        The box's name, for the warning when it is dropped.
+    quartilemethod : str or None
+        The trace's ``quartilemethod``; ``None`` or ``"linear"`` is plotly's
+        default.
+    """
+    # Plotly's box calc skips every sample that is not a number (its
+    # `isNumeric` guard), so a `None` gap in the sample leaves the box it
+    # draws untouched. Left in, the NaN it became would poison every
+    # statistic and land as a bare `NaN` token in the schema. A box with
+    # nothing finite in it is the same "no samples" case as an empty one.
+    arr = arr[np.isfinite(arr)]
+    if arr.size == 0:
+        _logger.warning(
+            "maidr: box %r has no samples to summarise; dropping it.",
+            label or "<unnamed>",
+        )
+        return None
+
+    # Hazen quartiles, the rule plotly's `Lib.interp` applies -- the same
+    # constant the violin uses, measured there against plotly's calcdata.
+    # numpy's default `linear` disagrees in the third significant figure,
+    # and the fences and outliers all follow from q1/q3.
+    q2 = float(np.percentile(arr, 50, method=QUANTILE_METHOD))
+    # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
+    # answer for an odd sample size: the median is left out of, or shared
+    # by, the two halves whose medians become q1 and q3. An even sample
+    # is Hazen whatever the method says. So is a single sample under
+    # `exclusive`: its halves are empty, and plotly's `Lib.interp` on an
+    # empty array answers `undefined` -- there is no drawn quartile to
+    # match, and a NaN in the schema is worse than the value itself.
+    halves = None
+    if arr.size % 2 and quartilemethod in ("exclusive", "inclusive"):
+        middle = arr.size // 2
+        ordered = np.sort(arr)
+        if quartilemethod == "exclusive":
+            halves = ordered[:middle], ordered[middle + 1 :]
+        else:
+            halves = ordered[: middle + 1], ordered[middle:]
+    if halves is not None and all(half.size for half in halves):
+        q1, q3 = (float(np.median(half)) for half in halves)
+    else:
+        q1, q3 = (
+            float(q) for q in np.percentile(arr, [25, 75], method=QUANTILE_METHOD)
+        )
+    iqr = q3 - q1
+    lower_fence = q1 - 1.5 * iqr
+    upper_fence = q3 + 1.5 * iqr
+
+    min_val = (
+        float(np.min(arr[arr >= lower_fence])) if np.any(arr >= lower_fence) else q1
+    )
+    max_val = (
+        float(np.max(arr[arr <= upper_fence])) if np.any(arr <= upper_fence) else q3
+    )
+
+    lower_outliers = sorted(float(v) for v in arr[arr < lower_fence])
+    upper_outliers = sorted(float(v) for v in arr[arr > upper_fence])
+
+    result = {
+        MaidrKey.LOWER_OUTLIER.value: lower_outliers,
+        MaidrKey.MIN.value: min_val,
+        MaidrKey.Q1.value: q1,
+        MaidrKey.Q2.value: q2,
+        MaidrKey.Q3.value: q3,
+        MaidrKey.MAX.value: max_val,
+        MaidrKey.UPPER_OUTLIER.value: upper_outliers,
+    }
+    if label:
+        result[MaidrKey.Z.value] = label
+    return result
+
+
 class PlotlyBoxPlot(PlotlyPlot):
     """Extract data from a Plotly box trace."""
 
@@ -240,7 +339,7 @@ class PlotlyBoxPlot(PlotlyPlot):
         data = y if y is not None else x
         if data is not None:
             arr = np.array(as_list(data), dtype=float)
-            stats = self._compute_stats(
+            stats = _compute_stats(
                 arr,
                 label=self._trace.get("name", ""),
                 quartilemethod=self._trace.get("quartilemethod"),
@@ -262,7 +361,7 @@ class PlotlyBoxPlot(PlotlyPlot):
         results = []
         for cat in categories:
             arr = np.array(groups[cat], dtype=float)
-            stats = self._compute_stats(
+            stats = _compute_stats(
                 arr,
                 label=str(cat),
                 quartilemethod=self._trace.get("quartilemethod"),
@@ -270,88 +369,3 @@ class PlotlyBoxPlot(PlotlyPlot):
             if stats is not None:
                 results.append(stats)
         return results
-
-    def _compute_stats(
-        self,
-        arr: np.ndarray,
-        label: str = "",
-        quartilemethod: str | None = None,
-    ) -> dict | None:
-        """
-        Compute box plot statistics for a numeric array.
-
-        The statistics are the ones plotly draws, not a textbook's: non-finite
-        samples are skipped, and the quartiles follow the trace's
-        ``quartilemethod`` the way plotly's box calc reads it.
-
-        Answers None for an array with no finite samples. Every quartile of a
-        box with no samples is undefined -- `np.percentile` raises rather than
-        inventing one -- and an array arrives empty when the samples behind it
-        could not be read, a corrupt typed-array spec being the way that
-        happens. The caller drops the box; letting the raise through would take
-        the whole figure with it, including the layers that read perfectly
-        well. The precomputed path bounds its loop for the same reason.
-        """
-        # Plotly's box calc skips every sample that is not a number (its
-        # `isNumeric` guard), so a `None` gap in the sample leaves the box it
-        # draws untouched. Left in, the NaN it became would poison every
-        # statistic and land as a bare `NaN` token in the schema. A box with
-        # nothing finite in it is the same "no samples" case as an empty one.
-        arr = arr[np.isfinite(arr)]
-        if arr.size == 0:
-            _logger.warning(
-                "maidr: box %r has no samples to summarise; dropping it.",
-                label or "<unnamed>",
-            )
-            return None
-
-        # Hazen quartiles, the rule plotly's `Lib.interp` applies -- the same
-        # constant the violin uses, measured there against plotly's calcdata.
-        # numpy's default `linear` disagrees in the third significant figure,
-        # and the fences and outliers all follow from q1/q3.
-        q1, q2, q3 = (
-            float(q) for q in np.percentile(arr, [25, 50, 75], method=QUANTILE_METHOD)
-        )
-        # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
-        # answer for an odd sample size: the median is left out of, or shared
-        # by, the two halves whose medians become q1 and q3. An even sample
-        # is Hazen whatever the method says. So is a single sample under
-        # `exclusive`: its halves are empty, and plotly's `Lib.interp` on an
-        # empty array answers `undefined` -- there is no drawn quartile to
-        # match, and a NaN in the schema is worse than the value itself.
-        if arr.size % 2 and quartilemethod in ("exclusive", "inclusive"):
-            middle = arr.size // 2
-            ordered = np.sort(arr)
-            if quartilemethod == "exclusive":
-                lower_half, upper_half = ordered[:middle], ordered[middle + 1 :]
-            else:
-                lower_half, upper_half = ordered[: middle + 1], ordered[middle:]
-            if lower_half.size and upper_half.size:
-                q1 = float(np.median(lower_half))
-                q3 = float(np.median(upper_half))
-        iqr = q3 - q1
-        lower_fence = q1 - 1.5 * iqr
-        upper_fence = q3 + 1.5 * iqr
-
-        min_val = (
-            float(np.min(arr[arr >= lower_fence])) if np.any(arr >= lower_fence) else q1
-        )
-        max_val = (
-            float(np.max(arr[arr <= upper_fence])) if np.any(arr <= upper_fence) else q3
-        )
-
-        lower_outliers = sorted(float(v) for v in arr[arr < lower_fence])
-        upper_outliers = sorted(float(v) for v in arr[arr > upper_fence])
-
-        result = {
-            MaidrKey.LOWER_OUTLIER.value: lower_outliers,
-            MaidrKey.MIN.value: min_val,
-            MaidrKey.Q1.value: q1,
-            MaidrKey.Q2.value: q2,
-            MaidrKey.Q3.value: q3,
-            MaidrKey.MAX.value: max_val,
-            MaidrKey.UPPER_OUTLIER.value: upper_outliers,
-        }
-        if label:
-            result[MaidrKey.Z.value] = label
-        return result

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -89,6 +89,16 @@ def _build_box_selector(
     }
 
 
+def _has_precomputed_stats(trace: dict) -> bool:
+    """Return whether *trace* carries its quartiles rather than its samples.
+
+    Plotly's own signature for the form (``_hasPreCompStats``): ``q1``,
+    ``median`` and ``q3`` all present. Both extractors branch on it in more
+    than one place, so it is spelled once.
+    """
+    return "q1" in trace and "median" in trace
+
+
 def _compute_stats(
     arr: np.ndarray,
     label: str = "",
@@ -243,7 +253,7 @@ class PlotlyBoxPlot(PlotlyPlot):
         # With both a 1-D `x` and `y` (plotly's case "11") the trace sets no
         # orientation at all: plotly hides it and draws nothing, so the
         # fall-through `vert` below is a default, not a match.
-        if self._has_precomputed_stats():
+        if _has_precomputed_stats(self._trace):
             return self._trace.get("y") is not None and self._trace.get("x") is None
         # Plotly uses x for horizontal when y is absent
         return self._trace.get("x") is not None and self._trace.get("y") is None
@@ -257,7 +267,7 @@ class PlotlyBoxPlot(PlotlyPlot):
 
     def _extract_plot_data(self) -> list[dict]:
         # Plotly box traces can have pre-computed stats or raw data
-        if self._has_precomputed_stats():
+        if _has_precomputed_stats(self._trace):
             data = self._extract_precomputed()
         else:
             data = self._extract_from_raw_data()
@@ -270,10 +280,6 @@ class PlotlyBoxPlot(PlotlyPlot):
             for d in data
         ]
         return data
-
-    def _has_precomputed_stats(self) -> bool:
-        """Check if the trace has pre-computed quartile values."""
-        return "q1" in self._trace and "median" in self._trace
 
     def _extract_precomputed(self) -> list[dict]:
         """

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -128,9 +128,20 @@ class PlotlyBoxPlot(PlotlyPlot):
         ]
 
     def _is_horizontal(self) -> bool:
-        """Detect if this box trace is horizontal."""
+        """Detect if this box trace is horizontal.
+
+        A precomputed box reads its arrays the other way round from a raw
+        one. Raw samples in ``x`` alone are the values of a horizontal box;
+        but once ``q1``/``median``/``q3`` carry the values, a lone ``x`` is
+        the *positions* of vertical boxes and a lone ``y`` the positions of
+        horizontal ones -- plotly's box defaults, case ``"10"`` -> ``v`` and
+        case ``"01"`` -> ``h``. Applying the raw rule to both swapped the
+        announced value axis for every precomputed box with one array.
+        """
         if self._trace.get("orientation") == "h":
             return True
+        if self._has_precomputed_stats():
+            return self._trace.get("y") is not None and self._trace.get("x") is None
         # Plotly uses x for horizontal when y is absent
         return self._trace.get("x") is not None and self._trace.get("y") is None
 
@@ -225,7 +236,11 @@ class PlotlyBoxPlot(PlotlyPlot):
         data = y if y is not None else x
         if data is not None:
             arr = np.array(as_list(data), dtype=float)
-            stats = self._compute_stats(arr, label=self._trace.get("name", ""))
+            stats = self._compute_stats(
+                arr,
+                label=self._trace.get("name", ""),
+                quartilemethod=self._trace.get("quartilemethod"),
+            )
             return [stats] if stats is not None else []
 
         return []
@@ -243,23 +258,42 @@ class PlotlyBoxPlot(PlotlyPlot):
         results = []
         for cat in categories:
             arr = np.array(groups[cat], dtype=float)
-            stats = self._compute_stats(arr, label=str(cat))
+            stats = self._compute_stats(
+                arr,
+                label=str(cat),
+                quartilemethod=self._trace.get("quartilemethod"),
+            )
             if stats is not None:
                 results.append(stats)
         return results
 
-    def _compute_stats(self, arr: np.ndarray, label: str = "") -> dict | None:
+    def _compute_stats(
+        self,
+        arr: np.ndarray,
+        label: str = "",
+        quartilemethod: str | None = None,
+    ) -> dict | None:
         """
         Compute box plot statistics for a numeric array.
 
-        Answers None for an empty array. Every quartile of a box with no
-        samples is undefined -- `np.percentile` raises rather than inventing
-        one -- and an array arrives empty when the samples behind it could not
-        be read, a corrupt typed-array spec being the way that happens. The
-        caller drops the box; letting the raise through would take the whole
-        figure with it, including the layers that read perfectly well. The
-        precomputed path bounds its loop for the same reason.
+        The statistics are the ones plotly draws, not a textbook's: non-finite
+        samples are skipped, and the quartiles follow the trace's
+        ``quartilemethod`` the way plotly's box calc reads it.
+
+        Answers None for an array with no finite samples. Every quartile of a
+        box with no samples is undefined -- `np.percentile` raises rather than
+        inventing one -- and an array arrives empty when the samples behind it
+        could not be read, a corrupt typed-array spec being the way that
+        happens. The caller drops the box; letting the raise through would take
+        the whole figure with it, including the layers that read perfectly
+        well. The precomputed path bounds its loop for the same reason.
         """
+        # Plotly's box calc skips every sample that is not a number (its
+        # `isNumeric` guard), so a `None` gap in the sample leaves the box it
+        # draws untouched. Left in, the NaN it became would poison every
+        # statistic and land as a bare `NaN` token in the schema. A box with
+        # nothing finite in it is the same "no samples" case as an empty one.
+        arr = arr[np.isfinite(arr)]
         if arr.size == 0:
             _logger.warning(
                 "maidr: box %r has no samples to summarise; dropping it.",
@@ -267,9 +301,26 @@ class PlotlyBoxPlot(PlotlyPlot):
             )
             return None
 
-        q1 = float(np.percentile(arr, 25))
-        q2 = float(np.percentile(arr, 50))
-        q3 = float(np.percentile(arr, 75))
+        # Hazen quartiles, the rule plotly's `Lib.interp` applies -- see
+        # `violin_stats._QUANTILE_METHOD`, measured against plotly's calcdata.
+        # numpy's default `linear` disagrees in the third significant figure,
+        # and the fences and outliers all follow from q1/q3.
+        q1, q2, q3 = (
+            float(q) for q in np.percentile(arr, [25, 50, 75], method="hazen")
+        )
+        # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
+        # answer for an odd sample size: the median is left out of, or shared
+        # by, the two halves whose medians become q1 and q3. An even sample
+        # is Hazen whatever the method says.
+        if arr.size % 2 and quartilemethod in ("exclusive", "inclusive"):
+            middle = arr.size // 2
+            ordered = np.sort(arr)
+            if quartilemethod == "exclusive":
+                lower_half, upper_half = ordered[:middle], ordered[middle + 1 :]
+            else:
+                lower_half, upper_half = ordered[: middle + 1], ordered[middle:]
+            q1 = float(np.median(lower_half))
+            q3 = float(np.median(upper_half))
         iqr = q3 - q1
         lower_fence = q1 - 1.5 * iqr
         upper_fence = q3 + 1.5 * iqr

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -94,10 +94,11 @@ def _has_precomputed_stats(trace: dict) -> bool:
     """Return whether *trace* carries its quartiles rather than its samples.
 
     Plotly's own signature for the form (``_hasPreCompStats``): ``q1``,
-    ``median`` and ``q3`` all present. Both extractors branch on it in more
+    ``median`` and ``q3`` all present and non-empty; a trace missing any of
+    the three is read as a raw sample. Both extractors branch on it in more
     than one place, so it is spelled once.
     """
-    return "q1" in trace and "median" in trace
+    return all(bool(trace.get(key)) for key in ("q1", "median", "q3"))
 
 
 def _is_finite_number(value: Any) -> bool:

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -98,7 +98,12 @@ def _has_precomputed_stats(trace: dict) -> bool:
     the three is read as a raw sample. Both extractors branch on it in more
     than one place, so it is spelled once.
     """
-    return all(bool(trace.get(key)) for key in ("q1", "median", "q3"))
+    for key in ("q1", "median", "q3"):
+        value = trace.get(key)
+        # Sized rather than truthy: a numpy array raises on ``bool()``.
+        if value is None or not hasattr(value, "__len__") or len(value) == 0:
+            return False
+    return True
 
 
 def _is_finite_number(value: Any) -> bool:

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -171,6 +171,30 @@ def _precomputed_box(
     }
 
 
+def _trace_is_horizontal(trace: dict) -> bool:
+    """Return whether plotly draws *trace*'s boxes horizontally.
+
+    An explicit ``orientation="h"`` wins. Otherwise a precomputed trace reads
+    its arrays the other way round from a raw one. Raw samples in ``x`` alone
+    are the values of a horizontal box; but once ``q1``/``median``/``q3``
+    carry the values, a lone ``x`` is the *positions* of vertical boxes and a
+    lone ``y`` the positions of horizontal ones -- plotly's box defaults,
+    case ``"10"`` -> ``v`` and case ``"01"`` -> ``h``. Applying the raw rule
+    to both swapped the announced value axis for every precomputed trace
+    with one array.
+
+    With both a 1-D ``x`` and ``y`` (plotly's case ``"11"``) a precomputed
+    trace sets no orientation at all: plotly hides it and draws nothing, so
+    the ``False`` it gets here is a default, not a match.
+    """
+    if trace.get("orientation") == "h":
+        return True
+    if _has_precomputed_stats(trace):
+        return trace.get("y") is not None and trace.get("x") is None
+    # Plotly uses x for horizontal when y is absent
+    return trace.get("x") is not None and trace.get("y") is None
+
+
 def _compute_stats(
     arr: np.ndarray,
     label: str = "",
@@ -310,25 +334,8 @@ class PlotlyBoxPlot(PlotlyPlot):
         ]
 
     def _is_horizontal(self) -> bool:
-        """Detect if this box trace is horizontal.
-
-        A precomputed box reads its arrays the other way round from a raw
-        one. Raw samples in ``x`` alone are the values of a horizontal box;
-        but once ``q1``/``median``/``q3`` carry the values, a lone ``x`` is
-        the *positions* of vertical boxes and a lone ``y`` the positions of
-        horizontal ones -- plotly's box defaults, case ``"10"`` -> ``v`` and
-        case ``"01"`` -> ``h``. Applying the raw rule to both swapped the
-        announced value axis for every precomputed box with one array.
-        """
-        if self._trace.get("orientation") == "h":
-            return True
-        # With both a 1-D `x` and `y` (plotly's case "11") the trace sets no
-        # orientation at all: plotly hides it and draws nothing, so the
-        # fall-through `vert` below is a default, not a match.
-        if _has_precomputed_stats(self._trace):
-            return self._trace.get("y") is not None and self._trace.get("x") is None
-        # Plotly uses x for horizontal when y is absent
-        return self._trace.get("x") is not None and self._trace.get("y") is None
+        """Detect if this box trace is horizontal -- see `_trace_is_horizontal`."""
+        return _trace_is_horizontal(self._trace)
 
     def render(self) -> dict:
         schema = super().render()

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -8,6 +8,7 @@ import numpy as np
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.violin_stats import _QUANTILE_METHOD
 
 _logger = logging.getLogger(__name__)
 
@@ -140,6 +141,9 @@ class PlotlyBoxPlot(PlotlyPlot):
         """
         if self._trace.get("orientation") == "h":
             return True
+        # With both a 1-D `x` and `y` (plotly's case "11") the trace sets no
+        # orientation at all: plotly hides it and draws nothing, so the
+        # fall-through `vert` below is a default, not a match.
         if self._has_precomputed_stats():
             return self._trace.get("y") is not None and self._trace.get("x") is None
         # Plotly uses x for horizontal when y is absent
@@ -301,12 +305,12 @@ class PlotlyBoxPlot(PlotlyPlot):
             )
             return None
 
-        # Hazen quartiles, the rule plotly's `Lib.interp` applies -- see
-        # `violin_stats._QUANTILE_METHOD`, measured against plotly's calcdata.
+        # Hazen quartiles, the rule plotly's `Lib.interp` applies -- the same
+        # constant the violin uses, measured there against plotly's calcdata.
         # numpy's default `linear` disagrees in the third significant figure,
         # and the fences and outliers all follow from q1/q3.
         q1, q2, q3 = (
-            float(q) for q in np.percentile(arr, [25, 50, 75], method="hazen")
+            float(q) for q in np.percentile(arr, [25, 50, 75], method=_QUANTILE_METHOD)
         )
         # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
         # answer for an odd sample size: the median is left out of, or shared

--- a/maidr/plotly/box.py
+++ b/maidr/plotly/box.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any
 
 import numpy as np
@@ -97,6 +98,71 @@ def _has_precomputed_stats(trace: dict) -> bool:
     than one place, so it is spelled once.
     """
     return "q1" in trace and "median" in trace
+
+
+def _is_finite_number(value: Any) -> bool:
+    """Return whether *value* is a number plotly's ``isNumeric`` would take."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )
+
+
+def _precomputed_box(
+    q1: Any,
+    median: Any,
+    q3: Any,
+    lowerfence: Any,
+    upperfence: Any,
+    label: str = "",
+) -> dict | None:
+    """
+    Build one box's stats from its precomputed values, the way plotly reads them.
+
+    Plotly's calc keeps a precomputed box only when ``q1``, ``median`` and
+    ``q3`` are all numeric and in order; otherwise it draws nothing there.
+    Such a box is dropped here for the same reason the sample path drops a
+    box with no finite samples: a ``None`` or NaN sent straight through
+    became a bare ``null``/``NaN`` in the schema, and plotly's ``boxlayer``
+    has no ``path.box`` for it, so leaving it in would also shift every
+    later box's positional selector off the element it describes.
+
+    A fence plotly rejects -- non-numeric, or a lower fence above ``q1`` /
+    an upper fence below ``q3`` -- does not cost it the box: with no sample
+    points to fall back on it uses the quartile itself, and so does this.
+
+    Parameters
+    ----------
+    q1, median, q3, lowerfence, upperfence : Any
+        The box's precomputed values, as native scalars.
+    label : str
+        The box's name, for the warning when it is dropped.
+    """
+    if not (
+        _is_finite_number(q1)
+        and _is_finite_number(median)
+        and _is_finite_number(q3)
+        and q1 <= median <= q3
+    ):
+        _logger.warning(
+            "maidr: box %r has no complete quartiles; dropping it.",
+            label or "<unnamed>",
+        )
+        return None
+
+    min_val = lowerfence if _is_finite_number(lowerfence) and lowerfence <= q1 else q1
+    max_val = upperfence if _is_finite_number(upperfence) and upperfence >= q3 else q3
+
+    return {
+        MaidrKey.LOWER_OUTLIER.value: [],
+        MaidrKey.MIN.value: min_val,
+        MaidrKey.Q1.value: q1,
+        MaidrKey.Q2.value: median,
+        MaidrKey.Q3.value: q3,
+        MaidrKey.MAX.value: max_val,
+        MaidrKey.UPPER_OUTLIER.value: [],
+    }
 
 
 def _compute_stats(
@@ -291,6 +357,9 @@ class PlotlyBoxPlot(PlotlyPlot):
         the loop indexing past the end of it. A short layer is the same answer
         the rest of this module gives to data it cannot read; a crash would
         take the whole figure with it.
+
+        A box whose quartiles are missing or out of order is dropped too,
+        because plotly draws none there -- see `_precomputed_box`.
         """
         q1_vals = as_list(self._trace.get("q1"))
         median_vals = as_list(self._trace.get("median"))
@@ -313,19 +382,19 @@ class PlotlyBoxPlot(PlotlyPlot):
                 count,
             )
 
+        name = self._trace.get("name") or "box"
         results = []
         for i in range(count):
-            results.append(
-                {
-                    MaidrKey.LOWER_OUTLIER.value: [],
-                    MaidrKey.MIN.value: self._to_native(lowerfence[i]),
-                    MaidrKey.Q1.value: self._to_native(q1_vals[i]),
-                    MaidrKey.Q2.value: self._to_native(median_vals[i]),
-                    MaidrKey.Q3.value: self._to_native(q3_vals[i]),
-                    MaidrKey.MAX.value: self._to_native(upperfence[i]),
-                    MaidrKey.UPPER_OUTLIER.value: [],
-                }
+            box = _precomputed_box(
+                self._to_native(q1_vals[i]),
+                self._to_native(median_vals[i]),
+                self._to_native(q3_vals[i]),
+                self._to_native(lowerfence[i]),
+                self._to_native(upperfence[i]),
+                label=f"{name} {i + 1}",
             )
+            if box is not None:
+                results.append(box)
         return results
 
     def _extract_from_raw_data(self) -> list[dict]:

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -83,10 +83,23 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         return selectors
 
     def _is_horizontal(self) -> bool:
-        """Detect if box traces are horizontal."""
+        """Detect if box traces are horizontal.
+
+        A precomputed trace reads its arrays the other way round from a raw
+        one. Raw samples in ``x`` alone are the values of a horizontal box;
+        but once ``q1``/``median``/``q3`` carry the values, a lone ``x`` is
+        the *positions* of vertical boxes and a lone ``y`` the positions of
+        horizontal ones -- plotly's box defaults, case ``"10"`` -> ``v`` and
+        case ``"01"`` -> ``h``. Applying the raw rule to both swapped the
+        announced value axis for every precomputed trace with one array.
+        """
         for trace in self._traces:
             if trace.get("orientation") == "h":
                 return True
+            if "q1" in trace and "median" in trace:
+                if trace.get("y") is not None and trace.get("x") is None:
+                    return True
+                continue
             if trace.get("x") is not None and trace.get("y") is None:
                 return True
         return False
@@ -125,7 +138,11 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
 
             # Grouped by x
             if x is not None and y is not None:
-                all_boxes.extend(self._extract_grouped(x, y))
+                all_boxes.extend(
+                    self._extract_grouped(
+                        x, y, quartilemethod=trace.get("quartilemethod")
+                    )
+                )
                 self._boxes_per_trace.append(len(all_boxes) - before)
                 continue
 
@@ -133,7 +150,9 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
             data = y if y is not None else x
             if data is not None:
                 arr = np.array(as_list(data), dtype=float)
-                stats = self._compute_stats(arr, label=name)
+                stats = self._compute_stats(
+                    arr, label=name, quartilemethod=trace.get("quartilemethod")
+                )
                 if stats is not None:
                     all_boxes.append(stats)
             self._boxes_per_trace.append(len(all_boxes) - before)
@@ -196,7 +215,7 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         return results
 
     def _extract_grouped(
-        self, x: list[Any], y: list[Any]
+        self, x: list[Any], y: list[Any], quartilemethod: str | None = None
     ) -> list[dict]:
         """Extract stats grouped by x categories."""
         x_list = as_list(x)
@@ -209,23 +228,40 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         results = []
         for cat in categories:
             arr = np.array(groups[cat], dtype=float)
-            stats = self._compute_stats(arr, label=str(cat))
+            stats = self._compute_stats(
+                arr, label=str(cat), quartilemethod=quartilemethod
+            )
             if stats is not None:
                 results.append(stats)
         return results
 
-    def _compute_stats(self, arr: np.ndarray, label: str = "") -> dict | None:
+    def _compute_stats(
+        self,
+        arr: np.ndarray,
+        label: str = "",
+        quartilemethod: str | None = None,
+    ) -> dict | None:
         """
         Compute box plot statistics for a numeric array.
 
-        Answers None for an empty array. Every quartile of a box with no
-        samples is undefined -- `np.percentile` raises rather than inventing
-        one -- and an array arrives empty when the samples behind it could not
-        be read, a corrupt typed-array spec being the way that happens. The
-        caller drops the box; letting the raise through would take the whole
-        figure with it, including the layers that read perfectly well. The
-        precomputed path bounds its loop for the same reason.
+        The statistics are the ones plotly draws, not a textbook's: non-finite
+        samples are skipped, and the quartiles follow the trace's
+        ``quartilemethod`` the way plotly's box calc reads it.
+
+        Answers None for an array with no finite samples. Every quartile of a
+        box with no samples is undefined -- `np.percentile` raises rather than
+        inventing one -- and an array arrives empty when the samples behind it
+        could not be read, a corrupt typed-array spec being the way that
+        happens. The caller drops the box; letting the raise through would take
+        the whole figure with it, including the layers that read perfectly
+        well. The precomputed path bounds its loop for the same reason.
         """
+        # Plotly's box calc skips every sample that is not a number (its
+        # `isNumeric` guard), so a `None` gap in the sample leaves the box it
+        # draws untouched. Left in, the NaN it became would poison every
+        # statistic and land as a bare `NaN` token in the schema. A box with
+        # nothing finite in it is the same "no samples" case as an empty one.
+        arr = arr[np.isfinite(arr)]
         if arr.size == 0:
             _logger.warning(
                 "maidr: box %r has no samples to summarise; dropping it.",
@@ -233,9 +269,26 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
             )
             return None
 
-        q1 = float(np.percentile(arr, 25))
-        q2 = float(np.percentile(arr, 50))
-        q3 = float(np.percentile(arr, 75))
+        # Hazen quartiles, the rule plotly's `Lib.interp` applies -- see
+        # `violin_stats._QUANTILE_METHOD`, measured against plotly's calcdata.
+        # numpy's default `linear` disagrees in the third significant figure,
+        # and the fences and outliers all follow from q1/q3.
+        q1, q2, q3 = (
+            float(q) for q in np.percentile(arr, [25, 50, 75], method="hazen")
+        )
+        # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
+        # answer for an odd sample size: the median is left out of, or shared
+        # by, the two halves whose medians become q1 and q3. An even sample
+        # is Hazen whatever the method says.
+        if arr.size % 2 and quartilemethod in ("exclusive", "inclusive"):
+            middle = arr.size // 2
+            ordered = np.sort(arr)
+            if quartilemethod == "exclusive":
+                lower_half, upper_half = ordered[:middle], ordered[middle + 1 :]
+            else:
+                lower_half, upper_half = ordered[: middle + 1], ordered[middle:]
+            q1 = float(np.median(lower_half))
+            q3 = float(np.median(upper_half))
         iqr = q3 - q1
         lower_fence = q1 - 1.5 * iqr
         upper_fence = q3 + 1.5 * iqr

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -9,7 +9,7 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.box import _build_box_selector
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
-from maidr.plotly.violin_stats import _QUANTILE_METHOD
+from maidr.plotly.violin_stats import QUANTILE_METHOD
 
 _logger = logging.getLogger(__name__)
 
@@ -278,7 +278,7 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         # numpy's default `linear` disagrees in the third significant figure,
         # and the fences and outliers all follow from q1/q3.
         q1, q2, q3 = (
-            float(q) for q in np.percentile(arr, [25, 50, 75], method=_QUANTILE_METHOD)
+            float(q) for q in np.percentile(arr, [25, 50, 75], method=QUANTILE_METHOD)
         )
         # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
         # answer for an odd sample size: the median is left out of, or shared

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -11,6 +11,7 @@ from maidr.plotly.box import (
     _build_box_selector,
     _compute_stats,
     _has_precomputed_stats,
+    _precomputed_box,
 )
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
@@ -184,6 +185,9 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         the loop indexing past the end of it. A short layer is the same answer
         the rest of this module gives to data it cannot read; a crash would
         take the whole figure with it.
+
+        A box whose quartiles are missing or out of order is dropped too,
+        because plotly draws none there -- see `_precomputed_box`.
         """
         q1_vals = as_list(trace.get("q1"))
         median_vals = as_list(trace.get("median"))
@@ -206,19 +210,19 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
                 count,
             )
 
+        name = trace.get("name") or "box"
         results = []
         for i in range(count):
-            results.append(
-                {
-                    MaidrKey.LOWER_OUTLIER.value: [],
-                    MaidrKey.MIN.value: self._to_native(lowerfence[i]),
-                    MaidrKey.Q1.value: self._to_native(q1_vals[i]),
-                    MaidrKey.Q2.value: self._to_native(median_vals[i]),
-                    MaidrKey.Q3.value: self._to_native(q3_vals[i]),
-                    MaidrKey.MAX.value: self._to_native(upperfence[i]),
-                    MaidrKey.UPPER_OUTLIER.value: [],
-                }
+            box = _precomputed_box(
+                self._to_native(q1_vals[i]),
+                self._to_native(median_vals[i]),
+                self._to_native(q3_vals[i]),
+                self._to_native(lowerfence[i]),
+                self._to_native(upperfence[i]),
+                label=f"{name} {i + 1}",
             )
+            if box is not None:
+                results.append(box)
         return results
 
     def _extract_grouped(

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -7,9 +7,8 @@ import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.box import _build_box_selector
+from maidr.plotly.box import _build_box_selector, _compute_stats
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
-from maidr.plotly.violin_stats import QUANTILE_METHOD
 
 _logger = logging.getLogger(__name__)
 
@@ -154,7 +153,7 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
             data = y if y is not None else x
             if data is not None:
                 arr = np.array(as_list(data), dtype=float)
-                stats = self._compute_stats(
+                stats = _compute_stats(
                     arr, label=name, quartilemethod=trace.get("quartilemethod")
                 )
                 if stats is not None:
@@ -232,98 +231,9 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         results = []
         for cat in categories:
             arr = np.array(groups[cat], dtype=float)
-            stats = self._compute_stats(
+            stats = _compute_stats(
                 arr, label=str(cat), quartilemethod=quartilemethod
             )
             if stats is not None:
                 results.append(stats)
         return results
-
-    def _compute_stats(
-        self,
-        arr: np.ndarray,
-        label: str = "",
-        quartilemethod: str | None = None,
-    ) -> dict | None:
-        """
-        Compute box plot statistics for a numeric array.
-
-        The statistics are the ones plotly draws, not a textbook's: non-finite
-        samples are skipped, and the quartiles follow the trace's
-        ``quartilemethod`` the way plotly's box calc reads it.
-
-        Answers None for an array with no finite samples. Every quartile of a
-        box with no samples is undefined -- `np.percentile` raises rather than
-        inventing one -- and an array arrives empty when the samples behind it
-        could not be read, a corrupt typed-array spec being the way that
-        happens. The caller drops the box; letting the raise through would take
-        the whole figure with it, including the layers that read perfectly
-        well. The precomputed path bounds its loop for the same reason.
-        """
-        # Plotly's box calc skips every sample that is not a number (its
-        # `isNumeric` guard), so a `None` gap in the sample leaves the box it
-        # draws untouched. Left in, the NaN it became would poison every
-        # statistic and land as a bare `NaN` token in the schema. A box with
-        # nothing finite in it is the same "no samples" case as an empty one.
-        arr = arr[np.isfinite(arr)]
-        if arr.size == 0:
-            _logger.warning(
-                "maidr: box %r has no samples to summarise; dropping it.",
-                label or "<unnamed>",
-            )
-            return None
-
-        # Hazen quartiles, the rule plotly's `Lib.interp` applies -- the same
-        # constant the violin uses, measured there against plotly's calcdata.
-        # numpy's default `linear` disagrees in the third significant figure,
-        # and the fences and outliers all follow from q1/q3.
-        q1, q2, q3 = (
-            float(q) for q in np.percentile(arr, [25, 50, 75], method=QUANTILE_METHOD)
-        )
-        # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
-        # answer for an odd sample size: the median is left out of, or shared
-        # by, the two halves whose medians become q1 and q3. An even sample
-        # is Hazen whatever the method says. So is a single sample under
-        # `exclusive`: its halves are empty, and plotly's `Lib.interp` on an
-        # empty array answers `undefined` -- there is no drawn quartile to
-        # match, and a NaN in the schema is worse than the value itself.
-        if arr.size % 2 and quartilemethod in ("exclusive", "inclusive"):
-            middle = arr.size // 2
-            ordered = np.sort(arr)
-            if quartilemethod == "exclusive":
-                lower_half, upper_half = ordered[:middle], ordered[middle + 1 :]
-            else:
-                lower_half, upper_half = ordered[: middle + 1], ordered[middle:]
-            if lower_half.size and upper_half.size:
-                q1 = float(np.median(lower_half))
-                q3 = float(np.median(upper_half))
-        iqr = q3 - q1
-        lower_fence = q1 - 1.5 * iqr
-        upper_fence = q3 + 1.5 * iqr
-
-        min_val = (
-            float(np.min(arr[arr >= lower_fence]))
-            if np.any(arr >= lower_fence)
-            else q1
-        )
-        max_val = (
-            float(np.max(arr[arr <= upper_fence]))
-            if np.any(arr <= upper_fence)
-            else q3
-        )
-
-        lower_outliers = sorted(float(v) for v in arr[arr < lower_fence])
-        upper_outliers = sorted(float(v) for v in arr[arr > upper_fence])
-
-        result = {
-            MaidrKey.LOWER_OUTLIER.value: lower_outliers,
-            MaidrKey.MIN.value: min_val,
-            MaidrKey.Q1.value: q1,
-            MaidrKey.Q2.value: q2,
-            MaidrKey.Q3.value: q3,
-            MaidrKey.MAX.value: max_val,
-            MaidrKey.UPPER_OUTLIER.value: upper_outliers,
-        }
-        if label:
-            result[MaidrKey.Z.value] = label
-        return result

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -9,6 +9,7 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.box import _build_box_selector
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
+from maidr.plotly.violin_stats import _QUANTILE_METHOD
 
 _logger = logging.getLogger(__name__)
 
@@ -96,6 +97,9 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         for trace in self._traces:
             if trace.get("orientation") == "h":
                 return True
+            # With both a 1-D `x` and `y` (plotly's case "11") the trace sets no
+            # orientation at all: plotly hides it and draws nothing, so the
+            # fall-through `vert` below is a default, not a match.
             if "q1" in trace and "median" in trace:
                 if trace.get("y") is not None and trace.get("x") is None:
                     return True
@@ -269,12 +273,12 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
             )
             return None
 
-        # Hazen quartiles, the rule plotly's `Lib.interp` applies -- see
-        # `violin_stats._QUANTILE_METHOD`, measured against plotly's calcdata.
+        # Hazen quartiles, the rule plotly's `Lib.interp` applies -- the same
+        # constant the violin uses, measured there against plotly's calcdata.
         # numpy's default `linear` disagrees in the third significant figure,
         # and the fences and outliers all follow from q1/q3.
         q1, q2, q3 = (
-            float(q) for q in np.percentile(arr, [25, 50, 75], method="hazen")
+            float(q) for q in np.percentile(arr, [25, 50, 75], method=_QUANTILE_METHOD)
         )
         # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
         # answer for an odd sample size: the median is left out of, or shared

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -283,7 +283,10 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         # `quartilemethod="exclusive"`/`"inclusive"` only change plotly's
         # answer for an odd sample size: the median is left out of, or shared
         # by, the two halves whose medians become q1 and q3. An even sample
-        # is Hazen whatever the method says.
+        # is Hazen whatever the method says. So is a single sample under
+        # `exclusive`: its halves are empty, and plotly's `Lib.interp` on an
+        # empty array answers `undefined` -- there is no drawn quartile to
+        # match, and a NaN in the schema is worse than the value itself.
         if arr.size % 2 and quartilemethod in ("exclusive", "inclusive"):
             middle = arr.size // 2
             ordered = np.sort(arr)
@@ -291,8 +294,9 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
                 lower_half, upper_half = ordered[:middle], ordered[middle + 1 :]
             else:
                 lower_half, upper_half = ordered[: middle + 1], ordered[middle:]
-            q1 = float(np.median(lower_half))
-            q3 = float(np.median(upper_half))
+            if lower_half.size and upper_half.size:
+                q1 = float(np.median(lower_half))
+                q3 = float(np.median(upper_half))
         iqr = q3 - q1
         lower_fence = q1 - 1.5 * iqr
         upper_fence = q3 + 1.5 * iqr

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -12,6 +12,7 @@ from maidr.plotly.box import (
     _compute_stats,
     _has_precomputed_stats,
     _precomputed_box,
+    _trace_is_horizontal,
 )
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
@@ -90,27 +91,10 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
     def _is_horizontal(self) -> bool:
         """Detect if box traces are horizontal.
 
-        A precomputed trace reads its arrays the other way round from a raw
-        one. Raw samples in ``x`` alone are the values of a horizontal box;
-        but once ``q1``/``median``/``q3`` carry the values, a lone ``x`` is
-        the *positions* of vertical boxes and a lone ``y`` the positions of
-        horizontal ones -- plotly's box defaults, case ``"10"`` -> ``v`` and
-        case ``"01"`` -> ``h``. Applying the raw rule to both swapped the
-        announced value axis for every precomputed trace with one array.
+        Any one horizontal trace makes the layer horizontal; each is judged
+        by its own form, precomputed or raw -- see `_trace_is_horizontal`.
         """
-        for trace in self._traces:
-            if trace.get("orientation") == "h":
-                return True
-            # With both a 1-D `x` and `y` (plotly's case "11") the trace sets no
-            # orientation at all: plotly hides it and draws nothing, so the
-            # fall-through `vert` below is a default, not a match.
-            if _has_precomputed_stats(trace):
-                if trace.get("y") is not None and trace.get("x") is None:
-                    return True
-                continue
-            if trace.get("x") is not None and trace.get("y") is None:
-                return True
-        return False
+        return any(_trace_is_horizontal(trace) for trace in self._traces)
 
     def render(self) -> dict:
         schema = super().render()

--- a/maidr/plotly/multibox.py
+++ b/maidr/plotly/multibox.py
@@ -7,7 +7,11 @@ import numpy as np
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.box import _build_box_selector, _compute_stats
+from maidr.plotly.box import (
+    _build_box_selector,
+    _compute_stats,
+    _has_precomputed_stats,
+)
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
 
 _logger = logging.getLogger(__name__)
@@ -99,7 +103,7 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
             # With both a 1-D `x` and `y` (plotly's case "11") the trace sets no
             # orientation at all: plotly hides it and draws nothing, so the
             # fall-through `vert` below is a default, not a match.
-            if "q1" in trace and "median" in trace:
+            if _has_precomputed_stats(trace):
                 if trace.get("y") is not None and trace.get("x") is None:
                     return True
                 continue
@@ -134,7 +138,7 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
             before = len(all_boxes)
 
             # Pre-computed stats
-            if "q1" in trace and "median" in trace:
+            if _has_precomputed_stats(trace):
                 all_boxes.extend(self._extract_precomputed(trace))
                 self._boxes_per_trace.append(len(all_boxes) - before)
                 continue
@@ -231,9 +235,7 @@ class PlotlyMultiBoxPlot(PlotlyPlot):
         results = []
         for cat in categories:
             arr = np.array(groups[cat], dtype=float)
-            stats = _compute_stats(
-                arr, label=str(cat), quartilemethod=quartilemethod
-            )
+            stats = _compute_stats(arr, label=str(cat), quartilemethod=quartilemethod)
             if stats is not None:
                 results.append(stats)
         return results

--- a/maidr/plotly/scatter.py
+++ b/maidr/plotly/scatter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
-from maidr.plotly.plotly_plot import PlotlyPlot, paired_axes
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list, paired_axes
 from maidr.plotly.step_shape import renders_through_webgl
 
 
@@ -160,9 +160,12 @@ class PlotlyScatterPlot(PlotlyPlot):
             except (TypeError, ValueError):
                 pass
 
-        # Method 2: Compute from tickvals (if tickmode is 'array')
-        tickvals = axis.get("tickvals")
-        if tickvals and len(tickvals) >= 2:
+        # Method 2: Compute from tickvals (if tickmode is 'array'). Through
+        # `as_list`, because a numpy `tickvals` is exported as a typed-array
+        # spec whose two keys pass the length test and then fail `float`,
+        # which silently dropped the grid from both axes.
+        tickvals = as_list(axis.get("tickvals"))
+        if len(tickvals) >= 2:
             try:
                 vals = [float(v) for v in tickvals]
                 diffs = [vals[i + 1] - vals[i] for i in range(len(vals) - 1)]

--- a/maidr/plotly/violin_stats.py
+++ b/maidr/plotly/violin_stats.py
@@ -181,7 +181,7 @@ def violin_stats(values: np.ndarray) -> ViolinStats | None:
     # position at a time rather than as an (intervals x n) outer product.
     # The outer product is O(intervals * n) memory, and intervals grows with
     # n: measured, 1.5 GB of peak memory for a 200k-sample violin, for every
-    # violin on the subplot. A row at a time is O(n). The result is
+    # violin on the subplot. A row at a time is O(n) memory. The result is
     # bit-identical, because reducing one contiguous row of the matrix is the
     # same pairwise summation numpy applies to a one-dimensional array.
     density = np.empty(len(positions))

--- a/maidr/plotly/violin_stats.py
+++ b/maidr/plotly/violin_stats.py
@@ -56,7 +56,7 @@ _MIN_BANDWIDTH_FRACTION = 100
 #: The quantile rule plotly uses. Not numpy's default (`linear`), and not
 #: plotly's own documented `quartilemethod` values either -- measured against
 #: plotly's `calcdata` across eight sample sizes, this is the one that agrees.
-_QUANTILE_METHOD = "hazen"
+QUANTILE_METHOD = "hazen"
 
 _INV_SQRT_2PI = 1.0 / math.sqrt(2.0 * math.pi)
 
@@ -156,7 +156,7 @@ def violin_stats(values: np.ndarray) -> ViolinStats | None:
         )
 
     q1, median, q3 = (
-        float(q) for q in np.percentile(values, [25, 50, 75], method=_QUANTILE_METHOD)
+        float(q) for q in np.percentile(values, [25, 50, 75], method=QUANTILE_METHOD)
     )
     bandwidth = _bandwidth(values, q1, q3)
 

--- a/maidr/plotly/violin_stats.py
+++ b/maidr/plotly/violin_stats.py
@@ -177,9 +177,16 @@ def violin_stats(values: np.ndarray) -> ViolinStats | None:
     step = width / intervals
     positions = low + np.arange(intervals + 1) * step
 
-    # The Gaussian kernel, summed over the sample at every position.
-    scaled = (positions[:, None] - values[None, :]) / bandwidth
-    density = np.exp(-0.5 * scaled**2).sum(axis=1)
+    # The Gaussian kernel, summed over the sample at every position -- one
+    # position at a time rather than as an (intervals x n) outer product.
+    # The outer product is O(intervals * n) memory, and intervals grows with
+    # n: measured, 1.5 GB of peak memory for a 200k-sample violin, for every
+    # violin on the subplot. A row at a time is O(n). The result is
+    # bit-identical, because reducing one contiguous row of the matrix is the
+    # same pairwise summation numpy applies to a one-dimensional array.
+    density = np.empty(len(positions))
+    for i, position in enumerate(positions):
+        density[i] = np.exp(-0.5 * ((position - values) / bandwidth) ** 2).sum()
     density *= _INV_SQRT_2PI / (len(values) * bandwidth)
 
     return ViolinStats(

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -504,6 +504,41 @@ class TestPlotlyMultiBoxPlot:
 
         assert plot.render()["orientation"] == "horz"
 
+    @pytest.mark.parametrize(
+        "precomputed_axis, raw_axis, expected",
+        [
+            # A lone x positions a precomputed trace's boxes: vertical, like
+            # a raw trace whose samples are in y.
+            ("x", "y", "vert"),
+            # A lone y positions them horizontally, and one horizontal trace
+            # makes the layer horizontal -- even beside a raw y-sample trace,
+            # which read alone would say vertical.
+            ("y", "y", "horz"),
+            # The raw rule is the reverse: samples in x alone are horizontal,
+            # and that outvotes the precomputed x-positioned trace.
+            ("x", "x", "horz"),
+        ],
+    )
+    def test_orientation_is_judged_per_trace_across_mixed_forms(
+        self, precomputed_axis, raw_axis, expected
+    ):
+        traces = [
+            {
+                "type": "box",
+                "q1": [4],
+                "median": [5],
+                "q3": [6],
+                precomputed_axis: [0],
+            },
+            {"type": "box", raw_axis: [1, 2, 3, 4, 5]},
+        ]
+        plot = PlotlyMultiBoxPlot(traces, {})
+        schema = plot.render()
+
+        assert schema["orientation"] == expected
+        assert [box["q2"] for box in schema["data"]] == [5, 3.0]
+        assert plot._boxes_per_trace == [1, 1]
+
     def test_a_precomputed_trace_with_both_arrays_falls_through_to_vertical(self):
         # Plotly's case "11": the trace is hidden and draws nothing, so this
         # pins the extractor's default rather than a plotly rule.

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -359,6 +359,19 @@ class TestPlotlyBoxPlot:
         assert len(data) == 1
         assert data[0]["q2"] == 3.0
 
+    def test_numpy_quartile_arrays_are_read_as_precomputed(self):
+        # ``bool(np.ndarray)`` raises; the predicate has to size, not test.
+        trace = {
+            "type": "box",
+            "q1": np.array([1.0, 2.0]),
+            "median": np.array([2.0, 3.0]),
+            "q3": np.array([3.0, 4.0]),
+        }
+
+        data = PlotlyBoxPlot(trace, {})._extract_plot_data()
+
+        assert [box["q2"] for box in data] == [2.0, 3.0]
+
     def test_unordered_precomputed_quartiles_are_dropped(self):
         # Plotly's calc requires q1 <= median <= q3 before it draws anything.
         trace = {"type": "box", "q1": [3], "median": [2], "q3": [4]}

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -9,6 +9,7 @@ from maidr.plotly.bar import PlotlyBarPlot
 from maidr.plotly.scatter import PlotlyScatterPlot
 from maidr.plotly.line import PlotlyLinePlot
 from maidr.plotly.box import PlotlyBoxPlot
+from maidr.plotly.multibox import PlotlyMultiBoxPlot
 from maidr.plotly.heatmap import PlotlyHeatmapPlot
 from maidr.plotly.histogram import PlotlyHistogramPlot
 from maidr.plotly.grouped_bar import PlotlyGroupedBarPlot
@@ -200,6 +201,197 @@ class TestPlotlyBoxPlot:
         assert len(data) == 2
         assert data[0]["z"] == "A"
         assert data[1]["z"] == "B"
+
+    @pytest.mark.parametrize(
+        "sample, expected",
+        [
+            ([1, 2, 3, 4], (1.5, 2.5, 3.5)),
+            ([1, 2, 3, 4, 5], (1.75, 3.0, 4.25)),
+        ],
+    )
+    def test_quartiles_are_plotlys(self, sample, expected):
+        """Hazen, the rule plotly's `Lib.interp` draws with.
+
+        Read straight from the bundle: `t = p * n - 0.5`, interpolated between
+        the samples either side. The violin module already pins that rule
+        against plotly's calcdata; the box has to agree with the same chart.
+        """
+        plot = PlotlyBoxPlot({"type": "box", "y": sample}, {})
+        box = plot._extract_plot_data()[0]
+
+        assert (box["q1"], box["q2"], box["q3"]) == expected
+
+    def test_the_default_quantile_rule_would_not_pass(self):
+        """The control, so the test above cannot pass by coincidence."""
+        linear = np.percentile([1, 2, 3, 4], [25, 75], method="linear")
+
+        assert tuple(linear) != (1.5, 3.5)
+
+    @pytest.mark.parametrize(
+        "method, expected",
+        [
+            ("exclusive", (2.5, 7.5)),
+            ("inclusive", (3.0, 7.0)),
+        ],
+    )
+    def test_quartilemethod_splits_an_odd_sample_the_way_plotly_does(
+        self, method, expected
+    ):
+        """Plotly's own documented example for the two methods, 1..9."""
+        trace = {"type": "box", "y": list(range(1, 10)), "quartilemethod": method}
+        box = PlotlyBoxPlot(trace, {})._extract_plot_data()[0]
+
+        assert (box["q1"], box["q3"]) == expected
+
+    @pytest.mark.parametrize("method", ["exclusive", "inclusive"])
+    def test_quartilemethod_leaves_an_even_sample_hazen(self, method):
+        # Plotly only branches on the method when the sample size is odd.
+        trace = {"type": "box", "y": [1, 2, 3, 4], "quartilemethod": method}
+        box = PlotlyBoxPlot(trace, {})._extract_plot_data()[0]
+
+        assert (box["q1"], box["q3"]) == (1.5, 3.5)
+
+    def test_a_gap_in_the_sample_is_skipped(self):
+        """Plotly's box calc skips a non-numeric sample; so does this.
+
+        Left in, the `None` becomes a NaN that poisons every statistic and
+        lands in the schema as a bare `NaN` token.
+        """
+        with_gap = PlotlyBoxPlot(
+            {"type": "box", "y": [1, 2, None, 3, 4, 100]}, {}
+        )._extract_plot_data()
+        without = PlotlyBoxPlot(
+            {"type": "box", "y": [1, 2, 3, 4, 100]}, {}
+        )._extract_plot_data()
+
+        assert with_gap == without
+        assert with_gap[0]["upperOutliers"] == [100.0]
+
+    def test_an_all_missing_box_is_dropped(self):
+        plot = PlotlyBoxPlot({"type": "box", "y": [None, None]}, {})
+
+        assert plot._extract_plot_data() == []
+
+    @pytest.mark.parametrize(
+        "extra, expected",
+        [
+            ({"x": [0, 1, 2]}, "vert"),
+            ({"x": ["a", "b", "c"]}, "vert"),
+            ({"y": [0, 1, 2]}, "horz"),
+            ({"y": ["a", "b", "c"]}, "horz"),
+            ({}, "vert"),
+            ({"y": [0, 1, 2], "orientation": "h"}, "horz"),
+        ],
+    )
+    def test_a_precomputed_box_reads_its_lone_array_as_positions(self, extra, expected):
+        """Plotly's box defaults: case "10" draws `v`, case "01" draws `h`.
+
+        With the values in `q1`/`median`/`q3`, a lone `x` is where the boxes
+        stand, not what they hold -- the reverse of the raw-sample rule.
+        """
+        trace = {"type": "box", "q1": [1, 2, 3], "median": [4, 5, 6], "q3": [7, 8, 9]}
+        trace.update(extra)
+
+        assert PlotlyBoxPlot(trace, {}).render()["orientation"] == expected
+
+    def test_a_raw_sample_in_x_alone_is_still_horizontal(self):
+        plot = PlotlyBoxPlot({"type": "box", "x": [1, 2, 3, 4]}, {})
+
+        assert plot.render()["orientation"] == "horz"
+
+
+class TestPlotlyMultiBoxPlot:
+    """The multi-trace extractor keeps its own copy of the box rules."""
+
+    @pytest.mark.parametrize(
+        "sample, expected",
+        [
+            ([1, 2, 3, 4], (1.5, 2.5, 3.5)),
+            ([1, 2, 3, 4, 5], (1.75, 3.0, 4.25)),
+        ],
+    )
+    def test_quartiles_are_plotlys(self, sample, expected):
+        plot = PlotlyMultiBoxPlot([{"type": "box", "y": sample}], {})
+        box = plot._extract_plot_data()[0]
+
+        assert (box["q1"], box["q2"], box["q3"]) == expected
+
+    @pytest.mark.parametrize(
+        "method, expected",
+        [
+            ("exclusive", (2.5, 7.5)),
+            ("inclusive", (3.0, 7.0)),
+        ],
+    )
+    def test_quartilemethod_is_read_per_trace(self, method, expected):
+        traces = [
+            {"type": "box", "y": list(range(1, 10)), "quartilemethod": method},
+            {"type": "box", "y": list(range(1, 10))},
+        ]
+        boxes = PlotlyMultiBoxPlot(traces, {})._extract_plot_data()
+
+        assert (boxes[0]["q1"], boxes[0]["q3"]) == expected
+        assert (boxes[1]["q1"], boxes[1]["q3"]) == (2.75, 7.25)
+
+    def test_quartilemethod_reaches_a_grouped_trace(self):
+        trace = {
+            "type": "box",
+            "x": ["a"] * 9,
+            "y": list(range(1, 10)),
+            "quartilemethod": "exclusive",
+        }
+        box = PlotlyMultiBoxPlot([trace], {})._extract_plot_data()[0]
+
+        assert (box["q1"], box["q3"]) == (2.5, 7.5)
+
+    def test_a_gap_in_the_sample_is_skipped(self):
+        with_gap = PlotlyMultiBoxPlot(
+            [{"type": "box", "y": [1, 2, None, 3, 4, 100]}], {}
+        )._extract_plot_data()
+        without = PlotlyMultiBoxPlot(
+            [{"type": "box", "y": [1, 2, 3, 4, 100]}], {}
+        )._extract_plot_data()
+
+        assert with_gap == without
+        assert with_gap[0]["upperOutliers"] == [100.0]
+
+    def test_a_gap_in_a_grouped_sample_is_skipped(self):
+        trace = {
+            "type": "box",
+            "x": ["a", "a", "a", "b", "b", "b"],
+            "y": [1, 2, 3, 4, None, 6],
+        }
+        boxes = PlotlyMultiBoxPlot([trace], {})._extract_plot_data()
+
+        assert boxes[1]["z"] == "b"
+        assert boxes[1]["q2"] == 5.0
+
+    def test_an_all_missing_box_is_dropped(self):
+        plot = PlotlyMultiBoxPlot([{"type": "box", "y": [None, None]}], {})
+
+        assert plot._extract_plot_data() == []
+
+    @pytest.mark.parametrize(
+        "extra, expected",
+        [
+            ({"x": [0, 1, 2]}, "vert"),
+            ({"y": [0, 1, 2]}, "horz"),
+            ({}, "vert"),
+            ({"y": [0, 1, 2], "orientation": "h"}, "horz"),
+        ],
+    )
+    def test_a_precomputed_trace_reads_its_lone_array_as_positions(
+        self, extra, expected
+    ):
+        trace = {"type": "box", "q1": [1, 2, 3], "median": [4, 5, 6], "q3": [7, 8, 9]}
+        trace.update(extra)
+
+        assert PlotlyMultiBoxPlot([trace], {}).render()["orientation"] == expected
+
+    def test_a_raw_sample_in_x_alone_is_still_horizontal(self):
+        plot = PlotlyMultiBoxPlot([{"type": "box", "x": [1, 2, 3, 4]}], {})
+
+        assert plot.render()["orientation"] == "horz"
 
 
 class TestPlotlyHeatmapPlot:

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -251,6 +251,23 @@ class TestPlotlyBoxPlot:
 
         assert (box["q1"], box["q3"]) == (1.5, 3.5)
 
+    @pytest.mark.parametrize("method", ["exclusive", "inclusive"])
+    def test_a_single_sample_box_keeps_finite_quartiles(self, method):
+        # One sample is odd, so the method branch runs -- and under
+        # `exclusive` both halves are empty. Plotly's `Lib.interp` on an
+        # empty array answers `undefined`, so there is nothing drawn to
+        # match; the Hazen rule gives the only value there is.
+        trace = {"type": "box", "y": [7.0], "quartilemethod": method}
+        box = PlotlyBoxPlot(trace, {})._extract_plot_data()[0]
+
+        assert (box["min"], box["q1"], box["q2"], box["q3"], box["max"]) == (
+            7.0,
+            7.0,
+            7.0,
+            7.0,
+            7.0,
+        )
+
     def test_a_gap_in_the_sample_is_skipped(self):
         """Plotly's box calc skips a non-numeric sample; so does this.
 
@@ -347,6 +364,19 @@ class TestPlotlyMultiBoxPlot:
 
         assert (boxes[0]["q1"], boxes[0]["q3"]) == expected
         assert (boxes[1]["q1"], boxes[1]["q3"]) == (2.75, 7.25)
+
+    @pytest.mark.parametrize("method", ["exclusive", "inclusive"])
+    def test_a_single_sample_box_keeps_finite_quartiles(self, method):
+        trace = {"type": "box", "y": [7.0], "quartilemethod": method}
+        box = PlotlyMultiBoxPlot([trace], {})._extract_plot_data()[0]
+
+        assert (box["min"], box["q1"], box["q2"], box["q3"], box["max"]) == (
+            7.0,
+            7.0,
+            7.0,
+            7.0,
+            7.0,
+        )
 
     def test_quartilemethod_reaches_a_grouped_trace(self):
         trace = {

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -343,6 +343,22 @@ class TestPlotlyBoxPlot:
         assert [box["q1"] for box in data] == [1]
         assert len(plot._get_selector()) == 1
 
+    @pytest.mark.parametrize("absent", ["q1", "median", "q3"])
+    def test_a_trace_missing_one_quartile_array_is_read_as_a_sample(self, absent):
+        """Plotly's ``_hasPreCompStats`` needs ``q1``, ``median`` and ``q3``.
+
+        With one of them absent the trace is a raw box, so its ``y`` is the
+        sample and the two quartile arrays it does carry are ignored.
+        """
+        trace = {"type": "box", "y": [1, 2, 3, 4, 5], "q1": [0], "median": [0]}
+        trace["q3"] = [0]
+        del trace[absent]
+
+        data = PlotlyBoxPlot(trace, {})._extract_plot_data()
+
+        assert len(data) == 1
+        assert data[0]["q2"] == 3.0
+
     def test_unordered_precomputed_quartiles_are_dropped(self):
         # Plotly's calc requires q1 <= median <= q3 before it draws anything.
         trace = {"type": "box", "q1": [3], "median": [2], "q3": [4]}

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -299,6 +299,21 @@ class TestPlotlyBoxPlot:
 
         assert plot.render()["orientation"] == "horz"
 
+    def test_a_precomputed_box_with_both_arrays_falls_through_to_vertical(self):
+        # Plotly's case "11": no orientation is chosen and the trace is hidden
+        # (`visible = false`), so nothing is drawn to match. This pins the
+        # default the extractor answers with rather than a plotly rule.
+        trace = {
+            "type": "box",
+            "q1": [1, 2, 3],
+            "median": [4, 5, 6],
+            "q3": [7, 8, 9],
+            "x": [0, 1, 2],
+            "y": [0, 1, 2],
+        }
+
+        assert PlotlyBoxPlot(trace, {}).render()["orientation"] == "vert"
+
 
 class TestPlotlyMultiBoxPlot:
     """The multi-trace extractor keeps its own copy of the box rules."""
@@ -392,6 +407,20 @@ class TestPlotlyMultiBoxPlot:
         plot = PlotlyMultiBoxPlot([{"type": "box", "x": [1, 2, 3, 4]}], {})
 
         assert plot.render()["orientation"] == "horz"
+
+    def test_a_precomputed_trace_with_both_arrays_falls_through_to_vertical(self):
+        # Plotly's case "11": the trace is hidden and draws nothing, so this
+        # pins the extractor's default rather than a plotly rule.
+        trace = {
+            "type": "box",
+            "q1": [1, 2, 3],
+            "median": [4, 5, 6],
+            "q3": [7, 8, 9],
+            "x": [0, 1, 2],
+            "y": [0, 1, 2],
+        }
+
+        assert PlotlyMultiBoxPlot([trace], {}).render()["orientation"] == "vert"
 
 
 class TestPlotlyHeatmapPlot:

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -331,6 +331,41 @@ class TestPlotlyBoxPlot:
 
         assert PlotlyBoxPlot(trace, {}).render()["orientation"] == "vert"
 
+    @pytest.mark.parametrize("missing", [None, float("nan")])
+    def test_a_precomputed_box_with_a_missing_quartile_is_dropped(self, missing):
+        # Sent straight through, the gap landed in the schema as a bare
+        # `null`/`NaN`. Plotly draws no box for it, so dropping it keeps the
+        # remaining boxes' positional selectors on the elements they describe.
+        trace = {"type": "box", "q1": [1, missing], "median": [2, 3], "q3": [3, 4]}
+        plot = PlotlyBoxPlot(trace, {})
+        data = plot._extract_plot_data()
+
+        assert [box["q1"] for box in data] == [1]
+        assert len(plot._get_selector()) == 1
+
+    def test_unordered_precomputed_quartiles_are_dropped(self):
+        # Plotly's calc requires q1 <= median <= q3 before it draws anything.
+        trace = {"type": "box", "q1": [3], "median": [2], "q3": [4]}
+
+        assert PlotlyBoxPlot(trace, {})._extract_plot_data() == []
+
+    def test_a_bad_precomputed_fence_falls_back_to_its_quartile(self):
+        # A fence plotly rejects -- missing, or on the wrong side of its
+        # quartile -- costs nothing but the fence: with no points to measure
+        # from, plotly uses the quartile itself.
+        trace = {
+            "type": "box",
+            "q1": [1, 2],
+            "median": [2, 3],
+            "q3": [3, 4],
+            "lowerfence": [None, 5],
+            "upperfence": [float("nan"), 3],
+        }
+        data = PlotlyBoxPlot(trace, {})._extract_plot_data()
+
+        assert [box["min"] for box in data] == [1, 2]
+        assert [box["max"] for box in data] == [3, 4]
+
 
 class TestPlotlyMultiBoxPlot:
     """The multi-trace extractor keeps its own copy of the box rules."""
@@ -451,6 +486,33 @@ class TestPlotlyMultiBoxPlot:
         }
 
         assert PlotlyMultiBoxPlot([trace], {}).render()["orientation"] == "vert"
+
+    @pytest.mark.parametrize("missing", [None, float("nan")])
+    def test_a_precomputed_box_with_a_missing_quartile_is_dropped(self, missing):
+        traces = [
+            {"type": "box", "q1": [1, missing], "median": [2, 3], "q3": [3, 4]},
+            {"type": "box", "q1": [5], "median": [6], "q3": [7]},
+        ]
+        plot = PlotlyMultiBoxPlot(traces, {})
+        data = plot._extract_plot_data()
+
+        assert [box["q1"] for box in data] == [1, 5]
+        assert plot._boxes_per_trace == [1, 1]
+        assert len(plot._get_selector()) == 2
+
+    def test_a_bad_precomputed_fence_falls_back_to_its_quartile(self):
+        trace = {
+            "type": "box",
+            "q1": [1, 2],
+            "median": [2, 3],
+            "q3": [3, 4],
+            "lowerfence": [None, 5],
+            "upperfence": [float("nan"), 3],
+        }
+        data = PlotlyMultiBoxPlot([trace], {})._extract_plot_data()
+
+        assert [box["min"] for box in data] == [1, 2]
+        assert [box["max"] for box in data] == [3, 4]
 
 
 class TestPlotlyHeatmapPlot:

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -455,7 +455,9 @@ class TestPlotlyMultiBoxPlot:
         "extra, expected",
         [
             ({"x": [0, 1, 2]}, "vert"),
+            ({"x": ["a", "b", "c"]}, "vert"),
             ({"y": [0, 1, 2]}, "horz"),
+            ({"y": ["a", "b", "c"]}, "horz"),
             ({}, "vert"),
             ({"y": [0, 1, 2], "orientation": "h"}, "horz"),
         ],

--- a/tests/plotly/test_plotly_typed_arrays.py
+++ b/tests/plotly/test_plotly_typed_arrays.py
@@ -183,6 +183,26 @@ def test_a_numpy_backed_trace_is_counted_by_its_points_not_its_spec_keys():
     assert default_mode(numpy_trace) == default_mode(list_trace) == "lines"
 
 
+def test_numpy_tickvals_keep_the_grid():
+    # A numpy `tickvals` is exported as a typed-array spec like any other
+    # numeric array. Read raw, the spec's two keys passed the `>= 2` length
+    # test and then failed `float`, which the extractor swallowed -- and one
+    # missing tick step silently drops `min`/`max`/`tickStep` from *both*
+    # axes, taking grid navigation with it.
+    fig = go.Figure(go.Scatter(x=list(range(11)), y=list(range(11)), mode="markers"))
+    fig.update_xaxes(tickvals=np.arange(0, 11, 2))
+    fig.update_yaxes(tickvals=[0, 2, 4, 6, 8, 10])
+
+    assert isinstance(fig.to_dict()["layout"]["xaxis"]["tickvals"], dict)
+
+    axes = PlotlyMaidr(fig)._plots[0].schema["axes"]
+    x_axis = {str(getattr(k, "value", k)): v for k, v in axes["x"].items()}
+
+    assert x_axis["tickStep"] == 2.0
+    assert x_axis["min"] == 0.0
+    assert x_axis["max"] == 10.0
+
+
 class TestAsList:
     """The decoder leaves everything that already worked alone."""
 

--- a/tests/plotly/test_plotly_typed_arrays.py
+++ b/tests/plotly/test_plotly_typed_arrays.py
@@ -203,6 +203,18 @@ def test_numpy_tickvals_keep_the_grid():
     assert x_axis["max"] == 10.0
 
 
+def test_a_nan_in_a_precomputed_statistic_does_not_reach_the_schema():
+    # A numpy `q1` with a NaN is exported as an `f8` typed array and decoded
+    # back to a NaN, which `json.dumps` writes as a bare `NaN` token -- the
+    # same failure a NaN sample used to cause. Plotly draws no box there.
+    fig = go.Figure(go.Box(q1=np.array([1.0, np.nan]), median=[2, 3], q3=[3, 4]))
+
+    data = _data_of(fig)[0]
+
+    assert len(data) == 1
+    assert "NaN" not in str(PlotlyMaidr(fig).render())
+
+
 class TestAsList:
     """The decoder leaves everything that already worked alone."""
 

--- a/tests/plotly/test_plotly_violin_stats.py
+++ b/tests/plotly/test_plotly_violin_stats.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import json
 import math
 import pathlib
+import tracemalloc
 
 import numpy as np
 import pytest
@@ -200,6 +201,29 @@ def test_the_density_is_a_density(size: str) -> None:
 
     area = float(np.trapezoid(stats.density, stats.positions))
     assert 0.9 < area <= 1.0, area
+
+
+def test_the_kernel_is_evaluated_in_linear_memory() -> None:
+    """One row of the kernel at a time, never the whole (points x n) matrix.
+
+    The outer product costs `intervals * n` doubles three times over, and
+    `intervals` grows with `n`: measured, 260 MB at n=50,000 and 1.5 GB at
+    n=200,000 -- for every violin on the subplot. Evaluating position by
+    position is O(n) and, because each row of that matrix is reduced by the
+    same pairwise summation as a one-dimensional array, bit-identical; the
+    reference tests above are what guard the values.
+    """
+    sample = np.random.default_rng(0).normal(size=50_000)
+
+    tracemalloc.start()
+    try:
+        stats = violin_stats(sample)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert stats is not None
+    assert peak < 16 * 1024 * 1024, f"peak {peak / 1e6:.0f} MB"
 
 
 def test_a_shifted_sample_shifts_its_curve() -> None:

--- a/tests/plotly/test_plotly_violin_stats.py
+++ b/tests/plotly/test_plotly_violin_stats.py
@@ -209,9 +209,9 @@ def test_the_kernel_is_evaluated_in_linear_memory() -> None:
     The outer product costs `intervals * n` doubles three times over, and
     `intervals` grows with `n`: measured, 260 MB at n=50,000 and 1.5 GB at
     n=200,000 -- for every violin on the subplot. Evaluating position by
-    position is O(n) and, because each row of that matrix is reduced by the
-    same pairwise summation as a one-dimensional array, bit-identical; the
-    reference tests above are what guard the values.
+    position is O(n) memory and, because each row of that matrix is reduced
+    by the same pairwise summation as a one-dimensional array, bit-identical;
+    the reference tests above are what guard the values.
     """
     sample = np.random.default_rng(0).normal(size=50_000)
 


### PR DESCRIPTION
## What

Five places where the plotly adapter told a reader something other than what the chart draws. Closes #700.

- **Quartile rule.** `box.py` and `multibox.py` used `np.percentile`'s default (Hyndman-Fan type 7). plotly.js's default `quartilemethod='linear'` is `Lib.interp`: `n = p*len - 0.5` then linear interpolation, i.e. Hazen (type 5) — the rule `violin_stats.py` already documents and `tests/plotly/plotly_violin_reference.json` (measured from plotly's calcdata) pins. `go.Box(y=[1,2,3,4])` announced q1/q3 = 1.75/3.25 where plotly draws 1.5/3.5; fences, whisker ends and the outlier split all follow. Both `_compute_stats` now use `method='hazen'`, and the odd-n `exclusive`/`inclusive` branch is read straight from the bundle (halves' medians; plotly's own example 1..9 gives exclusive 2.5/7.5, inclusive 3/7, default 2.75/7.25).
- **A gap in the sample.** `go.Box(y=[1, 2, None, 3, 4, 100])` emitted `{min: NaN, q1: NaN, ...}` and the bare `NaN` token reached the page. plotly's calc loop is guarded by `isNumeric`; `_compute_stats` now filters to finite samples first, and an all-missing box falls into the existing "no samples" branch.
- **Precomputed orientation.** For the q1/median/q3 signature plotly's defaults invert the raw-sample rule (`case "10"` → vertical, `"01"` → horizontal): `go.Box(x=[0,1,2], q1=..., median=..., q3=...)` is vertical on screen and was emitted `horz`. Both `_is_horizontal` now apply the precomputed rule after the explicit `orientation` check.
- **Violin KDE memory.** `violin_stats` built an (intervals × n) matrix three times: 290 MB peak at 50k samples, 1.5 GB at 200k. A per-position loop is bit-identical (each row is the same contiguous pairwise reduction; `np.array_equal` True at n = 7, 100, 1k, 10k, 50k) and O(n): 50k samples 198 ms / 259 MB → 93 ms / 1.2 MB here.
- **numpy tickvals.** `fig.update_xaxes(tickvals=np.arange(...))` arrives as a typed-array spec; `_get_tick_step` read it raw, `float('dtype')` raised, the except swallowed it and grid navigation was silently dropped from both axes. It now goes through `as_list`.

## Output changes

Box `q1`/`q3` (and fences, `min`/`max`, outliers) move to the values plotly draws; a box with `None`/NaN samples emits finite statistics; a precomputed x-only box is `vert`, y-only `horz`; numpy `tickvals` keep `min`/`max`/`tickStep`.

## Tests

`tests/plotly/test_plotly_plots.py`: `[1,2,3,4]` → (1.5, 2.5, 3.5) and `[1..5]` → (1.75, 3.0, 4.25) for box and multibox with a control that numpy's default disagrees; a gap equals the stats of the finite sample; an all-missing box is dropped; the four precomputed x/y combinations plus a raw x-only control; exclusive/inclusive on 1..9. `test_plotly_violin_stats.py`: tracemalloc peak under 16 MB at n = 50 000. `test_plotly_typed_arrays.py`: numpy tickvals keep the grid. With the source changes reverted: 23 failed, 132 passed — every failure a new case.

## Verified

```
uv run pytest      3635 passed, 68 skipped
ruff check         All checks passed (maidr/plotly, tests/plotly)
```

Left alone (separate issue): a string-valued raw box sample, e.g. date strings, still raises from `np.array(dtype=float)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_