### PR TITLE
perf(scatter): stop re-sorting slots per point and rebuilding stand-ins to count

### DIFF
--- a/maidr/core/plot/scatterplot.py
+++ b/maidr/core/plot/scatterplot.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import uuid
 
 import numpy as np
@@ -653,19 +652,36 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
         # diverge over. `test_seaborn_drops_a_non_finite_row_before_drawing`
         # pins that, and turns red on the release where this arithmetic
         # starts mattering.
+        #
+        # The tick maps and their sorted slots are the same for every point,
+        # so they are read once here rather than once per point: measured on
+        # a 100k-point numeric scatter, sorting the two (empty) maps inside
+        # the loop was most of the extraction (#715). The finiteness test is
+        # one array pass for the same reason, and `drawn_at` is the running
+        # count of drawn points up to each offset -- the position the old
+        # per-point counter reached -- so an offset's place in the SVG is
+        # read off rather than counted up to.
+        x_slots = sorted(x_ticks)
+        y_slots = sorted(y_ticks)
+
+        offsets = np.asarray(ma.getdata(plot.get_offsets()), dtype=float)
+        offsets = offsets.reshape(-1, 2)
+        finite = np.isfinite(offsets).all(axis=1)
+        drawn_at = (np.cumsum(finite) - 1).tolist()
+        xs = offsets[:, 0].tolist()
+        ys = offsets[:, 1].tolist()
+
         samples: list[dict] = []
         positions: list[int] = []
-        position = 0
-
-        for index, (x, y) in enumerate(ma.getdata(plot.get_offsets())):
-            if not (math.isfinite(x) and math.isfinite(y)):
-                continue
-            drawn_at = position
-            position += 1
+        for index in np.flatnonzero(finite).tolist():
             if members is not None and index not in members:
                 continue
-            samples.append(self._sample(float(x), float(y), x_ticks, y_ticks))
-            positions.append(drawn_at)
+            samples.append(
+                self._sample_on(
+                    xs[index], ys[index], x_ticks, y_ticks, x_slots, y_slots
+                )
+            )
+            positions.append(drawn_at[index])
 
         return samples, positions
 
@@ -711,8 +727,44 @@ class ScatterPlot(MaidrPlot, CollectionExtractorMixin, LineExtractorMixin):
         dict
             The sample, carrying a label only for an axis that has one.
         """
-        x_slots = sorted(x_ticks)
-        y_slots = sorted(y_ticks)
+        return cls._sample_on(x, y, x_ticks, y_ticks, sorted(x_ticks), sorted(y_ticks))
+
+    @classmethod
+    def _sample_on(
+        cls,
+        x: float,
+        y: float,
+        x_ticks: dict[float, str],
+        y_ticks: dict[float, str],
+        x_slots: list[float],
+        y_slots: list[float],
+    ) -> dict:
+        """
+        :meth:`_sample`, given the slots it would otherwise sort itself.
+
+        The one difference is who sorts. A scatter reads thousands of points
+        against the same two tick maps, and sorting them afresh for each was
+        most of what a large extraction cost (#715); a caller that has the
+        slots already hands them in here. :meth:`_sample` stays the
+        one-point spelling for the layers that read a handful -- a dash, a
+        text label -- so nothing about *what* is announced lives in two
+        places.
+
+        Parameters
+        ----------
+        x, y : float
+            The drawn coordinates.
+        x_ticks, y_ticks : dict of float to str
+            As for :meth:`_sample`.
+        x_slots, y_slots : list of float
+            ``sorted(x_ticks)`` and ``sorted(y_ticks)``, what
+            :meth:`_on_axis` snaps to.
+
+        Returns
+        -------
+        dict
+            The sample, carrying a label only for an axis that has one.
+        """
         sample = {
             MaidrKey.X: cls._on_axis(x, x_slots),
             MaidrKey.Y: cls._on_axis(y, y_slots),

--- a/maidr/core/plot/segment_lineplot.py
+++ b/maidr/core/plot/segment_lineplot.py
@@ -139,6 +139,10 @@ class SegmentLinePlot(MultiLinePlot):
         that already begins with ``maidr-`` when the artist is drawn, so the
         one written here is the one that reaches the SVG.
 
+        The count is the collection's own path count -- one per segment, as
+        above -- rather than the length of :meth:`_series`, which would build
+        every stand-in a second time per render only to count them (#715).
+
         Returns
         -------
         list of str
@@ -151,5 +155,5 @@ class SegmentLinePlot(MultiLinePlot):
 
         return [
             f"g[id='{gid}'] > path:nth-of-type({position + 1})"
-            for position in range(len(self._series()))
+            for position in range(len(self._collection.get_paths()))
         ]

--- a/tests/core/plot/test_scatter_category_label.py
+++ b/tests/core/plot/test_scatter_category_label.py
@@ -159,6 +159,46 @@ class TestWhatMustNotChange:
         assert {sample["xLabel"] for sample in drawn} == {"a", "b", "c"}
 
 
+class TestSnappingToASlot:
+    """How a drawn coordinate finds its slot, pinned where the loop changed.
+
+    #715 moved the sorting of the slots out of the per-point loop and read the
+    coordinates off the collection in one pass. Nothing about *where* a point
+    lands was meant to change, and the one place a rewrite could quietly move
+    one is a tie.
+    """
+
+    def test_a_point_midway_between_two_slots_snaps_to_the_lower_one(self):
+        # `min()` keeps the first of two equally near slots and the slots are
+        # ascending, so a tie goes down. A snap written another way -- an
+        # `argmin` over a reversed list, a `searchsorted` that rounds up --
+        # would move exactly these points and no others, and no chart drawn
+        # by seaborn happens to place one there to notice.
+        _, ax = plt.subplots()
+        collection = ax.scatter(["a", "b", "c"], [1.0, 2.0, 3.0])
+        collection.set_offsets([[0.5, 1.0], [1.5, 2.0], [1.0, 3.0]])
+
+        assert [(p["x"], p["xLabel"]) for p in points(ax)] == [
+            (0.0, "a"),
+            (1.0, "b"),
+            (1.0, "b"),
+        ]
+
+    def test_sampling_with_the_slots_in_hand_reads_as_sampling_does(self):
+        # The scatter loop hands the sorted slots in; a dash or a text label
+        # still asks `_sample` to sort them. Both must be one reading.
+        from maidr.core.plot.scatterplot import ScatterPlot
+
+        x_ticks = {0.0: "a", 1.0: "b", 2.0: "c"}
+        y_ticks = {10.0: "low", 20.0: "high"}
+        x_slots, y_slots = sorted(x_ticks), sorted(y_ticks)
+
+        for x, y in [(-0.3, 9.0), (0.5, 15.0), (1.49, 21.0), (1.5, 14.9), (2.7, 30.0)]:
+            assert ScatterPlot._sample_on(
+                x, y, x_ticks, y_ticks, x_slots, y_slots
+            ) == ScatterPlot._sample(x, y, x_ticks, y_ticks)
+
+
 class TestADateAxis:
     """A tz-aware date axis carries units too, and is not a category axis.
 

--- a/tests/core/plot/test_scatter_gaps.py
+++ b/tests/core/plot/test_scatter_gaps.py
@@ -123,3 +123,27 @@ class TestWhatMustNotChange:
         collection = plt.scatter([-1, -2], [-10, -20])
 
         assert len(points_of(collection)) == 2
+
+
+class TestWhereADrawnPointSits:
+    def test_a_group_member_after_a_gap_is_numbered_by_what_was_drawn(self):
+        # Two indices run through extraction and they are not the same one: a
+        # hue group's membership is written in *offset* order, and the SVG is
+        # numbered in *drawn* order, so a dropped row between two members
+        # pulls the two apart. `_drawn_positions` is the drawn one, and it is
+        # what the selector addresses a marker by -- so a reading that
+        # numbered by offset would highlight the neighbour. Pinned because
+        # #715 stopped counting the drawn points up one by one and read the
+        # count off an array instead.
+        from maidr.core.plot.scatterplot import DRAWN_POINTS, HUE_GROUP, ScatterPlot
+
+        _, ax = plt.subplots()
+        collection = ax.scatter([1, 2, np.nan, 4, 5], [10, 20, 30, np.nan, 50])
+        layer = ScatterPlot(
+            ax, **{DRAWN_POINTS: collection, HUE_GROUP: ("g", [{0, 2, 4}])}
+        )
+
+        samples = layer._extract_plot_data()
+
+        assert [(s["x"], s["y"]) for s in samples] == [(1.0, 10.0), (5.0, 50.0)]
+        assert layer._drawn_positions == [(0, 0), (0, 2)]

--- a/tests/core/plot/test_seaborn_objects_lines.py
+++ b/tests/core/plot/test_seaborn_objects_lines.py
@@ -231,6 +231,31 @@ def test_one_colour_over_many_segments_is_cycled_the_way_it_is_drawn():
     }
 
 
+def test_the_selectors_are_counted_off_the_collection_rather_than_rebuilt(
+    monkeypatch,
+):
+    # A render needs the stand-ins once, to read the payload. Counting the
+    # selectors by building every one of them again doubled the work of a
+    # render for nothing but a length -- measured, 0.44 s to 0.27 s at 1000
+    # groups (#715). The count is the collection's own: one path per segment.
+    from maidr.core.plot.segment_lineplot import SegmentLinePlot
+
+    figure = plt.figure()
+    so.Plot(_frame(), x="x", y="y", color="g").add(so.Lines()).on(figure).plot()
+    plot = FigureManager.get_maidr(figure).plots[0]
+    collection = figure.axes[0].collections[0]
+
+    calls = []
+    series = SegmentLinePlot._series
+    monkeypatch.setattr(
+        SegmentLinePlot, "_series", lambda self: calls.append(1) or series(self)
+    )
+    schema = plot.render()
+
+    assert len(calls) == 1
+    assert len(schema["selectors"]) == len(collection.get_paths()) == 2
+
+
 def test_the_collection_is_what_gets_tagged_rather_than_the_stand_ins():
     # `plot.elements` is the list the highlight machinery writes a `maidr`
     # attribute onto. The stand-ins were never added to the axes, so tagging


### PR DESCRIPTION
## Summary

Two extraction hot spots that did the same work N times over.

- `ScatterPlot._extract_point_data` sorted the two category tick dicts inside the per-point loop and ran the finiteness test and drawn-position counter per point over numpy scalars. The slots are now sorted once per collection, offsets are read into Python floats in one pass with the finite mask and running drawn count taken off the array, and a new `_sample_on` classmethod does what `_sample` does given the slots. `_sample` stays as a thin wrapper, so `DashPlot`/`TextPlot` are untouched.
- `SegmentLinePlot._get_selector` called `len(self._series())`, rebuilding one stand-in `Line2D` per segment only to count them, so every render built the set twice. It now counts the collection's own paths (one per segment, as the docstring already states). No memoisation.

| Case | Before | After |
|---|---|---|
| Scatter 100k numeric, layer render | 0.28 s | 0.155 s |
| Scatter 10k numeric, layer render | 0.028 s | 0.014 s |
| stripplot 20k × 10 categories, layer render | 0.010 s | 0.006 s |
| `so.Lines` 1000 groups, layer render | 0.197 s | 0.129 s |
| `so.Lines` `_series` calls per render | 2 | 1 |

Emitted schemas are identical: verified across 12 figures (numeric, NaN, masked, string-category, strip x/y, swarm, hue splits, both-axes categorical, `so.Lines`, `so.Paths`) against `main`, ignoring only the per-render random `id`.

Closes #715

## Testing

- New: tie-break pin (a point midway between two slots goes to the lower one), `_sample_on` ≡ `_sample`, `_drawn_positions` for a collection with NaN rows and a members set, and `_series` called once per render with `len(selectors) == len(collection.get_paths())`.
- `pytest tests/core tests/patch`: 2203 passed, 1 skipped. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_