### PR TITLE
fix(violin): match matplotlib dataset shapes and keep every violin's bottom level

### DIFF
--- a/maidr/core/plot/violin_kde_plot.py
+++ b/maidr/core/plot/violin_kde_plot.py
@@ -258,11 +258,19 @@ class ViolinKdePlot(MaidrPlot):
             np.array([p[1] for p in right]),
         )
 
-        li = np.argsort(left_y)
-        ri = np.argsort(right_y)
+        # One knot per y, sorted. The polygon repeats its start vertex as its
+        # closing vertex and its turn-around at the top, at identical x, so a
+        # side holds 103 knots for 100 distinct y. Built on those, interp1d
+        # asked for exactly y_min divided by the zero gap between the two
+        # bottom knots: scipy warned on the user's console on every render,
+        # the level came back NaN, and the guard below dropped it, so the
+        # emitted range began one level above the drawn one (#705).
+        # `np.unique` sorts, which is what `assume_sorted` relies on.
+        left_y, li = np.unique(left_y, return_index=True)
+        right_y, ri = np.unique(right_y, return_index=True)
 
         f_left = interpolate.interp1d(
-            left_y[li],
+            left_y,
             left_x[li],
             kind="linear",
             bounds_error=False,
@@ -270,7 +278,7 @@ class ViolinKdePlot(MaidrPlot):
             assume_sorted=True,
         )
         f_right = interpolate.interp1d(
-            right_y[ri],
+            right_y,
             right_x[ri],
             kind="linear",
             bounds_error=False,

--- a/maidr/core/plot/violinplot.py
+++ b/maidr/core/plot/violinplot.py
@@ -136,16 +136,32 @@ class ViolinDataExtractor:
         if isinstance(df, pd.DataFrame) and isinstance(val_col, str):
             return ["Violin"], [df[val_col].dropna().values]
 
-        # Case 3 — list/array as positional arg
-        if len(args) > 0:
-            data = args[0]
-            if isinstance(data, (list, tuple, np.ndarray)):
-                if len(data) > 0 and isinstance(data[0], (list, tuple, np.ndarray)):
-                    return (
-                        [f"Group {i + 1}" for i in range(len(data))],
-                        [np.asarray(d).flatten() for d in data],
-                    )
-                return ["Violin"], [np.asarray(data).flatten()]
+        # Case 3 — the dataset, positional or as `dataset=` (its real name)
+        data = args[0] if len(args) > 0 else kwargs.get("dataset", None)
+
+        # Counted the way matplotlib counts them. It hands the dataset to
+        # `cbook._reshape_2D`, which unpacks a DataFrame to an ndarray and
+        # then reads "2D ndarrays [as] the list of their *columns*", while
+        # "lists of iterables are converted by applying `numpy.asanyarray` to
+        # each of their elements". Applying the element rule to an array
+        # read the rows of a (100, 3) array as 100 violins of three values
+        # for the three matplotlib drew, and the column rule must not reach a
+        # list -- `[[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]]` is two violins, not
+        # five (#705).
+        if isinstance(data, pd.DataFrame):
+            data = data.to_numpy()
+        if isinstance(data, np.ndarray) and data.ndim == 2:
+            return (
+                [f"Group {j + 1}" for j in range(data.shape[1])],
+                [data[:, j] for j in range(data.shape[1])],
+            )
+        if isinstance(data, (list, tuple, np.ndarray)):
+            if len(data) > 0 and isinstance(data[0], (list, tuple, np.ndarray)):
+                return (
+                    [f"Group {i + 1}" for i in range(len(data))],
+                    [np.asarray(d).flatten() for d in data],
+                )
+            return ["Violin"], [np.asarray(data).flatten()]
 
         # Case 4 — data= (non-DataFrame)
         if "data" in kwargs and not isinstance(kwargs["data"], pd.DataFrame):

--- a/tests/core/plot/test_violin_dataset_shapes.py
+++ b/tests/core/plot/test_violin_dataset_shapes.py
@@ -57,8 +57,8 @@ def _box_layer(fig):
     return layers[0] if layers else None
 
 
-#: (label, positional dataset, keyword arguments) -- every shape
-#: ``Axes.violinplot`` accepts, with the violin count matplotlib gives each.
+#: ``(positional dataset, keyword arguments)`` pairs, one per shape
+#: ``Axes.violinplot`` accepts; the ``id`` names the shape.
 SHAPES = [
     pytest.param(LIST_OF_LISTS, {}, id="list of lists"),
     pytest.param(np.array(LIST_OF_LISTS), {}, id="ndarray of the same lists"),

--- a/tests/core/plot/test_violin_dataset_shapes.py
+++ b/tests/core/plot/test_violin_dataset_shapes.py
@@ -1,0 +1,115 @@
+"""
+The box layer of ``ax.violinplot`` counts datasets the way matplotlib does.
+
+Matplotlib hands the ``dataset`` argument to ``cbook._reshape_2D``, whose rule
+is: a list of iterables is one dataset per *element*, while a 2-D ndarray is
+one dataset per *column* (a DataFrame is unpacked to an ndarray first). The
+KDE layer is built from the ``bodies`` matplotlib drew and so always agrees
+with it. The box layer read the call's arguments itself and applied the list
+rule to everything, so a ``(100, 3)`` array -- three drawn violins -- emitted
+100 box records named ``Group 1..100``, each summarising three numbers, with
+100 ``nth-child`` selectors pointing at segments that do not exist. A
+DataFrame passed positionally, or any data passed as ``dataset=`` (the
+parameter's real name), was not recognised at all, and the box layer was
+silently not registered (#705).
+
+What these assert is the one thing a reader depends on: the box layer has
+exactly one record and one selector per violin matplotlib drew.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: E402,F401  # activates patches
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+#: Two violins of five values, the shape the orientation tests draw.
+LIST_OF_LISTS = [[1, 2, 3, 4, 9], [2, 3, 4, 5, 6]]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _rng() -> np.random.Generator:
+    return np.random.default_rng(705)
+
+
+def _box_layer(fig):
+    """The figure's ``violin_box`` layer, or ``None`` when none registered."""
+    layers = [
+        plot
+        for plot in FigureManager.get_maidr(fig).plots
+        if plot.type is PlotType.VIOLIN_BOX
+    ]
+    assert len(layers) <= 1, f"expected at most one box layer, got {len(layers)}"
+    return layers[0] if layers else None
+
+
+#: (label, positional dataset, keyword arguments) -- every shape
+#: ``Axes.violinplot`` accepts, with the violin count matplotlib gives each.
+SHAPES = [
+    pytest.param(LIST_OF_LISTS, {}, id="list of lists"),
+    pytest.param(np.array(LIST_OF_LISTS), {}, id="ndarray of the same lists"),
+    pytest.param(_rng().normal(size=(100, 3)), {}, id="ndarray (100, 3)"),
+    pytest.param(
+        [_rng().normal(size=100) for _ in range(3)], {}, id="list of 3 arrays"
+    ),
+    pytest.param([[1, 2, 3], [4, 5, 6, 7, 8]], {}, id="ragged list"),
+    pytest.param(_rng().normal(size=100), {}, id="1-D array"),
+    pytest.param(pd.DataFrame(_rng().normal(size=(100, 3))), {}, id="DataFrame"),
+]
+
+
+@pytest.mark.parametrize(("dataset", "kwargs"), SHAPES)
+def test_one_box_record_and_selector_per_drawn_violin(dataset, kwargs) -> None:
+    fig, ax = plt.subplots()
+    parts = ax.violinplot(dataset, **kwargs)
+    drawn = len(parts["bodies"])
+    assert drawn > 0
+
+    layer = _box_layer(fig)
+    assert layer is not None, "the box layer was not registered"
+    schema = layer.render()
+
+    assert len(schema["data"]) == drawn
+    assert len(schema["selectors"]) == drawn
+
+
+def test_dataset_keyword_gets_a_box_layer() -> None:
+    """``dataset=`` is the parameter's real name and reads like the positional."""
+    fig, ax = plt.subplots()
+    parts = ax.violinplot(dataset=[_rng().normal(size=100) for _ in range(3)])
+    drawn = len(parts["bodies"])
+    assert drawn == 3
+
+    layer = _box_layer(fig)
+    assert layer is not None, "the box layer was not registered"
+    schema = layer.render()
+
+    assert len(schema["data"]) == drawn
+    assert len(schema["selectors"]) == drawn
+
+
+def test_columns_of_a_2d_array_are_the_violins() -> None:
+    """Each box record summarises the column matplotlib drew, not a row of it."""
+    data = _rng().normal(size=(100, 3)) + np.array([0.0, 10.0, 20.0])
+    fig, ax = plt.subplots()
+    ax.violinplot(data)
+
+    layer = _box_layer(fig)
+    assert layer is not None
+    medians = [record["q2"] for record in layer.render()["data"]]
+
+    assert medians == pytest.approx([float(np.median(data[:, j])) for j in range(3)])

--- a/tests/core/plot/test_violin_kde_knots.py
+++ b/tests/core/plot/test_violin_kde_knots.py
@@ -1,0 +1,95 @@
+"""
+The KDE layer keeps the bottom level of every violin, and renders quietly.
+
+A violin polygon repeats its start vertex as its closing vertex and its
+turn-around at the top, so one side of the outline holds 103 knots for 100
+distinct y values -- the duplicates at the very bottom and the very top, at
+identical x. ``interp1d(assume_sorted=True)`` built on those knots and asked
+for exactly ``y_min`` divides by the zero gap between the two bottom knots:
+scipy printed ``invalid value encountered in divide`` to the user's console
+on every violin render, the level came back NaN, and the NaN guard silently
+dropped it. The emitted y range began one level above the drawn one (#705).
+
+Seaborn and matplotlib both draw the polygon this way, so both are covered.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+from matplotlib.collections import PolyCollection  # noqa: E402
+
+import maidr  # noqa: E402
+from maidr.core.enum.plot_type import PlotType  # noqa: E402
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _seaborn_violins():
+    rng = np.random.default_rng(705)
+    cats = [cat for cat in ("ash", "birch", "cedar") for _ in range(40)]
+    vals = np.concatenate([rng.normal(loc, 1.0, 40) for loc in range(3)]).tolist()
+    fig, ax = plt.subplots()
+    sns.violinplot(x=cats, y=vals, ax=ax)
+    return fig, ax
+
+
+def _matplotlib_violins():
+    rng = np.random.default_rng(705)
+    fig, ax = plt.subplots()
+    ax.violinplot([rng.normal(loc, 1.0, 40) for loc in range(3)])
+    return fig, ax
+
+
+FIGURES = [
+    pytest.param(_seaborn_violins, id="seaborn"),
+    pytest.param(_matplotlib_violins, id="matplotlib"),
+]
+
+
+def _kde_layer(fig):
+    layers = [
+        plot
+        for plot in FigureManager.get_maidr(fig).plots
+        if plot.type is PlotType.VIOLIN_KDE
+    ]
+    assert len(layers) == 1, f"expected one KDE layer, got {len(layers)}"
+    return layers[0]
+
+
+@pytest.mark.parametrize("draw", FIGURES)
+def test_render_raises_no_runtime_warning(draw) -> None:
+    """Nothing scipy has to say reaches a screen-reader user's console."""
+    fig, _ = draw()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        maidr.render(fig)
+
+
+@pytest.mark.parametrize("draw", FIGURES)
+def test_the_lowest_level_of_every_violin_is_read(draw) -> None:
+    """The emitted y range of each violin starts where the drawn polygon does."""
+    fig, ax = draw()
+    maidr.render(fig)
+    violins = _kde_layer(fig).schema["data"]
+
+    bodies = [c for c in ax.collections if isinstance(c, PolyCollection)]
+    assert len(bodies) == len(violins) == 3
+
+    for body, points in zip(bodies, violins):
+        drawn_min = float(np.asarray(body.get_paths()[0].vertices)[:, 1].min())
+        assert min(point["y"] for point in points) == drawn_min


### PR DESCRIPTION
## Summary

- `ax.violinplot` on a 2-D ndarray now emits one box record and one selector per drawn violin (columns are datasets, as in `cbook._reshape_2D`), instead of 100 rows-as-groups for a `(100, 3)` array. A positional DataFrame and the `dataset=` keyword now get a box layer at all. Lists keep the per-element rule, so `[[1,2,3,4,9],[2,3,4,5,6]]` stays two violins.
- The KDE interpolant is built on unique y knots. The polygon's repeated start/closing vertex and turn-around made `interp1d` divide by zero at `y_min`: scipy printed a `RuntimeWarning` on every violin render, and the lowest level was silently dropped, so the emitted range began above the drawn one. Both seaborn and matplotlib violins are affected.

Closes #705

## Testing

- `tests/core/plot/test_violin_dataset_shapes.py` (8 dataset shapes, record/selector counts against `parts["bodies"]`, column medians) and `tests/core/plot/test_violin_kde_knots.py` (render with `RuntimeWarning` as error; emitted `min(y)` equals the drawn polygon minimum). Against the previous source: 9 failed, 4 passed; green after.
- `pytest tests/core tests/patch`: 2212 passed, 1 skipped. `ruff check` clean on changed files.
- Point count per violin unchanged at 30; the bottom level is now included and RDP re-selects 1–3 of the 15 retained levels.

Not changed: a `pd.Series` passed positionally still gets no box layer (only DataFrame is unpacked); matplotlib's `_unpack_to_numpy` accepts anything with `to_numpy`, which is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_