### PR TITLE
fix(api): resolve the figure once so close, clear_fig, save_html and seaborn grids behave

### DIFF
--- a/maidr/api.py
+++ b/maidr/api.py
@@ -170,7 +170,13 @@ def _resolve_use_cdn(
     """
     if value is None:
         return get_use_cdn()
-    if value is True or value is False or value == "auto":
+    if value is True or value is False:
+        return value
+    # The string check is guarded by `isinstance` so that a value with a
+    # vectorised `__eq__` -- a numpy array, a pandas Series -- gets the
+    # TypeError below rather than an "ambiguous truth value" ValueError
+    # from `value == "auto"` being asked for a bool.
+    if isinstance(value, str) and value == "auto":
         return value
     raise TypeError(
         f"use_cdn must be True, False or 'auto', got {value!r}; "

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -499,6 +499,8 @@ def _resolve_figure(plot: Any) -> Figure | None:
     """
     if isinstance(plot, Figure):
         return plot
+    # A raw list of artists resolves to its first entry's figure: every
+    # documented input maps to one figure, so first and last agree.
     ax = FigureManager.get_axes(plot)
     if isinstance(ax, list):
         # A seaborn Grid resolves to every axes of its figure; any one of

--- a/maidr/api.py
+++ b/maidr/api.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 from htmltools import Tag
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
+from matplotlib.figure import Figure
 
 from maidr.core import Maidr
 from maidr.core.enum import PlotType
@@ -148,16 +149,33 @@ def _resolve_use_cdn(
 
     When ``value`` is ``None`` the process-wide default (from
     :func:`get_use_cdn` / :data:`MAIDR_USE_CDN`) is consulted.
-    Explicit values (``True``, ``False``, or ``"auto"``) are honoured
-    verbatim.  Resolving the mode itself makes no network request:
-    offline *detection* is performed in the browser via a
-    ``<script onerror>`` fallback, not by probing from Python.  (The
+    Explicit values are validated: only ``True``, ``False`` and ``"auto"``
+    are accepted.  Anything else used to pass through untouched, and the
+    consumers branch ``is False`` / ``== "auto"`` / else-CDN, so a slip
+    like ``use_cdn="false"`` or ``use_cdn=0`` -- the string and integer
+    forms :func:`set_use_cdn` and ``MAIDR_USE_CDN`` do accept -- rendered
+    a CDN-only page with no offline fallback for the one reader who had
+    asked for offline, and said nothing.  Resolving the mode itself makes
+    no network request: offline *detection* is performed in the browser
+    via a ``<script onerror>`` fallback, not by probing from Python.  (The
     CDN modes do resolve the published version over the network when
     they build a URL — see :func:`get_use_cdn`.)
+
+    Raises
+    ------
+    TypeError
+        If ``value`` is not ``None``, ``True``, ``False`` or ``"auto"``.
+        Identity checks, so ``0`` and ``1`` are rejected rather than
+        passing as equal to ``False`` and ``True``.
     """
     if value is None:
         return get_use_cdn()
-    return value
+    if value is True or value is False or value == "auto":
+        return value
+    raise TypeError(
+        f"use_cdn must be True, False or 'auto', got {value!r}; "
+        "set_use_cdn() and MAIDR_USE_CDN accept the string forms"
+    )
 
 
 #: What the Altair path fetches remotely, named in the warning so a reader
@@ -447,6 +465,65 @@ def _get_plot_or_current(plot: Any | None) -> Any:
     return plot
 
 
+def _resolve_figure(plot: Any) -> Figure | None:
+    """
+    The figure ``plot`` lives on, resolved once for every entry point.
+
+    ``render``, ``show``, ``save_html`` and ``close`` all need the same
+    thing -- the ``Figure`` whose ``Maidr`` holds the registered layers --
+    and each used to work it out from :meth:`FigureManager.get_axes` on
+    its own. A ``Figure`` is an ``Artist``, so ``get_axes`` answers it
+    with ``fig.axes``, a list; three of the four grew a branch that walked
+    that list, one ``get_maidr`` lookup per axes, and the fourth did not
+    and raised. Walking it also meant the ``plot=None`` and ``plot=fig``
+    forms went through a different branch from ``plot=ax``, which is how
+    ``clear_fig`` came to be forwarded on one path and not the other, and
+    how a figure with no axes at all -- an empty list -- never bound the
+    ``Maidr`` and raised ``UnboundLocalError`` where a figure with an
+    empty *axes* reached the #443 fallback.
+
+    Parameters
+    ----------
+    plot : Any
+        A matplotlib ``Figure``, ``Axes``, artist or container, or a
+        seaborn ``FacetGrid``/``JointGrid``/``PairGrid`` -- anything
+        :meth:`FigureManager.get_axes` resolves.
+
+    Returns
+    -------
+    Figure or None
+        The figure, or ``None`` when nothing resolves. A ``Figure`` is
+        returned as it is, whether or not it has axes yet, so that
+        :meth:`FigureManager.get_maidr` can raise the empty-figure
+        ``UnsupportedPlotError`` for it rather than this function guessing.
+    """
+    if isinstance(plot, Figure):
+        return plot
+    ax = FigureManager.get_axes(plot)
+    if isinstance(ax, list):
+        # A seaborn Grid resolves to every axes of its figure; any one of
+        # them names the figure, and the list branch picks the first.
+        ax = FigureManager.get_axes(ax)
+    return None if ax is None else ax.get_figure()
+
+
+def _figure_or_raise(plot: Any) -> Figure:
+    """The figure for ``plot``, or a ``TypeError`` that names what was passed.
+
+    The failure used to be ``AttributeError: 'NoneType' object has no
+    attribute 'get_figure'``, which names maidr's bookkeeping rather than
+    the caller's mistake.
+    """
+    fig = _resolve_figure(plot)
+    if fig is None:
+        raise TypeError(
+            f"maidr cannot find a figure for {plot!r}; pass a matplotlib "
+            "Figure, Axes or artist, or a seaborn FacetGrid, JointGrid or "
+            "PairGrid"
+        )
+    return fig
+
+
 def render(
     plot: Any | None = None,
     use_cdn: bool | Literal["auto"] | None = None,
@@ -496,17 +573,10 @@ def render(
     if plot is not None and _is_plotly_figure(plot):
         return _get_plotly_maidr(plot).render(use_cdn=use_cdn)
 
-    plot = _get_plot_or_current(plot)
-
-    ax = FigureManager.get_axes(plot)
+    fig = _figure_or_raise(_get_plot_or_current(plot))
     try:
-        if isinstance(ax, list):
-            for axes in ax:
-                maidr = FigureManager.get_maidr(axes.get_figure())
-            return maidr.render(use_cdn=use_cdn)
-        else:
-            maidr = FigureManager.get_maidr(ax.get_figure())
-            return maidr.render(use_cdn=use_cdn)
+        maidr = FigureManager.get_maidr(fig)
+        return maidr.render(use_cdn=use_cdn)
     except UnsupportedPlotError as error:
         warn_unsupported(error, stacklevel=3)
         return fallback_tag(error.fig, error.message)
@@ -557,17 +627,10 @@ def show(
     if plot is not None and _is_plotly_figure(plot):
         return _get_plotly_maidr(plot).show(renderer, use_cdn=use_cdn)
 
-    plot = _get_plot_or_current(plot)
-
-    ax = FigureManager.get_axes(plot)
+    fig = _figure_or_raise(_get_plot_or_current(plot))
     try:
-        if isinstance(ax, list):
-            for axes in ax:
-                maidr = FigureManager.get_maidr(axes.get_figure())
-            return maidr.show(renderer, use_cdn=use_cdn)
-        else:
-            maidr = FigureManager.get_maidr(ax.get_figure())
-            return maidr.show(renderer, clear_fig=clear_fig, use_cdn=use_cdn)
+        maidr = FigureManager.get_maidr(fig)
+        return maidr.show(renderer, clear_fig=clear_fig, use_cdn=use_cdn)
     except UnsupportedPlotError as error:
         warn_unsupported(error, stacklevel=3)
         return fallback_tag(error.fig, error.message).show()
@@ -575,8 +638,8 @@ def show(
 
 def save_html(
     plot: Any | None = None,
+    file: str | None = None,
     *,
-    file: str,
     lib_dir: str | None = "lib",
     include_version: bool = True,
     data_in_svg: bool = True,
@@ -592,7 +655,11 @@ def save_html(
         Plotly figures, and Altair chart objects. If None, uses the
         current matplotlib figure.
     file : str
-        The file path where to save the HTML.
+        The file path where to save the HTML. Required; may be passed
+        positionally, as in ``maidr.save_html(plot, "output.html")``, the
+        form the getting-started tutorial uses and the form
+        :meth:`Maidr.save_html` and its Plotly and Altair counterparts
+        take.
     lib_dir : str or None, default "lib"
         Directory name for libraries.
     include_version : bool, default True
@@ -623,7 +690,19 @@ def save_html(
     -------
     str
         The path to the saved HTML file.
+
+    Raises
+    ------
+    TypeError
+        If ``file`` is not given.
     """
+    # `file` has a default only so that it can follow the optional `plot`
+    # positionally; it is no less required than it was as a keyword-only
+    # argument, and saying so here reads better than the AttributeError a
+    # `None` path would raise from inside htmltools.
+    if file is None:
+        raise TypeError("save_html() missing required argument: 'file'")
+
     if _is_altair_chart(plot):
         from maidr.altair import AltairMaidr
 
@@ -645,33 +724,20 @@ def save_html(
             use_cdn=use_cdn,
         )
 
-    plot = _get_plot_or_current(plot)
-
-    ax = FigureManager.get_axes(plot)
-    htmls = []
+    # Resolved to the figure once. The Figure form -- which includes the
+    # default, `plt.gcf()` -- used to walk `fig.axes` and build a whole
+    # HTML document per axes, keeping only the last: a `subplots(3, 3)`
+    # rendered nine times for one file (#694).
+    fig = _figure_or_raise(_get_plot_or_current(plot))
     try:
-        if isinstance(ax, list):
-            for axes in ax:
-                maidr = FigureManager.get_maidr(axes.get_figure())
-                htmls.append(
-                    maidr._create_html_doc(
-                        use_iframe=False,
-                        data_in_svg=data_in_svg,
-                        use_cdn=use_cdn,
-                    )
-                )
-            return htmls[-1].save_html(
-                file, libdir=lib_dir, include_version=include_version
-            )
-        else:
-            maidr = FigureManager.get_maidr(ax.get_figure())
-            return maidr.save_html(
-                file,
-                lib_dir=lib_dir,
-                include_version=include_version,
-                data_in_svg=data_in_svg,
-                use_cdn=use_cdn,
-            )
+        maidr = FigureManager.get_maidr(fig)
+        return maidr.save_html(
+            file,
+            lib_dir=lib_dir,
+            include_version=include_version,
+            data_in_svg=data_in_svg,
+            use_cdn=use_cdn,
+        )
     except UnsupportedPlotError as error:
         # A file still gets written, holding the image and the reason. Raising
         # instead would leave a build step that expected an artefact with
@@ -693,13 +759,17 @@ def close(plot: Any | None = None) -> None:
     Parameters
     ----------
     plot : Any or None, optional
-        The plot object to close. If None, uses the current matplotlib figure.
+        The plot object to close: a matplotlib ``Figure``, ``Axes`` or
+        artist, or a seaborn Grid. If None, uses the current matplotlib
+        figure.
     """
     if plot is not None and _is_plotly_figure(plot):
         # For Plotly figures, no FigureManager cleanup needed
         return
 
-    plot = _get_plot_or_current(plot)
-
-    ax = FigureManager.get_axes(plot)
-    FigureManager.destroy(ax.get_figure())
+    # Nothing resolved is nothing to close: `destroy` already treats an
+    # unregistered figure as done, and closing is the one call that should
+    # not raise about what it was handed.
+    fig = _resolve_figure(_get_plot_or_current(plot))
+    if fig is not None:
+        FigureManager.destroy(fig)

--- a/maidr/backend.py
+++ b/maidr/backend.py
@@ -60,7 +60,7 @@ def show(*args: Any, **kwargs: Any) -> None:
         other kwargs are accepted (per the backend protocol) and
         silently ignored.
     """
-    from maidr.api import get_use_cdn
+    from maidr.api import _resolve_use_cdn
     from maidr.core.figure_manager import FigureManager as MaidrFigureManager
 
     managers = Gcf.get_all_fig_managers()
@@ -70,10 +70,12 @@ def show(*args: Any, **kwargs: Any) -> None:
     # Prefer an explicit ``plt.show(use_cdn=...)`` over the module-level
     # default; fall back to ``maidr.api.get_use_cdn()`` otherwise.  This
     # lets users opt in via any of: per-call kwarg, ``maidr.set_use_cdn``,
-    # or the ``MAIDR_USE_CDN`` environment variable.
-    use_cdn = kwargs.pop("use_cdn", None)
-    if use_cdn is None:
-        use_cdn = get_use_cdn()
+    # or the ``MAIDR_USE_CDN`` environment variable.  Routed through the
+    # same resolver as ``maidr.render`` so that a value it would reject
+    # (``"false"``, ``0``) is rejected here too, rather than reaching
+    # ``Maidr.show`` and rendering CDN-only for someone who asked for
+    # offline.
+    use_cdn = _resolve_use_cdn(kwargs.pop("use_cdn", None))
 
     for manager in list(managers):
         fig = manager.canvas.figure

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -402,6 +402,13 @@ class FigureManager:
         is the answer every caller here is written for and the shape of
         failure #388, #520 and #529 removed from the extractors for the same
         reason.
+
+        Accepted inputs, and what each resolves to: an ``Axes`` (itself); a
+        ``BarContainer`` (the axes of its first child); any other ``Artist``
+        (its ``.axes`` -- for a ``Figure`` that is the list of its axes); a
+        dict of artist lists and a list (the first ``Axes`` found); and a
+        seaborn ``FacetGrid``, ``JointGrid`` or ``PairGrid`` (every axes of
+        its figure, as a list). ``None`` resolves to ``None``.
         """
         if artist is None:
             return None
@@ -440,3 +447,13 @@ class FigureManager:
                 ),
                 None,
             )
+        elif isinstance(getattr(artist, "figure", None), Figure):
+            # seaborn's figure-level functions -- lmplot, catplot, displot,
+            # jointplot, pairplot -- return a FacetGrid, JointGrid or
+            # PairGrid. None is an Artist, so the branches above fell through
+            # to None and every entry point raised on the value the user was
+            # handed, even though each layer was registered on the grid's
+            # figure and its axes carry them (#694). Duck-typed on `.figure`
+            # so this module does not import seaborn; on the >=0.13 floor
+            # every Grid exposes it (`.fig` is the deprecated spelling).
+            return artist.figure.axes

--- a/maidr/core/figure_manager.py
+++ b/maidr/core/figure_manager.py
@@ -450,10 +450,11 @@ class FigureManager:
         elif isinstance(getattr(artist, "figure", None), Figure):
             # seaborn's figure-level functions -- lmplot, catplot, displot,
             # jointplot, pairplot -- return a FacetGrid, JointGrid or
-            # PairGrid. None is an Artist, so the branches above fell through
-            # to None and every entry point raised on the value the user was
-            # handed, even though each layer was registered on the grid's
-            # figure and its axes carry them (#694). Duck-typed on `.figure`
+            # PairGrid. A Grid is not an Artist, so the branches above fell
+            # through and this returned None, and every entry point raised on
+            # the value the user was handed -- even though each layer was
+            # registered on the grid's figure and its axes carry them
+            # (#694). Duck-typed on `.figure`
             # so this module does not import seaborn; on the >=0.13 floor
             # every Grid exposes it (`.fig` is the deprecated spelling).
             return artist.figure.axes

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -289,7 +289,12 @@ class Maidr:
             return self._open_plot_in_browser(use_cdn=use_cdn)
 
         if clear_fig:
-            plt.close()
+            # This figure, not pyplot's current one: `plt.close()` with no
+            # argument closes whichever figure was created or activated
+            # last, which is not the one just rendered whenever the caller
+            # has more than one open (#694). A no-op for a `Figure()` that
+            # pyplot never tracked, as before.
+            plt.close(self._fig)
         return html.show(_renderer)
 
     def clear(self):

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -1,12 +1,17 @@
 import copy
 import gc
+import html
+import json
 import pickle
+import re
 import threading
 import weakref
 
 import matplotlib.pyplot as plt
+import pandas as pd
 import pytest
 import seaborn as sns
+from htmltools import Tag
 
 import maidr
 
@@ -89,6 +94,123 @@ class TestSeabornFigureManager:
     def test_get_figure_from_countplot_axes(self, axes):
         count_ax = sns.countplot(x=[1, 2, 2, 3, 3, 3])
         assert FigureManager.get_axes(count_ax) == axes
+
+    # seaborn's figure-level functions return a Grid, which is not an Artist.
+    # Each resolved to None, so `maidr.render(sns.lmplot(...))` raised on the
+    # very object the user was handed, though every layer was registered on
+    # the grid's figure (#694).
+    def test_get_axes_from_facet_grid(self):
+        grid = sns.lmplot(data=_frame(), x="x", y="y")
+        try:
+            assert FigureManager.get_axes(grid) == grid.figure.axes
+        finally:
+            plt.close(grid.figure)
+
+    def test_get_axes_from_joint_grid(self):
+        grid = sns.jointplot(data=_frame(), x="x", y="y")
+        try:
+            assert FigureManager.get_axes(grid) == grid.figure.axes
+        finally:
+            plt.close(grid.figure)
+
+    def test_get_axes_from_pair_grid(self):
+        grid = sns.pairplot(_frame())
+        try:
+            assert FigureManager.get_axes(grid) == grid.figure.axes
+        finally:
+            plt.close(grid.figure)
+
+
+def _frame():
+    return pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0], "y": [2.0, 4.0, 5.0, 4.0, 6.0]})
+
+
+def _layer_types(rendered) -> list[str]:
+    """The layer types in the schema on the emitted ``<svg>``."""
+    markup = str(rendered)
+    frame = re.search(r'srcdoc="([^"]*)"', markup)
+    if frame is not None:
+        markup = html.unescape(frame.group(1))
+    match = re.search(r'maidr="([^"]*)"', markup)
+    assert match, "no MAIDR schema in the emitted markup"
+    schema = json.loads(html.unescape(match.group(1)))
+    return [
+        layer["type"]
+        for row in schema["subplots"]
+        for cell in row
+        for layer in cell.get("layers", [])
+    ]
+
+
+class TestAGridGoesThroughTheFrontDoor:
+    """A seaborn Grid is what `lmplot` returns, and `lmplot` is documented
+    as stable, so the documented way to use it must reach every entry
+    point -- not only `grid.figure`, which is what the tests had been
+    handing over."""
+
+    def test_render_reads_the_layers_registered_on_the_grids_figure(self):
+        grid = sns.lmplot(data=_frame(), x="x", y="y")
+        try:
+            tag = maidr.render(grid, use_cdn=False)
+
+            assert isinstance(tag, Tag)
+            assert _layer_types(tag) == ["point", "smooth"]
+        finally:
+            plt.close(grid.figure)
+
+    def test_close_forgets_the_grids_figure(self):
+        grid = sns.lmplot(data=_frame(), x="x", y="y")
+        try:
+            assert grid.figure in FigureManager.figs
+
+            maidr.close(grid)
+
+            assert grid.figure not in FigureManager.figs
+        finally:
+            plt.close(grid.figure)
+
+
+class TestCloseResolvesTheFigureItIsHanded:
+    """`maidr.close()` and `maidr.close(fig)` raised `AttributeError`.
+
+    A `Figure` is an `Artist`, so `get_axes` answered it with `fig.axes` --
+    a list -- and `close` called `.get_figure()` on the list. Only the
+    `close(ax)` form was ever exercised, and the documented default
+    (`plot=None`, meaning `plt.gcf()`) was exactly the broken one (#694).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_figure(self):
+        plt.close("all")
+        fig, ax = plt.subplots()
+        ax.bar(["a", "b"], [1, 2])
+        assert fig in FigureManager.figs
+        self.fig, self.ax = fig, ax
+        yield
+        FigureManager.figs.pop(fig, None)
+        plt.close(fig)
+
+    def test_close_with_no_argument_closes_the_current_figure(self):
+        maidr.close()
+
+        assert self.fig not in FigureManager.figs
+
+    def test_close_with_the_figure(self):
+        maidr.close(self.fig)
+
+        assert self.fig not in FigureManager.figs
+
+    def test_close_with_an_axes_still_works(self):
+        maidr.close(self.ax)
+
+        assert self.fig not in FigureManager.figs
+
+    def test_close_on_something_that_is_not_a_plot_does_not_raise(self):
+        # Closing is the one call that should not complain about what it was
+        # handed: there is nothing to close, so nothing happens.
+        maidr.close("not a plot")
+
+        assert self.fig in FigureManager.figs
 
 
 def test_one_figure_registered_concurrently_gets_one_maidr():

--- a/tests/core/test_figure_manager.py
+++ b/tests/core/test_figure_manager.py
@@ -122,7 +122,9 @@ class TestSeabornFigureManager:
 
 
 def _frame():
-    return pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0, 5.0], "y": [2.0, 4.0, 5.0, 4.0, 6.0]})
+    return pd.DataFrame(
+        {"x": [1.0, 2.0, 3.0, 4.0, 5.0], "y": [2.0, 4.0, 5.0, 4.0, 6.0]}
+    )
 
 
 def _layer_types(rendered) -> list[str]:
@@ -204,6 +206,17 @@ class TestCloseResolvesTheFigureItIsHanded:
         maidr.close(self.ax)
 
         assert self.fig not in FigureManager.figs
+
+    def test_a_list_of_axes_resolves_to_their_figure(self):
+        # A raw list is resolved to its first entry; both axes here belong to
+        # the one figure, so that is the figure rendered.
+        other = self.fig.add_subplot(2, 1, 2)
+        other.bar(["c", "d"], [3, 4])
+
+        tag = maidr.render([self.ax, other], use_cdn=False)
+
+        assert isinstance(tag, Tag)
+        assert _layer_types(tag) == ["bar", "bar"]
 
     def test_close_on_something_that_is_not_a_plot_does_not_raise(self):
         # Closing is the one call that should not complain about what it was

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -8,6 +8,8 @@ import warnings
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
 import pytest
 
 import maidr
@@ -300,6 +302,21 @@ def test_render_rejects_non_canonical_use_cdn(bar_plot, tmp_path, value):
 @pytest.mark.parametrize("value", [True, False, "auto"])
 def test_canonical_use_cdn_values_pass_through_unchanged(value):
     assert maidr_api._resolve_use_cdn(value) is value
+
+
+# A value with a vectorised `__eq__` answers `value == "auto"` with an array,
+# and asking that for a bool raises ValueError ("ambiguous truth value")
+# rather than the TypeError every other wrong value gets.
+@pytest.mark.parametrize(
+    "value",
+    [np.array([True]), pd.Series([False]), [False]],
+    ids=["numpy_array", "pandas_series", "list"],
+)
+def test_array_like_use_cdn_gets_the_intended_type_error(bar_plot, value):
+    with pytest.raises(TypeError, match="use_cdn"):
+        maidr_api._resolve_use_cdn(value)
+    with pytest.raises(TypeError, match="use_cdn"):
+        maidr.render(bar_plot, use_cdn=value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/core/test_offline_bundle.py
+++ b/tests/core/test_offline_bundle.py
@@ -284,6 +284,24 @@ def test_render_auto_tag_contains_cdn_and_fallback(bar_plot):
     assert "onerror" in rendered
 
 
+# The consumers branch `is False` / `== "auto"` / else-CDN, so a value that
+# is none of the three used to fall into the CDN-only mode -- the one
+# furthest from what `use_cdn="false"` or `use_cdn=0` asked for -- with no
+# offline fallback and no warning. `set_use_cdn` and `MAIDR_USE_CDN` accept
+# those spellings, which is what makes the slip a plausible one (#694).
+@pytest.mark.parametrize("value", ["false", "False", 0, 1, "bundled"])
+def test_render_rejects_non_canonical_use_cdn(bar_plot, tmp_path, value):
+    with pytest.raises(TypeError, match="use_cdn"):
+        maidr.render(bar_plot, use_cdn=value)
+    with pytest.raises(TypeError, match="use_cdn"):
+        maidr.save_html(bar_plot, file=str(tmp_path / "out.html"), use_cdn=value)
+
+
+@pytest.mark.parametrize("value", [True, False, "auto"])
+def test_canonical_use_cdn_values_pass_through_unchanged(value):
+    assert maidr_api._resolve_use_cdn(value) is value
+
+
 # ---------------------------------------------------------------------------
 # Module-level default: ``set_use_cdn`` and ``MAIDR_USE_CDN``
 # ---------------------------------------------------------------------------

--- a/tests/core/test_save_html_renders_a_figure_once.py
+++ b/tests/core/test_save_html_renders_a_figure_once.py
@@ -1,0 +1,78 @@
+"""`maidr.save_html(fig)` renders the figure once, however many axes it has.
+
+Handed a `Figure` -- which includes the default, `plt.gcf()` -- `save_html`
+walked `fig.axes` and built a complete HTML document for every axes, then
+wrote the last one. Every axes of a figure resolves to the same `Maidr`,
+so a `subplots(3, 3)` grid was rendered nine times for one file; `render`
+and `show` only looked the `Maidr` up in that loop (#694).
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: E402
+from maidr.core.maidr import Maidr  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def renders(monkeypatch):
+    """Count how many times the chart is rendered to markup."""
+    calls = []
+    original = Maidr._build_html_tag
+
+    def counting(self, *args, **kwargs):
+        calls.append(None)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Maidr, "_build_html_tag", counting)
+    return calls
+
+
+def _two_by_two():
+    fig, axs = plt.subplots(2, 2)
+    for ax in axs.flat:
+        ax.bar(["a", "b"], [1, 2])
+    return fig
+
+
+def _subplot_count(page: str) -> int:
+    match = re.search(r'maidr="([^"]*)"', page)
+    assert match, "no MAIDR schema in the saved page"
+    schema = json.loads(html.unescape(match.group(1)))
+    return sum(len(row) for row in schema["subplots"])
+
+
+def test_a_figure_is_rendered_once(renders, tmp_path):
+    fig = _two_by_two()
+    target = tmp_path / "o.html"
+
+    maidr.save_html(fig, file=str(target), use_cdn=False)
+
+    assert len(renders) == 1
+    assert _subplot_count(target.read_text(encoding="utf-8")) == 4
+
+
+def test_the_current_figure_is_rendered_once(renders, tmp_path):
+    _two_by_two()
+    target = tmp_path / "o.html"
+
+    maidr.save_html(file=str(target), use_cdn=False)
+
+    assert len(renders) == 1
+    assert _subplot_count(target.read_text(encoding="utf-8")) == 4

--- a/tests/core/test_save_html_takes_file_positionally.py
+++ b/tests/core/test_save_html_takes_file_positionally.py
@@ -1,0 +1,96 @@
+"""`maidr.save_html(plot, "output.html")` is the call the tutorial shows.
+
+`file` was keyword-only in the public wrapper and nowhere else --
+`Maidr.save_html`, `PlotlyMaidr.save_html` and `AltairMaidr.save_html` all
+take it positionally, and `api.save_html` forwards it positionally to each
+-- so the getting-started line in `docs/index.qmd` raised `TypeError:
+save_html() takes from 0 to 1 positional arguments but 2 were given`,
+which tells a tutorial reader nothing useful (#694).
+
+The last test keeps the docs and the signature from drifting apart again:
+every `maidr.save_html(...)` call written in the docs must bind to the
+real signature.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import re
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: E402
+
+_DOCS = pathlib.Path(__file__).resolve().parents[2] / "docs"
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _bar():
+    _, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    return ax
+
+
+def test_file_may_be_passed_positionally(tmp_path):
+    target = tmp_path / "out.html"
+
+    written = maidr.save_html(_bar(), str(target), use_cdn=False)
+
+    assert written == str(target)
+    assert target.exists()
+
+
+def test_file_may_still_be_passed_by_keyword(tmp_path):
+    target = tmp_path / "out.html"
+
+    maidr.save_html(_bar(), file=str(target), use_cdn=False)
+
+    assert target.exists()
+
+
+def test_leaving_file_out_says_which_argument_is_missing():
+    with pytest.raises(TypeError, match="file"):
+        maidr.save_html(_bar())
+
+
+def _documented_calls() -> list[tuple[str, str]]:
+    """Every ``maidr.save_html(...)`` call in the docs, with its argument text.
+
+    Balanced-parenthesis scan rather than a regex, because a call may span
+    lines or nest a call of its own.
+    """
+    found = []
+    for page in sorted(_DOCS.rglob("*.qmd")):
+        text = page.read_text(encoding="utf-8")
+        for match in re.finditer(r"maidr\.save_html\(", text):
+            depth, start = 1, match.end()
+            for end in range(start, len(text)):
+                depth += {"(": 1, ")": -1}.get(text[end], 0)
+                if depth == 0:
+                    break
+            found.append(
+                (f"{page.name}:{text.count(chr(10), 0, start) + 1}", text[start:end])
+            )
+    return found
+
+
+@pytest.mark.parametrize("where,args", _documented_calls())
+def test_every_documented_call_binds_to_the_real_signature(where, args):
+    call = ast.parse(f"f({args})", mode="eval").body
+    assert isinstance(call, ast.Call)
+    positional = [None] * len(call.args)
+    keywords = {keyword.arg: None for keyword in call.keywords}
+
+    inspect.signature(maidr.save_html).bind(*positional, **keywords)

--- a/tests/core/test_save_html_takes_file_positionally.py
+++ b/tests/core/test_save_html_takes_file_positionally.py
@@ -65,25 +65,49 @@ def test_leaving_file_out_says_which_argument_is_missing():
         maidr.save_html(_bar())
 
 
-def _documented_calls() -> list[tuple[str, str]]:
-    """Every ``maidr.save_html(...)`` call in the docs, with its argument text.
+def _calls_in(text: str, page: str) -> list[tuple[str, str]]:
+    """Every ``maidr.save_html(...)`` call in ``text``, with its argument text.
 
     Balanced-parenthesis scan rather than a regex, because a call may span
-    lines or nest a call of its own.
+    lines or nest a call of its own. A call whose parenthesis never closes
+    is reported here, naming the page and the offset, rather than as a
+    ``SyntaxError`` from parsing the rest of the file as an argument list.
     """
     found = []
-    for page in sorted(_DOCS.rglob("*.qmd")):
-        text = page.read_text(encoding="utf-8")
-        for match in re.finditer(r"maidr\.save_html\(", text):
-            depth, start = 1, match.end()
-            for end in range(start, len(text)):
-                depth += {"(": 1, ")": -1}.get(text[end], 0)
-                if depth == 0:
-                    break
-            found.append(
-                (f"{page.name}:{text.count(chr(10), 0, start) + 1}", text[start:end])
-            )
+    for match in re.finditer(r"maidr\.save_html\(", text):
+        depth, start = 1, match.end()
+        for end in range(start, len(text)):
+            depth += {"(": 1, ")": -1}.get(text[end], 0)
+            if depth == 0:
+                break
+        assert depth == 0, (
+            f"{page}: maidr.save_html( at offset {match.start()} is never closed"
+        )
+        found.append((f"{page}:{text.count(chr(10), 0, start) + 1}", text[start:end]))
     return found
+
+
+def _documented_calls() -> list[tuple[str, str]]:
+    """Every ``maidr.save_html(...)`` call across the docs."""
+    return [
+        call
+        for page in sorted(_DOCS.rglob("*.qmd"))
+        for call in _calls_in(page.read_text(encoding="utf-8"), page.name)
+    ]
+
+
+def test_the_scan_finds_nested_and_multi_line_calls():
+    text = 'x = maidr.save_html(\n    fig, str(tmp / "o.html"),\n)\nmaidr.save_html(fig, file=f("a"))\n'
+
+    assert _calls_in(text, "page.qmd") == [
+        ("page.qmd:1", '\n    fig, str(tmp / "o.html"),\n'),
+        ("page.qmd:4", 'fig, file=f("a")'),
+    ]
+
+
+def test_an_unclosed_call_is_reported_with_its_page_and_offset():
+    with pytest.raises(AssertionError, match=r"page\.qmd: .* offset 7 is never closed"):
+        _calls_in("before maidr.save_html(fig, str(x)", "page.qmd")
 
 
 @pytest.mark.parametrize("where,args", _documented_calls())

--- a/tests/core/test_show_closes_the_shown_figure.py
+++ b/tests/core/test_show_closes_the_shown_figure.py
@@ -41,7 +41,7 @@ def _bar():
 
 
 def test_show_closes_the_figure_it_showed_and_not_the_current_one():
-    older, older_ax = _bar()
+    older, _ = _bar()
     newer, _ = _bar()
     assert plt.gcf() is newer
 

--- a/tests/core/test_show_closes_the_shown_figure.py
+++ b/tests/core/test_show_closes_the_shown_figure.py
@@ -1,0 +1,79 @@
+"""`maidr.show(clear_fig=...)` acts on the figure it showed.
+
+Two faults, one cause. `Maidr.show` closed the figure with a bare
+`plt.close()`, which closes pyplot's *current* figure -- the one created or
+activated last -- rather than the one it had just rendered, so showing an
+older figure while a newer one was open closed the wrong one. And
+`maidr.show(clear_fig=False)` was honoured only for an `Axes`: the `Figure`
+form, which includes the default `plot=None`, went through a branch of
+`maidr.show` that never forwarded `clear_fig`, so the figure was closed
+regardless (#694).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _quiet_show(monkeypatch):
+    """Keep `show` off the screen; the figure bookkeeping is what matters."""
+    monkeypatch.setattr("htmltools._core.Tag.show", lambda self, *a, **k: "shown")
+    monkeypatch.setattr(
+        "maidr.util.environment.Environment.is_notebook", staticmethod(lambda: False)
+    )
+    plt.close("all")
+    yield
+    plt.close("all")
+
+
+def _bar():
+    fig, ax = plt.subplots()
+    ax.bar(["a", "b"], [1, 2])
+    return fig, ax
+
+
+def test_show_closes_the_figure_it_showed_and_not_the_current_one():
+    older, older_ax = _bar()
+    newer, _ = _bar()
+    assert plt.gcf() is newer
+
+    maidr.show(older, renderer="ipython", use_cdn=False)
+
+    assert plt.get_fignums() == [newer.number]
+
+
+def test_show_by_axes_closes_that_axes_figure():
+    older, older_ax = _bar()
+    newer, _ = _bar()
+
+    maidr.show(older_ax, renderer="ipython", use_cdn=False)
+
+    assert plt.get_fignums() == [newer.number]
+
+
+@pytest.mark.parametrize("form", ["none", "figure", "axes"])
+def test_clear_fig_false_keeps_the_figure_whatever_form_it_was_passed_in(form):
+    fig, ax = _bar()
+    plot = {"none": None, "figure": fig, "axes": ax}[form]
+
+    maidr.show(plot, clear_fig=False, renderer="ipython", use_cdn=False)
+
+    assert fig.number in plt.get_fignums()
+
+
+@pytest.mark.parametrize("form", ["none", "figure", "axes"])
+def test_clear_fig_true_closes_the_figure_whatever_form_it_was_passed_in(form):
+    fig, ax = _bar()
+    plot = {"none": None, "figure": fig, "axes": ax}[form]
+
+    maidr.show(plot, clear_fig=True, renderer="ipython", use_cdn=False)
+
+    assert fig.number not in plt.get_fignums()

--- a/tests/core/test_unsupported_fallback.py
+++ b/tests/core/test_unsupported_fallback.py
@@ -47,6 +47,7 @@ import matplotlib  # noqa: E402
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
+from htmltools import Tag  # noqa: E402
 
 import maidr  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
@@ -219,6 +220,43 @@ class TestAnEmptyFigureIsADifferentProblem:
         _, messages = caught(maidr.render)
 
         assert not any("no plots on it yet" in message for message in messages)
+
+    # A figure with no axes at all is emptier still, and used to be the #443
+    # asymmetry in a new guise: `get_axes` answered it with an empty list, the
+    # loop over that list never bound a `Maidr`, and `render` and `show`
+    # raised `UnboundLocalError` while `save_html` raised `IndexError` --
+    # where a figure with an empty *axes* warned and drew the picture (#694).
+    def test_a_figure_with_no_axes_renders_the_fallback(self):
+        fig = plt.figure()
+        tag, messages = caught(lambda: maidr.render(fig))
+
+        assert isinstance(tag, Tag)
+        assert any("no plots on it yet" in message for message in messages)
+
+    def test_the_current_figure_with_no_axes_renders_the_fallback(self):
+        plt.figure()
+        tag, messages = caught(maidr.render)
+
+        assert isinstance(tag, Tag)
+        assert any("no plots on it yet" in message for message in messages)
+
+    def test_a_figure_with_no_axes_still_saves_a_file(self, tmp_path):
+        fig = plt.figure()
+        target = tmp_path / "out.html"
+        _, messages = caught(lambda: maidr.save_html(fig, file=str(target)))
+
+        assert target.exists()
+        assert any("no plots on it yet" in message for message in messages)
+
+    def test_a_figure_with_no_axes_can_be_shown(self, monkeypatch):
+        monkeypatch.setattr(
+            "htmltools._core.Tag.show", lambda self, *a, **k: "shown"
+        )
+        fig = plt.figure()
+        shown, messages = caught(lambda: maidr.show(fig, renderer="ipython"))
+
+        assert shown == "shown"
+        assert any("no plots on it yet" in message for message in messages)
 
 
 class TestTheExceptionItself:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -123,6 +123,25 @@ class TestBackendShow:
         plt.close("all")
         plt.show()  # Should not raise
 
+    def test_show_rejects_a_non_canonical_use_cdn_before_rendering(self, mocker):
+        """``plt.show(use_cdn="false")`` is refused, not rendered CDN-only.
+
+        The backend forwarded the kwarg to :meth:`Maidr.show` untouched,
+        so a spelling ``maidr.render`` now rejects reached the renderer
+        and picked the CDN-only branch for someone asking for offline
+        (#694). Routed through the same resolver, it fails first.
+        """
+        fig, ax = plt.subplots()
+        ax.bar([1, 2, 3], [4, 5, 6])
+
+        maidr_obj = FigureManager.get_maidr(fig)
+        mock_show = mocker.patch.object(maidr_obj, "show")
+
+        with pytest.raises(TypeError, match="use_cdn"):
+            plt.show(use_cdn="false")
+
+        mock_show.assert_not_called()
+
     def test_show_falls_back_for_untracked_figures(self, mocker):
         """plt.show() should warn and fall back to static image for untracked figures."""
         fig, ax = plt.subplots()

--- a/tests/widget/test_streamlit.py
+++ b/tests/widget/test_streamlit.py
@@ -681,7 +681,11 @@ def test_an_axes_less_current_figure_is_still_resolved_only_once(monkeypatch):
 
     monkeypatch.setattr(pyplot, "gcf", counting_gcf)
     try:
-        with pytest.raises(Exception):  # noqa: B017 - what it raises is not the point
+        # A figure with no axes used to raise out of the entry point; since
+        # #694 it reaches the same warn-and-fall-back path as a figure with
+        # an empty axes. What comes out is not the point -- the count is.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
             maidr_html(use_cdn=True)
     finally:
         monkeypatch.setattr(pyplot, "gcf", real_gcf)


### PR DESCRIPTION
## What

`maidr.render` / `show` / `save_html` / `close` went through `FigureManager.get_axes(plot)`, which answers a **list** for a `Figure` (a `Figure` is an `Artist`, so the `Artist` branch returns `fig.axes`), and each entry point handled that list differently. Every difference was a bug reachable through the documented default `plot=None`. Closes #694.

| before | after |
|---|---|
| `maidr.close()` / `close(fig)` raise `AttributeError: 'list' object has no attribute 'get_figure'` | remove the record; `close(grid)` too; `close("junk")` is a no-op |
| `show(clear_fig=False)` ignored for `None`/`Figure` (the list branch never forwarded it) | honoured on every path |
| `Maidr.show(clear_fig=True)` called `plt.close()` — the *current* figure, not the shown one | `plt.close(self._fig)` |
| `render()` on `plt.figure()` (no axes) → `UnboundLocalError`; `save_html` → `IndexError` | the #443 warn-and-fallback path, like an empty axes |
| `save_html(fig)` rendered the figure once **per axes** and kept the last document | one render |
| `render(sns.lmplot(...))` → `AttributeError` on `None` although every layer was registered on `g.figure` | `get_axes` accepts anything owning a `.figure` (FacetGrid, JointGrid, PairGrid, duck-typed, no seaborn import); works through `@render_maidr` and `maidr_html` too |
| `save_html(plot, "output.html")` as written in `docs/index.qmd:213` → `TypeError` (`file` keyword-only) | `file` positional-or-keyword; a missing `file` raises a `TypeError` that names it |
| `render(ax, use_cdn="false")` / `0` / `"bundled"` silently rendered **CDN-only** (the consumers' `else` branch); `plt.show(use_cdn=...)` bypassed resolution | `_resolve_use_cdn` accepts `True`/`False`/`"auto"` and raises `TypeError` otherwise, pointing at `set_use_cdn`/`MAIDR_USE_CDN` for the string forms; the backend routes through it |

A private `_resolve_figure(plot)` does the resolution once; `render`/`show`/`save_html` call `FigureManager.get_maidr(fig)` once inside the existing `try`, so an axes-less figure raises `UnsupportedPlotError(is_empty=True)` and reaches `warn_unsupported` + `fallback_tag`. Unresolvable input raises a `TypeError` naming the object instead of an `AttributeError` on `None`.

Emitted HTML and schema are unchanged for every previously working input. Timings from the audit for `save_html(fig)`: 4 subplots 1 814 → 613 ms, 9 subplots 7 203 → 1 152 ms.

## Tests

New `test_show_closes_the_shown_figure.py`, `test_save_html_takes_file_positionally.py` (positional, keyword, missing `file`, and a docs-consistency check binding every `maidr.save_html(...)` in `docs/**/*.qmd` to the real signature so the tutorial cannot drift again), `test_save_html_renders_a_figure_once.py`. Extended `test_figure_manager.py` (Grids through `get_axes`, `render(lmplot)` → `['point', 'smooth']`, `close` for every input), `test_unsupported_fallback.py` (axes-less figure through all four entry points), `test_offline_bundle.py` and `test_backend.py` (non-canonical `use_cdn` rejected, canonical values pass by identity). One pre-existing Streamlit test used `pytest.raises(Exception)` around an axes-less render as scaffolding for its `gcf()` count — that raise is the bug this fixes, so it now asserts under `catch_warnings` with the same count. Against `main`'s sources: 29 failed, 135 passed.

## Verified

```
uv run pytest      3643 passed, 68 skipped (one pre-existing Streamlit test adjusted as above; tests/widget + test_backend re-run: 102 passed)
ruff check         no findings in touched files (6 pre-existing F401 in untouched __init__.py files)
```

Note for merging: this touches the `plt.close` line of `Maidr.show`, which #725 reorders; whichever lands second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_