### PR TITLE
fix(regplot): match a smooth keyword as a whole word so 'Profit' is not a fit

### DIFF
--- a/maidr/core/enum/smooth_keywords.py
+++ b/maidr/core/enum/smooth_keywords.py
@@ -7,6 +7,9 @@ SMOOTH_KEYWORDS = [
     "linear regression",
     "linear fit",
     "fit",
+    # Matched as whole words (see `maidr.patch.regplot._looks_smooth`), so
+    # "Fitted values" needs its own entry rather than riding on "fit".
+    "fitted",
     "kde",
     "density",
     "gaussian",

--- a/maidr/patch/regplot.py
+++ b/maidr/patch/regplot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import uuid
 import numpy as np
 import wrapt
@@ -328,9 +329,44 @@ def regplot(wrapped, instance, args, kwargs) -> Axes:
     return drawn
 
 
+def _looks_smooth(label: str) -> bool:
+    """
+    Whether a line's label says it is a fitted curve.
+
+    A keyword matches as a whole word, because "Profit" is not a fit. The
+    match used to be a substring one, so any label containing ``fit``,
+    ``kde`` or ``density`` -- Profit, Benefit, Fitness -- registered the
+    line as a SMOOTH layer, and the per-axes rule that drops the ``line``
+    duplicate of a fitted curve then took every sibling series on the axes
+    with it: ``ax.plot(label="Profit"); ax.plot(label="Revenue")`` emitted
+    one smooth layer and no Revenue at all (#710).
+
+    A multi-word keyword such as ``linear fit`` is still matched as a
+    phrase, since its words are the boundary; a single-word one has to be
+    a word of the label on its own. Tokens are runs of letters, so
+    ``Group 1 KDE`` and ``kde_1`` both still read as a fit.
+
+    Parameters
+    ----------
+    label : str
+        The line's label, as matplotlib holds it.
+
+    Returns
+    -------
+    bool
+        True when a smooth keyword is a word, or a phrase, of the label.
+    """
+    text = label.lower()
+    tokens = set(re.findall(r"[a-z]+", text))
+    return any(
+        (key in text) if " " in key else (key in tokens) for key in SMOOTH_KEYWORDS
+    )
+
+
 def patched_plot(wrapped, instance, args, kwargs):
     """
-    Patch matplotlib Axes.plot to register SMOOTH layers for MAIDR if the label matches SMOOTH_KEYWORDS.
+    Patch matplotlib Axes.plot to register SMOOTH layers for MAIDR if the
+    label carries a SMOOTH_KEYWORDS entry as a whole word.
     """
     # Call the original plot function
     lines = _draw_quietly(wrapped, args, kwargs)
@@ -341,7 +377,7 @@ def patched_plot(wrapped, instance, args, kwargs):
             label = line.get_label() or ""
             label_str = str(label)
             # Detect if this is a smooth/regression line by label
-            if any(key in label_str.lower() for key in SMOOTH_KEYWORDS):
+            if _looks_smooth(label_str):
                 # Assign a unique gid if not already set
                 if line.get_gid() is None:
                     new_gid = f"maidr-{uuid.uuid4()}"

--- a/tests/core/plot/test_smooth_label_match.py
+++ b/tests/core/plot/test_smooth_label_match.py
@@ -1,0 +1,106 @@
+"""A smooth keyword is a whole word of a line's label, not a substring (#710).
+
+``regplot.patched_plot`` decides that an ``ax.plot`` call drew a fitted
+curve by its label, against ``SMOOTH_KEYWORDS``. The match was a substring
+one, so ``fit`` answered to Profit, Benefit and Fitness, ``kde`` to Kde and
+``density`` to Density, and each such line registered as a SMOOTH layer.
+
+That alone would be a mild mis-typing. What made it a loss is the per-axes
+rule in ``Maidr._superseded_line_layers`` (#378): an axes holding a smooth
+drops every LINE layer on it, as the duplicate of the curve. Measured::
+
+    ax.plot(..., label="Profit"); ax.plot(..., label="Revenue")
+        smooth(1 series)          -- Revenue is not in the schema at all
+
+A reader of that chart hears one "fitted" series and never learns there was
+a second. The label is the plainest public API there is, and Profit is an
+ordinary thing to plot.
+
+The match is now on whole words for single-word keywords and on the phrase
+for multi-word ones, so every label the docs use -- ``LOWESS smooth``,
+``KDE``, ``Group 1 KDE``, ``linear fit`` -- still types as a fit, and
+``fitted`` joins the list so "Fitted values" keeps its reading.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.patch.regplot import _looks_smooth  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _layers(fig) -> list[tuple[str, int]]:
+    """Each emitted layer of the figure's one panel as ``(type, series)``.
+
+    Read from the flattened schema rather than from the registered plots,
+    because the flattening pass is where a sibling line is dropped -- the
+    registrations alone would show the Revenue line present.
+    """
+    flat = FigureManager.get_maidr(fig)._flatten_maidr()
+    layers = flat["subplots"][0][0]["layers"]
+    return [(layer["type"].value, len(layer["data"])) for layer in layers]
+
+
+def _two_lines(label: str):
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [10, 12, 9], label=label)
+    ax.plot([1, 2, 3], [20, 25, 21], label="Other")
+    return fig
+
+
+@pytest.mark.parametrize("label", ["Profit", "Benefit", "Fitness", "Profit margin"])
+def test_a_label_that_merely_contains_a_keyword_is_a_line(label):
+    assert _layers(_two_lines(label)) == [("line", 2)]
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["fit", "KDE", "LOWESS smooth", "linear fit", "Group 1 KDE", "Fitted values"],
+)
+def test_a_label_that_is_a_keyword_is_still_a_fit(label):
+    kinds = [kind for kind, _ in _layers(_two_lines(label))]
+    assert "smooth" in kinds
+
+
+def test_a_profit_line_does_not_take_the_revenue_line_with_it():
+    # The regression itself, by name. The mis-typing was the cause; the
+    # missing sibling series is what a reader would have met.
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [10, 12, 9], label="Profit")
+    ax.plot([1, 2, 3], [20, 25, 21], label="Revenue")
+
+    flat = FigureManager.get_maidr(fig)._flatten_maidr()
+    (layer,) = flat["subplots"][0][0]["layers"]
+    assert [series[0]["y"] for series in layer["data"]] == [10, 20]
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Profit", False),
+        ("Benefit", False),
+        ("Kde", True),
+        ("kde_1", True),
+        ("Density", True),
+        ("linear regression", True),
+        # A multi-word keyword is a phrase, so its words are its boundary.
+        ("Linear fitting", True),
+        ("Fitness benefit", False),
+        ("", False),
+    ],
+)
+def test_looks_smooth_asks_for_a_whole_word_or_phrase(label, expected):
+    assert _looks_smooth(label) is expected


### PR DESCRIPTION
## What

`patched_plot` (the `Axes.plot` wrapper in `maidr/patch/regplot.py`) registered a SMOOTH layer when `any(key in label.lower() for key in SMOOTH_KEYWORDS)`. `SMOOTH_KEYWORDS` holds bare tokens such as `fit`, `kde` and `density`, and the test was a **substring** test, so ordinary series names matched: `Profit`, `Benefit`, `Outfit`, `Fitness`, `Profit margin`. Closes #710.

The consequence was not just a wrong type. `Maidr._superseded_line_layers` (the deliberate #378 rule) drops every LINE layer on an axes that holds a SMOOTH layer, so the *other* series vanished silently:

```python
ax.plot(months, profit,  label='Profit')
ax.plot(months, revenue, label='Revenue')
# before: [('smooth', Profit)]  -- Revenue announced nowhere
# after:  [('line', Profit, Revenue)]
```

A `_looks_smooth(label)` helper now tokenises the label and matches single-word keywords as whole words; multi-word keywords (`linear fit`, `lowess smooth`) keep the phrase match, so `Linear fitting` still types as smooth. `fitted` is added to `SMOOTH_KEYWORDS` so `Fitted values` keeps typing smooth; other inflections on their own (`fits`, `fitting`) now type as `line`, a milder failure than erasing sibling series. Every documented example label (`LOWESS smooth`, `KDE`, `Group 1 KDE`, `fit`, `linear fit`, `density`) still types as smooth, and `_child` labels are never matched.

## Tests

New `tests/core/plot/test_smooth_label_match.py` (20 cases): Profit/Benefit/Fitness/`Profit margin` → one two-series `line` layer and no `smooth`; fit/KDE/`LOWESS smooth`/`linear fit`/`Group 1 KDE`/`Fitted values` → `smooth`; a regression that `label='Profit'` followed by `label='Revenue'` emits both series in the flattened schema; direct `_looks_smooth` cases including `Fitness benefit` → not smooth. The related regplot/kde/smooth/unread-families/patch-reach/trendline files (224 tests) pass unchanged.

## Verified

```
uv run pytest      3624 passed, 68 skipped
ruff check         changed files clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_