### PR TITLE
fix(plotly): weight parcats rows by a scalar counts and give an empty pie no grid cell

### DIFF
--- a/maidr/plotly/parcats.py
+++ b/maidr/plotly/parcats.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numbers
+
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot, as_list
@@ -77,8 +79,10 @@ class PlotlyParcatsPlot(PlotlyPlot):
           nodes the chart never places side by side.
 
         ``counts`` weights each row and defaults to one per row, which is
-        what plotly does with it. A row longer than the shortest dimension is
-        dropped, because it has no value on every axis and so no ribbon.
+        what plotly does with it. It is ``arrayOk``, so a scalar is the
+        one-value-for-every-row spelling and weights each row at that value.
+        A row longer than the shortest dimension is dropped, because it has
+        no value on every axis and so no ribbon.
         """
         columns = [
             dimension
@@ -99,7 +103,14 @@ class PlotlyParcatsPlot(PlotlyPlot):
             return []
 
         labels = [_column_name(column, index) for index, column in enumerate(columns)]
-        weights = as_list(self._trace.get("counts")) or [1] * rows
+        raw_counts = self._trace.get("counts")
+        # `numbers.Real` takes a numpy scalar too, which is what `to_dict()`
+        # hands back for one; a bool is a Real that no author means as a
+        # weight, and `as_list` turns a scalar into nothing, not into a row.
+        if isinstance(raw_counts, numbers.Real) and not isinstance(raw_counts, bool):
+            weights = [float(raw_counts)] * rows
+        else:
+            weights = as_list(raw_counts) or [1] * rows
 
         flows: dict[tuple[str, str], float] = {}
         order: list[tuple[str, str]] = []

--- a/maidr/plotly/pie.py
+++ b/maidr/plotly/pie.py
@@ -150,29 +150,20 @@ class PlotlyPiePlot(PlotlyPlot):
         list of (str, float)
             One ``(label, value)`` pair per drawn wedge, in slice order.
         """
+        # Whether anything is drawn at all is decided by `draws_wedges`, which
+        # the subplot grid asks as well: a pie that yields no slices forms no
+        # layer, and a layer-less pie must not claim a grid cell either.
+        if not draws_wedges(self._trace):
+            return []
+
         raw_labels = self._trace.get("labels")
         raw_values = self._trace.get("values")
         labels = as_list(raw_labels)
         values = as_list(raw_values)
-
-        # Each array bounds the other, and an array the author never supplied
-        # bounds nothing -- an empty one still bounds the pie down to nothing.
         has_labels = raw_labels is not None
         has_values = raw_values is not None
-        lengths = [len(labels)] if has_labels else []
-        if has_values:
-            lengths.append(len(values))
-        length = min(lengths) if lengths else 0
-        if not length:
-            return []
-
+        length = _entry_count(self._trace)
         numbers = [_as_number(value) for value in values[:length]]
-        # Plotly marks a pie with nothing positive to draw invisible, so it
-        # renders no wedges at all. This is a short circuit, not a rule of its
-        # own: the merge and filter steps below reach the same empty answer,
-        # since merging can only sum values that were already non-positive.
-        if has_values and not any(n is not None and n > 0 for n in numbers):
-            return []
 
         # Without a ``values`` array plotly weighs every entry equally and the
         # pie reports label counts; without a ``labels`` array it names the
@@ -271,6 +262,74 @@ class PlotlyPiePlot(PlotlyPlot):
             MaidrKey.X: self._axis_config(label=_axis_title(x_axis, x_default)),
             MaidrKey.Y: self._axis_config(label=_axis_title(y_axis, y_default)),
         }
+
+
+def draws_wedges(trace: dict) -> bool:
+    """
+    Report whether plotly draws any wedge for a pie or funnelarea trace.
+
+    This is the emptiness rule of :meth:`PlotlyPiePlot._slices`, kept apart
+    so it has a second caller: :func:`~maidr.plotly.plotly_maidr.PlotlyMaidr`
+    decides whether the trace's ``domain`` rectangle earns a grid cell, and a
+    trace that draws nothing forms no layer (#638), so it must not reserve a
+    cell either (#702). The two go together: a cell without a layer is an
+    empty stop for the reader to tab into.
+
+    Two things leave a pie with nothing to draw. An array the author supplied
+    bounds the other, so an empty ``labels`` or ``values`` bounds the pie down
+    to no entries at all -- ``labels=["a", "b"]`` with ``values=[]`` draws
+    nothing, whatever the labels say. And plotly marks a pie whose values hold
+    nothing positive invisible, rendering no wedges; that is a short circuit
+    rather than a rule of its own, since the merge and filter steps of
+    :meth:`~PlotlyPiePlot._slices` reach the same empty answer, but it is
+    what lets the question be asked without building the slices.
+
+    Parameters
+    ----------
+    trace : dict
+        The pie or funnelarea trace dict.
+
+    Returns
+    -------
+    bool
+        True when at least one wedge is drawn.
+    """
+    length = _entry_count(trace)
+    if not length:
+        return False
+    raw_values = trace.get("values")
+    if raw_values is None:
+        # Without a `values` array every entry weighs one, so every entry is
+        # a wedge.
+        return True
+    numbers = [_as_number(value) for value in as_list(raw_values)[:length]]
+    return any(n is not None and n > 0 for n in numbers)
+
+
+def _entry_count(trace: dict) -> int:
+    """
+    Return how many entries plotly reads off a pie's arrays.
+
+    Each of ``labels`` and ``values`` bounds the other, and an array the
+    author never supplied bounds nothing -- an empty one still bounds the pie
+    down to nothing, and a pie with neither array has no entries at all.
+
+    Parameters
+    ----------
+    trace : dict
+        The pie or funnelarea trace dict.
+
+    Returns
+    -------
+    int
+        The length of the shortest supplied array, or 0 when none is.
+    """
+    lengths = [
+        len(as_list(trace.get(key)))
+        for key in ("labels", "values")
+        if trace.get(key) is not None
+    ]
+    return min(lengths) if lengths else 0
 
 
 def _wedge_label(label: Any, index: int) -> str:

--- a/maidr/plotly/plotly_maidr.py
+++ b/maidr/plotly/plotly_maidr.py
@@ -15,6 +15,7 @@ from maidr.plotly.candlestick import is_ohlc_trace, layer_position
 from maidr.plotly.geo import geo_block
 from maidr.plotly.gauge import draws_a_dial
 from maidr.plotly.hierarchy import has_one_root, is_hierarchy_trace
+from maidr.plotly.pie import draws_wedges
 from maidr.plotly.area import is_area_trace
 from maidr.plotly.contour import is_contour_trace
 from maidr.plotly.splom import is_splom_trace, splom_panels
@@ -111,10 +112,14 @@ def _occupies_a_cell(trace: dict) -> bool:
     through and shift every renderable subplot beside it into a different
     column.
 
-    Only ``indicator`` splits on that. A pie and a funnelarea are always
-    read; an indicator is read only when it draws a dial, so a
-    ``mode="number"`` one is a domain trace that renders nothing, exactly
-    like a ``go.Table``.
+    Each family answers that with the same rule its extractor uses to form a
+    layer, so the two cannot disagree. An indicator is read only when it
+    draws a dial, so a ``mode="number"`` one is a domain trace that renders
+    nothing, exactly like a ``go.Table``. A hierarchy is read only when it has
+    one root. A pie or funnelarea is read only when it draws a wedge: #638
+    made an empty one form no layer, and until #702 this still handed it a
+    cell, so a figure with an empty pie beside a bar tabbed through an empty
+    first column before reaching the bar in its second.
 
     Parameters
     ----------
@@ -131,6 +136,8 @@ def _occupies_a_cell(trace: dict) -> bool:
         return False
     if kind == "indicator":
         return draws_a_dial(trace)
+    if kind in ("pie", "funnelarea"):
+        return draws_wedges(trace)
     if is_hierarchy_trace(trace):
         return has_one_root(trace)
     return True

--- a/tests/plotly/test_plotly_empty_layers.py
+++ b/tests/plotly/test_plotly_empty_layers.py
@@ -217,3 +217,49 @@ def test_an_empty_trace_does_not_reserve_a_grid_cell() -> None:
 
     assert [layer["type"] for row in grid for cell in row for layer in cell["layers"]]
     assert sum(len(cell.get("layers", [])) for row in grid for cell in row) == 1
+
+
+def _grid_types(figure: go.Figure) -> list[list[list[str]]]:
+    """The subplot grid as the layer types each cell holds."""
+    grid = PlotlyMaidr(figure)._flatten_maidr()["subplots"]
+    return [
+        [[layer["type"] for layer in cell.get("layers", [])] for cell in row]
+        for row in grid
+    ]
+
+
+def _domain_beside_a_bar(trace: go.BaseTraceType) -> go.Figure:
+    """A domain trace in the left cell of a two-column figure, a bar in the right."""
+    from plotly.subplots import make_subplots
+
+    figure = make_subplots(rows=1, cols=2, specs=[[{"type": "domain"}, {"type": "xy"}]])
+    figure.add_trace(trace, row=1, col=1)
+    figure.add_trace(go.Bar(x=["a", "b"], y=[1, 2]), row=1, col=2)
+    return figure
+
+
+@pytest.mark.parametrize(
+    "trace",
+    [
+        pytest.param(go.Pie(labels=[], values=[]), id="pie-empty"),
+        pytest.param(go.Pie(labels=["a", "b"], values=[]), id="pie-labels-only"),
+        pytest.param(go.Funnelarea(labels=[], values=[]), id="funnelarea-empty"),
+    ],
+)
+def test_an_empty_domain_trace_does_not_reserve_a_grid_cell(trace) -> None:
+    """The same consequence for a trace placed by a ``domain`` rectangle.
+
+    A pie or funnelarea with nothing to draw forms no layer (#638), so its
+    rectangle must not claim a column either: that leaves an empty cell to
+    tab into and shifts the bar beside it into the second column (#702). The
+    rule is the pie's own -- ``labels=["a", "b"]`` with ``values=[]`` draws
+    nothing, whatever the labels say.
+    """
+    assert _grid_types(_domain_beside_a_bar(trace)) == [[["bar"]]]
+
+
+def test_a_drawn_pie_still_reserves_its_grid_cell() -> None:
+    """The control: a pie with a wedge keeps its column beside the bar."""
+    figure = _domain_beside_a_bar(go.Pie(labels=["a"], values=[1]))
+
+    assert _grid_types(figure) == [[["pie"], ["bar"]]]

--- a/tests/plotly/test_plotly_parcats.py
+++ b/tests/plotly/test_plotly_parcats.py
@@ -26,6 +26,7 @@ Two things measured in Chromium decided the rest:
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
@@ -191,6 +192,32 @@ def test_a_row_weighs_one_when_the_trace_declares_no_counts() -> None:
     )
 
     assert _flows(layer) == [("A: x", "B: p", 2.0)]
+
+
+@pytest.mark.parametrize("counts", [5, np.int64(5)], ids=["int", "numpy"])
+def test_a_scalar_counts_weighs_every_row(counts) -> None:
+    """A scalar `counts` is the array-of-one-value spelling, not a mistake.
+
+    Plotly declares `counts` as `arrayOk`, so `counts=5` weights every row
+    at five, and `to_dict()` hands a numpy scalar back as a numpy scalar.
+    Either has to read exactly as the list of the same value does; a scalar
+    that fell through to the default announced every flow at weight one.
+    """
+    dimensions = [
+        {"label": "A", "values": ["x", "y", "x"]},
+        {"label": "B", "values": ["p", "p", "q"]},
+    ]
+    (scalar,) = _layers(go.Figure([go.Parcats(dimensions=dimensions, counts=counts)]))
+    (listed,) = _layers(
+        go.Figure([go.Parcats(dimensions=dimensions, counts=[5, 5, 5])])
+    )
+
+    assert _flows(scalar) == _flows(listed)
+    assert _flows(scalar) == [
+        ("A: x", "B: p", 5.0),
+        ("A: y", "B: p", 5.0),
+        ("A: x", "B: q", 5.0),
+    ]
 
 
 def test_a_single_dimension_forms_no_layer() -> None:


### PR DESCRIPTION
## What

Two domain-trace details where the schema disagreed with the figure. Closes #702.

- **Scalar `counts`.** plotly declares `parcats.counts` as `valType: number, dflt 1, arrayOk`, so `go.Parcats(counts=5, ...)` weights every row by 5. `as_list(5)` hit `list(5)` → `TypeError` → `[]`, the `or [1] * rows` fallback ran, and every flow was announced at 1.0 where `counts=[5, 5, 5]` announced 5.0. A `numbers.Real` (bool excluded, numpy scalars included) now weights every row.
- **Empty pie still reserved a cell.** `_occupies_a_cell` decided membership for `pie`/`funnelarea` from the trace type alone. Its own docstring says a trace that draws no layer must occupy no cell, and that held when written for #632, but #638 made an empty pie form no layer hours later. `make_subplots(1, 2, specs=[[{'type': 'domain'}, {'type': 'xy'}]])` with `go.Pie(labels=[], values=[])` beside a bar flattened to `[[{'layers': []}, {'layers': [bar]}]]` — an empty leading cell to tab through and the bar shifted to column 1. The pie's own emptiness rule is now a module-level `draws_wedges(trace)` in `pie.py` (used by `_slices`, so the rule exists once; `PlotlyFunnelareaPlot` inherits it), and `_occupies_a_cell` asks it, the way it already asks `draws_a_dial` and `has_one_root`. `Pie(labels=['a', 'b'], values=[])` also loses its layer, so the predicate is the real rule rather than `bool(values or labels)`.

Only `_occupies_a_cell` and its docstring change in `plotly_maidr.py`. A drawn pie's grid, selectors and data are byte-identical; a label-only pie (`values=None`) still counts as drawing wedges, as before.

## Tests

`tests/plotly/test_plotly_parcats.py`: scalar `5` and `np.int64(5)` give the same flows as `[5, 5, 5]`. `tests/plotly/test_plotly_empty_layers.py`: `Pie(labels=[], values=[])`, `Pie(labels=['a','b'], values=[])` and `Funnelarea(labels=[], values=[])` beside a bar flatten to `[[['bar']]]`; a drawn pie still gives `[[['pie'], ['bar']]]`. The five new cases fail on `main`.

## Verified

```
uv run pytest      3610 passed, 68 skipped
ruff check         All checks passed (changed files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_