### PR TITLE
fix(line): read a band's edges per position and in numpy so a signed area is not an interval

### DIFF
--- a/maidr/util/confidence_band.py
+++ b/maidr/util/confidence_band.py
@@ -165,6 +165,12 @@ def edges_of(collection, x_data: np.ndarray, y_data: np.ndarray) -> tuple | None
     between vertices is also what matplotlib does to draw the band, so it
     reads the same shape the reader sees.
 
+    Read in numpy rather than vertex by vertex. The ring is sorted by (x, y),
+    so each column's lowest vertex is where its run starts and its highest is
+    the run's maximum -- the same lowest-and-highest-at-each-x the module
+    docstring describes, without a Python loop over what is, for a long line,
+    a couple of hundred thousand vertices (#714).
+
     Parameters
     ----------
     collection : matplotlib.collections.PolyCollection
@@ -180,21 +186,26 @@ def edges_of(collection, x_data: np.ndarray, y_data: np.ndarray) -> tuple | None
         Lower and upper bounds at each x, or ``None`` when this region is not
         this series' band.
     """
-    by_x: dict = {}
-    for path in collection.get_paths():
-        for x, y in path.vertices:
-            if not (np.isfinite(x) and np.isfinite(y)):
-                continue
-            key = float(x)
-            low, high = by_x.get(key, (float(y), float(y)))
-            by_x[key] = (min(low, float(y)), max(high, float(y)))
-
-    if len(by_x) < 2:
+    paths = collection.get_paths()
+    if not paths:
+        return None
+    # Every path, not only the first: `fill_between(..., where=...)` draws one
+    # polygon per run, and the band is all of them.
+    vertices = np.concatenate(
+        [np.asarray(path.vertices, dtype=float) for path in paths]
+    )
+    vertices = vertices[np.isfinite(vertices).all(axis=1)]
+    if len(vertices) == 0:
         return None
 
-    band_x = np.array(sorted(by_x))
-    lower = np.interp(x_data, band_x, np.array([by_x[x][0] for x in band_x]))
-    upper = np.interp(x_data, band_x, np.array([by_x[x][1] for x in band_x]))
+    order = np.lexsort((vertices[:, 1], vertices[:, 0]))
+    xs, ys = vertices[order, 0], vertices[order, 1]
+    band_x, start = np.unique(xs, return_index=True)
+    if len(band_x) < 2:
+        return None
+
+    lower = np.interp(x_data, band_x, ys[start])
+    upper = np.interp(x_data, band_x, np.maximum.reduceat(ys, start))
 
     # `np.interp` clamps outside the region's own x range, so a region that
     # does not span the series would still return numbers -- the bracketing
@@ -215,8 +226,16 @@ def edges_of(collection, x_data: np.ndarray, y_data: np.ndarray) -> tuple | None
     # whose edge coincides with the series throughout is not this series'
     # interval. Isolated contact is fine, and has to be: a real band can meet
     # its line at an endpoint.
-    on_upper = np.all(np.abs(upper - y_data) <= _TOLERANCE)
-    on_lower = np.all(np.abs(lower - y_data) <= _TOLERANCE)
-    if on_upper or on_lower:
+    #
+    # Per position, not per edge. An area under a series that changes sign
+    # switches edges where it crosses the baseline -- the line is on the upper
+    # edge where y > 0 and on the lower where y < 0 -- so it is on neither
+    # edge *throughout* and a whole-series test let it through as a band
+    # (#714). An area is on one edge or the other everywhere; a band is off
+    # both almost everywhere.
+    on_edge = (np.abs(upper - y_data) <= _TOLERANCE) | (
+        np.abs(lower - y_data) <= _TOLERANCE
+    )
+    if np.all(on_edge):
         return None
     return lower, upper

--- a/maidr/util/confidence_band.py
+++ b/maidr/util/confidence_band.py
@@ -165,11 +165,12 @@ def edges_of(collection, x_data: np.ndarray, y_data: np.ndarray) -> tuple | None
     between vertices is also what matplotlib does to draw the band, so it
     reads the same shape the reader sees.
 
-    Read in numpy rather than vertex by vertex. The ring is sorted by (x, y),
-    so each column's lowest vertex is where its run starts and its highest is
-    the run's maximum -- the same lowest-and-highest-at-each-x the module
-    docstring describes, without a Python loop over what is, for a long line,
-    a couple of hundred thousand vertices (#714).
+    Read in NumPy rather than vertex by vertex. The ring's vertices are
+    concatenated and sorted by (x, y) first, so each column's lowest vertex is
+    where its run starts and its highest is the run's maximum -- the same
+    lowest-and-highest-at-each-x the module docstring describes, without a
+    Python loop over what is, for a long line, a couple of hundred thousand
+    vertices (#714).
 
     Parameters
     ----------

--- a/tests/core/plot/test_line_confidence_band.py
+++ b/tests/core/plot/test_line_confidence_band.py
@@ -123,6 +123,81 @@ def test_an_area_from_an_explicit_zero_floor_is_not_one_either():
     assert _band(_series(fig)[0][0]) is None
 
 
+def test_an_area_under_a_series_that_changes_sign_is_not_one_either():
+    # The case a whole-series test misses (#714). An area under a signed
+    # series switches edges where it crosses the baseline: the line sits on
+    # the region's *upper* edge where y > 0 and on its *lower* edge where
+    # y < 0, so it is on neither edge throughout and was read as a band --
+    # "0.05, between 0 and 0.05" at every point. The test is per position: an
+    # area is on one edge or the other everywhere, a band is off both.
+    signed = np.sin(X)
+    fig, ax = plt.subplots()
+    ax.plot(X, signed)
+    ax.fill_between(X, 0, signed)
+
+    assert [_band(point) for point in _series(fig)[0]] == [None] * X.size
+
+
+def test_a_band_that_touches_its_line_at_one_endpoint_is_still_attached():
+    # The other side of the per-position rule. A real band can meet its line
+    # at an endpoint -- a regression's does, where the fit is pinned -- and
+    # isolated contact must not read as an area.
+    lower, upper = Y - 0.3, Y + 0.3
+    lower[0] = upper[0] = Y[0]
+    fig, ax = plt.subplots()
+    ax.plot(X, Y)
+    ax.fill_between(X, lower, upper)
+
+    points = _series(fig)[0]
+    assert _band(points[0]) == (round(Y[0], 3), round(Y[0], 3))
+    assert _band(points[1]) == (round(Y[1] - 0.3, 3), round(Y[1] + 0.3, 3))
+
+
+def test_the_edges_are_the_lowest_and_highest_vertex_at_each_x():
+    # Read straight off a ring that repeats x values -- as matplotlib's do,
+    # running out along one edge and back along the other -- with a
+    # non-finite vertex that has to be left out rather than poison the
+    # column it sits in.
+    from matplotlib.collections import PolyCollection
+
+    from maidr.util.confidence_band import edges_of
+
+    ring = [
+        (0.0, 1.0),
+        (1.0, 2.0),
+        (2.0, 1.0),
+        (2.0, 3.0),
+        (1.0, 4.0),
+        (0.0, 3.0),
+        (1.0, np.nan),
+        (0.0, 1.0),
+    ]
+    region = PolyCollection([ring])
+
+    lower, upper = edges_of(
+        region, np.array([0.0, 1.0, 2.0]), np.array([2.0, 3.0, 2.0])
+    )
+    assert lower.tolist() == [1.0, 2.0, 1.0]
+    assert upper.tolist() == [3.0, 4.0, 3.0]
+
+
+def test_a_where_region_with_several_paths_is_read_across_all_of_them():
+    # `fill_between(..., where=...)` draws one polygon per run, so the band
+    # is several paths and every one of them has to be read.
+    from maidr.util.confidence_band import edges_of
+
+    line = X.copy()
+    shown = (X < 4) | (X > 6)
+    fig, ax = plt.subplots()
+    ax.plot(X, line)
+    region = ax.fill_between(X, line - 0.3, line + 0.3, where=shown)
+    assert len(region.get_paths()) == 2
+
+    lower, upper = edges_of(region, X[shown], line[shown])
+    assert np.allclose(lower, line[shown] - 0.3)
+    assert np.allclose(upper, line[shown] + 0.3)
+
+
 def test_each_line_gets_its_own_band():
     # Two lines and two bands. The lower band is wide enough to bracket only
     # its own line, but a region is claimed by one series either way -- so


### PR DESCRIPTION
## What

Two problems in `maidr/util/confidence_band.py::edges_of`, fixed together because they are the same function. Closes #714.

**A signed area read as a band.** An *area* was rejected only when the line coincided with the upper edge throughout **or** the lower edge throughout — the guard the comment describes against announcing "an interval it does not state". A series with the region under it shaded (`ax.plot(x, y); ax.fill_between(x, 0, y)` with `y = sin(x)`: returns, anomalies, residuals) sits on the upper edge where `y > 0` and the lower where `y < 0`, so neither test fired and every point was announced with `yMin`/`yMax` spanning `0..y`. The test is now per position — a band is off both edges almost everywhere, an area is on one or the other everywhere — which is a strict superset of the old rejection: every region rejected before still is; a hand band, an `sns.lineplot` CI band, a regplot band and a band touching its line at one endpoint are still attached.

**Every vertex walked in Python.** `edges_of` iterated `for x, y in path.vertices` building a dict per x, once per (line, unclaimed region): 1.75 s for a 100k-point band here, and up to L(L+1)/2 passes on a chart with L lines and L bands drawn out of order. The vertices are now concatenated, non-finite rows dropped, `lexsort`ed by (x, y), `np.unique(..., return_index=True)` gives the lows and `np.maximum.reduceat` the highs; `np.interp` and the bracketing are unchanged, so the same floats flow through — the returned lower/upper arrays are `tobytes()`-identical. No cross-line cache was added.

## Measured (100k-point line + band, min of 3, loaded box)

| | before | after |
|---|---|---|
| `edges_of` | 1.750 s | 0.052 s |
| cold end-to-end `Maidr.render()` | 6.52 s | 4.23 s |

`Maidr.render()` caches each layer's schema after the first call, so only cold renders show the saving.

## Tests

`tests/core/plot/test_line_confidence_band.py`: `test_an_area_under_a_series_that_changes_sign_is_not_one_either` (fails on `main`); a band touching its line at an endpoint is still attached; a hand-built `PolyCollection` whose ring repeats x values and carries a NaN vertex yields the lowest/highest vertex per x; a `where=` region with several paths is read across all of them. The 14 band/area-related files (334 tests) pass unchanged.

## Verified

```
uv run pytest      3608 passed, 68 skipped
ruff check         All checks passed (changed files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_