### PR TITLE
fix(step): resolve stepDirection from the data-bearing lines only

### DIFF
--- a/maidr/util/step_utils.py
+++ b/maidr/util/step_utils.py
@@ -171,7 +171,8 @@ def resolve_step_direction(lines: Iterable[Line2D]) -> Optional[str]:
         return None
 
     directions = {
-        STEP_DRAWSTYLE_TO_DIRECTION.get(str(line.get_drawstyle())) for line in lines
+        STEP_DRAWSTYLE_TO_DIRECTION.get(str(line.get_drawstyle()))
+        for line in data_lines
     }
     if len(directions) != 1:
         return None

--- a/tests/core/plot/test_stepplot.py
+++ b/tests/core/plot/test_stepplot.py
@@ -422,6 +422,40 @@ class TestStepUtils:
         finally:
             plt.close(fig)
 
+    def test_a_companion_line_emptied_after_plotting_keeps_the_direction(self):
+        """
+        ``resolve_step_direction`` reads the same lines ``is_step_layer`` does.
+
+        Both helpers filter to data-bearing lines, and the docstrings promise
+        they make the same decision at registration and at render. A companion
+        line drained with ``set_data([], [])`` after plotting is the ordinary
+        way the two used to disagree: the layer stayed ``step`` while the
+        empty line's default drawstyle voted against the step line's, and the
+        direction silently went missing.
+        """
+        fig, ax = plt.subplots()
+        try:
+            ax.plot([0, 1, 2], [1, 2, 3], drawstyle="steps-post")
+            (companion,) = ax.plot([1, 2], [1, 2])
+            companion.set_data([], [])
+            layer = _only_layer(fig)
+
+            assert layer["type"] == PlotType.STEP
+            assert layer["stepDirection"] == "hv"
+        finally:
+            plt.close(fig)
+
+    def test_resolve_step_direction_accepts_a_one_shot_iterable(self):
+        """The parameter is typed ``Iterable``; an iterator must not be read twice."""
+        from maidr.util.step_utils import resolve_step_direction
+
+        fig, ax = plt.subplots()
+        try:
+            (step_line,) = ax.plot([0, 1, 2], [1, 2, 3], drawstyle="steps-post")
+            assert resolve_step_direction(iter([step_line])) == "hv"
+        finally:
+            plt.close(fig)
+
     def test_display_names_read_the_way_a_user_named_the_plot(self):
         """
         The fallback warning names plot types for users, not for the schema.

--- a/tests/core/plot/test_stepplot.py
+++ b/tests/core/plot/test_stepplot.py
@@ -445,6 +445,37 @@ class TestStepUtils:
         finally:
             plt.close(fig)
 
+    def test_a_step_line_emptied_after_plotting_drops_the_direction(self):
+        """
+        The mirror case: the step line is drained and a plain line survives.
+
+        The axes was classified ``step`` on the first plotting call and that
+        decision is never re-opened, so the layer keeps its type and the
+        surviving plain line rides in it (see
+        ``TestClassificationIsOrderDependent``). What the render-time helpers
+        see, though, is only the data-bearing lines — and the only one left
+        is not a step line. ``is_step_layer`` says so, and
+        ``resolve_step_direction`` must agree and return ``None`` rather than
+        report the drained line's ``hv``: the emitted payload no longer holds
+        a series that direction would describe.
+        """
+        from maidr.util.step_utils import is_step_layer, resolve_step_direction
+
+        fig, ax = plt.subplots()
+        try:
+            (step_line,) = ax.plot([0, 1, 2], [1, 2, 3], drawstyle="steps-post")
+            ax.plot([0, 1, 2], [3, 2, 1])
+            step_line.set_data([], [])
+            layer = _only_layer(fig)
+
+            assert is_step_layer(ax.get_lines()) is False
+            assert resolve_step_direction(ax.get_lines()) is None
+            assert layer["type"] == PlotType.STEP
+            assert "stepDirection" not in layer
+            assert len(layer["data"]) == 1  # only the surviving plain line
+        finally:
+            plt.close(fig)
+
     def test_resolve_step_direction_accepts_a_one_shot_iterable(self):
         """The parameter is typed ``Iterable``; an iterator must not be read twice."""
         from maidr.util.step_utils import resolve_step_direction


### PR DESCRIPTION
## Summary

`resolve_step_direction` filtered the layer's lines down to the data-bearing ones but only used that list for the emptiness check; the drawstyle set was built from the unfiltered iterable. That made it disagree with `is_step_layer`, whose docstring promises the two make the same decision at registration and at render:

- A step line whose companion was later drained with `set_data([], [])` still classified as `STEP`, but the empty line's default drawstyle outvoted the step line and `stepDirection` went missing from the schema.
- Passing an iterator (which the `Iterable`-typed parameter admits) always returned `None`, because `data_bearing_lines` consumed it before the comprehension ran.

The comprehension now iterates `data_lines`. The "step drawn first, plain line after" case still drops the direction, since that plain line does carry data.

Closes #716

## Testing

- Added `test_a_companion_line_emptied_after_plotting_keeps_the_direction` and `test_resolve_step_direction_accepts_a_one_shot_iterable` to `tests/core/plot/test_stepplot.py`; both fail before the fix and pass after.
- `test_step_drawn_first_keeps_the_axes_a_step_but_drops_the_direction` unchanged and passing.
- `pytest tests/core/plot/test_stepplot.py tests/util`: 85 passed. Full suite: 3697 passed, 68 skipped.
- `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_