### PR TITLE
perf(render): embed the schema compactly, build the page once for the browser and read trace types off the layers

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -274,19 +274,23 @@ class Maidr:
                 # the bundle is unreachable.
                 pass
 
-        html = self._create_html_tag(
-            use_iframe=True, use_cdn=use_cdn
-        )  # Always use iframe for display
-
         # Use the passed renderer parameter, fallback to auto-detection
         if renderer == "auto":
             _renderer = cast(Literal["ipython", "browser"], Environment.get_renderer())
         else:
             _renderer = renderer
 
-        # Only try browser opening if explicitly requested as browser and not in notebook
+        # Only try browser opening if explicitly requested as browser and not
+        # in notebook. That path renders through `save_html`, which builds
+        # the whole document itself, so the Tag must not be built ahead of
+        # this decision: it would rasterise the SVG and dump the schema
+        # twice and throw the first copy away.
         if _renderer == "browser" and not Environment.is_notebook():
             return self._open_plot_in_browser(use_cdn=use_cdn)
+
+        html = self._create_html_tag(
+            use_iframe=True, use_cdn=use_cdn
+        )  # Always use iframe for display
 
         if clear_fig:
             plt.close()
@@ -520,10 +524,13 @@ class Maidr:
         # is in one and not the other -- see :mod:`maidr.util.render_census`.
         warn_if_figure_changed(drawn_before, self._fig)
 
-        # Generate external payload if data is not embedded in SVG
+        # Generate external payload if data is not embedded in SVG.
+        # No `indent`: it would switch json to its pure-Python encoder
+        # (~6x slower, twice the bytes at 100k points) for whitespace the
+        # engine parses straight back out. Same in `_get_svg`.
         maidr = None
         if not data_in_svg:
-            maidr = f"\nvar maidr = {json.dumps(schema, indent=2)}\n"
+            maidr = f"\nvar maidr = {json.dumps(schema)}\n"
 
         # Inject plot's svg and MAIDR structure into html tag.
         return Maidr._inject_plot(
@@ -952,7 +959,10 @@ class Maidr:
             if isinstance(current_schema, dict) and "id" in current_schema:
                 element.attrib["id"] = str(current_schema["id"])  # ensure match
             if embed_data:
-                element.attrib["maidr"] = json.dumps(current_schema, indent=2)
+                # Compact on purpose: an attribute value is one line to a
+                # reader anyway (newlines become `&#10;`), and `indent`
+                # would cost the C encoder -- see `_create_html_tag`.
+                element.attrib["maidr"] = json.dumps(current_schema)
             root_svg = element
             break
 

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -1468,8 +1468,6 @@ class PlotlyMaidr:
                 # the bundle is unreachable.
                 pass
 
-        html = self._create_html_tag(use_iframe=True, use_cdn=use_cdn)
-
         if renderer == "auto":
             _renderer = cast(
                 Literal["ipython", "browser"], Environment.get_renderer()
@@ -1477,9 +1475,14 @@ class PlotlyMaidr:
         else:
             _renderer = renderer
 
+        # The browser path renders through `save_html`, which builds the
+        # whole document itself, so the Tag must not be built ahead of
+        # this decision: that would serialise the figure and the schema
+        # twice and throw the first copy away.
         if _renderer == "browser" and not Environment.is_notebook():
             return self._open_plot_in_browser(use_cdn=use_cdn)
 
+        html = self._create_html_tag(use_iframe=True, use_cdn=use_cdn)
         return html.show(_renderer)
 
     def save_html(
@@ -1662,8 +1665,13 @@ class PlotlyMaidr:
             notebook/Shiny srcdoc iframe.  Switches the loader to use
             the parent-window source strings instead of relative paths.
         """
+        # The browser re-serialises this with JSON.stringify before it
+        # reaches the DOM, so indentation would never be seen -- and passing
+        # `indent` switches json to its pure-Python encoder, which is 5-6x
+        # slower and ~2.8x the bytes at 50k points. Default separators are
+        # kept on purpose: the literal stays greppable (`"type": "pie"`).
         dom_wiring = f"""
-            var maidrSchema = {json.dumps(schema, indent=2)};
+            var maidrSchema = {json.dumps(schema)};
 
             var _maidrDone = false;
             function initMaidr() {{

--- a/maidr/util/bundle_capability.py
+++ b/maidr/util/bundle_capability.py
@@ -218,19 +218,30 @@ def schema_trace_types(schema: object) -> set[str]:
     -------
     set of str
         The distinct ``type`` values of every layer found.
+
+    Notes
+    -----
+    Only the dicts inside a ``layers`` list are read. ``type`` is not a
+    layer's key alone: an axis ``format`` carries one too, naming a number
+    format (``percent``, ``currency``, ``date``...) that no bundle has a
+    renderer for, so a walk over every dict reported a formatted axis as
+    an undrawable chart. And a layer's ``data`` is the bulk of the schema
+    -- one dict per point -- with nothing to find in it.
     """
     found: set[str] = set()
 
-    def walk(node: object) -> None:
+    def walk(node: object, in_layers: bool = False) -> None:
         if isinstance(node, dict):
-            name = _trace_type_name(node.get("type"))
-            if name is not None:
-                found.add(name)
-            for child in node.values():
-                walk(child)
+            if in_layers:
+                name = _trace_type_name(node.get("type"))
+                if name is not None:
+                    found.add(name)
+                return  # a layer's data, axes and format hold no layers
+            for key, child in node.items():
+                walk(child, key == "layers")
         elif isinstance(node, list):
             for child in node:
-                walk(child)
+                walk(child, in_layers)
 
     walk(schema)
     return found

--- a/tests/core/test_bundle_capability.py
+++ b/tests/core/test_bundle_capability.py
@@ -174,6 +174,72 @@ def test_a_layer_type_is_collected_as_the_string_it_is_emitted_as(bar_plot):
     assert all(str(name) == "bar" for name in collected)
 
 
+def test_an_axis_format_type_is_not_a_layer_type():
+    """
+    ``type`` is not a layer's key alone.
+
+    An axis ``format`` carries one too, naming a number format that no
+    bundle has a renderer for. The walk used to collect it, and a bar chart
+    with a percent axis was reported as a chart the bundle could not draw.
+    """
+    from matplotlib.ticker import PercentFormatter, StrMethodFormatter
+
+    fig, ax = plt.subplots()
+    try:
+        ax.bar([1.0, 2.0, 3.0], [0.2, 0.5, 0.3])
+        ax.yaxis.set_major_formatter(PercentFormatter(xmax=1.0))
+        ax.xaxis.set_major_formatter(StrMethodFormatter("${x:,.2f}"))
+        schema = FigureManager.figs.get(fig)._flatten_maidr()
+
+        assert schema_trace_types(schema) == {"bar"}
+        assert _caught(lambda: maidr.render(fig, use_cdn=False)) == []
+    finally:
+        plt.close(fig)
+
+
+def test_a_plotly_axis_format_type_is_not_a_layer_type():
+    """The plotly emitter formats its axes the same way."""
+    go = pytest.importorskip("plotly.graph_objects")
+    from maidr.plotly.plotly_maidr import PlotlyMaidr
+
+    fig = go.Figure(go.Bar(x=["a", "b"], y=[0.2, 0.8]))
+    fig.update_layout(yaxis_tickformat=",.0%")
+    pm = PlotlyMaidr(fig)
+
+    assert schema_trace_types(pm._flatten_maidr()) == {"bar"}
+    assert _caught(lambda: pm._create_html_tag(use_cdn=False)) == []
+
+
+def test_a_layer_payload_is_not_descended():
+    """
+    A layer's ``data`` is the bulk of the schema and holds no layers.
+
+    Reading it was ~24 ms of every 50k-point render, twice per ``show()``,
+    for nothing -- and anything in there spelled ``type`` is a data value,
+    not a renderer.
+    """
+    schema = {
+        "id": "x",
+        "subplots": [
+            [
+                {
+                    "id": "p",
+                    "layers": [
+                        {
+                            "id": "l",
+                            "type": "bar",
+                            "data": [{"x": "a", "y": 1, "type": "bogus"}],
+                            "axes": {"x": {"format": {"type": "percent"}}},
+                        }
+                    ],
+                }
+            ]
+        ],
+    }
+
+    assert schema_trace_types(schema) == {"bar"}
+
+
 def test_the_enum_is_not_the_source_of_truth():
     """
     ``PlotType`` and the emitted types are different sets.

--- a/tests/core/test_figure_metadata.py
+++ b/tests/core/test_figure_metadata.py
@@ -200,3 +200,50 @@ def test_figure_metadata_survives_svg_embedding():
         assert embedded["id"] == root.attrib["id"]
     finally:
         plt.close(fig)
+
+
+def test_the_embedded_schema_is_compact(monkeypatch):
+    """Both embeddings are written without indentation.
+
+    The ``maidr`` attribute is one line to a reader anyway (newlines become
+    ``&#10;``) and the ``var maidr`` script is parsed straight back out, so
+    the whitespace bought nothing -- while passing ``indent`` to
+    ``json.dumps`` drops CPython's C encoder, ~6x slower and twice the
+    bytes on a 100k-point line. Equality once parsed is the contract; no
+    newline in either literal pins the C-encoder path.
+    """
+    import json
+
+    from lxml import etree
+
+    fig, ax = plt.subplots()
+    try:
+        ax.bar(["a", "b"], [1, 2])
+        fig.suptitle("Sales by Region")
+
+        m = FigureManager.get_maidr(fig)
+
+        # Every flatten mints fresh ids, so the reference is the schema each
+        # embedding was actually handed rather than a second flatten.
+        handed = []
+        flatten = m._flatten_maidr
+
+        def recording_flatten():
+            handed.append(flatten())
+            return handed[-1]
+
+        monkeypatch.setattr(m, "_flatten_maidr", recording_flatten)
+
+        svg = str(m._get_svg(embed_data=True))
+        attribute = etree.fromstring(svg.encode(), parser=None).attrib["maidr"]
+        assert json.loads(attribute) == json.loads(json.dumps(handed[-1]))
+        assert "\n" not in attribute
+
+        html_str = str(m._create_html_tag(data_in_svg=False, use_cdn=True))
+        marker = "var maidr = "
+        start = html_str.index(marker) + len(marker)
+        script, consumed = json.JSONDecoder().raw_decode(html_str[start:])
+        assert script == json.loads(json.dumps(handed[-1]))
+        assert "\n" not in html_str[start : start + consumed]
+    finally:
+        plt.close(fig)

--- a/tests/core/test_show_builds_the_page_once.py
+++ b/tests/core/test_show_builds_the_page_once.py
@@ -1,0 +1,66 @@
+"""``Maidr.show()`` builds the page exactly once, whichever way it is shown.
+
+The browser path renders through ``save_html``, which builds the whole
+document itself. Building the Tag before deciding on the renderer
+rasterised the SVG and dumped the schema twice and threw the first copy
+away -- roughly double the time of ``save_html`` alone on a 100k-point line.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core import maidr as module  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.util.environment import Environment  # noqa: E402
+
+
+@pytest.fixture
+def bar_plot():
+    fig, ax = plt.subplots()
+    ax.bar(["A", "B", "C"], [1.0, 2.0, 3.0])
+    yield fig
+    plt.close(fig)
+
+
+@pytest.fixture
+def build_count(monkeypatch):
+    """Count calls to ``_create_html_tag`` without changing its result."""
+    calls = []
+    original = module.Maidr._create_html_tag
+
+    def counted(self, *args, **kwargs):
+        calls.append(kwargs)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(module.Maidr, "_create_html_tag", counted)
+    return calls
+
+
+def test_show_in_browser_builds_the_document_once(bar_plot, build_count, monkeypatch):
+    opened = []
+    monkeypatch.setattr(module.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(Environment, "is_notebook", staticmethod(lambda: False))
+    monkeypatch.setattr(Environment, "get_renderer", staticmethod(lambda: "browser"))
+
+    FigureManager.get_maidr(bar_plot).show(clear_fig=False)
+
+    assert len(opened) == 1
+    assert len(build_count) == 1
+
+
+def test_show_in_ipython_builds_the_document_once(bar_plot, build_count, monkeypatch):
+    """The reorder must not cost the notebook path its one build."""
+    monkeypatch.setattr(Environment, "is_notebook", staticmethod(lambda: False))
+    monkeypatch.setattr("htmltools._core.Tag.show", lambda self, *a, **k: "shown")
+
+    shown = FigureManager.get_maidr(bar_plot).show(renderer="ipython", clear_fig=False)
+
+    assert shown == "shown"
+    assert len(build_count) == 1

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -740,3 +740,98 @@ class TestPlotlyFigureMetadata:
         metadata = pm._figure_metadata()
 
         assert metadata == {MaidrKey.TITLE: "Overview"}
+
+
+class TestPlotlyEmbeddedSchema:
+    """The `var maidrSchema = {...}` literal inside the init script."""
+
+    def test_embedded_schema_is_emitted_compact_and_round_trips(self, monkeypatch):
+        """Compact on the wire, equal once parsed.
+
+        The browser re-serialises the literal with ``JSON.stringify`` so
+        indentation never reaches the DOM, and passing ``indent`` to
+        ``json.dumps`` drops CPython's C encoder -- 5-6x slower and ~2.8x
+        the bytes on a 50k-point line. The consumed slice holding no
+        newline is what pins the C-encoder path.
+        """
+        import json
+
+        fig = go.Figure(go.Scatter(x=[1, 2, 3], y=[4, 5, 6], mode="lines"))
+        pm = PlotlyMaidr(fig)
+
+        # Every flatten mints fresh subplot ids, so the reference is the
+        # schema the page was actually handed rather than a second flatten.
+        handed = []
+        flatten = pm._flatten_maidr
+
+        def recording_flatten():
+            handed.append(flatten())
+            return handed[-1]
+
+        monkeypatch.setattr(pm, "_flatten_maidr", recording_flatten)
+        html_str = str(pm.render().get_html_string())
+
+        marker = "var maidrSchema = "
+        start = html_str.index(marker) + len(marker)
+        embedded, consumed = json.JSONDecoder().raw_decode(html_str[start:])
+
+        assert len(handed) == 1
+        assert embedded == json.loads(json.dumps(handed[0]))
+        assert "\n" not in html_str[start : start + consumed]
+
+
+class TestPlotlyShow:
+    """``show()`` builds the page exactly once, whichever way it is shown."""
+
+    @pytest.fixture
+    def build_count(self, monkeypatch):
+        """Count calls to ``_create_html_tag`` without changing its result."""
+        from maidr.plotly import plotly_maidr as module
+
+        calls = []
+        original = module.PlotlyMaidr._create_html_tag
+
+        def counted(self, *args, **kwargs):
+            calls.append(kwargs)
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(module.PlotlyMaidr, "_create_html_tag", counted)
+        return calls
+
+    def test_show_in_browser_builds_the_document_once(
+        self, plotly_bar_fig, build_count, monkeypatch
+    ):
+        """The browser path renders through ``save_html``.
+
+        Building the Tag before deciding on the renderer serialised the
+        figure and the schema twice and threw the first copy away -- 2.9x
+        the time of ``save_html`` alone on a 50k-point line.
+        """
+        from maidr.plotly import plotly_maidr as module
+        from maidr.util.environment import Environment
+
+        opened = []
+        monkeypatch.setattr(module.webbrowser, "open", lambda url: opened.append(url))
+        monkeypatch.setattr(Environment, "is_notebook", staticmethod(lambda: False))
+        monkeypatch.setattr(
+            Environment, "get_renderer", staticmethod(lambda: "browser")
+        )
+
+        PlotlyMaidr(plotly_bar_fig).show()
+
+        assert len(opened) == 1
+        assert len(build_count) == 1
+
+    def test_show_in_ipython_builds_the_document_once(
+        self, plotly_bar_fig, build_count, monkeypatch
+    ):
+        """The reorder must not cost the notebook path its one build."""
+        from maidr.util.environment import Environment
+
+        monkeypatch.setattr(Environment, "is_notebook", staticmethod(lambda: False))
+        monkeypatch.setattr("htmltools._core.Tag.show", lambda self, *a, **k: "shown")
+
+        shown = PlotlyMaidr(plotly_bar_fig).show(renderer="ipython")
+
+        assert shown == "shown"
+        assert len(build_count) == 1


### PR DESCRIPTION
## What

Three costs in the HTML assembly, none of them in extraction. Closes #698.

**`json.dumps(schema, indent=2)`** at the plotly init script, the matplotlib `var maidr` script and the SVG `maidr` attribute. CPython uses its C encoder only when `indent is None`, so an indented dump of 50k-100k point dicts ran through the pure-Python `_iterencode_*` generators, and the indentation never reached anyone: the plotly page re-serialises with `JSON.stringify` before setting the attribute, and the SVG attribute is read with `JSON.parse`. The three sites now use `json.dumps(schema)` with the default separators (a test greps `"type": "pie"`, so no `separators=(',', ':')`).

**`show()` built the page twice in browser mode**, in both `Maidr` and `PlotlyMaidr`: `_create_html_tag(use_iframe=True)` ran unconditionally, then the browser branch discarded it and `_open_plot_in_browser → save_html → _create_html_tag` built it again. Both resolve the renderer first now; the ipython path is unchanged and `clear_fig` handling stays where it was.

**`schema_trace_types`** walked every dict in the schema collecting any `type` key. The canonical axes payload nests `format: {type: percent|currency|date|…}`, so a `PercentFormatter`, a `'$'` formatter or a plotly `tickformat` made `warn_if_bundle_cannot_render` report that the bundle has "no renderer for percent" — a `MaidrBundleTraceWarning` under `use_cdn=False` and a `logger.warning` under the default — and the walk visited every data point on the way. It now collects `type` only from dicts inside a `layers` list and does not descend into a layer, keeping the docstring's "any nested structure containing a schema" promise.

## Measured (100k-point line, min of 3, same machine)

| | before | after |
|---|---|---|
| matplotlib `render()` | 1 088 ms / 14.8 MB | 396 ms / 6.2 MB |
| matplotlib `show()` browser path | 2 182 ms | 288 ms |
| plotly `render()` | 1 071 ms / 12.9 MB | 305 ms / 5.9 MB |
| plotly `show()` browser path | 2 753 ms | 714 ms |

## Output change

The emitted HTML is not byte-identical: the whitespace inside the three JSON literals is gone. The parsed schema is identical, the DOM is identical, and the file is 55-60 % smaller. A formatted axis no longer triggers the spurious bundle warning.

## Tests

`tests/plotly/test_plotly_maidr.py` and `tests/core/test_figure_metadata.py`: the embedded literal `raw_decode`s to the schema `_flatten_maidr()` returned during the embedding (each flatten mints fresh ids, so the recorded schema is compared, not a second flatten) and the consumed slice contains no newline. New `tests/core/test_show_builds_the_page_once.py`: browser renderer builds once for both emitters; ipython builds once. `tests/core/test_bundle_capability.py`: a `PercentFormatter` + `'$'` axis gives `{'bar'}` and `maidr.render(fig, use_cdn=False)` emits no `MaidrBundleTraceWarning`; a plotly `yaxis_tickformat` gives `{'bar'}`; a hand-built payload with `{'type': 'bogus'}` inside `data` is not descended. Against a pristine snapshot of `main`: 7 failed, 2 passed (the two ipython-path guards hold both ways).

## Verified

```
uv run pytest             3613 passed, 68 skipped
ruff check --diff .       exit 0
ruff check --select FA102 All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_