### PR TITLE
fix(plotly): read date axes as ISO strings and bin a histogram over its finite samples

### DIFF
--- a/maidr/plotly/grouped_histogram.py
+++ b/maidr/plotly/grouped_histogram.py
@@ -21,6 +21,7 @@ from maidr.plotly.histogram import (
     as_numeric,
     binned_axis,
     compute_bin_edges,
+    is_temporal_sample,
     paired_arrays,
 )
 from maidr.plotly.plotly_plot import PlotlyPlot
@@ -153,7 +154,12 @@ class PlotlyGroupedHistogramPlot(PlotlyPlot):
         if not pooled.size:
             return None
         bins, nbins = group_bin_spec(self._traces, self._binned)
-        return compute_bin_edges(pooled, bins, nbins)
+        edges = compute_bin_edges(pooled, bins, nbins)
+        # Fewer than two edges is no grid: a negative width, a window past
+        # the data, or a pool of nothing but blanks. The single-trace path
+        # reads that as no layer, and so does this, rather than handing an
+        # empty array to `_bin_counts` and raising out of it (#699).
+        return edges if edges.size >= 2 else None
 
     def _extract_plot_data(self) -> list[list[dict]]:
         samples: list[np.ndarray] = []
@@ -164,6 +170,11 @@ class PlotlyGroupedHistogramPlot(PlotlyPlot):
                 samples.append(np.empty(0))
                 values.append(None)
                 continue
+            # A date axis is binned by rules this does not port yet -- see
+            # `is_temporal_sample`. Declining the group as a whole, since
+            # every trace of it shares the one axis.
+            if is_temporal_sample(trace.get(self._binned)):
+                return []
             try:
                 samples.append(np.array(sample, dtype=float))
             except (ValueError, TypeError):

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import math
+from datetime import date
+from typing import Any
 
 import numpy as np
 
@@ -35,7 +37,9 @@ def _plotly_round_up(val: float, array: list[float], reverse: bool = False) -> f
     return array[lo]
 
 
-def _plotly_default_size0(arr: np.ndarray, *, is_2d: bool = False) -> float:
+def _plotly_default_size0(
+    arr: np.ndarray, *, is_2d: bool = False, sample_size: int | None = None
+) -> float:
     """Compute the default rough bin size when ``nbinsx`` is not given.
 
     Mirrors the logic in Plotly.js ``axes.autoBin`` (the ``else`` branch
@@ -49,7 +53,7 @@ def _plotly_default_size0(arr: np.ndarray, *, is_2d: bool = False) -> float:
     Parameters
     ----------
     arr : np.ndarray
-        The raw data values.
+        The finite data values.
     is_2d : bool, default False
         Bin an axis of a **two-dimensional** histogram, which plotly bins
         more coarsely: the sample-size exponent is ``0.25`` rather than
@@ -58,9 +62,17 @@ def _plotly_default_size0(arr: np.ndarray, *, is_2d: bool = False) -> float:
         axes across four figures -- gaussian, uniform, a six-value sample and
         a normalised one -- ``0.4`` matched none of them and ``0.25`` matched
         all eight.
+    sample_size : int, optional
+        How long the sample was *before* its blanks were dropped, for the
+        exponent alone. That is the one place plotly reads the whole array:
+        ``distinctVals`` sorts the blanks to the end and stops short of them,
+        and ``stdev`` divides by the numeric count, but the ``n`` in
+        ``n ** 0.4`` is ``data.length`` as given. Defaults to the length of
+        *arr*, which is the same number for a sample with no blanks.
     """
     sorted_arr = np.sort(arr)
     n = len(sorted_arr)
+    n_total = sample_size or n
     if n < 2:
         return 1.0
 
@@ -82,7 +94,7 @@ def _plotly_default_size0(arr: np.ndarray, *, is_2d: bool = False) -> float:
 
     # size0 = max(minSize, 2 * stdev / n^(is2d ? 0.25 : 0.4))
     stdev = float(np.std(arr, ddof=0))
-    size0 = max(min_size, 2 * stdev / (n ** (0.25 if is_2d else 0.4)))
+    size0 = max(min_size, 2 * stdev / (n_total ** (0.25 if is_2d else 0.4)))
 
     if not np.isfinite(size0) or size0 <= 0:
         return 1.0
@@ -517,6 +529,51 @@ def _occupied_span(counts: np.ndarray) -> tuple[int | None, int | None]:
     return int(occupied[0]), int(occupied[-1])
 
 
+def is_temporal_sample(values: Any) -> bool:
+    """Whether plotly would bin *values* along a date axis.
+
+    Plotly bins a date axis by rules of its own -- a width from the date
+    branch of ``autoTicks`` (day multiples, then months), no anti-clustering
+    shift, date labels -- and none of that is ported yet. Run through the
+    numeric arithmetic instead, six days of ``px.histogram`` came out as bin
+    bounds around ``1.704e15`` on a grid of ``1e11`` microseconds, which is
+    no number on the chart (#699). Until the date rules are measured, a
+    temporal sample forms no layer, which is what #636 settled for every
+    other reading this cannot make right, and what the two-dimensional path
+    already does with one.
+
+    Read off the trace's array as ``to_dict`` handed it over, rather than
+    after :func:`~maidr.plotly.plotly_plot.as_list` has spelled a
+    ``datetime64`` array as ISO strings. A sample the author wrote as date
+    *strings* is not caught here, and takes the categorical path as before.
+
+    Parameters
+    ----------
+    values : Any
+        A trace's binned array: a numpy array, a list, a typed-array spec,
+        or ``None``.
+
+    Returns
+    -------
+    bool
+        True for a ``datetime64`` array, or any list holding a ``date``, a
+        ``datetime`` (``pandas.Timestamp`` is one) or a ``datetime64``.
+    """
+    if values is None or isinstance(values, (dict, str)):
+        return False
+    if isinstance(values, np.ndarray):
+        if values.dtype.kind == "M":
+            return True
+        # Only an object array can hold a date; the check per entry below is
+        # not worth walking a numeric one for.
+        if values.dtype.kind != "O":
+            return False
+    try:
+        return any(isinstance(value, (date, np.datetime64)) for value in values)
+    except TypeError:
+        return False
+
+
 def binned_axis(trace: dict) -> str:
     """Return which of ``x``/``y`` plotly bins for *trace*.
 
@@ -637,6 +694,9 @@ class PlotlyHistogramPlot(PlotlyPlot):
     def _extract_plot_data(self) -> list[dict]:
         values, _ = paired_arrays(self._trace, self._binned)
         if values is None:
+            return []
+
+        if is_temporal_sample(self._trace.get(self._binned)):
             return []
 
         # Detect categorical (string) data — Plotly renders these as
@@ -823,10 +883,20 @@ def compute_bin_edges(
     ybins=dict(size=2))`` does the same. Reading ``xbins`` for every trace
     would have honoured a spec plotly discards and missed the one it uses.
 
+    A blank in the sample -- a ``None`` or a ``NaN``, which plotly draws
+    around -- is no observation, and the grid is worked out from the values
+    that are. ``min``/``max``, ``distinctVals`` and ``stdev`` all skip a blank
+    in plotly.js, and ``autoShiftNumericBins`` counts them off its length;
+    read off the whole array instead, the minimum was ``NaN`` and the first
+    ``ceil`` of it raised out of a figure plotly draws (#699). For a sample
+    with no blanks every intermediate is the same number, so its grid is
+    unchanged. A sample of nothing but blanks draws no bars, and comes back
+    as no edges at all.
+
     Parameters
     ----------
     arr : np.ndarray
-        The raw data values.
+        The raw data values, blanks included.
     is_2d : bool, default False
         Bin one axis of a ``histogram2d``, which changes only the sample-size
         exponent of the automatic width -- see :func:`_plotly_default_size0`.
@@ -836,10 +906,13 @@ def compute_bin_edges(
     Returns
     -------
     np.ndarray
-        Bin edges matching what Plotly renders.
+        Bin edges matching what Plotly renders; empty when it renders none.
     """
     named = bins if isinstance(bins, dict) else {}
-    data_min, data_max = float(arr.min()), float(arr.max())
+    finite = arr[np.isfinite(arr)]
+    if not finite.size:
+        return np.array([])
+    data_min, data_max = float(finite.min()), float(finite.max())
     data_range = data_max - data_min
     # A sample with no spread and nothing said about it: one bin around the
     # single value, which is what plotly draws (measured -- a run of 3s is
@@ -850,7 +923,9 @@ def compute_bin_edges(
 
     # 1. The width: the author's, the one an `nbins` hint rounds up to, or
     #    the automatic one -- see :func:`_bin_size`.
-    size = _bin_size(arr, named, nbins, data_range, is_2d=is_2d)
+    size = _bin_size(
+        finite, named, nbins, data_range, is_2d=is_2d, sample_size=arr.size
+    )
     if size <= 0:
         # Only a *negative* explicit width reaches here -- a zero one is read
         # as an absence above. Plotly draws something for it rather than
@@ -875,7 +950,11 @@ def compute_bin_edges(
         start = float(named["start"])
     else:
         start = _auto_shift_bins(
-            math.ceil(data_min / size) * size - size, arr, size, data_min, data_max
+            math.ceil(data_min / size) * size - size,
+            finite,
+            size,
+            data_min,
+            data_max,
         )
 
     # 3. How many bins. Plotly steps from `start` while the *bin's own*
@@ -910,6 +989,7 @@ def _bin_size(
     data_range: float,
     *,
     is_2d: bool,
+    sample_size: int | None = None,
 ) -> float:
     """The bin width plotly settles on, before any start or end is applied.
 
@@ -939,5 +1019,6 @@ def _bin_size(
     # differently.
     if nbins is not None and "size" not in named:
         return _plotly_dtick(data_range / max(1, nbins))
-    return _plotly_dtick(_plotly_default_size0(arr, is_2d=is_2d))
-
+    return _plotly_dtick(
+        _plotly_default_size0(arr, is_2d=is_2d, sample_size=sample_size)
+    )

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -886,12 +886,17 @@ def compute_bin_edges(
     A blank in the sample -- a ``None`` or a ``NaN``, which plotly draws
     around -- is no observation, and the grid is worked out from the values
     that are. ``min``/``max``, ``distinctVals`` and ``stdev`` all skip a blank
-    in plotly.js, and ``autoShiftNumericBins`` counts them off its length;
-    read off the whole array instead, the minimum was ``NaN`` and the first
-    ``ceil`` of it raised out of a figure plotly draws (#699). For a sample
-    with no blanks every intermediate is the same number, so its grid is
-    unchanged. A sample of nothing but blanks draws no bars, and comes back
-    as no edges at all.
+    in plotly.js, and ``autoShiftNumericBins`` **subtracts the blanks from
+    its length** before every threshold it tests: the bundle counts them in
+    the same pass as the integers (``t[c]%1===0?s++:zh(t[c])||l++``), takes
+    ``f=t.length-l``, and reads ``s===f``, ``f*.1`` and ``f*.3`` off that
+    ``f``. So the finite sample is what it is handed here, and the one term
+    that does see the whole length is the automatic width's exponent -- see
+    :func:`_plotly_default_size0`. Read off the whole array instead, the
+    minimum was ``NaN`` and the first ``ceil`` of it raised out of a figure
+    plotly draws (#699). For a sample with no blanks every intermediate is
+    the same number, so its grid is unchanged. A sample of nothing but blanks
+    draws no bars, and comes back as no edges at all.
 
     Parameters
     ----------

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -27,6 +27,11 @@ _logger = logging.getLogger(__name__)
 #: checked separately -- see :meth:`PlotlyPlot._looks_like_date`.
 _ISO_DATE = re.compile(r"^(\d{4})-(\d{1,2})(?:-(\d{1,2}))?(?:[ T].*)?$")
 
+#: Date units coarsest first, the order :func:`_iso_dates` tries them in.
+#: No hour on its own: ``2024-01-01T12`` is ISO 8601 but reads as nothing to
+#: a listener, where ``2024-01-01T12:00`` is a time.
+_DATE_UNITS = ("D", "m", "s", "ms", "us", "ns")
+
 
 class PlotlyPlot(ABC):
     """
@@ -68,6 +73,15 @@ class PlotlyPlot(ABC):
     def _to_native(val: Any) -> Any:
         """Convert numpy scalars to native Python types.
 
+        A date is spelled as the ISO string plotly's own ``to_json`` writes
+        for it, rather than unwrapped: ``.item()`` on a ``datetime64`` gives a
+        ``datetime`` at microsecond resolution and an epoch *integer* at
+        nanosecond, and neither is what the schema wants -- the first cannot
+        be serialised at all and the second announces a date as
+        ``1704067200000000000`` (#699). The ``datetime64`` check comes before
+        ``.item()`` for that reason, and ``date`` covers ``datetime`` and
+        ``pandas.Timestamp`` with it.
+
         Parameters
         ----------
         val : Any
@@ -76,9 +90,13 @@ class PlotlyPlot(ABC):
         Returns
         -------
         Any
-            A native Python type if the input was a numpy scalar,
-            otherwise the original value.
+            A native Python type if the input was a numpy scalar, an ISO
+            string if it was a date, otherwise the original value.
         """
+        if isinstance(val, np.datetime64):
+            return str(np.datetime_as_string(val, unit="auto"))
+        if isinstance(val, date):
+            return val.isoformat()
         if hasattr(val, "item"):
             return val.item()
         return val
@@ -949,6 +967,11 @@ def as_list(value: Any) -> list:
     A multi-dimensional array carries its extents alongside the buffer and is
     restored to nested lists, so a heatmap's ``z`` still arrives as rows.
 
+    A date column is one of the arrays that stays numpy, and it is spelled
+    here as the ISO strings plotly's own ``to_json`` writes, since the
+    ``datetime64`` scalars it would otherwise decompose into serialise as
+    nothing the schema can hold -- see :meth:`PlotlyPlot._to_native` (#699).
+
     A plain list or tuple is handed back as a list, so a hand-built
     ``go.Bar(y=[1, 2, 3])`` travels this path unchanged. An absent array
     becomes an empty list rather than staying ``None``: every caller reads a
@@ -976,10 +999,44 @@ def as_list(value: Any) -> list:
     if isinstance(value, str):
         return []
 
+    if isinstance(value, np.ndarray) and value.dtype.kind == "M":
+        return _iso_dates(value)
+
     try:
         return list(value)
     except TypeError:
         return []
+
+
+def _iso_dates(values: np.ndarray) -> list[str]:
+    """
+    Spell a ``datetime64`` array as ISO strings.
+
+    One unit for the whole array, the coarsest that loses nothing of any
+    entry: a daily series reads ``2024-01-01`` rather than the
+    ``2024-01-01T00:00:00.000000`` plotly's verbatim rule writes, and an
+    hourly one ``2024-01-01T12:00`` throughout. Numpy's ``unit="auto"``
+    chooses per entry, which would spell the midnight and the noon of one
+    series differently.
+
+    Parameters
+    ----------
+    values : np.ndarray
+        An array of ``datetime64`` values, at any resolution.
+
+    Returns
+    -------
+    list[str]
+        One ISO string per entry; ``NaT`` stays ``"NaT"``.
+    """
+    # NaT is unequal to everything including itself, so it is excused from
+    # the comparison rather than forcing the finest unit on every real entry.
+    real = ~np.isnat(values)
+    for unit in _DATE_UNITS:
+        coarse = values.astype(f"datetime64[{unit}]")
+        if np.array_equal(coarse[real], values[real]):
+            return np.datetime_as_string(coarse).tolist()
+    return np.datetime_as_string(values).tolist()
 
 
 def _decode_typed_array(spec: dict) -> list:

--- a/maidr/plotly/plotly_plot.py
+++ b/maidr/plotly/plotly_plot.py
@@ -971,6 +971,7 @@ def as_list(value: Any) -> list:
     here as the ISO strings plotly's own ``to_json`` writes, since the
     ``datetime64`` scalars it would otherwise decompose into serialise as
     nothing the schema can hold -- see :meth:`PlotlyPlot._to_native` (#699).
+    A list of such scalars is spelled the same way, for the same reason.
 
     A plain list or tuple is handed back as a list, so a hand-built
     ``go.Bar(y=[1, 2, 3])`` travels this path unchanged. An absent array
@@ -1001,6 +1002,17 @@ def as_list(value: Any) -> list:
 
     if isinstance(value, np.ndarray) and value.dtype.kind == "M":
         return _iso_dates(value)
+
+    # A list of `datetime64` scalars is the same series spelled by hand, and
+    # takes the same path so it gets one unit throughout: entry by entry
+    # through `_to_native` it would come out as `2024-01-01` beside
+    # `2024-01-01T12:00`. `all` of nothing is True, hence the emptiness check.
+    if (
+        isinstance(value, (list, tuple))
+        and value
+        and all(isinstance(entry, np.datetime64) for entry in value)
+    ):
+        return _iso_dates(np.array(value))
 
     try:
         return list(value)

--- a/tests/plotly/test_plotly_dates.py
+++ b/tests/plotly/test_plotly_dates.py
@@ -1,0 +1,140 @@
+"""A date axis made ``render()`` raise, or announced epoch nanoseconds (#699).
+
+``Figure.to_dict()`` hands a date column over as a ``datetime64`` array -- it
+base64-encodes only the numeric kinds -- and a hand-written one as the
+``datetime`` or ``date`` objects the author gave. Neither survived the
+schema: ``as_list`` decomposed the array into ``datetime64`` scalars,
+``_to_native`` unwrapped those with ``.item()``, and what came out was a
+``datetime`` that ``json.dumps`` rejects at microsecond resolution or an
+epoch *integer* at nanosecond. So ``px.line`` over a ``date_range`` raised,
+and a ``datetime64[ns]`` array announced ``1704067200000000000`` as a day.
+
+Plotly's own ``to_json`` spells the same values as ISO strings, and an ISO
+string on an axis is an input every extractor already expects -- see
+``PlotlyPlot._looks_like_date``. So that is what both now emit, with one
+spelling across an array: the coarsest unit that loses nothing of any entry.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import plotly.express as px  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+from maidr.plotly.plotly_plot import PlotlyPlot, as_list  # noqa: E402
+
+DAYS = pd.date_range("2024-01-01", periods=6, freq="D")
+SPELLED = [f"2024-01-0{day}" for day in range(1, 7)]
+VALUES = [1, 3, 2, 5, 4, 6]
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame({"d": DAYS, "v": VALUES})
+
+
+def serialised(fig) -> dict:
+    """The schema, round-tripped through the JSON the page embeds it as."""
+    return json.loads(json.dumps(PlotlyMaidr(fig)._flatten_maidr()))
+
+
+def points(fig) -> list[dict]:
+    """Every point of a single-subplot figure's first layer, series flattened."""
+    data = serialised(fig)["subplots"][0][0]["layers"][0]["data"]
+    if data and isinstance(data[0], list):
+        return [point for series in data for point in series]
+    return data
+
+
+class TestADateAxisRenders:
+    @pytest.mark.parametrize("plot", [px.line, px.bar, px.scatter])
+    def test_an_express_date_column_serialises(self, plot):
+        # Raised `TypeError: Object of type datetime is not JSON serializable`
+        # from inside the page template.
+        figure = plot(frame(), x="d", y="v")
+
+        assert [point["x"] for point in points(figure)] == SPELLED
+
+    @pytest.mark.parametrize(
+        "spelling",
+        [
+            list(DAYS.to_pydatetime()),
+            [day.date() for day in DAYS],
+            list(DAYS),
+            DAYS.to_numpy().astype("datetime64[D]"),
+            DAYS.to_numpy(),
+        ],
+        ids=["datetime", "date", "Timestamp", "datetime64[D]", "datetime64[ns]"],
+    )
+    def test_every_spelling_of_a_date_is_a_string_plotly_reads_as_one(self, spelling):
+        figure = go.Figure(go.Scatter(x=spelling, y=VALUES))
+
+        emitted = [point["x"] for point in points(figure)]
+
+        assert len(emitted) == len(VALUES)
+        assert all(isinstance(x, str) for x in emitted)
+        assert all(PlotlyPlot._looks_like_date(x) for x in emitted)
+
+    def test_a_date_on_y_is_spelled_the_same_way(self):
+        figure = go.Figure(go.Scatter(x=VALUES, y=DAYS.to_numpy()))
+
+        assert [point["y"] for point in points(figure)] == SPELLED
+
+    def test_the_page_renders(self):
+        # `render` is where the schema meets `json.dumps`, so it is the call
+        # that raised.
+        assert PlotlyMaidr(px.line(frame(), x="d", y="v")).render() is not None
+
+
+class TestTheSpelling:
+    def test_an_array_of_midnights_reads_as_dates(self):
+        # Plotly's verbatim rule writes `2024-01-01T00:00:00.000000` for a
+        # `datetime64[us]`; nothing of that is a date to a listener.
+        assert as_list(DAYS.to_numpy()) == SPELLED
+
+    def test_an_array_with_a_time_carries_it_throughout(self):
+        # One unit for the array: `unit="auto"` picks per entry and would
+        # spell the midnight and the noon of the same series differently.
+        half_days = pd.date_range("2024-01-01", periods=3, freq="12h")
+
+        assert as_list(half_days.to_numpy()) == [
+            "2024-01-01T00:00",
+            "2024-01-01T12:00",
+            "2024-01-02T00:00",
+        ]
+
+    def test_a_missing_date_stays_missing(self):
+        with_a_gap = np.array(
+            ["2024-01-01", "NaT", "2024-01-03"], dtype="datetime64[ns]"
+        )
+
+        assert as_list(with_a_gap) == ["2024-01-01", "NaT", "2024-01-03"]
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (np.datetime64("2024-01-01T00:00:00.000000000"), "2024-01-01"),
+            (np.datetime64("2024-01-01T12:30"), "2024-01-01T12:30"),
+            (datetime(2024, 1, 1, 12, 30), "2024-01-01T12:30:00"),
+            (date(2024, 1, 1), "2024-01-01"),
+            (pd.Timestamp("2024-01-01"), "2024-01-01T00:00:00"),
+        ],
+        ids=["datetime64[ns]", "datetime64[m]", "datetime", "date", "Timestamp"],
+    )
+    def test_a_scalar_is_spelled_as_plotly_would(self, value, expected):
+        assert PlotlyPlot._to_native(value) == expected
+
+    def test_a_number_is_still_unwrapped(self):
+        unwrapped = PlotlyPlot._to_native(np.float64(1.5))
+
+        assert unwrapped == 1.5
+        assert isinstance(unwrapped, float)
+        assert PlotlyPlot._to_native(np.int64(3)) == 3

--- a/tests/plotly/test_plotly_dates.py
+++ b/tests/plotly/test_plotly_dates.py
@@ -111,6 +111,23 @@ class TestTheSpelling:
             "2024-01-02T00:00",
         ]
 
+    def test_a_list_of_datetime64_scalars_is_spelled_as_one_series(self):
+        # Entry by entry through `_to_native` the midnight would read
+        # `2024-01-01` and the noon `2024-01-01T12:00`; as one series they
+        # share the finer unit.
+        by_hand = [
+            np.datetime64("2024-01-01T00:00"),
+            np.datetime64("2024-01-01T12:00"),
+            np.datetime64("2024-01-02"),
+        ]
+
+        assert as_list(by_hand) == [
+            "2024-01-01T00:00",
+            "2024-01-01T12:00",
+            "2024-01-02T00:00",
+        ]
+        assert as_list(tuple(by_hand)) == as_list(by_hand)
+
     def test_a_missing_date_stays_missing(self):
         with_a_gap = np.array(
             ["2024-01-01", "NaT", "2024-01-03"], dtype="datetime64[ns]"

--- a/tests/plotly/test_plotly_grouped_histogram.py
+++ b/tests/plotly/test_plotly_grouped_histogram.py
@@ -37,6 +37,7 @@ import pytest
 
 plotly = pytest.importorskip("plotly")
 
+import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
 import plotly.express as px  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402
@@ -304,3 +305,37 @@ class TestBarnormValuesStayRaw:
     def test_the_type_still_reports_the_normalisation(self):
         layer = only_layer(stacked(SMALL_A, SMALL_B, barnorm="percent"))
         assert layer["type"] == PlotType.NORMALIZED.value
+
+
+class TestABlankIsNoObservation:
+    """A missing entry in any series raised out of the whole figure (#699).
+
+    The shared grid is worked out from the pooled sample, and one ``nan`` in
+    it made the pool's minimum ``nan`` -- the same failure as the single
+    histogram's, reached through the union. The grouped path also handed an
+    empty grid straight to ``_bin_counts``, so a spec the single-trace path
+    declines raised ``IndexError`` here instead.
+    """
+
+    def test_a_blank_in_one_series_leaves_the_shared_grid_alone(self):
+        with_a_blank = pd.concat(
+            [frame(), pd.DataFrame({"v": [np.nan], "h": ["x"]})],
+            ignore_index=True,
+        )
+
+        emitted = only_layer(px.histogram(with_a_blank, x="v", color="h"))
+        clean = only_layer(px.histogram(frame(), x="v", color="h"))
+
+        assert emitted["data"] == clean["data"]
+
+    def test_a_negative_width_forms_no_layer(self):
+        # What the single-trace path already does with it -- see
+        # `test_plotly_histogram_bins.py` -- rather than an `IndexError`.
+        figure = px.histogram(frame(), x="v", color="h").update_traces(
+            xbins=dict(size=-2)
+        )
+
+        assert layers(figure) == []
+
+    def test_a_group_of_nothing_but_blanks_forms_no_layer(self):
+        assert layers(stacked([None, None], [float("nan")])) == []

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -538,6 +538,31 @@ class TestABlankIsNoObservation:
         # distribution the chart does not draw (#636).
         assert layers(go.Figure(go.Histogram(x=[None, float("nan")]))) == []
 
+    def test_the_shift_counts_the_sample_without_its_blanks(self):
+        """``autoShiftNumericBins`` subtracts the blanks from its length.
+
+        The bundle tallies them alongside the integers
+        (``t[c]%1===0?s++:zh(t[c])||l++``), takes ``f=t.length-l``, and tests
+        ``s===f``, ``f*.1`` and ``f*.3`` against that ``f``. Forty integers
+        and thirty blanks pin which length is meant: over the finite sample
+        every value is an integer and the grid shifts half a step off them,
+        to ``-0.5``. Counted over the whole array, ``s`` would be 40 against
+        an ``f`` of 70, the integer branch would not fire, and the sample's
+        minimum sitting on an edge would send it half a *bin* down instead,
+        to ``-2.5`` -- a start the chart does not draw.
+
+        The width is named so that only the shift is under test: the
+        automatic one does read the whole length, through its exponent.
+        """
+        integers = list(range(40))
+        with_blanks = integers + [None] * 30
+
+        finite = bins(go.Figure(go.Histogram(x=integers, xbins=dict(size=5))))
+        blanked = bins(go.Figure(go.Histogram(x=with_blanks, xbins=dict(size=5))))
+
+        assert blanked == finite
+        assert finite[0][0] == -0.5
+
     def test_a_blank_still_counts_toward_the_width_exponent(self):
         """The one term plotly reads off the whole array, blanks included.
 

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -45,9 +45,15 @@ import pytest
 plotly = pytest.importorskip("plotly")
 
 import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import plotly.express as px  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402
 
-from maidr.plotly.histogram import _auto_shift_bins, _occupied_span  # noqa: E402
+from maidr.plotly.histogram import (  # noqa: E402
+    _auto_shift_bins,
+    _occupied_span,
+    _plotly_default_size0,
+)
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 #: Spans a window given below in one test and above it in another.
@@ -292,9 +298,7 @@ class TestTheRoundUpIsStrict:
         the loose reading would have given a width of 2.
         """
         values = list(np.linspace(0, 30, 61))
-        figure = go.Figure(
-            go.Histogram2d(x=values, y=values, nbinsx=15, nbinsy=15)
-        )
+        figure = go.Figure(go.Histogram2d(x=values, y=values, nbinsx=15, nbinsy=15))
 
         layer = PlotlyMaidr(figure)._flatten_maidr()["subplots"][0][0]["layers"][0]
 
@@ -345,9 +349,7 @@ class TestABinSpecWithoutASize:
 
     def test_both_ends_without_a_width_get_one_derived_for_them(self):
         """The width is still the automatic one; only the window is theirs."""
-        drawn = bins(
-            go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(start=2, end=6)))
-        )
+        drawn = bins(go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(start=2, end=6))))
 
         assert drawn == [(2.0, 4.0, 5), (4.0, 6.0, 5)]
 
@@ -405,9 +407,9 @@ class TestABinSpecWithoutASize:
         flat = [3, 3, 3, 3, 3]
 
         assert bins(go.Figure(go.Histogram(x=flat))) == [(2.5, 3.5, 5)]
-        assert bins(
-            go.Figure(go.Histogram(x=flat, xbins=dict(start=0)))
-        ) == [(3.0, 4.0, 5)]
+        assert bins(go.Figure(go.Histogram(x=flat, xbins=dict(start=0)))) == [
+            (3.0, 4.0, 5)
+        ]
 
     def test_a_window_a_hair_over_whole_bins_is_still_whole_bins(self):
         """``(-2.8 - -3.0) / 0.1`` is 2.0000000000000018 in binary.
@@ -478,3 +480,88 @@ class TestABinSpecWithoutASize:
         figure = go.Figure(go.Histogram(x=self.SAMPLE, xbins=dict(start=20)))
 
         assert layers(figure) == []
+
+
+class TestABlankIsNoObservation:
+    """A ``None`` or a ``NaN`` in the sample raised out of the figure (#699).
+
+    ``_bin_assignment`` already put a blank in no bin; the grid was still
+    worked out from the whole array, so its minimum was ``NaN`` and the first
+    ``ceil`` of it raised ``ValueError`` -- out of ``maidr.render``, taking
+    every other layer of the figure down with the histogram. Plotly draws
+    around a blank: ``min``/``max``, ``distinctVals`` and ``stdev`` all skip
+    it, and only the ``data.length`` under the automatic width's exponent
+    still counts it.
+    """
+
+    WITH_BLANKS = BIMODAL[:3] + [None, float("nan")] + BIMODAL[3:]
+
+    def test_the_finite_values_are_binned_as_they_would_be_alone(self):
+        with_blanks = go.Figure(go.Histogram(x=self.WITH_BLANKS))
+        finite = go.Figure(go.Histogram(x=BIMODAL))
+
+        assert bins(with_blanks) == bins(finite)
+        assert bins(finite) == [(0.0, 5.0, 4), (5.0, 10.0, 2), (10.0, 15.0, 2)]
+
+    def test_on_a_horizontal_trace_too(self):
+        with_blanks = go.Figure(go.Histogram(y=self.WITH_BLANKS))
+        finite = go.Figure(go.Histogram(y=BIMODAL))
+
+        assert bins(with_blanks) == bins(finite)
+
+    def test_from_a_frame_column(self):
+        # The ordinary way to meet one: a column with a missing entry, which
+        # `to_dict` hands over as an array holding a `nan`.
+        column = px.histogram(pd.DataFrame({"v": self.WITH_BLANKS}), x="v")
+
+        assert bins(column) == bins(go.Figure(go.Histogram(x=BIMODAL)))
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            dict(xbins=dict(size=2)),
+            dict(xbins=dict(start=0.5)),
+            dict(nbinsx=3),
+        ],
+        ids=["size", "start", "nbins"],
+    )
+    def test_under_every_spelling_of_the_spec(self, spec):
+        # Each spelling read the minimum or the maximum on a path of its own,
+        # and every one of them raised.
+        with_blanks = go.Figure(go.Histogram(x=self.WITH_BLANKS, **spec))
+        finite = go.Figure(go.Histogram(x=BIMODAL, **spec))
+
+        assert bins(with_blanks) == bins(finite)
+
+    def test_a_sample_of_nothing_but_blanks_forms_no_layer(self):
+        # Plotly draws no bars for it, and a layer of no bins would announce a
+        # distribution the chart does not draw (#636).
+        assert layers(go.Figure(go.Histogram(x=[None, float("nan")]))) == []
+
+    def test_a_blank_still_counts_toward_the_width_exponent(self):
+        """The one term plotly reads off the whole array, blanks included.
+
+        ``autoBin`` divides ``2 * stdev`` by ``data.length ** 0.4``, and that
+        length is the array as given, where the standard deviation beside it
+        is over the numeric entries alone. So the finite values do **not**
+        always bin as they would on their own: two blanks make this sample
+        two longer, the rough width smaller by ``(6 / 8) ** 0.4``, and that is
+        enough to carry it across the 2 the nice rounding turns on.
+        """
+        sample = np.array(NARROW, dtype=float)
+        alone = _plotly_default_size0(sample)
+        with_two_blanks = _plotly_default_size0(sample, sample_size=len(NARROW) + 2)
+
+        assert with_two_blanks == pytest.approx(alone * (6 / 8) ** 0.4)
+
+        two_blanks = NARROW[:3] + [None, float("nan")] + NARROW[3:]
+        assert bins(go.Figure(go.Histogram(x=NARROW))) == [
+            (-5.0, 0.0, 2),
+            (0.0, 5.0, 4),
+        ]
+        assert bins(go.Figure(go.Histogram(x=two_blanks))) == [
+            (-4.0, -2.0, 1),
+            (-2.0, 0.0, 1),
+            (0.0, 2.0, 2),
+            (2.0, 4.0, 2),
+        ]

--- a/tests/plotly/test_plotly_histogram_dates.py
+++ b/tests/plotly/test_plotly_histogram_dates.py
@@ -1,0 +1,112 @@
+"""A histogram over a date column announced epoch microseconds (#699).
+
+``px.histogram`` over a ``date_range`` reached the numeric binning as a
+``datetime64`` array, and six days came out as bin bounds around
+``1.704e15`` on a grid of ``1e11`` microseconds -- about 1.157 days, a width
+that is in no date tick sequence of plotly's. Plotly bins a date axis by
+rules of its own: a width from the date branch of ``autoTicks``, no
+anti-clustering shift, date labels. None of that is ported yet, so a temporal
+sample forms no layer -- what #636 settled for every other reading this
+cannot make right, and what the two-dimensional path already does with one --
+rather than announcing numbers that are nowhere on the chart.
+
+A list of ``Timestamp`` objects took a different wrong turn: it failed the
+float coercion and was counted as *categories*, one bar per instant.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+plotly = pytest.importorskip("plotly")
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import plotly.express as px  # noqa: E402
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.plotly.histogram import is_temporal_sample  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
+
+DAYS = pd.date_range("2024-01-01", periods=6, freq="D")
+
+
+def frame() -> pd.DataFrame:
+    return pd.DataFrame({"d": DAYS, "v": [1, 3, 2, 5, 4, 6], "g": list("aabbab")})
+
+
+def layers(fig) -> list[dict]:
+    return PlotlyMaidr(fig)._flatten_maidr()["subplots"][0][0]["layers"]
+
+
+class TestATemporalSampleFormsNoLayer:
+    def test_an_express_date_column(self):
+        assert layers(px.histogram(frame(), x="d")) == []
+
+    def test_on_a_horizontal_trace(self):
+        assert layers(px.histogram(frame(), y="d")) == []
+
+    def test_a_grouped_one(self):
+        assert layers(px.histogram(frame(), x="d", color="g")) == []
+
+    def test_a_list_of_timestamps_is_not_a_count_bar_chart(self):
+        # Plotly bins these on a date axis like any other; counting each
+        # instant as a category described a chart it does not draw.
+        assert layers(go.Figure(go.Histogram(x=list(DAYS)))) == []
+
+    def test_a_numeric_sample_is_unaffected(self):
+        emitted = layers(px.histogram(frame(), x="v"))
+
+        assert [layer["type"] for layer in emitted] == [PlotType.HIST.value]
+
+    def test_a_numeric_group_is_unaffected(self):
+        emitted = layers(px.histogram(frame(), x="v", color="g"))
+
+        assert [layer["type"] for layer in emitted] == [PlotType.STACKED.value]
+
+
+class TestIsTemporalSample:
+    @pytest.mark.parametrize(
+        ("values", "expected"),
+        [
+            (DAYS.to_numpy(), True),
+            (DAYS.to_numpy().astype("datetime64[D]"), True),
+            (list(DAYS), True),
+            ([datetime(2024, 1, 1), datetime(2024, 1, 2)], True),
+            ([date(2024, 1, 1), date(2024, 1, 2)], True),
+            ([np.datetime64("2024-01-01"), np.datetime64("2024-01-02")], True),
+            (np.array([pd.Timestamp("2024-01-01"), None], dtype=object), True),
+            ([1.0, 2.0, 3.0], False),
+            (np.array([1.0, 2.0, 3.0]), False),
+            # A sample the author spelled as strings takes the categorical
+            # path as it did before; this reads only what `to_dict` typed.
+            (["2024-01-01", "2024-01-02"], False),
+            (["a", "b"], False),
+            (np.array(["a", None], dtype=object), False),
+            ({"dtype": "f8", "bdata": "AAAAAAAA8D8="}, False),
+            (None, False),
+            ([], False),
+        ],
+        ids=[
+            "datetime64[ns]",
+            "datetime64[D]",
+            "Timestamps",
+            "datetimes",
+            "dates",
+            "datetime64 scalars",
+            "object array",
+            "floats",
+            "float array",
+            "date strings",
+            "strings",
+            "object strings",
+            "typed-array spec",
+            "None",
+            "empty",
+        ],
+    )
+    def test_it_reads_what_plotly_would_put_on_a_date_axis(self, values, expected):
+        assert is_temporal_sample(values) is expected


### PR DESCRIPTION
## What

Closes #699.

**Dates.** `PlotlyPlot._to_native` only unwrapped numpy scalars and `as_list` only decoded typed-array specs. `Figure.to_dict()` exports a date column as a `datetime64` ndarray (px) or leaves `datetime`/`date` objects in a list (go), and the schema then hit `json.dumps` with no `default=`: `px.line`/`px.scatter`/`px.bar` on a `pd.date_range` column, `go.Scatter` with `datetime`, `date`, `Timestamp`, `datetime64[D]` x, `go.Bar(x=pd.date_range(...))` — every one raised `TypeError: Object of type datetime is not JSON serializable`; `datetime64[ns]` rendered and announced `x = 1704067200000000000`. Dates are now spelled the way plotly's own `to_json` spells them — `np.datetime_as_string` for arrays, `isoformat()` for objects — so the accessible layer says what the figure JSON in the same page says. One refinement over plotly's per-element `unit='auto'`: an array uses the coarsest unit that loses nothing of any entry, so a daily series reads `2024-01-01` throughout instead of mixing `2024-01-01` and `2024-01-02T12:00`.

**Histogram blanks.** `_extract_plot_data` coerced with `np.array(values, dtype=float)` (None → NaN) and `compute_bin_edges` took NaN min/max into `math.floor(math.log10(NaN))`: `ValueError` for `go.Histogram(x=[1, 2, None, 3, 4, 5])`, for `px.histogram` over a column with one NaN (plain, `color=`, horizontal, `nbinsx`, size-only or start-only `xbins`), and nothing caught it, so one blank took every layer of the figure down. plotly.js draws the chart, skipping BADNUM in `autoBin` while keeping `e.length` for the size exponent. `compute_bin_edges` now bins the finite sample and hands `sample_size=arr.size` to `_plotly_default_size0` for the exponent, so a finite sample is byte-identical (1 500 random cases compared against the unpatched module: all identical). An all-blank sample forms no layer; `_shared_edges` returns `None` for fewer than two edges, which also closes the grouped `xbins.size=-2` `IndexError`.

**Histogram over dates.** `px.histogram` over a datetime column converted silently to epoch microseconds and emitted bins of `1e11 µs` that plotly does not draw; `go.Histogram(x=list_of_Timestamps)` emitted a BAR per instant. A temporal sample now declines the 1-D and grouped layers (debug log), consistent with #636 and the 2-D path; porting plotly's date autobin is a follow-up to measure in a browser first. A sample the author wrote as ISO *strings* still takes the categorical path exactly as before (pinned by a test; same class of bug, out of scope here).

## Output changes

Beyond the raising cases: any layer that received a `datetime64` array now carries ISO strings — the plotly candlestick's date labels change from `2024-01-01 00:00:00` to `2024-01-01`. For `NARROW`-style samples with blanks, the width can differ from the blank-free sample because plotly's `n ** 0.4` counts blanks (documented in the test).

## Tests

New `tests/plotly/test_plotly_dates.py` and `test_plotly_histogram_dates.py`; a `TestABlankIsNoObservation` class in `test_plotly_histogram_bins.py` and `test_plotly_grouped_histogram.py`. Against `main`'s sources: 29 failed, 108 passed, 1 import error (`is_temporal_sample` does not exist before the fix).

## Verified

```
uv run pytest      3655 passed, 68 skipped
ruff check         All checks passed (changed files)
```

`_auto_shift_bins` is untouched here; #701 vectorises it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_