### PR TITLE
fix(streamlit): warn when a render falls back to the process-global current figure

### DIFF
--- a/maidr/widget/streamlit.py
+++ b/maidr/widget/streamlit.py
@@ -66,7 +66,9 @@ def maidr_html(
     plot : Any, optional
         The plot to render -- a matplotlib or seaborn artist, a Plotly
         ``Figure``, or an Altair chart.  ``None`` uses the current
-        matplotlib figure.
+        matplotlib figure, and warns: that figure is process-global, and
+        Streamlit runs sessions on separate threads, so by the time it is
+        rendered it may be another session's.  Pass the plot explicitly.
     use_cdn : bool, {"auto"}, or None, default None
         Where the chart loads ``maidr.js`` from; see :func:`maidr.render`.
         ``None`` defers to the process-wide default.
@@ -106,6 +108,28 @@ def maidr_html(
     reference to the bundle would not survive; the source itself has to.
     """
     stacklevel = _stacklevel
+    if plot is None:
+        # ``maidr.render(None)`` falls back to ``plt.gcf()``, which is the
+        # right default for a script or a notebook and is why it is kept
+        # rather than refused.  It is the wrong one here: pyplot's figure
+        # registry is process-global and Streamlit runs each session on its
+        # own thread, so between one session's ``plt.subplots()`` and its
+        # render call another session's figure can become current -- and
+        # the render then succeeds, handing a blind reader the wrong chart
+        # with nothing to say so.  Streamlit's own ``st.pyplot()`` has
+        # warned about the same default since 0.67; this does the same
+        # rather than removing a documented default without notice.
+        warnings.warn(
+            "maidr: maidr_html()/render_maidr() called without a plot uses "
+            "matplotlib's current figure, which is process-global; Streamlit "
+            "runs sessions on separate threads, so another session's figure "
+            "can be rendered in its place. Pass the figure or axes explicitly.",
+            UserWarning,
+            # Same arithmetic as the ``use_cdn=False`` warning below: raised
+            # from inside this function, so one less than
+            # ``_warn_if_no_runtime`` gets.
+            stacklevel=stacklevel - 1,
+        )
     # Resolved once and then passed on, rather than read again inside
     # ``render``.  ``set_use_cdn`` writes process-wide state and Streamlit
     # runs sessions on separate threads, so reading it twice leaves a window
@@ -251,7 +275,9 @@ def render_maidr(
     plot : Any, optional
         The plot to render -- a matplotlib or seaborn artist, a Plotly
         ``Figure``, or an Altair chart.  ``None`` uses the current
-        matplotlib figure.
+        matplotlib figure, and warns: that figure is process-global, and
+        Streamlit runs sessions on separate threads, so by the time it is
+        rendered it may be another session's.  Pass the plot explicitly.
     height : int, {"content", "stretch"}, default "content"
         Height of the embed.  ``"content"`` lets Streamlit measure the
         chart, which is what keeps maidr's braille and text panels visible

--- a/tests/widget/test_streamlit.py
+++ b/tests/widget/test_streamlit.py
@@ -707,6 +707,8 @@ def test_no_plot_warns_and_blames_the_caller(bar_axes, monkeypatch):
     from either.
     """
     st, _v1 = _stub_streamlit(monkeypatch, with_iframe=True)
+    # ``bar_axes`` is what makes there be a current figure to fall back to.
+    assert plt.gcf() is bar_axes.figure
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")

--- a/tests/widget/test_streamlit.py
+++ b/tests/widget/test_streamlit.py
@@ -688,3 +688,52 @@ def test_an_axes_less_current_figure_is_still_resolved_only_once(monkeypatch):
         plt.close("all")
 
     assert calls == [1], f"the current figure was resolved {len(calls)} times"
+
+
+# ---------------------------------------------------------------------------
+# The current-figure default (#713)
+# ---------------------------------------------------------------------------
+
+
+def test_no_plot_warns_and_blames_the_caller(bar_axes, monkeypatch):
+    """Rendering with no plot still works, and says what it fell back on.
+
+    ``plt.gcf()`` is process-global and Streamlit runs each session on its
+    own thread, so a render that resolves it can serve one session another
+    session's chart -- silently, since the render succeeds.  The default
+    is kept, because it is ``maidr.render``'s and scripts rely on it, but
+    it is not kept quiet.  Both entry points, because they sit at
+    different call depths and the warning has to land on the user's line
+    from either.
+    """
+    st, _v1 = _stub_streamlit(monkeypatch, with_iframe=True)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        html = maidr_html(use_cdn=True)
+    fallbacks = [w for w in caught if "current figure" in str(w.message)]
+    assert len(fallbacks) == 1, [str(w.message) for w in caught]
+    assert issubclass(fallbacks[0].category, UserWarning)
+    assert fallbacks[0].filename == __file__, (
+        f"warning was blamed on {fallbacks[0].filename}, not the caller"
+    )
+    # The default still renders the current figure; the warning is not a refusal.
+    assert "maidr=" in html
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        render_maidr(use_cdn=True)
+    fallbacks = [w for w in caught if "current figure" in str(w.message)]
+    assert len(fallbacks) == 1, [str(w.message) for w in caught]
+    assert fallbacks[0].filename == __file__, (
+        f"warning was blamed on {fallbacks[0].filename}, not the caller"
+    )
+    assert "maidr=" in st.iframe.calls[0][0][0]
+
+
+def test_an_explicit_plot_does_not_warn(bar_axes):
+    """The warning is about the fallback, not about rendering."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        maidr_html(bar_axes, use_cdn=True)
+    assert not [w for w in caught if "current figure" in str(w.message)]


### PR DESCRIPTION
## What

`render_maidr()` and `maidr_html()` accept `plot=None`, documented as "uses the current matplotlib figure", and resolve it through `plt.gcf()`. pyplot's figure registry is process-global and Streamlit runs each session's script on its own thread, so between session A's `plt.subplots()` and its `render_maidr()` call, session B's `plt.subplots()` can make B's figure current: A renders, and its user is served, B's chart — silently, as a valid accessible chart with the wrong data. Reproduced three of three runs with two threads on a barrier. Closes #713.

The module already treats process-wide state as unsafe across sessions (the `use_cdn` resolution comment), and Streamlit itself has warned on `st.pyplot()` without a figure since 0.67.0 for exactly this reason and still only warns. So this is a `UserWarning`, not a `TypeError`: `maidr_html()` warns when `plot is None`, attributed to the caller's line from both entry points through the module's existing stacklevel arithmetic (the same as the Altair `use_cdn=False` warning), and both `plot` docstrings say why. `maidr.render(None)` is untouched: scripts and notebooks are single-threaded.

No emitted HTML or schema changes. Existing no-plot callers in the repo: only the resolved-once test; the smoke app and every doc pass a plot.

## Tests

`tests/widget/test_streamlit.py`: `test_no_plot_warns_and_blames_the_caller` (both entry points; exactly one warning mentioning "current figure", `filename == __file__`, and the HTML still carries the chart) and `test_an_explicit_plot_does_not_warn`; `test_an_axes_less_current_figure_is_still_resolved_only_once` unchanged. The warning test fails on `main`.

## Verified

```
uv run pytest      3606 passed, 68 skipped
ruff check         All checks passed (changed files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_