### PR TITLE
fix(candlestick): skip a NaN row and read the frame by column rather than by cell

### DIFF
--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -122,7 +122,9 @@ class CandlestickPlot(MaidrPlot):
         ``len(df)``.
         """
         try:
-            columns = [df[name].to_numpy() for name in ("Open", "High", "Low", "Close")]
+            columns = [
+                df[name].to_numpy() for name in ("Open", "High", "Low", "Close")
+            ]
         except KeyError:
             return []
         volumes = df["Volume"].to_numpy() if "Volume" in df.columns else None

--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Union, Dict
 from matplotlib.axes import Axes
 import pandas as pd
@@ -101,25 +102,54 @@ class CandlestickPlot(MaidrPlot):
         Returns
         -------
         list[dict]
-            List of candlestick data dictionaries with raw values.
+            List of candlestick data dictionaries with raw values. A row whose
+            open, high, low or close is not finite is left out; a missing or
+            non-finite volume is reported as ``0.0``.
+
+        Notes
+        -----
+        The frame is read one column at a time. Building ``df.iloc[i]`` for
+        every row constructs a fresh Series (with dtype upcasting) five times
+        per candle, which came to about 0.5 ms a row -- 39% of a render of a
+        decade of daily bars (#706). Column access gives the same values.
+
+        A row mplfinance draws as a gap (all four prices NaN) is skipped rather
+        than emitted, for the reason `test_non_finite_coordinates.py` gives:
+        ``json.dumps`` writes a bare ``NaN`` token, ``JSON.parse`` rejects it,
+        and the whole figure -- volume bars and moving averages included --
+        loses its accessibility. The SVG still holds a body path and two wick
+        paths for the gap row, which is why `_get_selector` keeps counting
+        ``len(df)``.
         """
+        try:
+            columns = [df[name].to_numpy() for name in ("Open", "High", "Low", "Close")]
+        except KeyError:
+            return []
+        volumes = df["Volume"].to_numpy() if "Volume" in df.columns else None
+        # Raw representation of the index, exactly as ``str(df.index[i])``.
+        dates = [str(date) for date in df.index]
+
         candles = []
-
-        for i in range(len(df)):
+        for i, date_value in enumerate(dates):
             try:
-                # Get date directly from index - raw representation
-                date_value = str(df.index[i])
+                open_price, high_price, low_price, close_price = (
+                    float(column[i]) for column in columns
+                )
+                # Volume when available, otherwise 0
+                volume = float(volumes[i]) if volumes is not None else 0.0
+            except (ValueError, TypeError):
+                continue
 
-                # Get OHLC values directly from DataFrame columns
-                open_price = float(df.iloc[i]["Open"])
-                high_price = float(df.iloc[i]["High"])
-                low_price = float(df.iloc[i]["Low"])
-                close_price = float(df.iloc[i]["Close"])
+            if not all(
+                math.isfinite(price)
+                for price in (open_price, high_price, low_price, close_price)
+            ):
+                continue
+            if not math.isfinite(volume):
+                volume = 0.0
 
-                # Get volume if available, otherwise 0
-                volume = float(df.iloc[i].get("Volume", 0.0))
-
-                candle_data = {
+            candles.append(
+                {
                     "value": date_value,
                     "open": open_price,
                     "high": high_price,
@@ -127,9 +157,7 @@ class CandlestickPlot(MaidrPlot):
                     "close": close_price,
                     "volume": volume,
                 }
-                candles.append(candle_data)
-            except (KeyError, IndexError, ValueError, TypeError):
-                continue
+            )
 
         return candles
 

--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -103,8 +103,8 @@ class CandlestickPlot(MaidrPlot):
         -------
         list[dict]
             List of candlestick data dictionaries with raw values. A row whose
-            open, high, low or close is not finite is left out; a missing or
-            non-finite volume is reported as ``0.0``.
+            open, high, low or close is not finite or not a number is left out;
+            a missing, non-finite or non-numeric volume is reported as ``0.0``.
 
         Notes
         -----
@@ -127,7 +127,14 @@ class CandlestickPlot(MaidrPlot):
             ]
         except KeyError:
             return []
-        volumes = df["Volume"].to_numpy() if "Volume" in df.columns else None
+        # A stray string in Volume is no reason to lose the candle: coerced to
+        # NaN here, it is reported as 0.0 below, exactly like a NaN in the
+        # frame, and the prices are read as usual.
+        volumes = (
+            pd.to_numeric(df["Volume"], errors="coerce").to_numpy(dtype=float)
+            if "Volume" in df.columns
+            else None
+        )
         # Raw representation of the index, exactly as ``str(df.index[i])``.
         dates = [str(date) for date in df.index]
 
@@ -137,8 +144,6 @@ class CandlestickPlot(MaidrPlot):
                 open_price, high_price, low_price, close_price = (
                     float(column[i]) for column in columns
                 )
-                # Volume when available, otherwise 0
-                volume = float(volumes[i]) if volumes is not None else 0.0
             except (ValueError, TypeError):
                 continue
 
@@ -147,6 +152,8 @@ class CandlestickPlot(MaidrPlot):
                 for price in (open_price, high_price, low_price, close_price)
             ):
                 continue
+            # Volume when available, otherwise 0
+            volume = float(volumes[i]) if volumes is not None else 0.0
             if not math.isfinite(volume):
                 volume = 0.0
 

--- a/maidr/patch/mplfinance.py
+++ b/maidr/patch/mplfinance.py
@@ -73,7 +73,9 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
             try:
                 import matplotlib.dates as mdates
 
-                date_nums = [mdates.date2num(d) for d in data.index]
+                # The array form gives the same values as a call per
+                # element, without the Python call per row (#706).
+                date_nums = list(mdates.date2num(data.index))
             except Exception:
                 pass
 

--- a/maidr/util/datetime_conversion.py
+++ b/maidr/util/datetime_conversion.py
@@ -120,13 +120,13 @@ class DatetimeConverter:
         if len(self.data) < 2:
             return "unknown"
 
-        # Calculate average time difference between consecutive data points
-        time_diffs = []
-        for i in range(1, len(self.data)):
-            diff = self.data.index[i] - self.data.index[i - 1]
-            time_diffs.append(diff.total_seconds())
-
-        avg_diff_seconds = np.mean(time_diffs)
+        # Average time difference between consecutive data points, computed
+        # on the datetime64 array rather than one Timestamp pair at a time
+        # (#706). Dividing by a one-second timedelta rather than by 1e9 keeps
+        # this right whatever resolution the index carries.
+        avg_diff_seconds = float(
+            np.diff(self.data.index.values).mean() / np.timedelta64(1, "s")
+        )
 
         # Determine time period based on average difference
         if avg_diff_seconds < 60:  # Less than 1 minute
@@ -230,14 +230,7 @@ class DatetimeConverter:
         try:
             import matplotlib.dates as mdates
 
-            date_nums = []
-            for d in self.data.index:
-                try:
-                    date_num = mdates.date2num(d)
-                    date_nums.append(float(date_num))
-                except (ValueError, TypeError):
-                    continue
-            return date_nums
+            return [float(num) for num in mdates.date2num(self.data.index)]
         except Exception:
             return []
 
@@ -366,18 +359,18 @@ class DatetimeConverter:
         This method extracts volume data from the original DataFrame and formats
         datetime values using the enhanced datetime conversion logic.
         """
-        volume_data = []
-        if hasattr(self.data, "Volume"):
-            for i in range(len(self.data)):
-                try:
-                    volume = self.data.iloc[i]["Volume"]
-                    if pd.isna(volume) or volume <= 0:
-                        continue
-                    formatted_datetime = self.get_formatted_datetime(i)
-                    volume_data.append((formatted_datetime, float(volume)))
-                except (KeyError, IndexError, ValueError):
-                    continue
-        return volume_data
+        if not hasattr(self.data, "Volume"):
+            return []
+
+        # One mask over the column instead of an ``iloc`` row per bar (#706).
+        # The label still comes from ``get_formatted_datetime`` so its text is
+        # unchanged.
+        volumes = self.data["Volume"].to_numpy()
+        keep = ~pd.isna(volumes) & (volumes > 0)
+        return [
+            (self.get_formatted_datetime(int(i)), float(volumes[i]))
+            for i in np.flatnonzero(keep)
+        ]
 
 
 def create_datetime_converter(

--- a/maidr/util/datetime_conversion.py
+++ b/maidr/util/datetime_conversion.py
@@ -220,7 +220,7 @@ class DatetimeConverter:
         -------
         List[float]
             List of matplotlib date numbers converted from the DatetimeIndex.
-            Empty list if conversion fails.
+            A NaT in the index is left out. Empty list if conversion fails.
 
         Notes
         -----
@@ -230,7 +230,12 @@ class DatetimeConverter:
         try:
             import matplotlib.dates as mdates
 
-            return [float(num) for num in mdates.date2num(self.data.index)]
+            # ``date2num`` maps a NaT to NaN on a naive index and raises on a
+            # tz-aware one, so the NaT goes first. The ``isfinite`` check is
+            # the promise itself: a NaN here would reach the ``int(date_num)``
+            # fallback in ``mplfinance_utils`` and raise there, uncaught.
+            index = self.data.index[self.data.index.notna()]
+            return [float(num) for num in mdates.date2num(index) if np.isfinite(num)]
         except Exception:
             return []
 

--- a/maidr/util/datetime_conversion.py
+++ b/maidr/util/datetime_conversion.py
@@ -352,7 +352,7 @@ class DatetimeConverter:
         -------
         List[Tuple[str, float]]
             List of tuples containing (formatted_datetime, volume) pairs.
-            Zero and NaN volume values are filtered out.
+            Zero, NaN, infinite and non-numeric volume values are filtered out.
 
         Notes
         -----
@@ -365,8 +365,13 @@ class DatetimeConverter:
         # One mask over the column instead of an ``iloc`` row per bar (#706).
         # The label still comes from ``get_formatted_datetime`` so its text is
         # unchanged.
-        volumes = self.data["Volume"].to_numpy()
-        keep = ~pd.isna(volumes) & (volumes > 0)
+        # ``errors="coerce"`` turns a value that is not a number into NaN, and
+        # ``isfinite`` drops NaN and infinity alike: ``json.dumps`` would write
+        # either as a bare token that ``JSON.parse`` rejects.
+        volumes = pd.to_numeric(self.data["Volume"], errors="coerce").to_numpy(
+            dtype=float
+        )
+        keep = np.isfinite(volumes) & (volumes > 0)
         return [
             (self.get_formatted_datetime(int(i)), float(volumes[i]))
             for i in np.flatnonzero(keep)

--- a/tests/core/plot/test_candlestick_extraction.py
+++ b/tests/core/plot/test_candlestick_extraction.py
@@ -104,6 +104,17 @@ def test_a_non_finite_price_skips_the_row(extract):
     assert extract(frame) == [EXPECTED[0], EXPECTED[2], EXPECTED[4]]
 
 
+def test_a_non_numeric_volume_is_zero_and_the_prices_survive(extract):
+    # A stray string in Volume is no reason to lose the candle: the prices
+    # are read, and the volume is reported as it would be for a NaN.
+    frame = _frame(Volume=[10, "n/a", 30, 40, 50])
+
+    candles = extract(frame)
+    assert len(candles) == 5
+    assert candles[1] == dict(EXPECTED[1], volume=0.0)
+    assert [candles[i] for i in (0, 2, 3, 4)] == [EXPECTED[i] for i in (0, 2, 3, 4)]
+
+
 def test_a_non_finite_volume_is_reported_as_zero(extract):
     # The same value the frame gets when it carries no Volume at all.
     frame = _frame(Volume=[10, 20, np.nan, 40, 50])

--- a/tests/core/plot/test_candlestick_extraction.py
+++ b/tests/core/plot/test_candlestick_extraction.py
@@ -1,0 +1,113 @@
+"""``CandlestickPlot`` reads the frame by column, not by cell (#706).
+
+The old loop built ``df.iloc[i]`` -- a fresh Series, with dtype upcasting --
+five times for every row, which came to about 0.5 ms a candle and 39% of a
+render of a decade of daily bars. Reading each column once gives the same
+dictionaries, so these tests pin what the loop promised: one dict per row
+with the raw ``str(index[i])`` as its value, ``0.0`` for a volume the frame
+does not carry, and a row that cannot be read as numbers skipped on its own.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+
+from maidr.core.plot.candlestick import CandlestickPlot  # noqa: E402
+
+
+@pytest.fixture
+def extract(axes):
+    return CandlestickPlot([axes])._extract_from_dataframe
+
+
+def _frame(**overrides) -> pd.DataFrame:
+    columns = {
+        "Open": [1, 2, 3, 4, 5],
+        "High": [2.5, 3.5, 4.5, 5.5, 6.5],
+        "Low": [0, 1, 2, 3, 4],
+        "Close": [1.5, 2.5, 3.5, 4.5, 5.5],
+        "Volume": [10, 20, 30, 40, 50],
+    }
+    columns.update(overrides)
+    return pd.DataFrame(columns, index=pd.date_range("2026-01-05", periods=5))
+
+
+def _candle(date, open_, high, low, close, volume) -> dict:
+    return {
+        "value": str(date),
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+    }
+
+
+EXPECTED = [
+    _candle(pd.Timestamp("2026-01-05"), 1.0, 2.5, 0.0, 1.5, 10.0),
+    _candle(pd.Timestamp("2026-01-06"), 2.0, 3.5, 1.0, 2.5, 20.0),
+    _candle(pd.Timestamp("2026-01-07"), 3.0, 4.5, 2.0, 3.5, 30.0),
+    _candle(pd.Timestamp("2026-01-08"), 4.0, 5.5, 3.0, 4.5, 40.0),
+    _candle(pd.Timestamp("2026-01-09"), 5.0, 6.5, 4.0, 5.5, 50.0),
+]
+
+
+def test_a_frame_with_volume_gives_one_dict_per_row(extract):
+    assert extract(_frame()) == EXPECTED
+
+
+def test_every_value_is_a_python_float(extract):
+    # Integer columns must not leak numpy scalars into the JSON payload.
+    # ``isinstance`` cannot say so: ``np.float64`` is a subclass of ``float``.
+    for candle in extract(_frame()):
+        for key in ("open", "high", "low", "close", "volume"):
+            assert type(candle[key]) is float  # noqa: E721
+
+
+def test_volume_is_zero_when_the_frame_has_none(extract):
+    frame = _frame().drop(columns="Volume")
+
+    assert extract(frame) == [dict(candle, volume=0.0) for candle in EXPECTED]
+
+
+def test_the_date_is_the_raw_index_string(extract):
+    # Whatever the index holds is reported as ``str(index[i])`` -- a tz-aware
+    # stamp keeps its offset, an integer index its integers.
+    frame = _frame().tz_localize("US/Eastern")
+
+    values = [candle["value"] for candle in extract(frame)]
+    assert values == [str(frame.index[i]) for i in range(len(frame))]
+    assert values[0] == "2026-01-05 00:00:00-05:00"
+
+
+def test_a_non_numeric_close_skips_that_row_only(extract):
+    frame = _frame(Close=[1.5, "n/a", 3.5, 4.5, 5.5])
+
+    assert extract(frame) == [EXPECTED[0]] + EXPECTED[2:]
+
+
+def test_a_missing_price_column_gives_nothing(extract):
+    assert extract(_frame().drop(columns="Close")) == []
+
+
+def test_a_non_finite_price_skips_the_row(extract):
+    # The rule `test_non_finite_coordinates.py` states: a bare NaN or Infinity
+    # in the payload stops the whole figure initialising, and no price a
+    # reader could be told is lost by leaving the row out.
+    frame = _frame(Low=[0, np.nan, 2, 3, 4], High=[2.5, 3.5, 4.5, np.inf, 6.5])
+
+    assert extract(frame) == [EXPECTED[0], EXPECTED[2], EXPECTED[4]]
+
+
+def test_a_non_finite_volume_is_reported_as_zero(extract):
+    # The same value the frame gets when it carries no Volume at all.
+    frame = _frame(Volume=[10, 20, np.nan, 40, 50])
+
+    candles = extract(frame)
+    assert len(candles) == 5
+    assert candles[2] == dict(EXPECTED[2], volume=0.0)

--- a/tests/core/plot/test_mplfinance_dates.py
+++ b/tests/core/plot/test_mplfinance_dates.py
@@ -1,0 +1,74 @@
+"""The mplfinance patch converts the whole index to date numbers at once
+(#706).
+
+``mdates.date2num`` accepts an index and returns the same float64 values as
+a call per element, at about 60 us a row less. The values are what the
+volume bars and moving averages are labelled from, so the two spellings are
+asserted equal here for a naive and a tz-aware index.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.dates as mdates  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+
+import maidr  # noqa: E402,F401
+from maidr.core.enum import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+mpf = pytest.importorskip("mplfinance")
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+INDEXES = {
+    "naive": pd.date_range("2026-01-01", periods=5),
+    "tz-aware": pd.date_range("2026-01-01", periods=5, tz="US/Eastern"),
+}
+
+
+def _prices(index: pd.DatetimeIndex) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "Open": [1, 2, 3, 4, 5],
+            "High": [2, 3, 4, 5, 6],
+            "Low": [0, 1, 2, 3, 4],
+            "Close": [1.5, 2.5, 3.5, 4.5, 5.5],
+            "Volume": [10, 20, 30, 40, 50],
+        },
+        index=index,
+    )
+
+
+def _layer(fig, plot_type: PlotType):
+    return next(p for p in FigureManager.get_maidr(fig)._plots if p.type == plot_type)
+
+
+@pytest.mark.parametrize("index", list(INDEXES.values()), ids=list(INDEXES))
+def test_the_date_numbers_match_a_call_per_element(index):
+    frame = _prices(index)
+    fig, _ = mpf.plot(frame, type="candle", volume=True, mav=3, returnfig=True)
+
+    # The one list the patch builds is handed to the volume layer and set on
+    # every moving-average line; the candlestick layer does not keep it.
+    date_nums = _layer(fig, PlotType.BAR)._maidr_date_nums
+    assert date_nums == [mdates.date2num(stamp) for stamp in frame.index]
+    assert date_nums == list(mdates.date2num(frame.index))
+    for line in _layer(fig, PlotType.LINE).ax.get_lines():
+        assert line._maidr_date_nums == date_nums
+
+
+def test_the_candlestick_still_registers():
+    fig, _ = mpf.plot(_prices(INDEXES["naive"]), type="candle", returnfig=True)
+
+    assert _layer(fig, PlotType.CANDLESTICK).schema["data"]

--- a/tests/core/plot/test_non_finite_coordinates.py
+++ b/tests/core/plot/test_non_finite_coordinates.py
@@ -40,6 +40,7 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
 
+from maidr.core.enum import PlotType  # noqa: E402
 from maidr.core.figure_manager import FigureManager  # noqa: E402
 
 
@@ -206,3 +207,70 @@ class TestWhatMustNotChange:
         line = plt.plot(["a", "b", "c"], [1, 2, 3])[0]
 
         assert [point["x"] for point in series_of(line)[0]] == ["a", "b", "c"]
+
+
+class TestTheCandlestickWithAGap:
+    """A row mplfinance draws as a gap took the whole figure down.
+
+    mplfinance accepts a row whose open, high, low and close are all NaN and
+    draws it as empty geometry. ``float(nan)`` raises none of the errors the
+    extraction loop skipped a row on, so the candle went out as a bare
+    ``NaN`` -- the #427 failure again, and worse here, because the volume
+    bars and moving averages on the same figure share the payload and went
+    dark with it (#706).
+    """
+
+    @staticmethod
+    def _frame():
+        import pandas as pd
+
+        frame = pd.DataFrame(
+            {
+                "Open": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                "High": [2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+                "Low": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0],
+                "Close": [1.5, 2.5, 3.5, 4.5, 5.5, 6.5],
+            },
+            index=pd.date_range("2026-01-01", periods=6),
+        )
+        frame.iloc[2] = np.nan
+        return frame
+
+    def _candlestick(self):
+        mpf = pytest.importorskip("mplfinance")
+        frame = self._frame()
+        fig, _ = mpf.plot(frame, type="candle", returnfig=True)
+        plots = FigureManager.get_maidr(fig)._plots
+        return frame, next(p for p in plots if p.type == PlotType.CANDLESTICK)
+
+    def test_its_payload_is_parseable(self):
+        _, plot = self._candlestick()
+
+        parses_as_strict_json(plot.ax)
+
+    def test_the_gap_row_is_dropped_and_the_rest_kept(self):
+        frame, plot = self._candlestick()
+        candles = plot.schema["data"]
+
+        assert len(candles) == len(frame) - 1
+        # The rows either side of the gap keep their own values, so what is
+        # lost is the gap and nothing else.
+        assert [candle["open"] for candle in candles] == [1.0, 2.0, 4.0, 5.0, 6.0]
+        assert not any(
+            value != value  # NaN is the one float unequal to itself
+            for candle in candles
+            for value in candle.values()
+            if isinstance(value, float)
+        )
+
+    def test_the_wick_selectors_still_count_every_row(self):
+        # The SVG keeps a body path and two wick paths for the gap row, so the
+        # nth-child split between low and high wicks must go on counting the
+        # frame, not the candles emitted. The cost is that a highlight after
+        # the gap lands one path early; before, there was no highlight at all.
+        frame, plot = self._candlestick()
+        selectors = plot.schema["selectors"]
+
+        assert len(plot._maidr_wick_collection.get_paths()) == 2 * len(frame)
+        assert f"nth-child(-n+{len(frame)})" in selectors["wickLow"]
+        assert f"nth-child(n+{len(frame) + 1})" in selectors["wickHigh"]

--- a/tests/util/test_datetime_conversion.py
+++ b/tests/util/test_datetime_conversion.py
@@ -129,6 +129,28 @@ def test_a_frame_without_volume_gives_nothing():
     assert create_datetime_converter(frame).extract_volume_data(None) == []
 
 
+def _with_a_nat(index: pd.DatetimeIndex, at: int) -> pd.DatetimeIndex:
+    values = index.tz_localize(None).to_numpy().copy()
+    values[at] = np.datetime64("NaT")
+    return pd.DatetimeIndex(values).tz_localize(index.tz)
+
+
+@pytest.mark.parametrize("name", ["daily", "tz-aware hourly"])
+def test_a_nat_in_the_index_is_left_out_of_date_nums(name):
+    # ``date2num`` maps a NaT to NaN on a naive index and raises on a tz-aware
+    # one; either way the number list must not carry it. A NaN would reach
+    # ``_convert_date_num_to_string``, whose fallback is ``int(date_num)``.
+    index = _with_a_nat(INDEXES[name], at=50)
+    converter = create_datetime_converter(_frame(index))
+
+    date_nums = converter.date_nums
+    assert len(date_nums) == ROWS - 1
+    assert all(math.isfinite(num) for num in date_nums)
+    assert date_nums == [
+        float(mdates.date2num(stamp)) for stamp in index if stamp is not pd.NaT
+    ]
+
+
 def test_date_nums_match_a_call_per_element(frame):
     converter = create_datetime_converter(frame)
 

--- a/tests/util/test_datetime_conversion.py
+++ b/tests/util/test_datetime_conversion.py
@@ -1,0 +1,182 @@
+"""``DatetimeConverter`` works on the index and the Volume column as arrays
+(#706).
+
+Detecting the time period subtracted one Timestamp pair at a time,
+``extract_volume_data`` built ``iloc[i]`` for every bar, and ``date_nums``
+called ``date2num`` once per element. Each has a vectorised spelling with the
+same result, and the reference loops below are the plain per-row versions of
+what the class promises, so any drift between the two would show here.
+"""
+
+from __future__ import annotations
+
+import math
+
+import matplotlib
+import matplotlib.dates as mdates
+import numpy as np
+import pandas as pd
+import pytest
+
+matplotlib.use("Agg")
+
+from maidr.core.plot.candlestick import CandlestickPlot  # noqa: E402
+from maidr.util.datetime_conversion import (  # noqa: E402
+    DatetimeConverter,
+    create_datetime_converter,
+)
+
+ROWS = 200
+
+
+def _frame(index: pd.DatetimeIndex) -> pd.DataFrame:
+    rng = np.random.default_rng(706)
+    opens = 100 + rng.normal(size=len(index)).cumsum()
+    closes = opens + rng.normal(size=len(index))
+    volume = rng.integers(1, 1000, len(index)).astype(float)
+    volume[17] = np.nan
+    volume[42] = 0.0
+    return pd.DataFrame(
+        {
+            "Open": opens,
+            "High": np.maximum(opens, closes) + 1,
+            "Low": np.minimum(opens, closes) - 1,
+            "Close": closes,
+            "Volume": volume,
+        },
+        index=index,
+    )
+
+
+INDEXES = {
+    "daily": pd.date_range("2024-01-01", periods=ROWS, freq="D"),
+    "minute bars": pd.date_range("2024-01-01 09:30", periods=ROWS, freq="min"),
+    "tz-aware hourly": pd.date_range(
+        "2024-01-01", periods=ROWS, freq="h", tz="US/Eastern"
+    ),
+    "second resolution": pd.DatetimeIndex(
+        pd.date_range("2024-01-01", periods=ROWS, freq="D").values.astype(
+            "datetime64[s]"
+        )
+    ),
+}
+
+
+@pytest.fixture(params=list(INDEXES), ids=list(INDEXES))
+def frame(request) -> pd.DataFrame:
+    return _frame(INDEXES[request.param])
+
+
+def _reference_volume(frame: pd.DataFrame) -> list[tuple[str, float]]:
+    out = []
+    for i in range(len(frame)):
+        volume = frame.iloc[i]["Volume"]
+        if pd.isna(volume) or volume <= 0:
+            continue
+        out.append((str(frame.index[i]), float(volume)))
+    return out
+
+
+def _reference_date_nums(frame: pd.DataFrame) -> list[float]:
+    return [float(mdates.date2num(stamp)) for stamp in frame.index]
+
+
+def _reference_candles(frame: pd.DataFrame) -> list[dict]:
+    out = []
+    for i in range(len(frame)):
+        row = frame.iloc[i]
+        prices = [float(row[name]) for name in ("Open", "High", "Low", "Close")]
+        if not all(math.isfinite(price) for price in prices):
+            continue
+        volume = float(row["Volume"]) if "Volume" in frame.columns else 0.0
+        if not math.isfinite(volume):
+            volume = 0.0
+        out.append(
+            {
+                "value": str(frame.index[i]),
+                "open": prices[0],
+                "high": prices[1],
+                "low": prices[2],
+                "close": prices[3],
+                "volume": volume,
+            }
+        )
+    return out
+
+
+def test_volume_matches_a_row_by_row_loop(frame):
+    converter = create_datetime_converter(frame)
+
+    volume = converter.extract_volume_data(None)
+    assert volume == _reference_volume(frame)
+    # The NaN and the zero are the two bars the loop leaves out.
+    assert len(volume) == ROWS - 2
+
+
+def test_the_volume_label_is_still_the_formatted_datetime(frame):
+    converter = create_datetime_converter(frame)
+
+    labels = [label for label, _ in converter.extract_volume_data(None)]
+    assert labels[0] == converter.get_formatted_datetime(0)
+    assert labels == [
+        str(stamp) for i, stamp in enumerate(frame.index) if i not in (17, 42)
+    ]
+
+
+def test_a_frame_without_volume_gives_nothing():
+    frame = _frame(INDEXES["daily"]).drop(columns="Volume")
+
+    assert create_datetime_converter(frame).extract_volume_data(None) == []
+
+
+def test_date_nums_match_a_call_per_element(frame):
+    converter = create_datetime_converter(frame)
+
+    assert converter.date_nums == _reference_date_nums(frame)
+    # Plain floats, as before -- ``np.float64`` would pass ``isinstance``.
+    assert all(type(num) is float for num in converter.date_nums)  # noqa: E721
+
+
+@pytest.mark.parametrize(
+    ("freq", "expected"),
+    [
+        ("s", "minute"),
+        ("min", "intraday"),
+        ("h", "hour"),
+        ("D", "day"),
+        ("W", "week"),
+        ("MS", "month"),
+    ],
+)
+def test_the_time_period_is_read_off_the_whole_index(freq, expected):
+    frame = _frame(pd.date_range("2024-01-01", periods=ROWS, freq=freq))
+
+    assert create_datetime_converter(frame).time_period == expected
+
+
+def test_the_time_period_of_the_reference_indexes(frame):
+    # A second-resolution index must not be read as a thousand times shorter.
+    diffs = [
+        (frame.index[i] - frame.index[i - 1]).total_seconds()
+        for i in range(1, len(frame))
+    ]
+    average = sum(diffs) / len(diffs)
+    expected = "hour" if average < 86400 else "day"
+    if average < 3600:
+        expected = "intraday"
+
+    assert create_datetime_converter(frame).time_period == expected
+
+
+def test_a_single_row_has_no_time_period():
+    frame = _frame(INDEXES["daily"]).iloc[:1]
+
+    assert DatetimeConverter(frame).time_period == "unknown"
+
+
+def test_the_candlestick_layer_matches_a_row_by_row_loop(frame, axes):
+    frame.iloc[100, :4] = np.nan  # a gap mplfinance draws as empty geometry
+
+    candles = CandlestickPlot([axes])._extract_from_dataframe(frame)
+    assert candles == _reference_candles(frame)
+    assert len(candles) == ROWS - 1

--- a/tests/util/test_datetime_conversion.py
+++ b/tests/util/test_datetime_conversion.py
@@ -180,3 +180,20 @@ def test_the_candlestick_layer_matches_a_row_by_row_loop(frame, axes):
     candles = CandlestickPlot([axes])._extract_from_dataframe(frame)
     assert candles == _reference_candles(frame)
     assert len(candles) == ROWS - 1
+
+
+@pytest.mark.parametrize(
+    "bad", [np.inf, -np.inf, "n/a"], ids=["inf", "-inf", "non-numeric"]
+)
+def test_a_volume_that_is_not_a_finite_number_is_left_out(bad):
+    """``inf`` would serialise as ``Infinity`` and a string would raise on ``>``."""
+    frame = _frame(INDEXES["daily"])
+    frame["Volume"] = frame["Volume"].astype(object)
+    frame.loc[frame.index[3], "Volume"] = bad
+    converter = create_datetime_converter(frame)
+
+    labels = [label for label, _ in converter.extract_volume_data(None)]
+
+    assert str(frame.index[3]) not in labels
+    assert len(labels) == ROWS - 3
+    assert all(np.isfinite(v) for _, v in converter.extract_volume_data(None))


### PR DESCRIPTION
## What

Closes #706.

**A NaN row broke the whole figure.** `Candlestick._extract_from_dataframe` did `float(df.iloc[i]['Open'])` etc. and appended the candle regardless of finiteness; only `KeyError`/`IndexError`/`ValueError`/`TypeError` skipped a row and `float(nan)` raises none of them. mplfinance accepts a row whose O/H/L/C are all NaN and draws a gap; the emitted HTML then carried `"open": NaN` inside the `maidr` attribute, `JSON.parse` rejected it, and the figure — volume bars and moving averages included — lost its accessibility (#427). A non-finite price row is now skipped and a non-finite volume reads as `0.0` (what the function already emits when the column is absent). `_get_selector`'s `N = len(df)` is left alone: the SVG really has one body path and two wick paths per row, NaN row included, so after a gap the body highlight is offset by one path — versus no accessibility at all before.

**The frame was read by cell.** The same loop materialised `df.iloc[i]` five times per row; `maidr/patch/mplfinance.py` called `mdates.date2num` once per element; `DatetimeConverter` subtracted one Timestamp pair at a time in `_detect_time_period` and did `iloc[i]['Volume']` per row. Each column is now read once (`KeyError` → `[]`), `date2num` takes the whole index, the period comes from `np.diff(index.values)` divided by a one-second timedelta (unit-safe under pandas 3, where `asi8` is in the index's own unit), and the volume extraction is a mask that still builds each label through `get_formatted_datetime`. Output is value-identical.

## Measured (5 000-row minute-bar frame, min of 3)

| | before | after |
|---|---|---|
| `_extract_from_dataframe` | 775 ms | 20 ms |
| `DatetimeConverter()` | 75 ms | 3.5 ms |
| `extract_volume_data` | 331 ms | 25 ms |
| `date_nums` | 161 ms | 0.4 ms |
| patched `mpf.plot(type='candle', volume=True)` | 5.13 s | 3.96 s |

## Tests

`tests/core/plot/test_non_finite_coordinates.py` gains a candlestick class (one all-NaN OHLC row: strict JSON round trip, `len(df) - 1` candles, wick selectors still count `len(df)`); new `test_candlestick_extraction.py` (8), `tests/util/test_datetime_conversion.py` (25, parametrised over daily, minute, tz-aware hourly and second-resolution indexes against a per-row reference loop) and `test_mplfinance_dates.py` (3). Eight of the new tests fail on `main`; the vectorisation-only ones pass both ways, as an equal-output rewrite should.

## Verified

```
uv run pytest      3646 passed, 68 skipped
ruff check         only the 6 pre-existing F401s in untouched __init__.py files
```

The `returnfig`/`plt.show` behaviour and the addplot label rewriting in `mplfinance.py` are untouched here (#717).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_