### PR TITLE
perf(violin): settle the figure layout once per extraction instead of once per point

### DIFF
--- a/maidr/core/plot/regplot.py
+++ b/maidr/core/plot/regplot.py
@@ -12,6 +12,7 @@ from maidr.util.regression_line_utils import find_regression_line
 from maidr.util.svg_utils import (
     data_to_svg_coords,
     from_scaled_coords,
+    settle_layout,
     to_scaled_coords,
 )
 
@@ -148,6 +149,7 @@ class SmoothPlot(MaidrPlot):
 
         x_data, y_data = self._thin_to_even_steps(x_data, y_data)
 
+        settle_layout(self.ax.figure)
         x_svg, y_svg = data_to_svg_coords(self.ax, x_data, y_data)
         lower, upper = self._confidence_band_at(x_data, y_data)
         points = []

--- a/maidr/core/plot/violin_kde_plot.py
+++ b/maidr/core/plot/violin_kde_plot.py
@@ -13,7 +13,7 @@ from maidr.core.enum.plot_type import PlotType
 from maidr.core.plot.maidr_plot import MaidrPlot
 from maidr.util.mixin.extractor_mixin import LevelExtractorMixin
 from maidr.util.rdp_utils import simplify_curve
-from maidr.util.svg_utils import data_to_svg_coords
+from maidr.util.svg_utils import data_to_svg_coords, settle_layout
 
 #: Default maximum number of output points per violin KDE curve.
 _DEFAULT_MAX_KDE_POINTS = 30
@@ -105,6 +105,12 @@ class ViolinKdePlot(MaidrPlot):
             self._elements.append(poly)
 
         is_horz = self._orientation == "horz"
+
+        # The SVG coordinates read the axes position, which is only final once
+        # the layout has been settled. Once for the whole layer, not once per
+        # point: a layout pass measures every artist on the figure, and this
+        # layer used to pay for one twice per retained level (#704).
+        settle_layout(self.ax.figure)
 
         for idx, kde_line in enumerate(self._kde_lines):
             self._elements.append(kde_line)
@@ -310,30 +316,28 @@ class ViolinKdePlot(MaidrPlot):
         else:
             indices = np.arange(len(y_arr))
 
+        # --- Convert the retained Y-levels to SVG coordinates ------------
+        # One call per side rather than one per level: the transform is
+        # affine and applied row by row, so the batch gives the same floats
+        # the per-level calls did, without a transform per point (#704).
+        sel_y = y_arr[indices]
+        sel_l = np.array(xl_vals)[indices]
+        sel_r = np.array(xr_vals)[indices]
+        if is_horz:
+            # Horizontal: xl/xr are density-axis (y in mpl), y_val is
+            # value-axis (x in mpl).
+            sx_l, sy_l = data_to_svg_coords(self.ax, sel_y, sel_l)
+            sx_r, sy_r = data_to_svg_coords(self.ax, sel_y, sel_r)
+        else:
+            sx_l, sy_l = data_to_svg_coords(self.ax, sel_l, sel_y)
+            sx_r, sy_r = data_to_svg_coords(self.ax, sel_r, sel_y)
+
         # --- Build output points for retained Y-levels -------------------
         points: list[dict] = []
-        for i in indices:
+        for k, i in enumerate(indices):
             y_val = y_vals[i]
             xl = xl_vals[i]
-            xr = xr_vals[i]
             width = widths[i]
-
-            if is_horz:
-                # Horizontal: xl/xr are density-axis (y in mpl), y_val is
-                # value-axis (x in mpl).
-                sx_l, sy_l = data_to_svg_coords(
-                    self.ax, np.array([y_val]), np.array([xl])
-                )
-                sx_r, sy_r = data_to_svg_coords(
-                    self.ax, np.array([y_val]), np.array([xr])
-                )
-            else:
-                sx_l, sy_l = data_to_svg_coords(
-                    self.ax, np.array([xl]), np.array([y_val])
-                )
-                sx_r, sy_r = data_to_svg_coords(
-                    self.ax, np.array([xr]), np.array([y_val])
-                )
 
             base: dict = {
                 MaidrKey.X: x_label if x_label else xl,
@@ -343,16 +347,16 @@ class ViolinKdePlot(MaidrPlot):
                 {
                     **base,
                     "width": float(width),
-                    "svg_x": float(sx_l[0]),
-                    "svg_y": float(sy_l[0]),
+                    "svg_x": float(sx_l[k]),
+                    "svg_y": float(sy_l[k]),
                 }
             )
             points.append(
                 {
                     **base,
                     "width": float(width),
-                    "svg_x": float(sx_r[0]),
-                    "svg_y": float(sy_r[0]),
+                    "svg_x": float(sx_r[k]),
+                    "svg_y": float(sy_r[k]),
                 }
             )
 

--- a/maidr/util/svg_utils.py
+++ b/maidr/util/svg_utils.py
@@ -1,8 +1,38 @@
 import numpy as np
 from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from matplotlib.transforms import Transform
 from matplotlib.lines import Line2D
 from typing import List, Optional, Tuple
+
+
+def settle_layout(fig: Figure) -> None:
+    """
+    Run the figure's tight layout so the axes sit where the SVG will draw them.
+
+    :func:`data_to_svg_coords` reads the axes position, and that position is
+    only final once the layout has been settled -- which is why the transform
+    used to do this itself, on every call.  A layout pass measures the text
+    extent of every artist on the figure, so an extraction converting its
+    points one at a time paid for the whole figure once per point: 124 passes
+    for four seaborn violins, nearly all of the render time (#704).  Settle
+    once per extraction, before the first conversion, and let the conversions
+    be pure.
+
+    The SVG is written after extraction, from whatever layout the figure is
+    then in, so one pass here leaves the coordinates and the drawing agreeing
+    just as the repeated passes did.  Failures are swallowed as before: a
+    figure whose layout cannot be tightened is still worth reading.
+
+    Parameters
+    ----------
+    fig : Figure
+        The figure whose layout to settle.
+    """
+    try:
+        fig.tight_layout()
+    except Exception:
+        pass
 
 
 def data_to_svg_coords(
@@ -11,16 +41,16 @@ def data_to_svg_coords(
     """
     Convert data coordinates to SVG coordinates using matplotlib transforms.
     Returns x_svg, y_svg arrays in SVG points.
+
+    A pure transform: it reads the axes position as it stands, so call
+    :func:`settle_layout` on the figure once before the first conversion of
+    an extraction.
     """
     fig = getattr(ax, "figure", None)
     if fig is None:
         import matplotlib.pyplot as plt
 
         fig = plt.gcf()
-    try:
-        fig.tight_layout()
-    except Exception:
-        pass
     xy_disp = ax.transData.transform(np.column_stack([x_data, y_data]))
     xy_figpix = fig.transFigure.inverted().transform(xy_disp)
     fig_width_pts = fig.get_size_inches()[0] * 72

--- a/tests/core/plot/test_violin_kde_layout.py
+++ b/tests/core/plot/test_violin_kde_layout.py
@@ -1,0 +1,150 @@
+"""
+The KDE layer settles the figure layout once per extraction, not once per point.
+
+``svg_x``/``svg_y`` are read off the axes position, and that position is only
+final after ``tight_layout`` has run -- so the transform used to settle the
+layout before converting each point, and one violin render ran a full layout
+pass (text extents for every artist on the figure) once per KDE curve and
+twice more per retained level: 124 passes for four seaborn violins, ~95% of
+the render time, and every one of them rewriting the caller's subplot
+parameters (#704).
+
+The layout only has to be settled before the *first* conversion. What a reader
+depends on is not the pass count but that the coordinates were computed under
+the same layout the SVG was then saved from, so that is what these assert --
+never SVG bytes or the ``svg_*`` floats themselves, which a single layout
+pass is free to move by a fraction of a point.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+
+import maidr  # noqa: E402
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+#: Four categories, so the RDP pass has something to thin on every violin.
+CATEGORIES = ["ash", "birch", "cedar", "dogwood"]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _violins(orientation: str):
+    """Draw four seaborn violins and return ``(fig, ax)``."""
+    rng = np.random.default_rng(704)
+    cats = [cat for cat in CATEGORIES for _ in range(25)]
+    vals = np.concatenate(
+        [rng.normal(loc, 1.0, 25) for loc, _ in enumerate(CATEGORIES)]
+    ).tolist()
+    fig, ax = plt.subplots()
+    if orientation == "horz":
+        sns.violinplot(x=vals, y=cats, ax=ax)
+    else:
+        sns.violinplot(x=cats, y=vals, ax=ax)
+    return fig, ax
+
+
+def _kde_layer(fig):
+    """The figure's single ``violin_kde`` layer."""
+    layers = [
+        plot
+        for plot in FigureManager.get_maidr(fig).plots
+        if plot.type is PlotType.VIOLIN_KDE
+    ]
+    assert len(layers) == 1, f"expected one KDE layer, got {len(layers)}"
+    return layers[0]
+
+
+def _svg_coords_now(fig, ax, x: float, y: float) -> tuple[float, float]:
+    """Where the figure's *current* transform puts a data point, in SVG points."""
+    disp = ax.transData.transform([[x, y]])
+    figpix = fig.transFigure.inverted().transform(disp)
+    width_pts = fig.get_size_inches()[0] * 72
+    height_pts = fig.get_size_inches()[1] * 72
+    return float(figpix[0, 0] * width_pts), float((1 - figpix[0, 1]) * height_pts)
+
+
+@pytest.mark.parametrize("orientation", ["vert", "horz"])
+def test_one_layout_pass_per_extraction(mocker, orientation: str) -> None:
+    """Extracting the KDE layer settles the layout once, however many points."""
+    fig, _ = _violins(orientation)
+    layer = _kde_layer(fig)
+    spy = mocker.spy(Figure, "tight_layout")
+
+    points = sum(len(violin) for violin in layer.render()["data"])
+
+    assert points > 4, "the fixture must retain several levels per violin"
+    assert spy.call_count == 1
+
+
+def test_one_layout_pass_per_render(mocker) -> None:
+    """A whole ``maidr.render`` of a violin figure settles the layout once."""
+    fig, _ = _violins("vert")
+    spy = mocker.spy(Figure, "tight_layout")
+
+    maidr.render(fig)
+
+    assert spy.call_count == 1
+
+
+@pytest.mark.parametrize("orientation", ["vert", "horz"])
+def test_svg_coords_match_the_layout_the_svg_was_saved_from(orientation) -> None:
+    """
+    After a render, every ``svg_*`` agrees exactly with the figure's transform.
+
+    The SVG is written after extraction, from whatever layout the figure is
+    then in. A reader's cursor lands on the outline only if the coordinates
+    were computed under that same layout -- the property the pass count was
+    standing in for.
+    """
+    fig, ax = _violins(orientation)
+    maidr.render(fig)
+    layer = _kde_layer(fig)
+
+    # A value on the category axis has no bearing on the value axis.
+    axis = 1 if orientation == "vert" else 0
+    key = "svg_y" if orientation == "vert" else "svg_x"
+    checked = 0
+    for violin in layer.schema["data"]:
+        for point in violin:
+            value = point["y"]
+            probe = (0.0, value) if orientation == "vert" else (value, 0.0)
+            assert point[key] == _svg_coords_now(fig, ax, *probe)[axis]
+            checked += 1
+    assert checked > 0
+
+
+@pytest.mark.parametrize("orientation", ["vert", "horz"])
+def test_data_coordinates_do_not_follow_the_layout(orientation: str) -> None:
+    """Only ``svg_*`` moves with the layout; ``x``, ``y`` and ``width`` stay."""
+    fig, _ = _violins(orientation)
+    layer = _kde_layer(fig)
+    before = layer.render()["data"]
+
+    # A different canvas gives tight_layout a different answer, so the axes
+    # position -- and with it every svg_* -- genuinely moves between renders.
+    width, height = fig.get_size_inches()
+    fig.set_size_inches(width * 1.5, height * 0.75)
+    after = layer.render()["data"]
+
+    def _data_only(violins):
+        return [
+            [{k: v for k, v in pt.items() if not k.startswith("svg_")} for pt in v]
+            for v in violins
+        ]
+
+    assert _data_only(after) == _data_only(before)
+    assert after != before, "the layout change did not reach the svg_* keys"


### PR DESCRIPTION
## What

`data_to_svg_coords` called `fig.tight_layout()` unconditionally before transforming its points. `ViolinKdePlot` called it once per KDE line and then **twice per retained level** with a one-element array, `SmoothPlot` once per regression line. `tight_layout` is a full text-extent/tightbbox pass, so a 4-violin seaborn chart ran it 124 times, a 10-category one 310 times, and the catplot grid in `test_seaborn_patch_reach` 277 times — 95 % of the render, and the reason 21 of the 40 slowest tests in the suite are violin tests. Closes #704.

The layout pass is now `settle_layout(fig)`, called once at the top of `ViolinKdePlot._extract_plot_data` and once in `SmoothPlot`; `data_to_svg_coords` is a pure transform, and `_interpolated_points` gathers the retained levels into arrays and converts each side of a violin with one vectorised call (batch vs per-row `transData.transform` is bit-identical).

## Measured

| | before | after |
|---|---|---|
| 4-violin seaborn `maidr.render`, `tight_layout` calls | 124 | 1 |
| same, wall time (from the audit) | 1.34 s | 0.13 s |
| six violin test files, pytest-reported | 105.7 s | 23.3 s |
| same, wall | 115.8 s | 27.4 s |

## Output

Emitted `x`, `y` and `width` are bit-identical. `svg_x`/`svg_y` and the SVG are now computed under the first `tight_layout` pass rather than the 124th: matplotlib's `tight_layout` never reaches a fixed point (`left` flips by one ulp every call), and on some figures the first pass differs from later ones by up to 0.23 pt in the top margin. It is a valid tight layout, invisible, and the schema and the SVG still agree exactly — in fact more exactly than before: on `main` a horizontal violin's `svg_x` was one ulp off the SVG because the SVG was saved after the last of 124 oscillating passes. `tight_layout` still runs on a constrained-layout figure (it replaces the engine); whether it should is left to its own issue.

## Tests

New `tests/core/plot/test_violin_kde_layout.py`: `mocker.spy(Figure, 'tight_layout')` shows one call per `ViolinKdePlot.render()` of a 4-violin `sns.violinplot` and one per `maidr.render(fig)` (124 on `main`); every emitted `svg_y` (vertical) / `svg_x` (horizontal) equals the value computed from the figure's final transform with exact `==`; resizing the figure moves `svg_*` but leaves `x`/`y`/`width` unchanged. No SVG bytes or `svg_*` floats are pinned.

## Verified

```
uv run pytest      3611 passed, 68 skipped
ruff check         All checks passed (changed files)
```

The scipy `RuntimeWarning` on duplicate KDE knots seen in the new test file is pre-existing and belongs to #705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_