### PR TITLE
fix(axes): read a tz-aware date axis as numeric rather than as string categories

### DIFF
--- a/maidr/core/plot/pointplot.py
+++ b/maidr/core/plot/pointplot.py
@@ -5,6 +5,7 @@ from typing import Sequence
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.axis import Axis
+from matplotlib.category import UnitData
 from matplotlib.lines import Line2D
 
 from maidr.core.enum import MaidrKey
@@ -316,7 +317,10 @@ class PointPlot(ErrorBarPlot):
            category machinery, which leaves ``UnitData`` on that axis and
            nothing on the other. That holds whatever the category *values*
            are -- a numeric grouping column still travels this way -- so it
-           is the whole answer whenever it fires.
+           is the whole answer whenever it fires. The test is for
+           ``UnitData`` itself rather than for any units at all, because a
+           tz-aware date axis carries its ``tzinfo`` as units and is not a
+           category axis (#709).
         2. Under ``native_scale=True`` the category axis is an ordinary
            numeric one and signal 1 is silent. Then the intervals themselves
            say it: an interval spans the value axis and, at the default
@@ -328,8 +332,8 @@ class PointPlot(ErrorBarPlot):
             True when the categories run along x, which is seaborn's default
             and the answer when neither signal fires.
         """
-        x_is_category = self.ax.xaxis.units is not None
-        y_is_category = self.ax.yaxis.units is not None
+        x_is_category = isinstance(self.ax.xaxis.units, UnitData)
+        y_is_category = isinstance(self.ax.yaxis.units, UnitData)
         if x_is_category != y_is_category:
             return x_is_category
 
@@ -359,8 +363,9 @@ class PointPlot(ErrorBarPlot):
             Coordinate to label, for the labelled ticks only.
         """
         axis: Axis = self.ax.xaxis if is_vertical else self.ax.yaxis
-        if axis.units is None:
-            # A numeric axis under `native_scale=True`. Its tick labels are
+        if not isinstance(axis.units, UnitData):
+            # A numeric axis under `native_scale=True` -- including a tz-aware
+            # date axis, whose units are its `tzinfo`. Its tick labels are
             # renderings of the coordinates rather than names, and returning
             # them would replace a group's value with whatever rounding the
             # tick formatter happened to apply.

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -2,6 +2,7 @@ import numpy as np
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from matplotlib.axes import Axes
+from matplotlib.category import UnitData
 from matplotlib.cm import ScalarMappable
 from matplotlib.collections import PolyQuadMesh, QuadMesh
 from matplotlib.image import AxesImage
@@ -201,11 +202,16 @@ class LineExtractorMixin:
         tick layouts that are neither contiguous nor zero-based.
 
         Empty unless the axis really is a string-category axis: matplotlib
-        leaves a ``UnitData`` on the axis it mapped strings onto, and nothing
-        else. A numeric axis has tick labels too -- "0", "25", "1.00" -- and
-        they are formatted renderings of the numbers rather than names for
-        them, so substituting one costs the value both its type and its
-        precision.
+        leaves a ``UnitData`` on the axis it mapped strings onto. It is the
+        *kind* of units that decides, not their presence -- a date axis
+        carries units too, because matplotlib's date converter records the
+        data's ``tzinfo`` there, so a tz-aware index leaves a ``timezone``
+        where a naive one leaves ``None``. That axis is numeric for this
+        purpose: reading it as categories snapped every hourly point onto a
+        daily tick (#709). A numeric axis has tick labels too -- "0", "25",
+        "1.00" -- and they are formatted renderings of the numbers rather than
+        names for them, so substituting one costs the value both its type and
+        its precision.
 
         Parameters
         ----------
@@ -220,7 +226,7 @@ class LineExtractorMixin:
             Tick coordinate to label, or an empty mapping on a numeric axis
         """
         holder = ax.xaxis if axis == "x" else ax.yaxis
-        if holder.units is None:
+        if not isinstance(holder.units, UnitData):
             return {}
 
         positions = ax.get_xticks() if axis == "x" else ax.get_yticks()

--- a/tests/core/plot/test_pointplot.py
+++ b/tests/core/plot/test_pointplot.py
@@ -241,6 +241,33 @@ def test_native_scale_still_finds_the_category_axis():
     assert [point["x"] for point in schema["data"]] == [1.0, 2.0, 3.0]
 
 
+def test_native_scale_reads_a_tz_aware_date_axis_as_numeric():
+    """
+    A tz-aware date axis carries units and is still not a category axis.
+
+    matplotlib's date converter records the data's ``tzinfo`` as the axis
+    units, so a ``tz="UTC"`` index left a ``timezone`` where a naive one left
+    ``None``, and "has units" was read as "is the category axis": the naive
+    chart emitted ordinals and the tz-aware one the tick strings (#709).
+    """
+    days = pd.date_range("2024-01-01", periods=6, freq="D", tz="UTC")
+    aware = pd.DataFrame(
+        {"d": np.repeat(days, 5), "v": np.tile([1.0, 2.0, 3.0, 4.0, 5.0], 6)}
+    )
+    naive = aware.assign(d=aware["d"].dt.tz_localize(None))
+
+    fig_aware, ax = plt.subplots()
+    sns.pointplot(aware, x="d", y="v", native_scale=True, ax=ax)
+    fig_naive, ax = plt.subplots()
+    sns.pointplot(naive, x="d", y="v", native_scale=True, ax=ax)
+
+    aware_x = [point["x"] for point in _schema(fig_aware)["data"]]
+    naive_x = [point["x"] for point in _schema(fig_naive)["data"]]
+
+    assert all(isinstance(x, float) for x in aware_x)
+    assert aware_x == naive_x
+
+
 def test_a_symmetric_interval_does_not_flip_the_orientation():
     """
     ``errorbar='sd'`` draws bounds equidistant from the estimate.

--- a/tests/core/plot/test_scatter_category_label.py
+++ b/tests/core/plot/test_scatter_category_label.py
@@ -67,6 +67,19 @@ def points(ax) -> list[dict]:
     ]
 
 
+def line_points(ax) -> list[dict]:
+    """Every sample of every line series on the axes, in series order."""
+    ax = getattr(ax, "axes", ax)
+    maidr = FigureManager.get_maidr(ax.get_figure())
+    return [
+        sample
+        for plot in maidr._plots
+        if plot.type.value == "line"
+        for series in plot.schema["data"]
+        for sample in series
+    ]
+
+
 @pytest.mark.parametrize("kind", ["stripplot", "swarmplot"])
 class TestTheCategoryAxisIsNamed:
     def test_every_sample_carries_its_category(self, kind):
@@ -144,3 +157,52 @@ class TestWhatMustNotChange:
         drawn = points(sns.scatterplot(frame(), x="g", y="v"))
 
         assert {sample["xLabel"] for sample in drawn} == {"a", "b", "c"}
+
+
+class TestADateAxis:
+    """A tz-aware date axis carries units too, and is not a category axis.
+
+    matplotlib's date converter records the data's ``tzinfo`` as the axis
+    units, so ``pd.date_range(..., tz="UTC")`` leaves ``timezone.utc`` on the
+    axis where a naive index leaves ``None``. Reading "has units" as "is a
+    string-category axis" snapped 48 hourly points onto the 9 daily ticks and
+    named each after the day it fell nearest, and turned a line's x into the
+    tick strings (#709). Naive dates were never affected, which is why it went
+    unseen.
+    """
+
+    VALUES = np.sin(np.arange(48) / 5)
+
+    @staticmethod
+    def hours(tz: str | None) -> pd.DatetimeIndex:
+        return pd.date_range("2024-01-01", periods=48, freq="h", tz=tz)
+
+    def test_a_tz_aware_scatter_keeps_every_hour(self):
+        _, ax = plt.subplots()
+        ax.scatter(self.hours("UTC"), self.VALUES)
+
+        assert len({sample["x"] for sample in points(ax)}) == 48
+
+    def test_a_tz_aware_scatter_is_not_named_after_its_ticks(self):
+        _, ax = plt.subplots()
+        ax.scatter(self.hours("UTC"), self.VALUES)
+
+        assert not any("xLabel" in sample for sample in points(ax))
+
+    def test_a_tz_aware_line_keeps_numeric_x(self):
+        _, ax = plt.subplots()
+        ax.plot(self.hours("UTC"), self.VALUES)
+        drawn = line_points(ax)
+
+        assert len(drawn) == 48
+        assert all(isinstance(sample["x"], float) for sample in drawn)
+
+    def test_a_timezone_does_not_move_the_points(self):
+        # The tz-aware chart must read as the naive one always has: the same
+        # ordinals, one per hour, with nothing rounded onto a tick.
+        _, aware = plt.subplots()
+        aware.scatter(self.hours("UTC"), self.VALUES)
+        _, naive = plt.subplots()
+        naive.scatter(self.hours(None), self.VALUES)
+
+        assert [s["x"] for s in points(aware)] == [s["x"] for s in points(naive)]


### PR DESCRIPTION
## What

`LineExtractorMixin._category_tick_labels` decided whether an axis is categorical with `holder.units is None`, on the documented assumption that matplotlib leaves a `UnitData` on the axis it mapped strings onto "and nothing else". That is false for dates: `DateConverter.default_units` returns the data's **tzinfo**, so any tz-aware datetime axis (`pd.date_range(..., tz='UTC')`, `datetime` objects with `tzinfo`, the normal shape of timestamps from databases and APIs) has `units == datetime.timezone.utc` and was read as a string-category axis. Closes #709.

```
ax.scatter(pd.date_range('2024-01-01', periods=48, freq='h', tz='UTC'), v)
  before: 9 distinct x of 48, every point snapped to a tick and given xLabel='01-01 00'
  after:  48 exact ordinals, no xLabel

ax.plot(same index, v)
  before: every x the string '01-01 00', '01-02 00', ...
  after:  numeric ordinals

sns.pointplot(native_scale=True) on tz-aware dates
  before: x = '2024-01-01' strings      after: ordinals matching the naive-date chart
```

The predicate is now `isinstance(holder.units, UnitData)`, which is what `StrCategoryConverter.default_units` installs and the only converter that maps strings; string-category axes and seaborn categorical axes still carry it. The same predicate replaces the two `units is not None` tests in `pointplot.py`. Naive datetimes, `numpy.datetime64`, string categories and seaborn axes are unaffected, which the unchanged full suite confirms.

## Tests

`tests/core/plot/test_scatter_category_label.py` gains `TestADateAxis` (tz-aware scatter keeps 48 distinct x and no `xLabel`; tz-aware line emits float x throughout; tz-aware and naive scatters emit identical x); `test_pointplot.py` gains the `native_scale=True` tz-aware case. Against `main`'s sources: 5 failed, 48 passed.

## Verified

```
uv run pytest      3609 passed, 68 skipped
ruff check         no findings in changed files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_