### PR TITLE
fix(box): read a box whose caps or fliers are hidden and drop one whose statistics are NaN

### DIFF
--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -536,17 +536,6 @@ class BoxPlot(
         key = MaidrKey.X if self._orientation == "vert" else MaidrKey.Y
         levels = self.extract_level(self.ax, key) or []
 
-        # A `hue` draws one box per category *per level*, and the axis still
-        # carries one tick per category -- so the `zip` below, which ends at
-        # the shortest of what it is given, stopped at the ticks and dropped
-        # every box past them. Measured on three categories and two levels:
-        # six boxes drawn, three announced, and the three that survived were
-        # the first level's paired with the tick labels in order (#593). The
-        # selector list is built from the artists rather than from this, so
-        # the same chart also emitted six selectors against three rows.
-        if len(medians) > len(levels):
-            levels = self._named_boxes(bxp_stats["boxes"], levels, key)
-
         # A box whose statistics are not finite was never on screen.
         # `cbook.boxplot_stats` does not drop a NaN, so one missing value in
         # a group -- or an empty group -- makes every statistic NaN, and
@@ -567,8 +556,28 @@ class BoxPlot(
             # artists at all when the fliers are hidden.
             return [items[index] for index in keep if index < len(items)]
 
-        # One level per box is the only shape a dropped box can be taken out
-        # of; more ticks than boxes is a chart the levels never lined up with.
+        # Two charts whose boxes and tick labels do not share an index, and
+        # so are named off the drawing -- each box by the tick nearest it --
+        # rather than paired with the labels in order:
+        #
+        # - A `hue` draws one box per category *per level*, and the axis
+        #   still carries one tick per category -- so the `zip` below, which
+        #   ends at the shortest of what it is given, stopped at the ticks and
+        #   dropped every box past them. Measured on three categories and two
+        #   levels: six boxes drawn, three announced, and the three that
+        #   survived were the first level's paired with the tick labels in
+        #   order (#593). The selector list is built from the artists rather
+        #   than from this, so the same chart also emitted six selectors
+        #   against three rows.
+        # - A chart with a box dropped. The labels are the ticks inside the
+        #   *data* limits, and a box that drew nothing contributes nothing to
+        #   those, so its own tick may or may not still be in the list --
+        #   the counts can agree while the alignment is off, and filtering
+        #   the labels by `keep` would then hand a surviving box the label
+        #   of an extra tick beside it. A chart missing nothing takes neither
+        #   branch and reads as it always has.
+        if len(medians) > len(levels) or len(keep) != len(medians):
+            levels = self._named_boxes(bxp_stats["boxes"], levels, key)
         if len(levels) == len(medians):
             levels = kept(levels)
         whiskers, caps, medians, outliers = (

--- a/maidr/core/plot/boxplot.py
+++ b/maidr/core/plot/boxplot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import uuid
 
 import numpy as np
@@ -90,6 +91,30 @@ def _box_colour(box):
     return None
 
 
+def _finite_box(whisker: dict, cap: dict, median: float) -> bool:
+    """
+    Whether one box's five statistics are all numbers matplotlib could draw.
+
+    Parameters
+    ----------
+    whisker : dict
+        The box's ``q1`` and ``q3``.
+    cap : dict
+        The box's ``min`` and ``max``.
+    median : float
+        The box's ``q2``.
+
+    Returns
+    -------
+    bool
+        ``False`` for a box any of whose statistics is ``NaN`` or infinite.
+    """
+    return all(
+        math.isfinite(value)
+        for value in (whisker["q1"], whisker["q3"], cap["min"], cap["max"], median)
+    )
+
+
 class BoxPlotContainer(DictMergerMixin):
     def __init__(self):
         self._orientation = None
@@ -137,12 +162,47 @@ class BoxPlotExtractor:
     def extract_whiskers(self, whiskers: list) -> list[dict]:
         return self._extract_extremes(whiskers, MaidrKey.Q1, MaidrKey.Q3)
 
-    def extract_caps(self, caps: list) -> list[dict]:
-        return self._extract_extremes(caps, MaidrKey.MIN, MaidrKey.MAX)
+    def extract_caps(self, caps: list, whiskers: list | None = None) -> list[dict]:
+        """
+        The min and max of every box, read off its caps.
+
+        A box drawn ``showcaps=False`` has no caps to read, and used to vanish
+        with them: the ``zip`` that assembles the rows ends at the shortest of
+        its lists, so an empty ``caps`` emptied the layer while the boxes
+        stayed on screen (#697). The whiskers still end where the caps would
+        have sat -- measured on the default chart, every cap's value equals
+        its whisker's far end -- so a chart with no caps reads its extremes
+        off the whiskers instead.
+
+        Parameters
+        ----------
+        caps : list
+            The cap artists, two per box, in drawing order.
+        whiskers : list, optional
+            The whisker artists, two per box, read only when ``caps`` is empty.
+
+        Returns
+        -------
+        list of dict
+            One ``{"min": ..., "max": ...}`` per box.
+        """
+        if caps:
+            return self._extract_extremes(caps, MaidrKey.MIN, MaidrKey.MAX)
+        return self._extract_extremes(
+            whiskers or [], MaidrKey.MIN, MaidrKey.MAX, position=1
+        )
 
     def _extract_extremes(
-        self, extremes: list, start_key: MaidrKey, end_key: MaidrKey
+        self,
+        extremes: list,
+        start_key: MaidrKey,
+        end_key: MaidrKey,
+        position: int = 0,
     ) -> list[dict]:
+        # `position` is which vertex of each line carries the value. A cap
+        # is a short stroke across the value, so any vertex does and the
+        # first is read; a whisker runs from the box edge out to the extreme,
+        # and the extreme is its second.
         data = []
 
         for start, end in zip(extremes[::2], extremes[1::2]):
@@ -151,8 +211,8 @@ class BoxPlotExtractor:
             )
             end_data_fn = end.get_ydata if self.orientation == "vert" else end.get_xdata
 
-            start_data = float(start_data_fn()[0])
-            end_data = float(end_data_fn()[0])
+            start_data = float(start_data_fn()[position])
+            end_data = float(end_data_fn()[position])
 
             data.append(
                 {
@@ -174,13 +234,44 @@ class BoxPlotExtractor:
         ]
 
     def extract_outliers(self, fliers: list, caps: list) -> list[dict]:
+        """
+        Every box's outliers, split into those below its min and above its max.
+
+        One entry per box in ``caps`` rather than per flier artist. A chart
+        drawn ``showfliers=False`` or ``sym=""`` has no flier artists at all,
+        and pairing the two lists with ``zip`` emptied every box along with
+        them (#697). A box with no flier artist shows nothing beyond its
+        whiskers, so two empty lists are what it shows.
+
+        A non-finite flier is left out: matplotlib draws nothing for it, and
+        it would reach the schema as a bare ``NaN`` token ``JSON.parse``
+        refuses.
+
+        Parameters
+        ----------
+        fliers : list
+            The flier artists, one per box or none at all.
+        caps : list of dict
+            The min and max of every box, as :meth:`extract_caps` returns.
+
+        Returns
+        -------
+        list of dict
+            One ``{"lowerOutliers": [...], "upperOutliers": [...]}`` per box.
+        """
         data = []
 
-        for outlier, cap in zip(fliers, caps):
-            outlier_fn = (
-                outlier.get_ydata if self.orientation == "vert" else outlier.get_xdata
-            )
-            outliers = [float(value) for value in outlier_fn()]
+        for index, cap in enumerate(caps):
+            outliers = []
+            if index < len(fliers):
+                outlier = fliers[index]
+                outlier_fn = (
+                    outlier.get_ydata
+                    if self.orientation == "vert"
+                    else outlier.get_xdata
+                )
+                outliers = [float(value) for value in outlier_fn()]
+                outliers = [value for value in outliers if math.isfinite(value)]
             _min, _max = cap.values()
 
             data.append(
@@ -395,6 +486,23 @@ class BoxPlot(
                 named.append(label or level or "")
         return named
 
+    def _claim(self, artists: list, slot: str) -> None:
+        """
+        Stamp a fresh gid on each artist and record it under ``slot``.
+
+        Parameters
+        ----------
+        artists : list
+            The artists of one kind, in box order.
+        slot : str
+            Which list of :attr:`elements_map` the gids belong to.
+        """
+        for artist in artists:
+            gid = "maidr-" + str(uuid.uuid4())
+            artist.set_gid(gid)
+            self.elements_map[slot].append(gid)
+            self._elements.append(artist)
+
     def _extract_plot_data(self) -> list:
         data = self._extract_bxp_maidr(self._bxp_stats)
 
@@ -419,15 +527,11 @@ class BoxPlot(
         self.lower_outliers_count.clear()
 
         whiskers = self._bxp_extractor.extract_whiskers(bxp_stats["whiskers"])
-        caps = self._bxp_extractor.extract_caps(bxp_stats["caps"])
+        caps = self._bxp_extractor.extract_caps(
+            bxp_stats["caps"], bxp_stats["whiskers"]
+        )
         medians = self._bxp_extractor.extract_medians(bxp_stats["medians"])
         outliers = self._bxp_extractor.extract_outliers(bxp_stats["fliers"], caps)
-
-        for outlier in outliers:
-            self.lower_outliers_count.append(len(outlier[MaidrKey.LOWER_OUTLIER.value]))
-
-        caps_elements = self._bxp_elements_extractor.extract_caps(bxp_stats["caps"])
-        bxp_maidr = []
 
         key = MaidrKey.X if self._orientation == "vert" else MaidrKey.Y
         levels = self.extract_level(self.ax, key) or []
@@ -443,6 +547,47 @@ class BoxPlot(
         if len(medians) > len(levels):
             levels = self._named_boxes(bxp_stats["boxes"], levels, key)
 
+        # A box whose statistics are not finite was never on screen.
+        # `cbook.boxplot_stats` does not drop a NaN, so one missing value in
+        # a group -- or an empty group -- makes every statistic NaN, and
+        # matplotlib draws nothing for it while `json.dumps` writes each as a
+        # bare `NaN` token that `JSON.parse` refuses, taking the whole chart
+        # with it. The grammar types the statistics as numbers, so `null` is
+        # no reading either: the box is dropped instead, together with its
+        # artists and its level, so data, selectors and levels stay one per
+        # box that is there to be read (#697).
+        keep = [
+            index
+            for index, (whisker, cap, median) in enumerate(zip(whiskers, caps, medians))
+            if _finite_box(whisker, cap, median)
+        ]
+
+        def kept(items: list) -> list:
+            # Tolerates a list shorter than the boxes: there are no flier
+            # artists at all when the fliers are hidden.
+            return [items[index] for index in keep if index < len(items)]
+
+        # One level per box is the only shape a dropped box can be taken out
+        # of; more ticks than boxes is a chart the levels never lined up with.
+        if len(levels) == len(medians):
+            levels = kept(levels)
+        whiskers, caps, medians, outliers = (
+            kept(whiskers),
+            kept(caps),
+            kept(medians),
+            kept(outliers),
+        )
+
+        for outlier in outliers:
+            self.lower_outliers_count.append(len(outlier[MaidrKey.LOWER_OUTLIER.value]))
+
+        # With the caps hidden, the min and max selectors address the
+        # whiskers, whose far ends are where the two values were read from.
+        caps_elements = kept(
+            self._bxp_elements_extractor.extract_caps(
+                bxp_stats["caps"] or bxp_stats["whiskers"]
+            )
+        )
         _pairs = [(e["min"], e["max"]) for e in caps_elements if e]
 
         if _pairs:
@@ -450,39 +595,24 @@ class BoxPlot(
         else:
             mins, maxs = [], []
 
-        elements = []
+        self._claim(mins, "min")
+        self._claim(maxs, "max")
+        self._claim(kept(bxp_stats["medians"]), "median")
+        self._claim(kept(bxp_stats["boxes"]), "boxes")
 
-        for element in mins:
-            gid = "maidr-" + str(uuid.uuid4())
-            element.set_gid(gid)
-            self.elements_map["min"].append(gid)
-            elements.append(element)
+        fliers = kept(bxp_stats["fliers"])
+        if fliers:
+            self._claim(fliers, "outliers")
+        else:
+            # No flier artist to address. `_get_selector` zips this list with
+            # the others, so leaving it empty would leave every box without a
+            # selector; the box's own gid stands in, and the outlier selectors
+            # built on it -- `g > use` under a box path -- match nothing,
+            # which is the empty list the core already reads for a box with
+            # no outliers.
+            self.elements_map["outliers"].extend(self.elements_map["boxes"])
 
-        for element in maxs:
-            gid = "maidr-" + str(uuid.uuid4())
-            element.set_gid(gid)
-            self.elements_map["max"].append(gid)
-            elements.append(element)
-
-        for element in bxp_stats["medians"]:
-            gid = "maidr-" + str(uuid.uuid4())
-            element.set_gid(gid)
-            self.elements_map["median"].append(gid)
-            elements.append(element)
-
-        for element in bxp_stats["boxes"]:
-            gid = "maidr-" + str(uuid.uuid4())
-            element.set_gid(gid)
-            self.elements_map["boxes"].append(gid)
-            elements.append(element)
-
-        for element in bxp_stats["fliers"]:
-            gid = "maidr-" + str(uuid.uuid4())
-            element.set_gid(gid)
-            self.elements_map["outliers"].append(gid)
-            elements.append(element)
-
-        self._elements.extend(elements)
+        bxp_maidr = []
 
         for whisker, cap, median, outlier, level in zip(
             whiskers, caps, medians, outliers, levels

--- a/tests/core/plot/test_box_gaps.py
+++ b/tests/core/plot/test_box_gaps.py
@@ -130,6 +130,23 @@ class TestABoxWithNoStatistics:
     def test_the_payload_is_loadable(self, groups, drawn):
         parses_as_strict_json(draw(groups))
 
+    def test_an_extra_tick_does_not_shift_the_surviving_boxes(self):
+        # The labels are the ticks inside the data limits, and a box that
+        # drew nothing contributes nothing to those -- so here the NaN box's
+        # own tick `a` drops out while the box-less tick `c` stays, leaving
+        # three labels for three boxes that do not line up. Filtering the
+        # labels by the kept indices would read the survivors as `c, d`;
+        # each is named by the tick nearest it instead.
+        fig, ax = plt.subplots()
+        ax.set_xticks([1, 2, 3, 4], ["a", "b", "c", "d"])
+        ax.boxplot(
+            [[np.nan, np.nan], FINITE, FINITE], positions=[1, 2, 4], manage_ticks=False
+        )
+
+        rows = _layer(fig)["data"]
+
+        assert [row["z"] for row in rows] == ["b", "d"]
+
 
 class TestWhatMustNotChange:
     def test_a_chart_with_no_gaps_is_unchanged(self):

--- a/tests/core/plot/test_box_gaps.py
+++ b/tests/core/plot/test_box_gaps.py
@@ -1,0 +1,144 @@
+"""A box matplotlib could not compute is dropped rather than read as NaN (#697).
+
+``cbook.boxplot_stats`` does not drop a missing value: a group holding one
+``NaN`` -- a pandas column with a gap, not only an empty or all-``NaN``
+group -- gets every statistic as ``NaN``, and ``Axes.bxp`` draws nothing for
+it. The extractor cast each with a bare ``float()`` and emitted::
+
+    {min: nan, q1: nan, q2: nan, q3: nan, max: nan}
+
+``json.dumps`` writes that as bare ``NaN`` tokens, which ``JSON.parse`` in
+the core refuses, so one such group stopped the whole figure initialising --
+the finite boxes beside it included.
+
+``null`` is not the answer the bar family gave (#429): the grammar types the
+five statistics as numbers, and ``Number(null)`` is ``0`` in the core, which
+would announce a false floor. Nothing is on screen for the box, so nothing
+is announced for it: the row, its artists and its level go together, leaving
+data, selectors and levels one per box that is there to be read.
+
+seaborn drops missing values itself before drawing, so ``sns.boxplot`` was
+never affected; ``ax.boxplot`` is the path measured here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.cbook import boxplot_stats  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+FINITE = [2.0, 3.0, 5.0]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _reject_constant(token: str):
+    raise ValueError(token)
+
+
+def draw(groups: list) -> plt.Figure:
+    fig, ax = plt.subplots()
+    ax.boxplot(groups)
+    return fig
+
+
+def _layer(fig) -> dict:
+    """The first layer's schema with plain string keys."""
+    plot = FigureManager.get_maidr(fig).plots[0]
+    return {(k.value if hasattr(k, "value") else k): v for k, v in plot.schema.items()}
+
+
+def parses_as_strict_json(fig) -> None:
+    """Assert the payload survives what the core actually runs on it.
+
+    ``json.loads`` accepts the bare tokens ``json.dumps`` emits, so a plain
+    round trip passes while ``JSON.parse`` in the browser fails.
+    """
+    schema = FigureManager.get_maidr(fig)._flatten_maidr()
+
+    json.loads(json.dumps(schema), parse_constant=_reject_constant)
+
+
+# (groups, the tick of the one box matplotlib drew)
+CASES = {
+    "a NaN inside a group": ([[1.0, 2.0, np.nan, 4.0], FINITE], "2"),
+    "an empty group": ([FINITE, []], "1"),
+    "an all-NaN group": ([FINITE, [np.nan, np.nan]], "1"),
+}
+
+parametrised = pytest.mark.parametrize(
+    ("groups", "drawn"), CASES.values(), ids=CASES.keys()
+)
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+class TestABoxWithNoStatistics:
+    @parametrised
+    def test_only_the_drawn_box_is_read(self, groups, drawn):
+        rows = _layer(draw(groups))["data"]
+
+        assert len(rows) == 1
+        assert rows[0]["z"] == drawn
+
+    @parametrised
+    def test_the_drawn_box_keeps_its_statistics(self, groups, drawn):
+        (row,) = _layer(draw(groups))["data"]
+        (stats,) = boxplot_stats(FINITE)
+
+        assert row["min"] == stats["whislo"]
+        assert row["q1"] == stats["q1"]
+        assert row["q2"] == stats["med"]
+        assert row["q3"] == stats["q3"]
+        assert row["max"] == stats["whishi"]
+        assert row["lowerOutliers"] == row["upperOutliers"] == []
+
+    @parametrised
+    def test_the_selectors_stay_one_per_row(self, groups, drawn):
+        layer = _layer(draw(groups))
+
+        assert len(layer["selectors"]) == len(layer["data"]) == 1
+
+    @parametrised
+    def test_the_selector_names_the_drawn_box(self, groups, drawn):
+        # Dropping the row without its artists would leave the surviving
+        # selector pointing at whichever box came first, drawn or not.
+        fig = draw(groups)
+        plot = FigureManager.get_maidr(fig).plots[0]
+        plot.schema  # noqa: B018  # extraction runs on first access
+        boxes = plot._bxp_stats["boxes"]
+        drawn_box = boxes[int(drawn) - 1]
+
+        assert plot.elements_map["boxes"] == [drawn_box.get_gid()]
+        assert [box.get_gid() for box in boxes if box is not drawn_box] == [None]
+
+    @parametrised
+    def test_the_payload_is_loadable(self, groups, drawn):
+        parses_as_strict_json(draw(groups))
+
+
+class TestWhatMustNotChange:
+    def test_a_chart_with_no_gaps_is_unchanged(self):
+        groups = [[1.0, 2.0, 4.0], FINITE]
+        rows = _layer(draw(groups))["data"]
+
+        assert [row["z"] for row in rows] == ["1", "2"]
+        for row, stats in zip(rows, boxplot_stats(groups)):
+            assert row["q2"] == stats["med"]
+            assert row["min"] == stats["whislo"]
+            assert row["max"] == stats["whishi"]
+        parses_as_strict_json(draw(groups))

--- a/tests/core/plot/test_box_hidden_parts.py
+++ b/tests/core/plot/test_box_hidden_parts.py
@@ -1,0 +1,219 @@
+"""A box drawn without its caps or its fliers is still read (#697).
+
+``showfliers=False``, ``sym=""`` and ``showcaps=False`` each leave a box on
+screen with one kind of artist missing, and each used to empty the whole
+layer: ``Axes.bxp`` hands back an empty ``caps`` or ``fliers`` list, and the
+``zip`` that assembles one row per box ends at the shortest of its lists.
+Measured on three samples::
+
+    default                          rows=3
+    showfliers=False                 rows=0
+    sym=''                           rows=0
+    showcaps=False                   rows=0
+    showfliers=False, showcaps=False rows=0
+
+Nothing raised: the layer registered as a box with ``data: []`` and
+``selectors: []``, so a reader met a silent chart that was plainly drawn.
+
+Both are recoverable from what is on screen. A whisker runs from the box edge
+to the same value a cap would mark -- on the default chart every cap sits at
+its whisker's far end -- so a chart with no caps reads its extremes off the
+whiskers. Hidden fliers are simply not drawn, so two empty outlier lists are
+the honest reading. The statistics do not change either way: ``showfliers``
+and ``showcaps`` are drawing options, not inputs to ``boxplot_stats``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+from matplotlib.cbook import boxplot_stats  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+# One upper outlier, one lower outlier, none: every branch of the outlier
+# split has a box exercising it.
+SAMPLES = [
+    [1.0, 2.0, 3.0, 4.0, 5.0, 30.0],
+    [2.0, 3.0, 4.0, 5.0, 6.0, -20.0],
+    [3.0, 4.0, 5.0, 6.0, 7.0],
+]
+STATISTICS = ("min", "q1", "q2", "q3", "max")
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _reject_constant(token: str):
+    raise ValueError(token)
+
+
+def draw_matplotlib(**kwargs) -> plt.Figure:
+    fig, ax = plt.subplots()
+    ax.boxplot(SAMPLES, **kwargs)
+    return fig
+
+
+def draw_seaborn(**kwargs) -> plt.Figure:
+    fig, ax = plt.subplots()
+    sns.boxplot(data=SAMPLES, ax=ax, **kwargs)
+    return fig
+
+
+def _layer(fig) -> dict:
+    """The first layer's schema with plain string keys."""
+    plot = FigureManager.get_maidr(fig).plots[0]
+    return {(k.value if hasattr(k, "value") else k): v for k, v in plot.schema.items()}
+
+
+def parses_as_strict_json(fig) -> None:
+    """Assert the payload survives what the core actually runs on it.
+
+    ``json.loads`` accepts the bare tokens ``json.dumps`` emits, so a plain
+    round trip passes while ``JSON.parse`` in the browser fails.
+    """
+    schema = FigureManager.get_maidr(fig)._flatten_maidr()
+
+    json.loads(json.dumps(schema), parse_constant=_reject_constant)
+
+
+# (draw, orientation keywords, hiding keywords). The reference chart for each
+# case is drawn with the orientation alone, so a horizontal case is compared
+# row for row against a horizontal default rather than a vertical one.
+CASES = {
+    "matplotlib showfliers=False": (draw_matplotlib, {}, {"showfliers": False}),
+    "matplotlib showcaps=False": (draw_matplotlib, {}, {"showcaps": False}),
+    "matplotlib both hidden": (
+        draw_matplotlib,
+        {},
+        {"showfliers": False, "showcaps": False},
+    ),
+    "matplotlib sym=''": (draw_matplotlib, {}, {"sym": ""}),
+    "matplotlib horizontal showfliers=False": (
+        draw_matplotlib,
+        {"vert": False},
+        {"showfliers": False},
+    ),
+    "matplotlib horizontal showcaps=False": (
+        draw_matplotlib,
+        {"vert": False},
+        {"showcaps": False},
+    ),
+    "seaborn showfliers=False": (draw_seaborn, {}, {"showfliers": False}),
+    "seaborn showcaps=False": (draw_seaborn, {}, {"showcaps": False}),
+    "seaborn both hidden": (
+        draw_seaborn,
+        {},
+        {"showfliers": False, "showcaps": False},
+    ),
+    "seaborn horizontal showfliers=False": (
+        draw_seaborn,
+        {"orient": "h"},
+        {"showfliers": False},
+    ),
+}
+
+parametrised = pytest.mark.parametrize(
+    ("draw", "orientation", "hidden"), CASES.values(), ids=CASES.keys()
+)
+
+
+def _fliers_hidden(hidden: dict) -> bool:
+    return hidden.get("showfliers") is False or hidden.get("sym") == ""
+
+
+@parametrised
+def test_every_box_is_still_read(draw, orientation, hidden):
+    rows = _layer(draw(**orientation, **hidden))["data"]
+
+    assert len(rows) == len(SAMPLES)
+
+
+@parametrised
+def test_the_statistics_match_the_default_chart(draw, orientation, hidden):
+    reference = _layer(draw(**orientation))["data"]
+    rows = _layer(draw(**orientation, **hidden))["data"]
+
+    for row, expected in zip(rows, reference):
+        assert {key: row[key] for key in STATISTICS} == {
+            key: expected[key] for key in STATISTICS
+        }
+        assert row["z"] == expected["z"]
+
+
+@parametrised
+def test_hidden_fliers_read_as_no_outliers(draw, orientation, hidden):
+    reference = _layer(draw(**orientation))["data"]
+    rows = _layer(draw(**orientation, **hidden))["data"]
+
+    for row, expected in zip(rows, reference):
+        if _fliers_hidden(hidden):
+            assert row["lowerOutliers"] == []
+            assert row["upperOutliers"] == []
+        else:
+            assert row["lowerOutliers"] == expected["lowerOutliers"]
+            assert row["upperOutliers"] == expected["upperOutliers"]
+
+
+@parametrised
+def test_one_selector_per_box(draw, orientation, hidden):
+    layer = _layer(draw(**orientation, **hidden))
+
+    assert len(layer["selectors"]) == len(layer["data"])
+
+
+@parametrised
+def test_the_payload_is_loadable(draw, orientation, hidden):
+    parses_as_strict_json(draw(**orientation, **hidden))
+
+
+def test_hidden_caps_point_the_extreme_selectors_at_the_whiskers():
+    # The values were read off the whiskers' far ends, so that is what the
+    # min and max selectors highlight.
+    fig = draw_matplotlib(showcaps=False)
+    plot = FigureManager.get_maidr(fig).plots[0]
+    plot.schema  # noqa: B018  # extraction runs on first access
+    whiskers = plot._bxp_stats["whiskers"]
+
+    assert plot.elements_map["min"] == [w.get_gid() for w in whiskers[::2]]
+    assert plot.elements_map["max"] == [w.get_gid() for w in whiskers[1::2]]
+
+
+class TestWhatMustNotChange:
+    def test_the_default_chart_reads_its_tukey_statistics(self):
+        rows = _layer(draw_matplotlib())["data"]
+        expected = boxplot_stats(SAMPLES)
+
+        assert [row["z"] for row in rows] == ["1", "2", "3"]
+        for row, stats in zip(rows, expected):
+            assert row["min"] == stats["whislo"]
+            assert row["q1"] == stats["q1"]
+            assert row["q2"] == stats["med"]
+            assert row["q3"] == stats["q3"]
+            assert row["max"] == stats["whishi"]
+        assert rows[0]["upperOutliers"] == [30.0]
+        assert rows[1]["lowerOutliers"] == [-20.0]
+        assert rows[2]["lowerOutliers"] == rows[2]["upperOutliers"] == []
+
+    def test_the_default_chart_addresses_its_flier_artists(self):
+        fig = draw_matplotlib()
+        plot = FigureManager.get_maidr(fig).plots[0]
+        plot.schema  # noqa: B018
+
+        assert plot.elements_map["outliers"] == [
+            flier.get_gid() for flier in plot._bxp_stats["fliers"]
+        ]
+        assert plot.elements_map["min"] == [
+            cap.get_gid() for cap in plot._bxp_stats["caps"][::2]
+        ]


### PR DESCRIPTION
## What

Closes #697.

**Hidden caps or fliers emptied the layer.** `BoxPlotExtractor` zipped `fliers` with `caps`, and the final zip stopped at the shortest list. `Axes.bxp` returns an empty `caps` list for `showcaps=False` and an empty `fliers` list for `showfliers=False` or `sym=''`, so every box was truncated: the layer registered with `data == []` and `selectors == []`, the figure rendered, and a reader heard nothing for a box chart that is on screen.

```
ax.boxplot(3 samples)                       rows 3  -> 3   unchanged
ax.boxplot(..., showfliers=False)           rows 0  -> 3
ax.boxplot(..., showcaps=False)             rows 0  -> 3
ax.boxplot(..., sym='')                     rows 0  -> 3
sns.boxplot(hue=..., showfliers=False)      rows 0  -> 6
```

`extract_caps` now falls back to the whiskers' far end when there are no caps (verified equal to the cap y for every box in the default case), `extract_outliers` reads `fliers[i]` only when it exists and otherwise emits two empty lists, and when no flier artist survives the outlier selectors are built on the box gid so `_get_selector`'s zip keeps one selector per box — the core already reads a selector that matches nothing as "no outliers".

**A NaN in the sample poisoned the box.** `cbook.boxplot_stats` does not drop NaN, so `ax.boxplot([[1, 2, nan, 4], [2, 3, 5]])` drew nothing for the first box and recorded NaN for every statistic; the emitted row was `{min: NaN, q1: NaN, ...}` and the whole figure failed `JSON.parse` (#427). `BoxPoint` types the statistics as non-nullable numbers and `Number(null)` is 0 in the core, so a box whose statistics are non-finite is now dropped together with its artists and its level, keeping data, selectors and levels aligned. seaborn drops missing values itself, so `sns.boxplot` was never affected by this half.

Default-path output is byte-identical after uuid normalisation across 22 cases (box default/horizontal, `sns.boxplot` plain and with hue in both orientations, plus every heat/stacked/dodged case in the audit's comparison script); only the four cases named above change. The five duplicated gid-tagging loops became one `_claim(artists, slot)` helper that preserves the original element order.

## Tests

New `tests/core/plot/test_box_hidden_parts.py` (parametrised over `ax.boxplot`/`sns.boxplot` × `showfliers=False` / `showcaps=False` / both / `sym=''` / `orient='h'`: one row per box, min/max equal to the default chart's, empty outliers when fliers are hidden, one selector per row, strict JSON round trip, default chart unchanged) and `tests/core/plot/test_box_gaps.py` (one NaN in a group, an empty group, an all-NaN group: the finite box keeps `z='2'`, one selector, strict JSON passes, NaN-free chart unchanged). Against `main`'s `boxplot.py`: 26 failed, 43 passed (the passing ones are the "must not change" guards).

## Verified

```
uv run pytest      3673 passed, 68 skipped
ruff check         All checks passed (changed files)
```

With caps hidden the min/max selectors highlight the whisker paths, where the values were read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_