### PR TITLE
perf(plotly): count autobin samples in numpy and trace contour curves without per-vertex calls

### DIFF
--- a/maidr/plotly/contour.py
+++ b/maidr/plotly/contour.py
@@ -188,14 +188,14 @@ class PlotlyContourPlot(PlotlyPlot):
             for curve in curves:
                 if not _has_extent(curve, cell):
                     continue
+                # `tolist()` hands over every coordinate as a plain float in
+                # one call, where indexing each vertex made an `np.float64`
+                # per coordinate to convert -- the same floats, and on a
+                # noisy field there are hundreds of thousands of them (#701).
                 data.append(
                     [
-                        {
-                            MaidrKey.X: float(vertex[0]),
-                            MaidrKey.Y: float(vertex[1]),
-                            MaidrKey.LEVEL: levels[index],
-                        }
-                        for vertex in curve
+                        {MaidrKey.X: x, MaidrKey.Y: y, MaidrKey.LEVEL: levels[index]}
+                        for x, y in curve.tolist()
                     ]
                 )
                 self._series_levels.append(index)
@@ -585,7 +585,12 @@ def _has_extent(curve: Any, cell: float) -> bool:
     vertices = np.asarray(curve, dtype=float)
     if vertices.size == 0:
         return False
-    span = max(float(np.ptp(vertices[:, 0])), float(np.ptp(vertices[:, 1])))
+    # The span `np.ptp` answers, as one reduction per axis rather than two
+    # over strided views: this runs once per curve, and a noisy field traces
+    # tens of thousands of them (#701).
+    lo = vertices.min(axis=0)
+    hi = vertices.max(axis=0)
+    span = float(max(hi[0] - lo[0], hi[1] - lo[1]))
     return span > cell * _POINT_FRACTION
 
 

--- a/maidr/plotly/histogram.py
+++ b/maidr/plotly/histogram.py
@@ -173,6 +173,12 @@ def _auto_shift_bins(
     start across a spread of samples and widths, which would otherwise be
     rediscovered by hand the next time this function is touched.
 
+    The three counts the branches consume are taken elementwise in numpy
+    rather than by the per-sample loop plotly writes, which cost ~100 ms per
+    50k samples and was most of a histogram's render (#701). The arithmetic
+    is the same IEEE operations the loop performed, in the same order, so the
+    counts -- and the start -- are bit-identical to the loop's.
+
     Parameters
     ----------
     bin_start : float
@@ -186,20 +192,22 @@ def _auto_shift_bins(
     data_max : float
         Maximum data value.
     """
-    edge_count = 0
-    mid_count = 0
-    int_count = 0
-
-    def near_edge(v: float) -> bool:
+    def near_edge(v: float | np.ndarray) -> bool | np.ndarray:
         return (1 + (v - bin_start) * 100 / dtick) % 100 < 2
 
-    for v in data:
-        if v % 1 == 0:
-            int_count += 1
-        if near_edge(v):
-            edge_count += 1
-        if near_edge(v + dtick / 2):
-            mid_count += 1
+    # Plotly's per-sample loop as three elementwise predicates. Iterating an
+    # ndarray already handed the loop `np.float64` scalars, so these are the
+    # operations it performed and the counts must stay bit-identical to its
+    # -- `test_plotly_histogram_bins.py` pins them against a copy of the
+    # loop. `near_edge` stays a closure because the scalar `data_min` and
+    # `data_max` checks below read it too. `invalid` is ignored so a `nan`
+    # sample -- which fails every predicate and still counts in `n`, as it
+    # did in the loop -- does not put a RuntimeWarning on a render.
+    data = np.asarray(data, dtype=float)
+    with np.errstate(invalid="ignore"):
+        int_count = int(np.count_nonzero(data % 1 == 0))
+        edge_count = int(np.count_nonzero(near_edge(data)))
+        mid_count = int(np.count_nonzero(near_edge(data + dtick / 2)))
 
     n = len(data)
     if n == 0:

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -239,6 +239,47 @@ def test_a_level_the_field_only_touches_draws_no_curve() -> None:
     assert "g.contourlevel:nth-of-type(2)" in layer["selectors"][0]
 
 
+def test_a_dense_field_emits_plain_floats() -> None:
+    """A noisy field traces thousands of short curves, each read off in one go.
+
+    Building the series from ``curve.tolist()`` rather than indexing every
+    vertex is where a dense field's Python-side cost went (#701). It must be
+    invisible: every coordinate is still a Python ``float`` -- not an
+    ``np.float64`` for the JSON encoder to choke on -- and still the vertex
+    ``contourpy`` traced, exactly.
+    """
+    from contourpy import contour_generator
+
+    x, y = list(range(12)), list(range(12))
+    z = np.random.default_rng(701).random((12, 12))
+    levels = [0.25, 0.5, 0.75]
+    figure = go.Figure(
+        go.Contour(
+            x=x,
+            y=y,
+            z=z.tolist(),
+            contours=dict(coloring="lines", start=0.25, end=0.75, size=0.25),
+        )
+    )
+    generator = contour_generator(
+        x=x, y=y, z=z, name="mpl2014", line_type="SeparateCode"
+    )
+    curves = [curve for level in levels for curve in generator.lines(level)[0]]
+
+    (layer,) = _layers(figure)
+
+    # Dozens of short curves, so it is the per-curve path being exercised
+    # rather than one ring.
+    assert len(layer["data"]) == len(curves) > 30
+    for series, curve in zip(layer["data"], curves):
+        # `is float` rather than `isinstance`: `np.float64` is a `float`
+        # subclass, and it is the subclass this guards against.
+        assert {type(v) for p in series for v in (p["x"], p["y"])} == {float}
+        assert [(p["x"], p["y"]) for p in series] == [
+            (float(v[0]), float(v[1])) for v in curve
+        ]
+
+
 def test_a_layer_with_an_island_ships_without_a_highlight() -> None:
     """Plotly's order for a level's curves is its own, and not derivable.
 

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -40,6 +40,9 @@ equal. The comparison is elementwise for that reason.
 
 from __future__ import annotations
 
+import math
+import warnings
+
 import pytest
 
 plotly = pytest.importorskip("plotly")
@@ -231,6 +234,108 @@ class TestBothCallersSeedTheShiftEquivalently:
         )
 
         assert from_explicit == pytest.approx(from_autobin, abs=1e-12)
+
+
+def _shift_by_plotly_loop(
+    bin_start: float,
+    data: np.ndarray,
+    dtick: float,
+    data_min: float,
+    data_max: float,
+) -> float:
+    """``_auto_shift_bins`` as it was before #701: plotly's loop, verbatim.
+
+    Kept as the reference because it is the port that was measured against
+    the browser. The numpy form is only right insofar as it agrees with this
+    on every sample, so the comparison is exact rather than approximate.
+    """
+    edge_count = 0
+    mid_count = 0
+    int_count = 0
+
+    def near_edge(v: float) -> bool:
+        return (1 + (v - bin_start) * 100 / dtick) % 100 < 2
+
+    for v in data:
+        if v % 1 == 0:
+            int_count += 1
+        if near_edge(v):
+            edge_count += 1
+        if near_edge(v + dtick / 2):
+            mid_count += 1
+
+    n = len(data)
+    if n == 0:
+        return bin_start
+
+    if int_count == n:
+        if dtick < 1:
+            return data_min - 0.5 * dtick
+        else:
+            shifted = bin_start - 0.5
+            if shifted + dtick < data_min:
+                shifted += dtick
+            return shifted
+
+    if mid_count < n * 0.1:
+        if edge_count > n * 0.3 or near_edge(data_min) or near_edge(data_max):
+            binshift = dtick / 2
+            if bin_start + binshift < data_min:
+                return bin_start + binshift
+            else:
+                return bin_start - binshift
+
+    return bin_start
+
+
+class TestTheCountsAreTakenInNumpy:
+    """``_auto_shift_bins`` counts its samples elementwise, and exactly.
+
+    The per-sample loop was most of a histogram's render at 50k samples
+    (#701), so the three counts the branches consume are now numpy
+    reductions. They are the same IEEE operations the loop performed, on
+    the same ``np.float64`` values, so the start they choose is bit-identical
+    -- which this pins, rather than approximates, against a copy of that
+    loop over seeded samples of every shape the predicates react to: whole
+    numbers, values rounded to a decimal or two, values sitting at an offset,
+    values far below the width, and a ``nan``.
+    """
+
+    #: One draw of a few hundred samples per kind, seeded so a mismatch is
+    #: reproducible.
+    KINDS = {
+        "normal": lambda rng: rng.normal(size=300),
+        "integer": lambda rng: rng.integers(-20, 20, size=300).astype(float),
+        "one decimal": lambda rng: np.round(rng.normal(size=300) * 5, 1),
+        "two decimals": lambda rng: np.round(rng.normal(size=300) * 5, 2),
+        "offset uniform": lambda rng: rng.uniform(0.25, 9.25, size=300),
+        "sub-milli": lambda rng: rng.normal(size=300) * 1e-3,
+        "with a nan": lambda rng: np.append(rng.normal(size=300), np.nan),
+    }
+
+    #: Both seeds the callers pass -- see the class above.
+    SEEDS = {
+        "autobin": lambda low, width: math.ceil(low / width) * width - width,
+        "explicit": lambda low, width: math.floor(low / width) * width,
+    }
+
+    @pytest.mark.parametrize("kind", sorted(KINDS))
+    @pytest.mark.parametrize("width", [0.1, 0.2, 0.25, 0.5, 1, 2, 5, 10])
+    @pytest.mark.parametrize("seed", sorted(SEEDS))
+    def test_the_vectorised_counts_match_the_plotly_loop(self, kind, width, seed):
+        arr = self.KINDS[kind](np.random.default_rng(701))
+        low, high = float(np.nanmin(arr)), float(np.nanmax(arr))
+        start = self.SEEDS[seed](low, width)
+
+        # The loop is the one that may warn, on the `nan` sample; the numpy
+        # form must not, because a render is not the place for one.
+        with np.errstate(invalid="ignore"):
+            expected = _shift_by_plotly_loop(start, arr, width, low, high)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            actual = _auto_shift_bins(start, arr, width, low, high)
+
+        assert float(actual) == float(expected)
 
 
 class TestNothingToAnnounce:


### PR DESCRIPTION
## What

Closes #701.

**Histogram autobin.** `_auto_shift_bins`, the port of plotly's `autoShiftNumericBins`, iterated the sample in Python computing three counts with two closure calls per element — once per 1-D histogram and once per axis for `histogram2d`/`histogram2dcontour`, about 80 % of `PlotlyMaidr()` for a 100k-sample histogram. The three predicates are elementwise, and iterating an ndarray already yields `np.float64` scalars, so `np.count_nonzero` over the same expressions is bit-identical (numpy's remainder follows Python's sign-of-divisor rule; `np.errstate(invalid='ignore')` keeps NaN/inf from raising a warning the loop would not). `n`, the scalar `near_edge(data_min)`/`near_edge(data_max)` calls and every branch are verbatim. A 4 800-trial sweep (12 generators including int dtype, float32, a Python list, NaN, huge values, an empty array × 10 widths × both caller seed formulas) found no mismatch. The diff is confined to the function body so it merges cleanly with #729.

**Contour tracing.** `_has_extent` called `np.asarray` plus two `np.ptp` on strided column views per curve, and the series comprehension indexed the 2-D curve row by row producing a view and a `float()` per vertex. On a noisy field with tens of thousands of short curves that was ~40 % of `_extract_plot_data`; one `min(axis=0)`/`max(axis=0)` per curve and `curve.tolist()` give identical floats (contourpy returns float64 whatever `z`'s dtype). Negligible on smooth fields.

## Measured (min of 3)

| | before | after |
|---|---|---|
| `_auto_shift_bins`, 100k normal samples, dtick 0.2 | 83.1 ms | 4.7 ms |
| contour 200×200 random field, `_extract_plot_data` (34 205 curves) | 1 291 ms | 751 ms |
| same, `PlotlyMaidr()` | 1 204 ms | 873 ms |

Emitted output is unchanged.

## Tests

`tests/plotly/test_plotly_histogram_bins.py` gains a literal copy of the old scalar loop as reference and a 112-case parity test (7 sample kinds including a NaN × 8 widths × both seed formulas) asserting exact float equality, with the numpy form additionally run under `warnings.simplefilter('error')`. `tests/plotly/test_plotly_contour.py`: a dense seeded field emits plain `float`s equal to contourpy's own vertices. Both pin identity rather than a behaviour change, so they pass before and after by design.

## Verified

```
uv run pytest      3717 passed, 68 skipped
ruff check         All checks passed (changed files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_