### PR TITLE
fix(kdeplot): register only the curves and bands this call drew

### DIFF
--- a/maidr/patch/kdeplot.py
+++ b/maidr/patch/kdeplot.py
@@ -237,10 +237,16 @@ def deferred_names(resolve, count: int) -> list:
 
 
 def _register_smooth(
-    ax: Axes | None, instance, args, kwargs, faceted: bool = False
+    ax: Axes | None,
+    instance,
+    args,
+    kwargs,
+    faceted: bool = False,
+    before_lines: set | frozenset = frozenset(),
+    before_fills: set | frozenset = frozenset(),
 ) -> None:
     """
-    Register every KDE curve on one axes as a SMOOTH layer.
+    Register the KDE curves this call drew on one axes as SMOOTH layers.
 
     Split out of :func:`kde` so ``seaborn.displot(kind="kde")`` can reuse it.
     ``displot`` does not import ``kdeplot`` -- it drives
@@ -249,6 +255,16 @@ def _register_smooth(
     ``line`` where the axes-level function gives ``smooth`` (#446). A fitted
     curve is not a series of observations, and `smooth` is the type that says
     so.
+
+    Only what *this call* drew, not everything on the axes. The sweep used to
+    take every line and every band it found, so a second ``kdeplot`` on the
+    same axes registered the first call's curve again -- and for a filled
+    one moved the band's gid onto the new layer, leaving the first layer
+    selecting a group no artist carried -- while a caller's own ``ax.plot``
+    was re-announced as a fitted curve and a ``fill_between`` as the smooth
+    of its outline (#711). The before/after snapshot is the answer
+    ``maidr/patch/regplot.py`` gave the same problem (#451): whatever was
+    on the axes beforehand already belongs to whichever call drew it.
 
     Parameters
     ----------
@@ -260,10 +276,18 @@ def _register_smooth(
     faceted : bool
         Whether this panel is one of several, which is what lets a panel
         holding a single curve still be named (#608).
+    before_lines, before_fills : set or frozenset
+        The lines and collections already on the axes before the call drew,
+        which are skipped. Empty by default, which is right for ``displot``:
+        its panels are fresh, so everything on them is its own.
     """
     if ax is not None:
-        # Register all unique Line2D objects
-        lines = [line for line in ax.get_lines() if isinstance(line, Line2D)]
+        # The Line2D curves this call drew, deduplicated by their data
+        lines = [
+            line
+            for line in ax.get_lines()
+            if isinstance(line, Line2D) and line not in before_lines
+        ]
         curves = list(unique_lines_by_xy(lines))
         for kde_line, name in zip(
             curves,
@@ -279,8 +303,12 @@ def _register_smooth(
                 args,
                 dict(kwargs, regression_line=kde_line, **{GROUP_NAME: name}),
             )
-        # Register all PolyCollection boundaries as SMOOTH
-        fills = [c for c in ax.collections if isinstance(c, PolyCollection)]
+        # The PolyCollection bands this call drew, each read as its boundary
+        fills = [
+            c
+            for c in ax.collections
+            if isinstance(c, PolyCollection) and c not in before_fills
+        ]
         for poly, fill_name in zip(
             fills, deferred_names(lambda: _fill_names(ax, fills, faceted), len(fills))
         ):
@@ -316,13 +344,27 @@ def kde(wrapped, instance, args, kwargs) -> Axes | Line2D | PolyCollection:
     bivariate one is a scalar field drawn as iso-value curves and registers as
     ``contour``; see :func:`_register_field` for why that has to happen here.
     """
-    before = _contour_sets_of(prospective_axes(kwargs))
+    target = prospective_axes(kwargs)
+    before = _contour_sets_of(target)
+    # The artists themselves rather than their ids, for the reason
+    # `maidr/patch/regplot.py` gives: an id is only unique while its object
+    # is, and holding the artist keeps it so. Sets, because membership is
+    # asked once per artist drawn.
+    before_lines = set(target.lines) if target is not None else set()
+    before_fills = set(target.collections) if target is not None else set()
 
     with ContextManager.set_internal_context():
         plot = _draw_quietly(wrapped, args, kwargs)
     ax = plot if isinstance(plot, Axes) else getattr(plot, "axes", None)
     _register_field(ax, before)
-    _register_smooth(ax, instance, args, kwargs)
+    _register_smooth(
+        ax,
+        instance,
+        args,
+        kwargs,
+        before_lines=before_lines,
+        before_fills=before_fills,
+    )
     return plot
 
 

--- a/tests/core/plot/test_kdeplot_own_artists.py
+++ b/tests/core/plot/test_kdeplot_own_artists.py
@@ -112,7 +112,9 @@ def test_two_unfilled_kdeplots_register_one_curve_each():
     assert _registered(fig) == [PlotType.SMOOTH, PlotType.SMOOTH]
 
 
-@pytest.mark.parametrize("first_filled", [True, False], ids=["band then curve", "curve then band"])
+@pytest.mark.parametrize(
+    "first_filled", [True, False], ids=["band then curve", "curve then band"]
+)
 def test_a_filled_and_an_unfilled_kdeplot_register_one_layer_each(first_filled):
     # Lines and bands are filtered independently, so a mixed pair must not
     # let the first call's artist through the second call's other filter.

--- a/tests/core/plot/test_kdeplot_own_artists.py
+++ b/tests/core/plot/test_kdeplot_own_artists.py
@@ -75,7 +75,9 @@ def _rendered_layers(fig) -> list:
 
 def _gid_of(layer: dict) -> str:
     (selector,) = layer["selectors"]
-    return re.search(r"id='([^']+)'", selector).group(1)
+    match = re.search(r"id='([^']+)'", selector)
+    assert match is not None, f"selector carries no gid: {selector!r}"
+    return match.group(1)
 
 
 class TestTwoFilledKdeplots:

--- a/tests/core/plot/test_kdeplot_own_artists.py
+++ b/tests/core/plot/test_kdeplot_own_artists.py
@@ -112,6 +112,17 @@ def test_two_unfilled_kdeplots_register_one_curve_each():
     assert _registered(fig) == [PlotType.SMOOTH, PlotType.SMOOTH]
 
 
+@pytest.mark.parametrize("first_filled", [True, False], ids=["band then curve", "curve then band"])
+def test_a_filled_and_an_unfilled_kdeplot_register_one_layer_each(first_filled):
+    # Lines and bands are filtered independently, so a mixed pair must not
+    # let the first call's artist through the second call's other filter.
+    fig, ax = plt.subplots()
+    sns.kdeplot(_samples(), fill=first_filled, ax=ax)
+    sns.kdeplot(_samples(1.0), fill=not first_filled, ax=ax)
+
+    assert _registered(fig) == [PlotType.SMOOTH, PlotType.SMOOTH]
+
+
 def test_a_line_drawn_beforehand_is_not_announced_as_a_curve():
     fig, ax = plt.subplots()
     ax.plot([0, 1, 2], [1, 2, 1])

--- a/tests/core/plot/test_kdeplot_own_artists.py
+++ b/tests/core/plot/test_kdeplot_own_artists.py
@@ -1,0 +1,153 @@
+"""
+``kdeplot`` registers the curves and bands its own call drew (#711).
+
+``_register_smooth`` swept the axes: every ``Line2D`` and every
+``PolyCollection`` it found, whoever drew them. Whatever was there beforehand
+was registered a second time as a fitted curve, and the reader was handed the
+consequences without anything saying so. Measured on seaborn 0.13.2::
+
+    kdeplot(fill=True); kdeplot(fill=True)   3 smooth, the first on no artist
+    ax.plot(...); kdeplot(...)               2 smooth, and the line dropped
+    ax.fill_between(...); kdeplot(...)       1 area, 2 smooth
+
+The filled case is the worst of them. The second call re-registers the first
+band under a fresh gid and writes that gid onto the band, so the first layer
+now selects a group no artist carries -- a highlight that lands nowhere.
+
+The before/after snapshot ``maidr/patch/regplot.py`` takes for the same
+reason (#451) is the fix: what was on the axes beforehand belongs to whichever
+call drew it. The cases below pin what each call registers, and the hue chart
+that draws its several curves in *one* call is kept as the guard that the
+snapshot only excludes what came before.
+
+One caveat, deliberately not asserted here. A line drawn before the kdeplot
+is no longer re-announced as a curve, but it is still not rendered:
+``Maidr._superseded_line_layers`` drops every ``LINE`` on an axes holding a
+``SMOOTH`` (#378), and that is a per-axes rule in the core, not this patch's
+to change.
+"""
+
+from __future__ import annotations
+
+import re
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import seaborn as sns  # noqa: E402
+from matplotlib.collections import PolyCollection  # noqa: E402
+
+from maidr.core.enum import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _samples(shift: float = 0.0) -> np.ndarray:
+    rng = np.random.default_rng(0)
+    return rng.normal(size=60) + shift
+
+
+def _registered(fig) -> list:
+    return [plot.type for plot in FigureManager.get_maidr(fig).plots]
+
+
+def _rendered_layers(fig) -> list:
+    """The layers of the one subplot, as the HTML would carry them.
+
+    Rendering first, because that is the pass that tags the artists and
+    assigns every smooth its gid; the schema read cold has none of them.
+    """
+    maidr = FigureManager.get_maidr(fig)
+    maidr.render(use_cdn=False)
+    return maidr._flatten_maidr()["subplots"][0][0]["layers"]
+
+
+def _gid_of(layer: dict) -> str:
+    (selector,) = layer["selectors"]
+    return re.search(r"id='([^']+)'", selector).group(1)
+
+
+class TestTwoFilledKdeplots:
+    def test_each_call_registers_one_band(self):
+        fig, ax = plt.subplots()
+        sns.kdeplot(_samples(), fill=True, ax=ax)
+        sns.kdeplot(_samples(1.0), fill=True, ax=ax)
+
+        assert _registered(fig) == [PlotType.SMOOTH, PlotType.SMOOTH]
+
+    def test_every_rendered_layer_selects_a_band_that_exists(self):
+        # The dangling highlight: three layers, and the first one's gid on
+        # no PolyCollection because the second call overwrote it.
+        fig, ax = plt.subplots()
+        sns.kdeplot(_samples(), fill=True, ax=ax)
+        sns.kdeplot(_samples(1.0), fill=True, ax=ax)
+
+        layers = _rendered_layers(fig)
+        bands = [c for c in ax.collections if isinstance(c, PolyCollection)]
+
+        assert [layer["type"] for layer in layers] == [PlotType.SMOOTH] * 2
+        assert {_gid_of(layer) for layer in layers} == {b.get_gid() for b in bands}
+
+
+def test_two_unfilled_kdeplots_register_one_curve_each():
+    # The rendered HTML hid this one: the duplicate carried the first curve's
+    # gid, and `_duplicate_smooth_layers` dropped it on the second pass.
+    fig, ax = plt.subplots()
+    sns.kdeplot(_samples(), ax=ax)
+    sns.kdeplot(_samples(1.0), ax=ax)
+
+    assert _registered(fig) == [PlotType.SMOOTH, PlotType.SMOOTH]
+
+
+def test_a_line_drawn_beforehand_is_not_announced_as_a_curve():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2], [1, 2, 1])
+    sns.kdeplot(_samples(), ax=ax)
+
+    assert _registered(fig) == [PlotType.LINE, PlotType.SMOOTH]
+
+
+def test_a_fill_drawn_beforehand_is_not_announced_as_a_curve():
+    fig, ax = plt.subplots()
+    ax.fill_between([0, 1, 2], [1, 2, 1])
+    sns.kdeplot(_samples(), ax=ax)
+
+    assert _registered(fig) == [PlotType.AREA, PlotType.SMOOTH]
+
+
+class TestOneCallDrawingSeveral:
+    """The snapshot must exclude only what was there before, not what the
+    call itself drew in several pieces."""
+
+    @staticmethod
+    def _frame() -> pd.DataFrame:
+        rng = np.random.default_rng(0)
+        return pd.DataFrame(
+            {"a": rng.normal(size=60), "g": rng.choice(["x", "y"], size=60)}
+        )
+
+    def test_a_hue_kdeplot_still_gives_two_named_curves(self):
+        fig, ax = plt.subplots()
+        sns.kdeplot(data=self._frame(), x="a", hue="g", ax=ax)
+
+        plots = FigureManager.get_maidr(fig).plots
+        assert [plot.type for plot in plots] == [PlotType.SMOOTH] * 2
+        assert sorted(plot.schema.get("name") for plot in plots) == ["x", "y"]
+
+    def test_a_filled_hue_kdeplot_still_gives_two_named_bands(self):
+        fig, ax = plt.subplots()
+        sns.kdeplot(data=self._frame(), x="a", hue="g", fill=True, ax=ax)
+
+        plots = FigureManager.get_maidr(fig).plots
+        assert [plot.type for plot in plots] == [PlotType.SMOOTH] * 2
+        assert sorted(plot.schema.get("name") for plot in plots) == ["x", "y"]

--- a/tests/core/plot/test_kdeplot_own_artists.py
+++ b/tests/core/plot/test_kdeplot_own_artists.py
@@ -42,6 +42,7 @@ import matplotlib.pyplot as plt  # noqa: E402
 import seaborn as sns  # noqa: E402
 from matplotlib.collections import PolyCollection  # noqa: E402
 
+import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.enum import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 
@@ -67,9 +68,9 @@ def _rendered_layers(fig) -> list:
     Rendering first, because that is the pass that tags the artists and
     assigns every smooth its gid; the schema read cold has none of them.
     """
-    maidr = FigureManager.get_maidr(fig)
-    maidr.render(use_cdn=False)
-    return maidr._flatten_maidr()["subplots"][0][0]["layers"]
+    figure = FigureManager.get_maidr(fig)
+    figure.render(use_cdn=False)
+    return figure._flatten_maidr()["subplots"][0][0]["layers"]
 
 
 def _gid_of(layer: dict) -> str:


### PR DESCRIPTION
## What

`_register_smooth` in `maidr/patch/kdeplot.py` swept `ax.get_lines()` and `ax.collections` with no before/after snapshot, unlike `regplot.py` (#451), `rugplot.py`, `lineplot.py` and `boxenplot.py`, so every artist already on the axes was registered again as a SMOOTH layer on each `kdeplot` call. Closes #711.

```
two sns.kdeplot(fill=True) on one axes   3 smooth layers -> 2   (the first band was re-registered under a fresh gid, leaving its first layer's selector on no artist)
two unfilled kdeplot                     3 registered, 2 rendered -> 2 / 2
ax.plot(...) then kdeplot                [LINE, SMOOTH, SMOOTH] -> [LINE, SMOOTH]
ax.fill_between(...) then kdeplot        [AREA, SMOOTH, SMOOTH] -> [AREA, SMOOTH]
kdeplot(hue=)                            2 named curves, unchanged
```

`kde()` now snapshots the target axes' lines and collections next to the existing contour snapshot (artists, not ids, for the reason regplot gives) and `_register_smooth` skips them; `sns_distribution_density` keeps the defaults since displot panels are fresh.

Caveat, unchanged here: plot-then-kdeplot still *renders* only the smooth, because `Maidr._superseded_line_layers` (the per-axes #378 rule) drops the user's LINE on an axes holding a SMOOTH. The wrong announcement is gone; making that rule per-artist is a separate core change and the tests say so.

## Tests

New `tests/core/plot/test_kdeplot_own_artists.py` (7 tests): two filled kdeplots register exactly two SMOOTHs and every rendered layer's gid is on a `PolyCollection`; two unfilled register one curve each; plot-then-kdeplot and fill-then-kdeplot register one SMOOTH; `hue=` still gives two curves named `x`/`y`, filled and unfilled. Five of the seven fail on `main`. The 13 related kde/smooth/contour/rugplot/displot/regplot files (281 tests) pass unchanged.

## Verified

```
uv run pytest      3611 passed, 68 skipped
ruff check         All checks passed (changed files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_