### PR TITLE
perf(stripplot): name each distinct colour once rather than every point

### DIFF
--- a/maidr/patch/stripplot.py
+++ b/maidr/patch/stripplot.py
@@ -43,6 +43,13 @@ def _point_colours(collection: PathCollection) -> list:
     the seaborn release that ends it turns a test red rather than this branch
     silently load-bearing.
 
+    The rows are converted per *distinct* row rather than per point. The
+    collection holds one colour per hue level, repeated down the panel, so
+    50,000 points are a handful of colours -- and ``to_rgba`` on every one of
+    them was over a second on a chart that size (#718). The same row gets the
+    same conversion either way, ``None`` included, so what comes back is
+    identical; only the number of calls changes.
+
     Parameters
     ----------
     collection : PathCollection
@@ -58,7 +65,11 @@ def _point_colours(collection: PathCollection) -> list:
     count = len(np.asarray(collection.get_offsets()))
     if len(rows) != count:
         return [None] * count
-    return [_rgba(row) for row in rows]
+    distinct, inverse = np.unique(rows, axis=0, return_inverse=True)
+    named = [_rgba(row) for row in distinct]
+    # numpy 2.0 shapes the inverse `(n, 1)` for `axis=0`; later releases and
+    # earlier ones give `(n,)`. Ravelled so it indexes either way.
+    return [named[index] for index in np.asarray(inverse).ravel()]
 
 
 def _hue_colours(plotter: Any) -> dict | None:

--- a/tests/core/plot/test_categorical_scatter_hue.py
+++ b/tests/core/plot/test_categorical_scatter_hue.py
@@ -483,6 +483,78 @@ class TestTheAssumptionTheGroupingRestsOn:
                 assert rows == len(np.asarray(collection.get_offsets()))
 
 
+class TestHowThePointColoursAreRead:
+    """
+    One conversion per distinct colour, one answer per point (#718).
+
+    ``_point_colours`` used to run ``to_rgba`` on every row, and a collection
+    of 50,000 points coloured by a two-level hue is 50,000 calls that return
+    two values between them: measured, over a second on top of a 370 ms draw.
+    Converting each distinct row once and fanning the result back out is the
+    same list, point for point.
+    """
+
+    def test_every_point_is_named_as_if_converted_on_its_own(self):
+        # Equality against the per-row spelling, on a translucent chart so
+        # the rows carry an alpha `to_rgba` has to keep, and on every one of
+        # the collections rather than a chosen one.
+        from maidr.core.plot.scatterplot import _rgba
+        from maidr.patch.stripplot import _point_colours
+
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", alpha=0.4, ax=ax)
+
+        for collection in ax.collections:
+            expected = [_rgba(row) for row in collection.get_facecolor()]
+            assert _point_colours(collection) == expected
+            assert len(expected) == len(collection.get_offsets())
+            # Two levels drawn, so two colours -- the reason the per-distinct
+            # conversion is worth having at all.
+            assert len(set(expected)) == 2
+
+    def test_a_row_count_that_does_not_match_the_points_still_declines(self):
+        # The guard the docstring describes: rows that do not correspond to
+        # the points answer `None` per point rather than a colour each,
+        # before any conversion happens. Monkeypatched, because seaborn never
+        # produces the mismatch (the test above pins that).
+        from maidr.patch.stripplot import _point_colours
+
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", ax=ax)
+        collection = ax.collections[0]
+        count = len(collection.get_offsets())
+        assert count > 1
+
+        # Read once, then patched in: matplotlib's `get_facecolors` alias
+        # dispatches back to the instance's `get_facecolor`, so a lambda that
+        # called either would be calling itself.
+        one_row = collection.get_facecolor()[:1]
+        collection.get_facecolor = lambda: one_row
+
+        assert _point_colours(collection) == [None] * count
+
+    def test_each_distinct_colour_is_converted_once(self, monkeypatch):
+        # The change itself, pinned by count rather than by clock: a
+        # collection of six points in two colours is two conversions, not
+        # six. A conversion per point would pass every equality test above
+        # and cost the second #718 measured back.
+        import maidr.patch.stripplot as stripplot
+
+        figure, ax = plt.subplots()
+        sns.stripplot(data=frame(), x="cat", y="val", hue="hue", ax=ax)
+        collection = ax.collections[0]
+        rows = np.asarray(collection.get_facecolor())
+        assert len(rows) == 6
+
+        converted = []
+        monkeypatch.setattr(
+            stripplot, "_rgba", lambda row: converted.append(row) or tuple(row)
+        )
+        stripplot._point_colours(collection)
+
+        assert len(converted) == len(np.unique(rows, axis=0)) == 2
+
+
 class TestHighlighting:
     def test_each_point_is_addressed_by_an_element_of_its_own(self):
         # A group spans several collections, so its selectors have to name

--- a/tests/core/plot/test_categorical_scatter_hue.py
+++ b/tests/core/plot/test_categorical_scatter_hue.py
@@ -501,7 +501,7 @@ class TestHowThePointColoursAreRead:
         from maidr.core.plot.scatterplot import _rgba
         from maidr.patch.stripplot import _point_colours
 
-        figure, ax = plt.subplots()
+        _, ax = plt.subplots()
         sns.stripplot(data=frame(), x="cat", y="val", hue="hue", alpha=0.4, ax=ax)
 
         for collection in ax.collections:
@@ -519,7 +519,7 @@ class TestHowThePointColoursAreRead:
         # produces the mismatch (the test above pins that).
         from maidr.patch.stripplot import _point_colours
 
-        figure, ax = plt.subplots()
+        _, ax = plt.subplots()
         sns.stripplot(data=frame(), x="cat", y="val", hue="hue", ax=ax)
         collection = ax.collections[0]
         count = len(collection.get_offsets())
@@ -540,7 +540,7 @@ class TestHowThePointColoursAreRead:
         # and cost the second #718 measured back.
         import maidr.patch.stripplot as stripplot
 
-        figure, ax = plt.subplots()
+        _, ax = plt.subplots()
         sns.stripplot(data=frame(), x="cat", y="val", hue="hue", ax=ax)
         collection = ax.collections[0]
         rows = np.asarray(collection.get_facecolor())


### PR DESCRIPTION
## What

`_point_colours` in `maidr/patch/stripplot.py` did `[_rgba(row) for row in rows]` over the collection's facecolor array — one `matplotlib.colors.to_rgba` plus `np.round` per point — for a collection that carries one colour per hue level. Closes #718.

It now takes `np.unique(rows, axis=0, return_inverse=True)`, converts each distinct row once and fans the names out through the inverse (ravelled for numpy 2.0's `(n, 1)` shape). The returned list is identical; `_collection_category` is left alone (stripplot jitters every x, so `np.unique` does not help there).

## Measured (50k-point `sns.stripplot` with two hue levels, min of 3)

| | before | after |
|---|---|---|
| registration overhead over draw-only | 1 196 ms (320 %) | 87 ms (31 %) |
| `_point_colours` over the five collections | 1 107 ms | 69 ms |

## Tests

`tests/core/plot/test_categorical_scatter_hue.py` gains `TestHowThePointColoursAreRead`: the result equals the per-row spelling on an `alpha=0.4` chart, a row-count mismatch still answers `[None] * n`, and `_rgba` is called once per distinct colour (six times on `main`, twice here).

## Verified

```
uv run pytest      3607 passed, 68 skipped
ruff check         All checks passed (changed files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_