### PR TITLE
fix(patch): resolve data= column names in fill_between, stackplot and errorbar

### DIFF
--- a/maidr/patch/areaplot.py
+++ b/maidr/patch/areaplot.py
@@ -7,7 +7,7 @@ from matplotlib.axes import Axes
 from maidr.core.context_manager import ContextManager
 from maidr.core.plot.areaplot import AreaPlot
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _draw_quietly
+from maidr.patch.common import _draw_quietly, _resolve
 
 
 def stackplot(wrapped, instance, args, kwargs):
@@ -81,12 +81,17 @@ def _positions_and_series(args: tuple, kwargs: dict):
     ``fill_between``, and a call with no positional series is rejected by
     matplotlib before it reaches here.
 
+    A third spelling names columns: ``stackplot("x", "a", "b", data=df)``
+    reaches matplotlib's `_preprocess_data` with strings where the arrays go,
+    and the patch sits outside that decorator, so it sees the names. They are
+    resolved against ``data`` here the way matplotlib resolves them.
+
     Parameters
     ----------
     args : tuple
         Positional arguments the caller passed.
     kwargs : dict
-        Keyword arguments the caller passed.
+        Keyword arguments the caller passed. Only ``data`` is read.
 
     Returns
     -------
@@ -97,8 +102,9 @@ def _positions_and_series(args: tuple, kwargs: dict):
     if not args:
         return None, []
 
-    x = args[0]
-    rest = list(args[1:])
+    data = kwargs.get("data")
+    x = _resolve(args[0], data)
+    rest = [_resolve(argument, data) for argument in args[1:]]
 
     if not rest:
         # `stackplot(x)` alone. Matplotlib rejects it before this is reached

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -74,6 +74,7 @@ def drew_nothing(plot: Any) -> bool:
         return all(drew_nothing(one) for one in plot)
     return False
 
+
 #: The most vertices one confidence-interval polyline can have.
 #:
 #: Seaborn draws an interval as a plain two-point segment, and as a capped
@@ -150,6 +151,46 @@ def _argument(name: str, wrapped: Callable, args: tuple, kwargs: dict) -> Any:
 
     index = positional.index(name)
     return args[index] if index < len(args) else None
+
+
+def _resolve(value: Any, data: Any) -> Any:
+    """
+    Resolve an argument that names a column of the call's ``data``.
+
+    ``Axes.pie``, ``fill_between``, ``stackplot`` and ``errorbar`` all sit
+    behind matplotlib's `_preprocess_data`, so ``ax.pie("sales", data=df)``
+    and ``ax.fill_between("x", "y1", data=df)`` are valid calls in which the
+    data-bearing arguments are column names. A patch wraps the outside of
+    that decorator and therefore sees the names, not the columns; this looks
+    them up the way matplotlib does, so a patch that reads its values off the
+    call rather than off the drawn artist describes the columns and not their
+    labels (#712).
+
+    Parameters
+    ----------
+    value : Any
+        The argument as the caller passed it.
+    data : Any
+        The call's ``data`` argument, or None when it had none.
+
+    Returns
+    -------
+    Any
+        The indexed value, or the argument unchanged when it does not name
+        anything in ``data``.
+    """
+    if data is None or not isinstance(value, str):
+        return value
+
+    try:
+        return data[value]
+    except (KeyError, IndexError, TypeError):
+        # Matplotlib treats an unresolvable name as a plain value too, and a
+        # chart that renders must not fail to be described. Only the three
+        # ways an indexable object says "not this key" are caught -- a wider
+        # net would swallow a genuinely broken ``data`` and leave nothing to
+        # debug from.
+        return value
 
 
 def resolve_orientation(wrapped: Callable, args: tuple, kwargs: dict) -> str:

--- a/maidr/patch/errorbar.py
+++ b/maidr/patch/errorbar.py
@@ -7,7 +7,7 @@ from matplotlib.container import ErrorbarContainer
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _argument, _draw_quietly
+from maidr.patch.common import _argument, _draw_quietly, _resolve
 
 
 def errorbar(wrapped, instance, args, kwargs) -> ErrorbarContainer:
@@ -43,9 +43,12 @@ def errorbar(wrapped, instance, args, kwargs) -> ErrorbarContainer:
     # Read the centres before drawing. `fmt="none"` renders the intervals
     # without the estimate markers, leaving the container with no data line,
     # and an asymmetric bar is not centred on its own midpoint -- so for that
-    # case the arguments are the only place the estimate still exists.
-    x = _argument("x", wrapped, args, kwargs)
-    y = _argument("y", wrapped, args, kwargs)
+    # case the arguments are the only place the estimate still exists. They
+    # may be column names of `data=`, which matplotlib resolves inside the
+    # call this wraps, so they are resolved the same way here.
+    data = _argument("data", wrapped, args, kwargs)
+    x = _resolve(_argument("x", wrapped, args, kwargs), data)
+    y = _resolve(_argument("y", wrapped, args, kwargs), data)
 
     # Set the internal context to avoid cyclic processing.
     with ContextManager.set_internal_context():
@@ -63,9 +66,7 @@ def errorbar(wrapped, instance, args, kwargs) -> ErrorbarContainer:
     # other holder of the method degrades instead of raising here.
     ax = instance if isinstance(instance, Axes) else getattr(instance, "axes", None)
 
-    FigureManager.create_maidr(
-        ax, PlotType.ERRORBAR, container=container, x=x, y=y
-    )
+    FigureManager.create_maidr(ax, PlotType.ERRORBAR, container=container, x=x, y=y)
 
     return container
 

--- a/maidr/patch/fillbetween.py
+++ b/maidr/patch/fillbetween.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import wrapt
 from matplotlib.axes import Axes
@@ -7,11 +9,11 @@ from matplotlib.collections import Collection
 
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
-from maidr.patch.common import _argument, _draw_quietly
+from maidr.patch.common import _argument, _draw_quietly, _resolve
 from maidr.util.confidence_band import DRAWN_ALONG_Y
 
 
-def _baseline_is_zero(wrapped, args: tuple, kwargs: dict, name: str) -> bool:
+def _baseline_is_zero(wrapped, args: tuple, kwargs: dict, name: str, data: Any) -> bool:
     """
     Whether the band runs from the value axis' zero to a single curve.
 
@@ -38,13 +40,15 @@ def _baseline_is_zero(wrapped, args: tuple, kwargs: dict, name: str) -> bool:
         Keyword arguments the caller passed.
     name : str
         ``"y2"`` for ``fill_between``, ``"x2"`` for ``fill_betweenx``.
+    data : Any
+        The call's ``data`` argument, against which a column name is resolved.
 
     Returns
     -------
     bool
         True when the second edge is absent or an explicit zero.
     """
-    other = _argument(name, wrapped, args, kwargs)
+    other = _resolve(_argument(name, wrapped, args, kwargs), data)
     if other is None:
         return True
     try:
@@ -56,7 +60,7 @@ def _baseline_is_zero(wrapped, args: tuple, kwargs: dict, name: str) -> bool:
     return bool(values.size > 0 and np.all(values == 0))
 
 
-def _fills_the_whole_range(wrapped, args: tuple, kwargs: dict) -> bool:
+def _fills_the_whole_range(wrapped, args: tuple, kwargs: dict, data: Any) -> bool:
     """
     Whether the fill covers every position, rather than a masked subset.
 
@@ -82,13 +86,15 @@ def _fills_the_whole_range(wrapped, args: tuple, kwargs: dict) -> bool:
         Positional arguments the caller passed.
     kwargs : dict
         Keyword arguments the caller passed.
+    data : Any
+        The call's ``data`` argument, against which a column name is resolved.
 
     Returns
     -------
     bool
         True when no mask was given, or the mask holds at every position.
     """
-    where = _argument("where", wrapped, args, kwargs)
+    where = _resolve(_argument("where", wrapped, args, kwargs), data)
     if where is None:
         return True
     try:
@@ -98,7 +104,9 @@ def _fills_the_whole_range(wrapped, args: tuple, kwargs: dict) -> bool:
     return bool(mask.size > 0 and np.all(mask))
 
 
-def _magnitudes(wrapped, args: tuple, kwargs: dict, position: str, value: str):
+def _magnitudes(
+    wrapped, args: tuple, kwargs: dict, position: str, value: str, data: Any
+):
     """
     Read the positions and the one curve a filled area is drawn from.
 
@@ -120,6 +128,8 @@ def _magnitudes(wrapped, args: tuple, kwargs: dict, position: str, value: str):
         The parameter naming the shared axis: ``"x"`` or ``"y"``.
     value : str
         The parameter naming the curve: ``"y1"`` or ``"x1"``.
+    data : Any
+        The call's ``data`` argument, against which a column name is resolved.
 
     Returns
     -------
@@ -127,8 +137,8 @@ def _magnitudes(wrapped, args: tuple, kwargs: dict, position: str, value: str):
         The positions and the values, or ``(None, None)`` when either is
         missing or they do not line up.
     """
-    positions = _argument(position, wrapped, args, kwargs)
-    values = _argument(value, wrapped, args, kwargs)
+    positions = _resolve(_argument(position, wrapped, args, kwargs), data)
+    values = _resolve(_argument(value, wrapped, args, kwargs), data)
     if positions is None or values is None:
         return None, None
 
@@ -245,13 +255,18 @@ def _fill(
     with ContextManager.set_internal_context():
         collection = _tagged(_draw_quietly(wrapped, args, kwargs), transposed)
 
-    if not _baseline_is_zero(wrapped, args, kwargs, other):
+    # Every argument below is read off the call rather than off the polygon,
+    # and `fill_between("x", "y1", data=df)` passes them as column names. Read
+    # `data` once here so each reader resolves against the same frame.
+    data = _argument("data", wrapped, args, kwargs)
+
+    if not _baseline_is_zero(wrapped, args, kwargs, other, data):
         return collection
 
-    if not _fills_the_whole_range(wrapped, args, kwargs):
+    if not _fills_the_whole_range(wrapped, args, kwargs, data):
         return collection
 
-    positions, values = _magnitudes(wrapped, args, kwargs, position, value)
+    positions, values = _magnitudes(wrapped, args, kwargs, position, value, data)
     if positions is None:
         return collection
 

--- a/maidr/patch/pieplot.py
+++ b/maidr/patch/pieplot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Callable
 
 import wrapt
 from matplotlib.axes import Axes
@@ -8,7 +8,7 @@ from matplotlib.axes import Axes
 from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
-from maidr.patch.common import _argument, _draw_quietly
+from maidr.patch.common import _argument, _draw_quietly, _resolve
 
 
 def pie(wrapped: Callable, instance: Axes, args: tuple, kwargs: dict) -> tuple:
@@ -70,43 +70,6 @@ def pie(wrapped: Callable, instance: Axes, args: tuple, kwargs: dict) -> tuple:
     )
 
     return plot
-
-
-def _resolve(value: Any, data: Any) -> Any:
-    """
-    Resolve an argument that names a column of the call's ``data``.
-
-    `Axes.pie` sits behind matplotlib's `_preprocess_data`, so
-    ``ax.pie("sales", labels="fruit", data=df)`` is a valid call in which both
-    arguments are column names. The patch wraps the outside of that decorator
-    and therefore sees the names, not the columns; this looks them up the way
-    matplotlib does.
-
-    Parameters
-    ----------
-    value : Any
-        The argument as the caller passed it.
-    data : Any
-        The call's ``data`` argument, or None when it had none.
-
-    Returns
-    -------
-    Any
-        The indexed value, or the argument unchanged when it does not name
-        anything in ``data``.
-    """
-    if data is None or not isinstance(value, str):
-        return value
-
-    try:
-        return data[value]
-    except (KeyError, IndexError, TypeError):
-        # Matplotlib treats an unresolvable name as a plain value too, and a
-        # pie that renders must not fail to be described. Only the three ways
-        # an indexable object says "not this key" are caught -- a wider net
-        # would swallow a genuinely broken ``data`` and leave nothing to
-        # debug from.
-        return value
 
 
 # Patch matplotlib function.

--- a/tests/core/plot/test_areaplot.py
+++ b/tests/core/plot/test_areaplot.py
@@ -206,6 +206,29 @@ def test_a_data_frame_of_series_is_read_by_row_like_matplotlib_reads_it(columns)
     assert _schema(fig_frame)["data"] == _schema(fig_args)["data"]
 
 
+def test_column_names_are_read_as_their_columns():
+    """
+    ``stackplot("x", "a", "b", data=df)`` is the positional spelling, by name.
+
+    The call sits behind matplotlib's `_preprocess_data`, which looks each
+    string up in ``data`` before drawing. The patch reads the arguments from
+    outside that decorator, so it saw the names and emitted them as values: a
+    stack of one-point series whose x was the string ``"x"`` and whose
+    magnitudes were the strings ``"a"`` and ``"b"``, over a chart that drew
+    two four-point bands (#712).
+    """
+    frame = pd.DataFrame({"x": X, "a": SUBS, "b": SERVICES})
+
+    fig_named, named = plt.subplots()
+    named.stackplot("x", "a", "b", data=frame, labels=["a", "b"])
+
+    fig_args, separate = plt.subplots()
+    separate.stackplot(X, SUBS, SERVICES, labels=["a", "b"])
+
+    assert _plots(fig_named)[0].type == PlotType.STACKED_AREA
+    assert _schema(fig_named)["data"] == _schema(fig_args)["data"]
+
+
 def test_each_band_is_named_after_its_label():
     """
     Without the name a reader hears two sets of numbers with nothing to say

--- a/tests/core/plot/test_errorbar.py
+++ b/tests/core/plot/test_errorbar.py
@@ -313,6 +313,51 @@ def test_fmt_none_still_reports_the_estimates():
     assert points[1] == {"x": 1.0, "y": 5.1, "yMin": 4.0, "yMax": 6.6}
 
 
+def test_fmt_none_reads_column_names_as_their_columns():
+    """
+    ``errorbar("x", "y", yerr="err", fmt="none", data=df)`` reads the columns.
+
+    ``fmt="none"`` is the one mode that takes the centres from the call's
+    arguments rather than from the data line, and the call sits behind
+    matplotlib's `_preprocess_data`, which resolves each string against
+    ``data`` before drawing. The patch reads from outside that decorator, so
+    it saw the names: one point whose x was the string ``"x"`` and whose y was
+    the string ``"y"``, carrying the first sample's bounds, for a chart that
+    drew three (#712). The marker spelling was already right, since it reads
+    the drawn line, and the two have to agree.
+    """
+    frame = pd.DataFrame({"x": X, "y": Y, "err": [0.4, 1.1, 0.2]})
+
+    fig_named, named = plt.subplots()
+    named.errorbar("x", "y", yerr="err", fmt="none", data=frame)
+
+    fig_arrays, arrays = plt.subplots()
+    arrays.errorbar(frame["x"], frame["y"], yerr=frame["err"], fmt="none")
+
+    assert _schema(fig_named)["data"] == _schema(fig_arrays)["data"]
+    assert [point["y"] for point in _schema(fig_named)["data"]] == Y
+
+
+def test_a_string_that_names_no_column_is_still_a_value():
+    """
+    A string ``data`` does not hold is the value itself, as in matplotlib.
+
+    `_preprocess_data` falls back to the argument when the lookup fails, so
+    ``errorbar("control", 4.2, ..., data=df)`` draws one categorical sample
+    labelled "control" when no such column exists. Resolving the name has to
+    stop where matplotlib stops, or the reading and the drawing would part
+    ways on a call that raised nothing.
+    """
+    frame = pd.DataFrame({"x": X, "y": Y})
+
+    fig, ax = plt.subplots()
+    ax.errorbar("control", 4.2, yerr=0.5, fmt="none", data=frame)
+
+    assert _schema(fig)["data"] == [
+        {"x": "control", "y": 4.2, "yMin": 3.7, "yMax": 4.7}
+    ]
+
+
 def test_a_nan_error_drops_only_that_sample_s_bounds():
     """
     One unmeasured sample leaves its neighbours intact.

--- a/tests/core/test_fill_between.py
+++ b/tests/core/test_fill_between.py
@@ -30,6 +30,7 @@ import json
 
 import matplotlib
 import numpy as np
+import pandas as pd
 import pytest
 
 matplotlib.use("Agg")
@@ -298,3 +299,62 @@ def test_a_label_is_carried_onto_the_points():
     ax.fill_between(X, Y, label="rainfall")
 
     assert all(point["z"] == "rainfall" for point in _layer(fig)["data"][0])
+
+
+@pytest.mark.parametrize("method", ["fill_between", "fill_betweenx"])
+def test_a_column_name_is_read_as_its_column(method):
+    """``fill_between("x", "y", data=df)`` is the array spelling, by name.
+
+    The call sits behind matplotlib's `_preprocess_data`, which looks each
+    string up in ``data`` before drawing. The patch reads the arguments from
+    outside that decorator, so it saw the names and emitted them as values: a
+    one-point chart whose x was the string ``"x"`` and whose y was the string
+    ``"y"``, reported without error over a chart that drew five numeric
+    points (#712). Both spellings draw the same picture and have to read the
+    same.
+    """
+    frame = pd.DataFrame({"x": X, "y": Y})
+
+    fig_named, named = plt.subplots()
+    getattr(named, method)("x", "y", data=frame)
+
+    fig_arrays, arrays = plt.subplots()
+    getattr(arrays, method)(frame["x"], frame["y"])
+
+    assert _layers(fig_named) == [PlotType.AREA]
+    assert _layer(fig_named)["data"] == _layer(fig_arrays)["data"]
+    assert [point["y"] for point in _layer(fig_named)["data"][0]] == Y.tolist()
+
+
+def test_a_named_second_edge_and_mask_are_read_by_name_too():
+    """The declines resolve their arguments as well, and still decide.
+
+    ``y2="zeros"`` names a column of zeros, which is the default baseline
+    spelled out, and ``where="everywhere"`` names a mask that holds at every
+    position, which is no mask: both are the chart the bare call draws and
+    read as one. Left as names, each was an unreadable string and the chart
+    was declined outright. A column that *is* a mask still declines, so
+    resolving the name changes what is read and not whether the rule applies.
+    """
+    frame = pd.DataFrame(
+        {
+            "x": X,
+            "y": Y,
+            "zeros": np.zeros_like(Y),
+            "everywhere": np.ones_like(Y, dtype=bool),
+            "gap": Y > 2,
+        }
+    )
+
+    fig_zero, zero = plt.subplots()
+    zero.fill_between("x", "y", "zeros", data=frame)
+
+    fig_everywhere, everywhere = plt.subplots()
+    everywhere.fill_between("x", "y", where="everywhere", data=frame)
+
+    fig_gap, gap = plt.subplots()
+    gap.fill_between("x", "y", where="gap", data=frame)
+
+    assert _layers(fig_zero) == [PlotType.AREA]
+    assert _layers(fig_everywhere) == [PlotType.AREA]
+    assert _layers(fig_gap) == []


### PR DESCRIPTION
## What

`Axes.fill_between`, `fill_betweenx`, `stackplot` and `errorbar` are `@_preprocess_data`-decorated, so `ax.fill_between('x', 'y1', data=df)` is a legal call whose positional arguments are strings. The patches wrap the *outside* of that decorator and read the raw arguments, so the column names themselves were emitted as the data. Closes #712.

```
fill_between('x', 'y1', data=df)               [[{x: 'x', y: 'y1'}]]                 -> four numeric points
fill_betweenx('x', 'y1', data=df)              same                                    -> same
stackplot('x', 'a', 'b', data=df)              [[{x: 'x', y: 'a'}], [{x: 'x', y: 'b'}]] -> two four-point bands
errorbar('x', 'y1', yerr='e', fmt='none', data=df)  [{x: 'x', y: 'y1', yMin: .9, yMax: 1.1}] -> four points
```

Every case rendered without raising, so nothing told the user. `pieplot.py` already solved exactly this with a private `_resolve()`; it now lives in `maidr/patch/common.py` as `_resolve(value, data)` (pieplot imports it from there) and the three patches apply it wherever they read a data-bearing argument — including `fill_between`'s `y2`/`where` reads, so a column-named baseline of zeros or an all-true `where` mask now registers while a real column mask still declines. A string naming no column is passed through unchanged, as before. All other schemas are byte-identical.

## Tests

`data=` cases in `tests/core/test_fill_between.py` (parametrised over `fill_between`/`fill_betweenx`, equal to the array spelling; column-named `y2`/`where`), `tests/core/plot/test_areaplot.py` (`stackplot`) and `tests/core/plot/test_errorbar.py` (`fmt='none'` with `data=`, plus the pass-through guard). Five of the six fail on `main`; the guard pins semantics that were already right.

## Verified

```
uv run pytest      3610 passed, 68 skipped
ruff check         All checks passed (maidr/patch, tests/core)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_