### PR TITLE
fix(mplfinance): show a plain mpf.plot() and keep addplot labels

### DIFF
--- a/maidr/patch/mplfinance.py
+++ b/maidr/patch/mplfinance.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import uuid
+from typing import Any
+
 import wrapt
 import matplotlib.pyplot as plt
 import mplfinance as mpf
 import numpy as np
 from matplotlib.collections import LineCollection, PolyCollection
+from matplotlib.figure import Figure
 from matplotlib.patches import Rectangle
 from matplotlib.lines import Line2D
 from maidr.core.enum import PlotType
@@ -44,7 +49,10 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
     with ContextManager.set_internal_context():
         result = _draw_quietly(wrapped, args, kwargs)
 
-    # Validate that we received the expected figure and axes tuple
+    # Validate that we received the expected figure and axes tuple. Nothing
+    # drawable came back (mplfinance returns None when drawing onto external
+    # axes), so there is nothing to register and nothing to show: the replay
+    # below is deliberately bypassed.
     if not (isinstance(result, tuple) and len(result) >= 2):
         return result if original_returnfig else None
 
@@ -264,7 +272,9 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
     return None
 
 
-def _finish_as_mplfinance_would(fig, savefig, block, closefig) -> None:
+def _finish_as_mplfinance_would(
+    fig: Figure, savefig: Any, block: bool | None, closefig: bool | str
+) -> None:
     """
     Replay what `mplfinance.plot` does after drawing when `returnfig` is false.
 

--- a/maidr/patch/mplfinance.py
+++ b/maidr/patch/mplfinance.py
@@ -193,14 +193,14 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
                 # Store the period directly on the line for easy access
                 setattr(line, "_maidr_ma_period", estimated_period)
 
-                # Create a better label for the line
+                # Name an unlabelled moving average after its period. A line
+                # the caller labelled (an addplot) keeps that label: it is the
+                # series name the schema announces and the legend entry, and
+                # the period is already on `_maidr_ma_period` for the line
+                # plot to read.
                 label = str(line.get_label())
                 if label.startswith("_child"):
                     new_label = f"Moving Average {estimated_period} days"
-                    line.set_label(new_label)
-                else:
-                    # If it's not a _child label, still add the period info
-                    new_label = f"{label}_MA{estimated_period}"
                     line.set_label(new_label)
 
             # Create a unique identifier for this line based on its data

--- a/maidr/patch/mplfinance.py
+++ b/maidr/patch/mplfinance.py
@@ -1,5 +1,6 @@
 import uuid
 import wrapt
+import matplotlib.pyplot as plt
 import mplfinance as mpf
 import numpy as np
 from matplotlib.collections import LineCollection, PolyCollection
@@ -21,10 +22,24 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
     This function intercepts calls to `mplfinance.plot`, identifies the resulting
     candlestick, volume, and moving average components, and registers them with
     maidr using the common patching mechanism.
+
+    mplfinance only hands back its figure and axes under ``returnfig=True``, so
+    the call is forced into that mode. That mode also skips mplfinance's own
+    ``plt.show()`` and ``closefig`` tail, which a caller who did not ask for
+    the figure is relying on, so it is replayed here once the layers are
+    registered -- see `_finish_as_mplfinance_would`.
     """
     # Ensure `returnfig=True` to capture the figure and axes objects.
     original_returnfig = kwargs.get("returnfig", False)
     kwargs["returnfig"] = True
+
+    # Under a forced `returnfig` mplfinance would still honour `closefig=True`,
+    # closing the figure before it can be shown -- and the maidr backend only
+    # renders figures that are still open. Hold the close back to the replay,
+    # where it follows the show as it does in mplfinance itself.
+    closefig = kwargs.get("closefig", "auto")
+    if not original_returnfig:
+        kwargs["closefig"] = False
 
     with ContextManager.set_internal_context():
         result = _draw_quietly(wrapped, args, kwargs)
@@ -240,10 +255,45 @@ def mplfinance_plot_patch(wrapped, instance, args, kwargs):
 
             common(PlotType.LINE, lambda *a, **k: price_ax, instance, args, line_kwargs)
 
-    if not original_returnfig:
-        return None
+    if original_returnfig:
+        return result
 
-    return result
+    _finish_as_mplfinance_would(
+        result[0], kwargs.get("savefig"), kwargs.get("block"), closefig
+    )
+    return None
+
+
+def _finish_as_mplfinance_would(fig, savefig, block, closefig) -> None:
+    """
+    Replay what `mplfinance.plot` does after drawing when `returnfig` is false.
+
+    This mirrors the tail of ``mplfinance/plotting.py::plot``. The ``savefig``
+    write itself has already happened inside mplfinance, so only its close is
+    replayed; otherwise the figure is shown and then closed on the same
+    conditions mplfinance uses. ``closefig`` is ``True``, ``False`` or
+    mplfinance's default ``'auto'``, which counts as set after a save but
+    closes after a show only when ``block`` is set.
+
+    Parameters
+    ----------
+    fig : Figure
+        The figure mplfinance drew.
+    savefig : Any
+        The caller's ``savefig`` argument, or ``None`` if there was none.
+    block : bool | None
+        The caller's ``block`` argument, forwarded to ``plt.show``.
+    closefig : bool | str
+        The caller's ``closefig`` argument, or ``'auto'``.
+    """
+    if savefig is not None:
+        if closefig:
+            plt.close(fig)
+        return
+
+    plt.show(block=block)
+    if closefig is True or (block and closefig):
+        plt.close(fig)
 
 
 # Apply the patch to mplfinance.plot

--- a/maidr/patch/mplfinance.py
+++ b/maidr/patch/mplfinance.py
@@ -286,13 +286,17 @@ def _finish_as_mplfinance_would(fig, savefig, block, closefig) -> None:
     closefig : bool | str
         The caller's ``closefig`` argument, or ``'auto'``.
     """
+    # mplfinance's validator admits only True and False, so the only other
+    # value is its untouched default 'auto'; name both rather than rely on
+    # truthiness, which would also close on an unexpected string.
+    close_is_set = closefig is True or closefig == "auto"
     if savefig is not None:
-        if closefig:
+        if close_is_set:
             plt.close(fig)
         return
 
     plt.show(block=block)
-    if closefig is True or (block and closefig):
+    if closefig is True or (block and close_is_set):
         plt.close(fig)
 
 

--- a/tests/core/plot/test_mplfinance_show.py
+++ b/tests/core/plot/test_mplfinance_show.py
@@ -36,6 +36,7 @@ from matplotlib._pylab_helpers import Gcf  # noqa: E402
 
 import maidr  # noqa: E402,F401
 from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.core.maidr import Maidr  # noqa: E402
 
 mpf = pytest.importorskip("mplfinance")
 
@@ -169,6 +170,52 @@ class TestCloseFigIsHonoured:
         )
 
         assert len(_open_figures()) == 1
+
+
+class TestThroughTheRealBackend:
+    """
+    The plain call reaches the maidr renderer with ``plt.show`` left alone.
+
+    The stubbed tests above pin the calls; this one runs the real backend,
+    whose ``show`` renders every open figure and then destroys it, so a
+    ``closefig`` close that follows must cope with a figure already gone.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _maidr_backend(self):
+        previous = matplotlib.get_backend()
+        plt.switch_backend("module://maidr.backend")
+        yield
+        plt.switch_backend(previous)
+
+    @pytest.fixture
+    def rendered(self, monkeypatch) -> list[Maidr]:
+        """Stub the renderer itself, one level below ``plt.show``."""
+        rendered: list[Maidr] = []
+
+        def record(maidr_obj: Maidr, *args, **kwargs) -> None:
+            rendered.append(maidr_obj)
+
+        monkeypatch.setattr(Maidr, "show", record)
+        return rendered
+
+    def test_the_plain_call_renders_once(self, rendered) -> None:
+        result = mpf.plot(_prices(), type="candle", volume=True, mav=2)
+
+        assert result is None
+        assert len(rendered) == 1
+        # The backend destroys what it rendered; nothing is left to show twice.
+        assert _open_figures() == []
+
+    def test_closefig_after_the_backend_has_destroyed_the_figure(
+        self, rendered
+    ) -> None:
+        # ``plt.close`` on a figure ``Gcf.destroy`` already dropped is a no-op
+        # in matplotlib, so the replayed close raises nothing here.
+        mpf.plot(_prices(), type="candle", closefig=True)
+
+        assert len(rendered) == 1
+        assert _open_figures() == []
 
 
 def _price_line_labels(axlist) -> list[str]:

--- a/tests/core/plot/test_mplfinance_show.py
+++ b/tests/core/plot/test_mplfinance_show.py
@@ -1,0 +1,169 @@
+"""
+A plain ``mpf.plot(df)`` still displays, and still returns nothing (#717).
+
+``mplfinance.plot`` only hands back its figure under ``returnfig=True``, so
+the patch forces that mode to register the layers. But mplfinance runs its
+own ``plt.show()`` and ``closefig`` handling only when ``returnfig`` is
+*false*, so forcing it skipped both: a caller writing the plain call from
+the mplfinance docs -- and from #199, the issue this patch was written for
+-- got no window, no inline render, no accessible HTML, and ``None`` where
+they were not expecting a handle anyway. With the maidr backend active,
+``plt.show()`` *is* the accessible renderer, so the plain call lost exactly
+the output the patch exists to produce.
+
+The patch now replays mplfinance's tail after registering: show unless
+``savefig`` was given, close on the same ``closefig``/``block`` conditions,
+and return ``None``. The close is deferred until after the show, because the
+maidr backend renders only figures that are still open.
+
+Measured before the fix, with ``plt.show`` stubbed: the patched call made 0
+show calls, returned ``None`` and left the figure open; the unpatched
+``mpf.plot.__wrapped__`` made 1 call with ``block=None``.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+from matplotlib._pylab_helpers import Gcf  # noqa: E402
+
+import maidr  # noqa: E402,F401
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+mpf = pytest.importorskip("mplfinance")
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _prices() -> pd.DataFrame:
+    index = pd.date_range("2026-01-01", periods=5)
+    return pd.DataFrame(
+        {
+            "Open": [1, 2, 3, 4, 5],
+            "High": [2, 3, 4, 5, 6],
+            "Low": [0, 1, 2, 3, 4],
+            "Close": [1.5, 2.5, 3.5, 4.5, 5.5],
+            "Volume": [10, 20, 30, 40, 50],
+        },
+        index=index,
+    )
+
+
+def _open_figures() -> list:
+    return [manager.canvas.figure for manager in Gcf.get_all_fig_managers()]
+
+
+@pytest.fixture
+def show_calls(monkeypatch) -> list[dict]:
+    """
+    Stub ``plt.show`` and record each call.
+
+    Every record carries the kwargs the call was made with plus, under
+    ``"open"``, the figures that were still open at that moment -- the ones
+    the maidr backend would actually render.
+    """
+    calls: list[dict] = []
+
+    def record(*args, **kwargs) -> None:
+        calls.append(dict(kwargs, open=_open_figures()))
+
+    monkeypatch.setattr(plt, "show", record)
+    return calls
+
+
+class TestThePlainCallIsShown:
+    def test_it_shows_once_and_returns_nothing(self, show_calls) -> None:
+        result = mpf.plot(_prices(), type="candle")
+
+        assert result is None
+        assert len(show_calls) == 1
+        # ``block`` is forwarded as mplfinance forwards it, default included.
+        assert show_calls[0]["block"] is None
+
+    def test_the_figure_it_shows_is_registered(self, show_calls) -> None:
+        # The property the fix exists for: what reaches the renderer is a
+        # figure maidr knows about, so the plain call yields accessible HTML.
+        mpf.plot(_prices(), type="candle", volume=True, mav=2)
+
+        (shown,) = show_calls[0]["open"]
+        assert shown in FigureManager.figs
+
+    def test_block_is_forwarded(self, show_calls) -> None:
+        mpf.plot(_prices(), type="candle", block=False)
+
+        assert [call["block"] for call in show_calls] == [False]
+
+    def test_the_figure_is_left_open_by_default(self, show_calls) -> None:
+        # mplfinance's default ``closefig='auto'`` closes after a show only
+        # when ``block`` is set, so the plain call leaves the figure up.
+        mpf.plot(_prices(), type="candle")
+
+        assert _open_figures() == show_calls[0]["open"]
+
+
+class TestItIsNotShownTwice:
+    def test_returnfig_shows_nothing_and_returns_the_tuple(self, show_calls) -> None:
+        result = mpf.plot(_prices(), type="candle", returnfig=True)
+
+        assert show_calls == []
+        fig, axlist = result
+        assert fig in FigureManager.figs
+        assert isinstance(axlist, list)
+
+    def test_savefig_shows_nothing(self, show_calls, tmp_path) -> None:
+        target = tmp_path / "candle.png"
+
+        result = mpf.plot(_prices(), type="candle", savefig=str(target))
+
+        assert show_calls == []
+        assert result is None
+        assert target.exists()
+
+
+class TestCloseFigIsHonoured:
+    def test_closefig_closes_after_the_show_not_before(self, show_calls) -> None:
+        mpf.plot(_prices(), type="candle", closefig=True)
+
+        # Under the forced ``returnfig`` mplfinance closed the figure itself,
+        # before anything could show it; the backend then had nothing to
+        # render. The figure must be open when shown and closed afterwards.
+        assert len(show_calls[0]["open"]) == 1
+        assert _open_figures() == []
+
+    def test_block_with_the_default_closefig_closes_after_the_show(
+        self, show_calls
+    ) -> None:
+        mpf.plot(_prices(), type="candle", block=True)
+
+        assert len(show_calls[0]["open"]) == 1
+        assert _open_figures() == []
+
+    def test_closefig_false_keeps_the_figure_after_a_blocking_show(
+        self, show_calls
+    ) -> None:
+        mpf.plot(_prices(), type="candle", block=True, closefig=False)
+
+        assert len(_open_figures()) == 1
+
+    def test_savefig_closes_by_default(self, show_calls, tmp_path) -> None:
+        mpf.plot(_prices(), type="candle", savefig=str(tmp_path / "c.png"))
+
+        assert _open_figures() == []
+
+    def test_savefig_with_closefig_false_keeps_the_figure(
+        self, show_calls, tmp_path
+    ) -> None:
+        mpf.plot(
+            _prices(), type="candle", savefig=str(tmp_path / "c.png"), closefig=False
+        )
+
+        assert len(_open_figures()) == 1

--- a/tests/core/plot/test_mplfinance_show.py
+++ b/tests/core/plot/test_mplfinance_show.py
@@ -23,6 +23,8 @@ show calls, returned ``None`` and left the figure open; the unpatched
 
 from __future__ import annotations
 
+import json
+
 import matplotlib
 import pytest
 
@@ -167,3 +169,51 @@ class TestCloseFigIsHonoured:
         )
 
         assert len(_open_figures()) == 1
+
+
+def _price_line_labels(axlist) -> list[str]:
+    return [str(line.get_label()) for line in axlist[0].get_lines()]
+
+
+def _schema_text(fig) -> str:
+    return json.dumps(FigureManager.figs[fig]._flatten_maidr())
+
+
+class TestACallersLineLabelIsKept:
+    """
+    An addplot line named by the caller keeps that name (#717).
+
+    Every ``Line2D`` on the price axes went through the moving-average
+    relabelling, so ``label='Upper band'`` came out as ``'Upper band_MA1'``:
+    that was the series name in the schema and the entry in any later
+    ``ax.legend()``, while mplfinance's own legend still read ``'Upper
+    band'``. The period was already stored on the line for
+    ``MplfinanceLinePlot`` to read, so the suffix carried nothing.
+    """
+
+    def _plot(self):
+        prices = _prices()
+        band = mpf.make_addplot(prices["Close"] * 1.01, label="Upper band")
+        return mpf.plot(prices, type="candle", mav=2, addplot=band, returnfig=True)
+
+    def test_the_label_on_the_line_is_unchanged(self) -> None:
+        _, axlist = self._plot()
+
+        labels = _price_line_labels(axlist)
+        assert "Upper band" in labels
+        assert not any("_MA" in label for label in labels)
+
+    def test_the_schema_names_the_series_after_it(self) -> None:
+        fig, _ = self._plot()
+
+        text = _schema_text(fig)
+        assert "Upper band" in text
+        assert "Upper band_MA" not in text
+
+    def test_an_unlabelled_moving_average_is_still_named(self) -> None:
+        # The other half of the relabelling is what the schema already calls
+        # these series, and stays.
+        fig, axlist = self._plot()
+
+        assert "Moving Average 2 days" in _price_line_labels(axlist)
+        assert "Moving Average 2 days" in _schema_text(fig)


### PR DESCRIPTION
## Summary

- With `maidr` imported, `mpf.plot(df)` without `returnfig` displayed nothing and returned `None`: the patch forces `returnfig=True`, and mplfinance runs its own `plt.show()`/`closefig` tail only when `returnfig` is false. Since `plt.show()` is the maidr renderer under the auto-activated backend, the plain call (the exact example from #199) produced no accessible HTML. Measured with `plt.show` stubbed: 0 show calls from the patched call vs 1 (`block=None`) from `mpf.plot.__wrapped__`.
- The patch now replays mplfinance's tail after registering the layers: show with the caller's `block` unless `savefig` was given, close on the same `closefig`/`block` conditions, return `None`. `closefig` is deferred to that replay so the figure is still open (and so rendered by the maidr backend) when shown. `returnfig=True` and `savefig` callers are unchanged and never shown twice.
- Separately, an addplot line labelled by the caller (`label='Upper band'`) was rewritten to `'Upper band_MA1'`, which was emitted as the series name and showed in a later `ax.legend()` while mplfinance's own legend said `'Upper band'`. Only unlabelled `_child` lines are renamed now; the period was already on `_maidr_ma_period`.
- Schema output changes only where a caller-supplied addplot label was previously suffixed.

Closes #717

## Testing

New `tests/core/plot/test_mplfinance_show.py` (`importorskip("mplfinance")`) stubs `plt.show` and checks: plain call shows once with `block=None` and returns `None`; the shown figure is registered with `FigureManager`; `returnfig=True` gives zero shows and the tuple; `savefig` gives zero shows and writes the file; `closefig=True` / `block=True` close *after* the show, `closefig=False` keeps the figure; addplot label `'Upper band'` survives on the line and in the schema, MA lines still named `Moving Average N days`. Against the previous source: 8 failed, 6 passed. `pytest tests/core tests/patch`: 2213 passed, 1 skipped. `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_