### PR TITLE
test(suite): keep a missing shiny or plotly from skipping the whole collection and close figures after each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,21 @@ def offline_cdn_version(monkeypatch):
     cdn.set_cdn_version(None)
 
 
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every pyplot figure a test leaves open.
+
+    Most tests build figures with ``plt.subplots()`` and never close them,
+    so isolation used to rest on whichever later test happened to call
+    ``plt.close("all")``, and a test that reads ``plt.gcf()``/``plt.gca()``
+    before drawing inherited the previous test's figure.  Closing here
+    makes each test start from an empty ``Gcf``; it is a no-op when
+    nothing is open.
+    """
+    yield
+    plt.close("all")
+
+
 # setup and teardown
 @pytest.fixture
 def plot_fixture():

--- a/tests/plotly/conftest.py
+++ b/tests/plotly/conftest.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-plotly = pytest.importorskip("plotly")
-import plotly.graph_objects as go  # noqa: E402
+# Not ``pytest.importorskip`` at module scope: the ``Skipped`` it raises
+# escapes a conftest, and on pytest 7 that skips the *session* being
+# collected -- zero tests, exit 5 -- rather than this directory.  Each
+# fixture skips instead, which pytest scopes to the test asking for it;
+# the modules in this directory guard their own ``plotly`` imports.
+try:
+    import plotly.graph_objects as go
+except ImportError:  # pragma: no cover - only without the plotly extra
+    go = None
 
 
 @pytest.fixture
 def plotly_bar_fig():
     """Create a simple Plotly bar chart."""
+    pytest.importorskip("plotly")
     fig = go.Figure(
         data=[go.Bar(x=["A", "B", "C"], y=[10, 20, 30])],
         layout=go.Layout(
@@ -24,6 +32,7 @@ def plotly_bar_fig():
 @pytest.fixture
 def plotly_scatter_fig():
     """Create a simple Plotly scatter plot."""
+    pytest.importorskip("plotly")
     fig = go.Figure(
         data=[go.Scatter(x=[1, 2, 3], y=[4, 5, 6], mode="markers")],
         layout=go.Layout(
@@ -38,6 +47,7 @@ def plotly_scatter_fig():
 @pytest.fixture
 def plotly_line_fig():
     """Create a simple Plotly line chart."""
+    pytest.importorskip("plotly")
     fig = go.Figure(
         data=[go.Scatter(x=[1, 2, 3], y=[10, 20, 15], mode="lines", name="Series A")],
         layout=go.Layout(
@@ -52,6 +62,7 @@ def plotly_line_fig():
 @pytest.fixture
 def plotly_box_fig():
     """Create a simple Plotly box plot from raw data."""
+    pytest.importorskip("plotly")
     np.random.seed(42)
     fig = go.Figure(
         data=[go.Box(y=np.random.randn(50).tolist(), name="Group A")],
@@ -66,6 +77,7 @@ def plotly_box_fig():
 @pytest.fixture
 def plotly_heatmap_fig():
     """Create a simple Plotly heatmap."""
+    pytest.importorskip("plotly")
     fig = go.Figure(
         data=[
             go.Heatmap(
@@ -86,6 +98,7 @@ def plotly_heatmap_fig():
 @pytest.fixture
 def plotly_histogram_fig():
     """Create a simple Plotly histogram."""
+    pytest.importorskip("plotly")
     np.random.seed(42)
     fig = go.Figure(
         data=[go.Histogram(x=np.random.randn(100).tolist())],
@@ -101,6 +114,7 @@ def plotly_histogram_fig():
 @pytest.fixture
 def plotly_pie_fig():
     """Create a simple Plotly pie chart."""
+    pytest.importorskip("plotly")
     fig = go.Figure(
         data=[go.Pie(labels=["Apples", "Bananas", "Cherries"], values=[30, 50, 20])],
         layout=go.Layout(
@@ -115,6 +129,7 @@ def plotly_pie_fig():
 @pytest.fixture
 def plotly_dodged_fig():
     """Create a grouped (dodged) bar chart."""
+    pytest.importorskip("plotly")
     fig = go.Figure(
         data=[
             go.Bar(name="Male", x=["A", "B"], y=[10, 20]),
@@ -133,6 +148,7 @@ def plotly_dodged_fig():
 @pytest.fixture
 def plotly_stacked_fig():
     """Create a stacked bar chart."""
+    pytest.importorskip("plotly")
     fig = go.Figure(
         data=[
             go.Bar(name="Q1", x=["A", "B"], y=[10, 20]),
@@ -151,6 +167,7 @@ def plotly_stacked_fig():
 @pytest.fixture
 def plotly_multiline_fig():
     """Create a multi-line chart."""
+    pytest.importorskip("plotly")
     fig = go.Figure(
         data=[
             go.Scatter(x=[1, 2, 3], y=[10, 20, 15], mode="lines", name="A"),

--- a/tests/plotly/test_api_plotly.py
+++ b/tests/plotly/test_api_plotly.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_area.py
+++ b/tests/plotly/test_plotly_area.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import pandas as pd  # noqa: E402
 import plotly.express as px  # noqa: E402

--- a/tests/plotly/test_plotly_bar_category_order.py
+++ b/tests/plotly/test_plotly_bar_category_order.py
@@ -47,7 +47,7 @@ import warnings
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402

--- a/tests/plotly/test_plotly_bar_category_order.py
+++ b/tests/plotly/test_plotly_bar_category_order.py
@@ -45,10 +45,12 @@ from __future__ import annotations
 
 import warnings
 
-import plotly.graph_objects as go
 import pytest
 
-from maidr.plotly.plotly_maidr import PlotlyMaidr
+plotly = pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 warnings.filterwarnings("ignore")
 

--- a/tests/plotly/test_plotly_bar_orientation.py
+++ b/tests/plotly/test_plotly_bar_orientation.py
@@ -24,11 +24,13 @@ from __future__ import annotations
 
 import warnings
 
-import plotly.graph_objects as go
 import pytest
 
-from maidr.core.enum.maidr_key import MaidrKey
-from maidr.plotly.plotly_maidr import PlotlyMaidr
+plotly = pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 warnings.filterwarnings("ignore")
 

--- a/tests/plotly/test_plotly_bar_orientation.py
+++ b/tests/plotly/test_plotly_bar_orientation.py
@@ -26,7 +26,7 @@ import warnings
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 
 from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402

--- a/tests/plotly/test_plotly_barmode.py
+++ b/tests/plotly/test_plotly_barmode.py
@@ -39,7 +39,7 @@ import pytest
 # `plotly` is an optional extra, so guard the import the way every other file
 # in this directory does -- without it, a minimal install fails at *collection*
 # rather than skipping.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 pd = pytest.importorskip("pandas")
 
 import plotly.express as px  # noqa: E402

--- a/tests/plotly/test_plotly_barnorm.py
+++ b/tests/plotly/test_plotly_barnorm.py
@@ -37,7 +37,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import pandas as pd  # noqa: E402
 import plotly.express as px  # noqa: E402

--- a/tests/plotly/test_plotly_box_selectors.py
+++ b/tests/plotly/test_plotly_box_selectors.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 np = pytest.importorskip("numpy")
 
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_candlestick.py
+++ b/tests/plotly/test_plotly_candlestick.py
@@ -28,7 +28,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_choropleth.py
+++ b/tests/plotly/test_plotly_choropleth.py
@@ -25,7 +25,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_contour.py
+++ b/tests/plotly/test_plotly_contour.py
@@ -45,7 +45,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_contour_holes.py
+++ b/tests/plotly/test_plotly_contour_holes.py
@@ -40,7 +40,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_drawn_positions.py
+++ b/tests/plotly/test_plotly_drawn_positions.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_empty_layers.py
+++ b/tests/plotly/test_plotly_empty_layers.py
@@ -31,7 +31,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_empty_series_alignment.py
+++ b/tests/plotly/test_plotly_empty_series_alignment.py
@@ -22,7 +22,7 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.plotly.multiline import PlotlyMultiLinePlot
 from maidr.plotly.step import PlotlyStepPlot
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 
 def _step(x: list, y: list, name: str) -> dict:

--- a/tests/plotly/test_plotly_funnel.py
+++ b/tests/plotly/test_plotly_funnel.py
@@ -39,7 +39,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_funnelarea.py
+++ b/tests/plotly/test_plotly_funnelarea.py
@@ -38,7 +38,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_gauge.py
+++ b/tests/plotly/test_plotly_gauge.py
@@ -30,7 +30,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_generated_positions.py
+++ b/tests/plotly/test_plotly_generated_positions.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_geo.py
+++ b/tests/plotly/test_plotly_geo.py
@@ -29,7 +29,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 from plotly.subplots import make_subplots  # noqa: E402

--- a/tests/plotly/test_plotly_grouped_histogram.py
+++ b/tests/plotly/test_plotly_grouped_histogram.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import pandas as pd  # noqa: E402
 import plotly.express as px  # noqa: E402

--- a/tests/plotly/test_plotly_grouped_histogram_orientation.py
+++ b/tests/plotly/test_plotly_grouped_histogram_orientation.py
@@ -27,7 +27,7 @@ import warnings
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 
 from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402

--- a/tests/plotly/test_plotly_grouped_histogram_orientation.py
+++ b/tests/plotly/test_plotly_grouped_histogram_orientation.py
@@ -25,11 +25,13 @@ from __future__ import annotations
 
 import warnings
 
-import plotly.graph_objects as go
 import pytest
 
-from maidr.core.enum.maidr_key import MaidrKey
-from maidr.plotly.plotly_maidr import PlotlyMaidr
+plotly = pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.core.enum.maidr_key import MaidrKey  # noqa: E402
+from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
 
 warnings.filterwarnings("ignore")
 

--- a/tests/plotly/test_plotly_heatmap_category_order.py
+++ b/tests/plotly/test_plotly_heatmap_category_order.py
@@ -38,10 +38,12 @@ from __future__ import annotations
 
 import warnings
 
-import plotly.graph_objects as go
 import pytest
 
-from maidr.plotly.heatmap import PlotlyHeatmapPlot
+plotly = pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.heatmap import PlotlyHeatmapPlot  # noqa: E402
 
 warnings.filterwarnings("ignore")
 

--- a/tests/plotly/test_plotly_heatmap_category_order.py
+++ b/tests/plotly/test_plotly_heatmap_category_order.py
@@ -40,7 +40,7 @@ import warnings
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 
 from maidr.plotly.heatmap import PlotlyHeatmapPlot  # noqa: E402

--- a/tests/plotly/test_plotly_heatmap_row_order.py
+++ b/tests/plotly/test_plotly_heatmap_row_order.py
@@ -28,10 +28,12 @@ from __future__ import annotations
 
 import warnings
 
-import plotly.graph_objects as go
 import pytest
 
-from maidr.plotly.heatmap import PlotlyHeatmapPlot
+plotly = pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+from maidr.plotly.heatmap import PlotlyHeatmapPlot  # noqa: E402
 
 warnings.filterwarnings("ignore")
 

--- a/tests/plotly/test_plotly_heatmap_row_order.py
+++ b/tests/plotly/test_plotly_heatmap_row_order.py
@@ -30,7 +30,7 @@ import warnings
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 
 from maidr.plotly.heatmap import PlotlyHeatmapPlot  # noqa: E402

--- a/tests/plotly/test_plotly_hidden_traces.py
+++ b/tests/plotly/test_plotly_hidden_traces.py
@@ -41,7 +41,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_hierarchy.py
+++ b/tests/plotly/test_plotly_hierarchy.py
@@ -28,7 +28,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_histogram2d.py
+++ b/tests/plotly/test_plotly_histogram2d.py
@@ -30,7 +30,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_histogram2dcontour.py
+++ b/tests/plotly/test_plotly_histogram2dcontour.py
@@ -38,7 +38,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_histogram_histfunc.py
+++ b/tests/plotly/test_plotly_histogram_histfunc.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_histogram_histnorm.py
+++ b/tests/plotly/test_plotly_histogram_histnorm.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_histogram_orientation.py
+++ b/tests/plotly/test_plotly_histogram_orientation.py
@@ -35,7 +35,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.express as px  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_image_layer_position.py
+++ b/tests/plotly/test_plotly_image_layer_position.py
@@ -54,7 +54,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_line_series_pass.py
+++ b/tests/plotly/test_plotly_line_series_pass.py
@@ -22,7 +22,7 @@ from maidr.plotly.multiline import PlotlyMultiLinePlot
 from maidr.plotly.plotly_plot import PlotlyPlot
 from maidr.plotly.step import PlotlyStepPlot
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 
 def _step(x, y, name: str) -> dict:

--- a/tests/plotly/test_plotly_maidr.py
+++ b/tests/plotly/test_plotly_maidr.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_mode_default.py
+++ b/tests/plotly/test_plotly_mode_default.py
@@ -19,7 +19,7 @@ from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_maidr import PlotlyMaidr
 from maidr.plotly.step_shape import default_mode, is_connected_line_trace
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 
 

--- a/tests/plotly/test_plotly_parcats.py
+++ b/tests/plotly/test_plotly_parcats.py
@@ -30,7 +30,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_parcoords.py
+++ b/tests/plotly/test_plotly_parcoords.py
@@ -31,7 +31,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_plot_factory.py
+++ b/tests/plotly/test_plotly_plot_factory.py
@@ -13,7 +13,7 @@ from maidr.plotly.histogram import PlotlyHistogramPlot
 from maidr.plotly.pie import PlotlyPiePlot
 from maidr.plotly.candlestick import PlotlyCandlestickPlot
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 
 class TestPlotlyPlotFactory:

--- a/tests/plotly/test_plotly_plot_factory.py
+++ b/tests/plotly/test_plotly_plot_factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
@@ -11,6 +12,8 @@ from maidr.plotly.heatmap import PlotlyHeatmapPlot
 from maidr.plotly.histogram import PlotlyHistogramPlot
 from maidr.plotly.pie import PlotlyPiePlot
 from maidr.plotly.candlestick import PlotlyCandlestickPlot
+
+plotly = pytest.importorskip("plotly")
 
 
 class TestPlotlyPlotFactory:

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -15,7 +15,7 @@ from maidr.plotly.grouped_bar import PlotlyGroupedBarPlot
 from maidr.plotly.multiline import PlotlyMultiLinePlot
 from maidr.plotly.pie import PlotlyPiePlot
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 
 class TestPlotlyBarPlot:

--- a/tests/plotly/test_plotly_plots.py
+++ b/tests/plotly/test_plotly_plots.py
@@ -15,6 +15,8 @@ from maidr.plotly.grouped_bar import PlotlyGroupedBarPlot
 from maidr.plotly.multiline import PlotlyMultiLinePlot
 from maidr.plotly.pie import PlotlyPiePlot
 
+plotly = pytest.importorskip("plotly")
+
 
 class TestPlotlyBarPlot:
     def test_extract_data(self):

--- a/tests/plotly/test_plotly_polar.py
+++ b/tests/plotly/test_plotly_polar.py
@@ -32,7 +32,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 from plotly.subplots import make_subplots  # noqa: E402

--- a/tests/plotly/test_plotly_sankey.py
+++ b/tests/plotly/test_plotly_sankey.py
@@ -27,7 +27,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_scattergl.py
+++ b/tests/plotly/test_plotly_scattergl.py
@@ -22,7 +22,7 @@ from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_maidr import PlotlyMaidr
 from maidr.plotly.step_shape import renders_through_webgl
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 
 

--- a/tests/plotly/test_plotly_selector_positions.py
+++ b/tests/plotly/test_plotly_selector_positions.py
@@ -23,7 +23,7 @@ from maidr.plotly.multiline import PlotlyMultiLinePlot
 from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
 from maidr.plotly.step import PlotlyStepPlot
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 
 def _line(name: str = "") -> dict:

--- a/tests/plotly/test_plotly_splom.py
+++ b/tests/plotly/test_plotly_splom.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_step.py
+++ b/tests/plotly/test_plotly_step.py
@@ -11,7 +11,7 @@ from maidr.plotly.plotly_plot_factory import PlotlyPlotFactory
 from maidr.plotly.step import PlotlyStepPlot
 from maidr.plotly.step_shape import group_by_direction, step_direction_of
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 
 

--- a/tests/plotly/test_plotly_step_area.py
+++ b/tests/plotly/test_plotly_step_area.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/plotly/test_plotly_step_mixed.py
+++ b/tests/plotly/test_plotly_step_mixed.py
@@ -22,7 +22,7 @@ from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_maidr import PlotlyMaidr
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 import plotly.graph_objects as go  # noqa: E402
 from plotly.subplots import make_subplots  # noqa: E402
 

--- a/tests/plotly/test_plotly_trendline.py
+++ b/tests/plotly/test_plotly_trendline.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 pd = pytest.importorskip("pandas")
 
 import plotly.express as px  # noqa: E402

--- a/tests/plotly/test_plotly_typed_arrays.py
+++ b/tests/plotly/test_plotly_typed_arrays.py
@@ -21,7 +21,7 @@ from typing import Any
 import numpy as np
 import pytest
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 pd = pytest.importorskip("pandas")
 
 import plotly.express as px  # noqa: E402

--- a/tests/plotly/test_plotly_violin.py
+++ b/tests/plotly/test_plotly_violin.py
@@ -31,7 +31,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import numpy as np  # noqa: E402
 import plotly.graph_objects as go  # noqa: E402

--- a/tests/plotly/test_plotly_violin_stats.py
+++ b/tests/plotly/test_plotly_violin_stats.py
@@ -36,6 +36,8 @@ import pytest
 
 from maidr.plotly.violin_stats import violin_stats
 
+plotly = pytest.importorskip("plotly")
+
 #: Comfortably above the 5.9e-15 worst case measured across eight samples,
 #: and far below the ~1e-2 a wrong rule moves things by.
 _TOLERANCE = 1e-12

--- a/tests/plotly/test_plotly_violin_stats.py
+++ b/tests/plotly/test_plotly_violin_stats.py
@@ -36,7 +36,7 @@ import pytest
 
 from maidr.plotly.violin_stats import violin_stats
 
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 #: Comfortably above the 5.9e-15 worst case measured across eight samples,
 #: and far below the ~1e-2 a wrong rule moves things by.

--- a/tests/plotly/test_plotly_waterfall.py
+++ b/tests/plotly/test_plotly_waterfall.py
@@ -37,7 +37,7 @@ import pytest
 
 # `plotly` is an optional extra; guard it the way the rest of this directory
 # does, so a minimal install skips rather than failing at collection.
-plotly = pytest.importorskip("plotly")
+pytest.importorskip("plotly")
 
 import plotly.graph_objects as go  # noqa: E402
 

--- a/tests/test_collection_survives_missing_extras.py
+++ b/tests/test_collection_survives_missing_extras.py
@@ -43,7 +43,10 @@ def _collect_with_shadowed(package: str, tmp_path: pathlib.Path) -> str:
         f'raise ImportError("{package} is shadowed for this test")\n'
     )
 
-    env = dict(os.environ)
+    # Start from the caller's environment minus anything that steers pytest
+    # itself (``PYTEST_ADDOPTS``, ``PYTEST_PLUGINS``, ...): the run has to
+    # reflect the repository's own defaults, not a developer's or a CI job's.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("PYTEST_")}
     env["PYTHONPATH"] = os.pathsep.join(
         p for p in (str(shadow.parent), env.get("PYTHONPATH", "")) if p
     )

--- a/tests/test_collection_survives_missing_extras.py
+++ b/tests/test_collection_survives_missing_extras.py
@@ -1,0 +1,122 @@
+"""Collection must survive a missing optional extra.
+
+``tests/widget/conftest.py`` and ``tests/plotly/conftest.py`` once called
+``pytest.importorskip`` at module scope.  ``Skipped`` is a
+``BaseException``, so pytest's conftest loader does not wrap it, and on
+the locked pytest 7 every sub-conftest is imported while the *session* is
+being collected: the session itself came out "skipped", zero tests were
+collected and pytest exited 5 -- which CI reads as a clean skip.  Anyone
+without the ``shiny`` or ``plotly`` extra (a ``uv sync --dev`` contributor,
+a downstream packager) ran nothing while looking green.
+
+Each case hides one package behind a shadow whose ``__init__`` raises
+``ImportError`` and collects the suite in a subprocess.  Collection must
+exit 0, the bulk of the suite must still be collected, and the modules
+that genuinely need the package must skip with a reason rather than
+vanish.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+#: Far above the 0 the bug gave, well below what survives either shadow:
+#: the suite has ~3 700 tests, ~1 300 of them under ``tests/plotly``.  The
+#: point is "the suite was collected", not a count that every new test file
+#: would have to update.
+PLENTY = 2000
+
+
+def _collect_with_shadowed(package: str, tmp_path: pathlib.Path) -> str:
+    """Collect the suite with ``package`` unimportable; return pytest's output."""
+    shadow = tmp_path / "shadow" / package
+    shadow.mkdir(parents=True)
+    (shadow / "__init__.py").write_text(
+        f'raise ImportError("{package} is shadowed for this test")\n'
+    )
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        p for p in (str(shadow.parent), env.get("PYTHONPATH", "")) if p
+    )
+    # The *installed* shiny registers a ``shiny-test`` pytest plugin that
+    # would import the shadow before collection starts and abort the run
+    # for a different reason.  An environment that really lacks the extra
+    # has no such plugin, so autoloading is off and the one plugin the
+    # suite relies on is named explicitly.
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "-rs",
+            "-p",
+            "no:cacheprovider",
+            "-p",
+            "pytest_mock",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        f"collection exited {result.returncode} with {package} shadowed:\n"
+        f"{result.stdout[-3000:]}\n{result.stderr[-3000:]}"
+    )
+    return result.stdout
+
+
+def _collected_count(output: str) -> int:
+    """The ``N tests collected`` figure from a ``--collect-only -q`` run."""
+    match = re.search(r"(\d+) tests? collected", output)
+    assert match, f"no collection summary in:\n{output[-2000:]}"
+    return int(match.group(1))
+
+
+def _skipped_modules(output: str) -> set[str]:
+    """The test files ``-rs`` reports as skipped during collection."""
+    return {
+        pathlib.Path(m).name
+        for m in re.findall(r"^SKIPPED \[\d+\] (tests/\S+?):\d+", output, re.M)
+    }
+
+
+@pytest.mark.parametrize(
+    ("package", "must_skip", "must_survive"),
+    [
+        (
+            "shiny",
+            {"test_shiny.py", "test_every_door_agrees.py"},
+            "tests/widget/test_streamlit.py::",
+        ),
+        (
+            "plotly",
+            {"test_plotly_maidr.py", "test_plotly_plots.py"},
+            "tests/core/test_figure_manager.py::",
+        ),
+    ],
+)
+def test_collection_survives_a_missing_extra(
+    package: str, must_skip: set[str], must_survive: str, tmp_path: pathlib.Path
+) -> None:
+    output = _collect_with_shadowed(package, tmp_path)
+
+    assert _collected_count(output) > PLENTY
+    assert must_survive in output
+    # The modules that need the package skip *with a reason*, which is
+    # what distinguishes "not installed here" from "silently dropped".
+    assert must_skip <= _skipped_modules(output), output[-3000:]

--- a/tests/widget/conftest.py
+++ b/tests/widget/conftest.py
@@ -5,6 +5,15 @@ session context -- without starting a server.  Only the three pieces of
 :class:`shiny.session.Session` that a renderer touches are stubbed:
 ``ns`` (namespacing), ``output`` (auto-registration) and ``_process_ui``
 (dependency resolution).
+
+Shiny is imported inside the fixture, not here.  ``pytest.importorskip``
+raises ``Skipped``, and a ``Skipped`` escaping a conftest is not "skip
+this directory": pytest 7 imports every sub-conftest while collecting the
+*session*, so the whole run collects nothing and exits 5, which CI reads
+as a clean skip.  The modules that need Shiny (``test_shiny.py``,
+``test_every_door_agrees.py``) guard themselves at module level, where a
+``Skipped`` means exactly one module; ``test_streamlit.py`` does not need
+it at all and must keep running without it.
 """
 
 from __future__ import annotations
@@ -12,12 +21,6 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-
-shiny = pytest.importorskip("shiny")
-
-from shiny import module  # noqa: E402
-from shiny.session import session_context  # noqa: E402
-from shiny.session._session import AppSession  # noqa: E402
 
 
 class FakeApp:
@@ -32,33 +35,49 @@ class FakeApp:
         self.registered.append(dep)
 
 
-class FakeSession:
-    """The subset of ``shiny.Session`` a custom renderer exercises."""
+def _fake_session_class() -> type:
+    """Build the ``FakeSession`` class against the installed Shiny.
 
-    ns = module.ResolvedId("")
+    Deferred so the two class attributes borrowed from Shiny are looked up
+    only once a test actually asks for a session -- see the module
+    docstring for why this file must import cleanly without Shiny.
+    """
+    from shiny import module
+    from shiny.session._session import AppSession
 
-    def __init__(self) -> None:
-        self.app = FakeApp()
-        self.outputs: list[Any] = []
+    class FakeSession:
+        """The subset of ``shiny.Session`` a custom renderer exercises."""
 
-    def output(self, renderer: Any) -> Any:
-        """Stand in for auto-registration via ``Renderer._auto_register``."""
-        self.outputs.append(renderer)
-        return renderer
+        ns = module.ResolvedId("")
 
-    # Borrowed from Shiny rather than reimplemented.  A hand-written copy
-    # would let the tests assert a payload shape this package invented:
-    # upstream could rename a key and every test would still pass while
-    # production broke.  ``AppSession._process_ui`` touches only
-    # ``self.app._register_web_dependency`` and ``self.app.lib_prefix``,
-    # both of which :class:`FakeApp` provides, so it runs unmodified --
-    # and an incompatible upstream change fails here loudly.
-    _process_ui = AppSession._process_ui
+        def __init__(self) -> None:
+            self.app = FakeApp()
+            self.outputs: list[Any] = []
+
+        def output(self, renderer: Any) -> Any:
+            """Stand in for auto-registration via ``Renderer._auto_register``."""
+            self.outputs.append(renderer)
+            return renderer
+
+        # Borrowed from Shiny rather than reimplemented.  A hand-written
+        # copy would let the tests assert a payload shape this package
+        # invented: upstream could rename a key and every test would still
+        # pass while production broke.  ``AppSession._process_ui`` touches
+        # only ``self.app._register_web_dependency`` and
+        # ``self.app.lib_prefix``, both of which :class:`FakeApp` provides,
+        # so it runs unmodified -- and an incompatible upstream change
+        # fails here loudly.
+        _process_ui = AppSession._process_ui
+
+    return FakeSession
 
 
 @pytest.fixture
 def fake_session():
-    """Yield a :class:`FakeSession` with its session context active."""
-    session = FakeSession()
+    """Yield a ``FakeSession`` with its session context active."""
+    pytest.importorskip("shiny")
+    from shiny.session import session_context
+
+    session = _fake_session_class()()
     with session_context(session):  # type: ignore[arg-type]
         yield session


### PR DESCRIPTION
## What

Closes #719.

**A conftest-level `importorskip` skipped the whole suite.** `tests/widget/conftest.py` did `pytest.importorskip("shiny")` at module scope and `tests/plotly/conftest.py` the same for plotly. `importorskip` raises `Skipped`, a `BaseException`; `_importconftest` wraps only `Exception`, so it escaped, and on the locked pytest 7.4 `Session.collect` imports every sub-conftest while the *Session* node is being collected — the whole session was reported `skipped`: **zero items, `no tests collected`, exit status 5**, which reads as a clean skip. Any environment without either optional package (a contributor's `uv sync --dev`, a downstream packager, a future CI job that narrows extras) ran nothing while looking green; `release.yml` already records that this class bit once. `tests/widget/conftest.py` now imports shiny inside the `fake_session` fixture and builds `FakeSession` lazily; `tests/plotly/conftest.py` imports `go` under `try`, every fixture `importorskip`s plotly, and the eight plotly modules that lacked their own guard gained one. The two shiny-only modules already guarded themselves correctly.

```
shiny shadowed:   before  no tests collected, exit 5
                  after   3630 tests collected, exit 0; test_streamlit.py's 35 tests run;
                          test_shiny.py and test_every_door_agrees.py skip with a reason
plotly shadowed:  before  no tests collected, exit 5
                  after   the rest of the suite collects; every tests/plotly module skips with a reason
```

**Figures leaked between tests.** Only the `axes` fixture and the fixture factories closed what they created; 894 of the core/patch/util tests left their figures open (peak 15) and isolation rested on unrelated tests calling `plt.close('all')`, while `plt.gcf()`/`plt.gca()` reads in two tests inherited whichever figure the previous test left current. `tests/conftest.py` gains an autouse `_close_figures` teardown.

**A guard test** (`tests/test_collection_survives_missing_extras.py`, parametrised over shiny and plotly) writes a shadow package whose `__init__` raises `ImportError`, runs `pytest --collect-only` in a subprocess with it first on `PYTHONPATH`, and asserts exit 0, well over 2 000 collected ids, the independent modules present, and the dependent modules reported as skipped. It fails on `main` with `collection exited 5 with shiny shadowed`. It adds ~25 s to a full run.

No change to emitted schema or HTML.

## Verified

```
uv run pytest      3606 passed, 68 skipped
ruff check tests   All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_