### PR TITLE
fix(plotly): rescale a groupnorm area to the shares plotly draws

### DIFF
--- a/maidr/plotly/area.py
+++ b/maidr/plotly/area.py
@@ -9,6 +9,9 @@ draws this chart rather than a multi-line one (#392).
 
 from __future__ import annotations
 
+import math
+from typing import Any, Hashable
+
 from maidr.core.enum.maidr_key import MaidrKey
 from maidr.core.enum.plot_type import PlotType
 from maidr.plotly.plotly_plot import PlotlyPlot
@@ -20,8 +23,12 @@ from maidr.plotly.step_shape import (
 
 #: The values ``groupnorm`` takes when plotly rescales a stack to a common
 #: total -- its own switch for a 100% stacked area, and the counterpart of
-#: ``barnorm`` on the bar path.
-_NORMALISING_GROUPNORMS = frozenset({"percent", "fraction"})
+#: ``barnorm`` on the bar path -- and the total each scales a position to.
+#: One table rather than a set beside a dict, so the type a stack is given
+#: and the scale its values are rescaled by cannot disagree (#409's lesson
+#: on the bar path).
+_GROUPNORM_SCALES: dict[str, float] = {"percent": 100.0, "fraction": 1.0}
+_NORMALISING_GROUPNORMS = frozenset(_GROUPNORM_SCALES)
 
 
 def is_area_trace(trace: dict) -> bool:
@@ -100,6 +107,105 @@ def area_plot_type(traces: list[dict]) -> PlotType:
     if len(traces) > 1:
         return PlotType.STACKED_AREA
     return PlotType.AREA
+
+
+def groupnorm_scale(traces: list[dict]) -> float | None:
+    """The total a stack's ``groupnorm`` scales each position to.
+
+    Read from the first trace in the stack that sets it, not the first trace.
+    plotly's ``stack_defaults`` reads ``groupnorm`` off the group's first
+    trace or, failing that, the first later trace that sets it -- it flags
+    ``groupnormFound`` and ignores the setting on every trace after -- so a
+    ``groupnorm`` on the second trace alone still governs the whole stack.
+    :func:`area_plot_type` already types the stack by that rule; the scale
+    has to be read by the same one or the type and the values part company.
+
+    Parameters
+    ----------
+    traces : list[dict]
+        The stack's traces, in declaration order.
+
+    Returns
+    -------
+    float or None
+        ``100.0`` for ``percent``, ``1.0`` for ``fraction``, and ``None``
+        when plotly normalises nothing -- ``None``, ``""`` and anything
+        unrecognised alike -- so the caller emits the values untouched.
+    """
+    for trace in traces:
+        groupnorm = trace.get("groupnorm")
+        if isinstance(groupnorm, str) and groupnorm in _GROUPNORM_SCALES:
+            return _GROUPNORM_SCALES[groupnorm]
+    return None
+
+
+def _finite(value: Any) -> bool:
+    """Whether a value takes part in a column total.
+
+    ``None`` and a non-finite number are gaps: plotly leaves them out of the
+    sum, and they come back as they went in rather than as a share.
+    """
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return False
+    return math.isfinite(value)
+
+
+def normalised_bands(bands: list[list[dict]], scale: float) -> list[list[dict]]:
+    """Rescale every band's value to its share of its column, as plotly does.
+
+    The rule is plotly.js's scatter cross-trace calc, not the bar one. For a
+    stack group it sums every band's own value at each position and then
+    divides each by ``(groupnorm === "fraction" ? m : m / 100) || 1``. Two
+    consequences that :func:`maidr.plotly.barnorm.stack_shares` does not
+    share, which is why that helper is not reused here:
+
+    * A position whose total is zero divides by **1**, so its values come
+      back unchanged -- zeros stay zeros -- where ``barnorm`` leaves such a
+      position undefined.
+    * There is no per-sign split and no ``barmode``: one signed total serves
+      every band at the position.
+
+    Positions are keyed by the emitted ``x`` and matched by value, not by
+    index, so a band that skips an x contributes nothing to that column and
+    the rest are not shifted -- plotly's default ``stackgaps`` of
+    ``"infer zero"``. A ``None`` or non-finite value is left out of the
+    total and left as it is.
+
+    Parameters
+    ----------
+    bands : list of list of dict
+        One list of ``{x, y[, z]}`` points per drawn band, as
+        ``_line_series_with_positions`` builds them.
+    scale : float
+        ``100.0`` or ``1.0``, from :func:`groupnorm_scale`.
+
+    Returns
+    -------
+    list of list of dict
+        New points, aligned elementwise with *bands*, with every finite ``y``
+        replaced by its share. The input is not touched, so a layer rendered
+        twice does not rescale an already rescaled stack.
+    """
+    totals: dict[Hashable, float] = {}
+    for band in bands:
+        for point in band:
+            value = point[MaidrKey.Y]
+            if _finite(value):
+                totals[point[MaidrKey.X]] = totals.get(point[MaidrKey.X], 0.0) + value
+
+    shares: list[list[dict]] = []
+    for band in bands:
+        row: list[dict] = []
+        for point in band:
+            value = point[MaidrKey.Y]
+            if _finite(value):
+                total = totals[point[MaidrKey.X]]
+                # plotly's `|| 1`: a zero total divides by one, not by zero.
+                divisor = (total if scale == 1.0 else total / scale) or 1.0
+                point = {**point, MaidrKey.Y: value / divisor}
+            row.append(point)
+        shares.append(row)
+    return shares
 
 
 class PlotlyAreaPlot(PlotlyPlot):
@@ -222,6 +328,22 @@ class PlotlyAreaPlot(PlotlyPlot):
         Shares the single pass with :meth:`_get_selector` rather than walking
         the traces again -- see ``_drawn_line_series`` for why the pass cannot
         simply be repeated.
+
+        A ``groupnorm`` stack is rescaled to the shares plotly draws. The
+        layer is typed ``stacked_normalized_area`` for it, and the values
+        underneath were the untouched inputs -- a reader heard ``30`` on a
+        chart whose axis runs 0..1 and whose band top sits at ``0.75`` (#691),
+        the area half of what #409 was for ``barnorm``. The core normalises
+        nothing: ``AreaTrace`` sums whatever values it is given, so a
+        normalised layer has to arrive already carrying shares. Gated on the
+        type rather than on the setting alone so a plain or stacked area is
+        emitted exactly as before.
         """
         bands, _ = self._drawn_line_series(self._traces, self._scatter_positions)
-        return bands
+        if self.type != PlotType.NORMALIZED_AREA:
+            return bands
+
+        scale = groupnorm_scale(self._traces)
+        if scale is None:
+            return bands
+        return normalised_bands(bands, scale)

--- a/maidr/plotly/barnorm.py
+++ b/maidr/plotly/barnorm.py
@@ -19,7 +19,10 @@ Both r-maidr paths do exactly that -- base R because the author normalised the
 matrix before calling ``barplot()``, ggplot2 because ``position = "fill"``
 builds its data in 0..1 -- which is what makes py-maidr's plotly path the
 outlier rather than the standard-setter. Contrast ``AreaTrace``, which *does*
-compute its own stack totals, and so is deliberately fed raw values.
+compute its own stack totals, and so is deliberately fed raw values -- for a
+plain stack. It normalises nothing either, so a ``groupnorm`` stack is
+rescaled too, in :mod:`maidr.plotly.area`, under plotly's scatter rule rather
+than this one (#691).
 """
 
 from __future__ import annotations

--- a/tests/plotly/test_plotly_area.py
+++ b/tests/plotly/test_plotly_area.py
@@ -41,7 +41,9 @@ from maidr.core.enum.plot_type import PlotType  # noqa: E402
 from maidr.plotly.area import (  # noqa: E402
     area_plot_type,
     area_stack_groups,
+    groupnorm_scale,
     is_area_trace,
+    normalised_bands,
 )
 from maidr.plotly.area import PlotlyAreaPlot  # noqa: E402
 from maidr.plotly.plotly_maidr import PlotlyMaidr  # noqa: E402
@@ -402,3 +404,189 @@ class TestAreasAndLinesCoexist:
             found = layer["selectors"]
             emitted += found if isinstance(found, list) else [found]
         assert len(emitted) == len(set(emitted))
+
+
+def issue_frame() -> pd.DataFrame:
+    """The figure from #691: two bands whose shares at each x are 3:1 and 1:3."""
+    return pd.DataFrame(
+        {"x": [1, 2, 1, 2], "y": [30, 20, 10, 60], "g": ["D", "D", "P", "P"]}
+    )
+
+
+def values(fig) -> list[list]:
+    return [[point["y"] for point in series] for series in only_layer(fig)["data"]]
+
+
+def bands_of(*series: list[tuple]) -> list[list[dict]]:
+    """Build bands the way ``_line_series_with_positions`` emits them."""
+    return [[{"x": x, "y": y} for x, y in one] for one in series]
+
+
+def ys(bands: list[list[dict]]) -> list[list]:
+    return [[point["y"] for point in series] for series in bands]
+
+
+class TestTheGroupnormScale:
+    @pytest.mark.parametrize(
+        ("groupnorm", "expected"), [("percent", 100.0), ("fraction", 1.0)]
+    )
+    def test_the_two_normalising_settings(self, groupnorm, expected):
+        assert groupnorm_scale([{"groupnorm": groupnorm}]) == expected
+
+    @pytest.mark.parametrize("groupnorm", [None, "", "nonsense", 5, True])
+    def test_everything_else_normalises_nothing(self, groupnorm):
+        assert groupnorm_scale([{"groupnorm": groupnorm}]) is None
+
+    def test_the_first_trace_that_sets_it_governs(self):
+        # plotly's `stack_defaults` reads `groupnorm` from the first trace in
+        # the group that sets it, so a later trace cannot override it.
+        traces = [{}, {"groupnorm": "percent"}, {"groupnorm": "fraction"}]
+        assert groupnorm_scale(traces) == 100.0
+
+
+class TestNormalisedBands:
+    """The scatter rule, which is not the bar rule.
+
+    plotly.js's cross-trace calc for a stack group sums every band's ``s`` at
+    each position and divides by ``(groupnorm === "fraction" ? m : m / 100)
+    || 1`` -- so a zero total divides by 1 rather than becoming a gap the way
+    ``barnorm`` makes it, and there is no per-sign split.
+    """
+
+    def test_fraction_gives_shares_of_one(self):
+        bands = bands_of([(1, 30), (2, 20)], [(1, 10), (2, 60)])
+        assert ys(normalised_bands(bands, 1.0)) == [[0.75, 0.25], [0.25, 0.75]]
+
+    def test_percent_gives_shares_of_a_hundred(self):
+        bands = bands_of([(1, 30), (2, 20)], [(1, 10), (2, 60)])
+        assert ys(normalised_bands(bands, 100.0)) == [[75.0, 25.0], [25.0, 75.0]]
+
+    def test_a_band_that_skips_an_x_contributes_zero_there(self):
+        # plotly's default `stackgaps` is "infer zero", so the lone band at
+        # x=2 is the whole of that column.
+        bands = bands_of([(1, 30), (2, 20)], [(1, 10)])
+        assert ys(normalised_bands(bands, 100.0)) == [[75.0, 100.0], [25.0]]
+
+    def test_totals_are_keyed_by_x_not_by_index(self):
+        bands = bands_of([(1, 30), (2, 20)], [(2, 60), (1, 10)])
+        assert ys(normalised_bands(bands, 1.0)) == [[0.75, 0.25], [0.75, 0.25]]
+
+    def test_a_column_totalling_zero_keeps_its_values(self):
+        # The `|| 1` in plotly's rule: a zero total divides by 1, so the
+        # zeros stay zeros rather than becoming an undefined 0/0. This is
+        # where the scatter rule parts from `barnorm.stack_shares`.
+        bands = bands_of([(1, 0), (2, 3)], [(1, 0), (2, 1)])
+        assert ys(normalised_bands(bands, 100.0)) == [[0.0, 75.0], [0.0, 25.0]]
+
+    def test_a_none_stays_none_and_leaves_the_total_alone(self):
+        bands = bands_of([(1, None), (2, 3)], [(1, 4), (2, 1)])
+        assert ys(normalised_bands(bands, 100.0)) == [[None, 75.0], [100.0, 25.0]]
+
+    def test_a_nan_is_left_alone_too(self):
+        bands = bands_of([(1, float("nan"))], [(1, 4)])
+        got = ys(normalised_bands(bands, 100.0))
+        assert got[0][0] != got[0][0]  # still NaN
+        assert got[1] == [100.0]
+
+    def test_the_input_is_not_mutated(self):
+        bands = bands_of([(1, 30)], [(1, 10)])
+        normalised_bands(bands, 100.0)
+        assert ys(bands) == [[30], [10]]
+
+    def test_the_other_keys_survive(self):
+        bands = [[{"x": 1, "y": 30, "z": "D"}], [{"x": 1, "y": 10, "z": "P"}]]
+        assert normalised_bands(bands, 100.0) == [
+            [{"x": 1, "y": 75.0, "z": "D"}],
+            [{"x": 1, "y": 25.0, "z": "P"}],
+        ]
+
+
+class TestTheEmittedNormalisedLayer:
+    """The layer's values match what plotly draws, as they do for `barnorm`."""
+
+    def test_fraction_reaches_the_layer(self):
+        fig = px.area(issue_frame(), x="x", y="y", color="g", groupnorm="fraction")
+        assert values(fig) == [[0.75, 0.25], [0.25, 0.75]]
+
+    def test_percent_reaches_the_layer(self):
+        fig = px.area(issue_frame(), x="x", y="y", color="g", groupnorm="percent")
+        assert values(fig) == [[75.0, 25.0], [25.0, 75.0]]
+
+    def test_the_type_and_the_values_now_agree(self):
+        fig = px.area(issue_frame(), x="x", y="y", color="g", groupnorm="fraction")
+        layer = only_layer(fig)
+        assert layer["type"] == PlotType.NORMALIZED_AREA.value
+        assert layer["data"][0][0]["y"] == 0.75
+
+    def test_a_band_that_skips_an_x_contributes_zero_there(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=[1, 2], y=[30, 20], stackgroup="one", groupnorm="percent"),
+                go.Scatter(x=[1], y=[10], stackgroup="one"),
+            ]
+        )
+        assert values(fig) == [[75.0, 100.0], [25.0]]
+
+    def test_a_column_totalling_zero_keeps_its_values(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=[1, 2], y=[0, 3], stackgroup="one", groupnorm="percent"),
+                go.Scatter(x=[1, 2], y=[0, 1], stackgroup="one"),
+            ]
+        )
+        assert values(fig) == [[0.0, 75.0], [0.0, 25.0]]
+
+    def test_a_stack_without_groupnorm_is_untouched(self):
+        fig = px.area(issue_frame(), x="x", y="y", color="g")
+        assert only_layer(fig)["type"] == PlotType.STACKED_AREA.value
+        assert values(fig) == [[30, 20], [10, 60]]
+
+    def test_a_lone_band_is_untouched(self):
+        single = issue_frame()[lambda d: d.g == "D"]
+        fig = px.area(single, x="x", y="y")
+        assert only_layer(fig)["type"] == PlotType.AREA.value
+        assert values(fig) == [[30, 20]]
+
+    def test_a_groupnorm_on_the_second_trace_alone_still_governs(self):
+        # `stack_defaults` takes the setting from the first trace that has
+        # one, wherever it sits in the group -- and `area_plot_type` already
+        # types the stack that way, so the values must follow the same rule.
+        fig = go.Figure(
+            [
+                go.Scatter(x=[1, 2], y=[30, 20], stackgroup="one"),
+                go.Scatter(x=[1, 2], y=[10, 60], stackgroup="one", groupnorm="percent"),
+            ]
+        )
+        layer = only_layer(fig)
+        assert layer["type"] == PlotType.NORMALIZED_AREA.value
+        assert values(fig) == [[75.0, 25.0], [25.0, 75.0]]
+
+    def test_only_the_group_carrying_groupnorm_is_rescaled(self):
+        fig = go.Figure(
+            [
+                go.Scatter(x=[1], y=[30], stackgroup="one", groupnorm="percent"),
+                go.Scatter(x=[1], y=[10], stackgroup="one"),
+                go.Scatter(x=[1], y=[5], stackgroup="two"),
+            ]
+        )
+        emitted = layers(fig)
+        assert [layer["type"] for layer in emitted] == [
+            PlotType.NORMALIZED_AREA.value,
+            PlotType.AREA.value,
+        ]
+        assert [point["y"] for point in emitted[1]["data"][0]] == [5]
+
+    def test_a_normalised_step_area_keeps_its_direction(self):
+        # The rescale touches the bands only; the step convention rides on
+        # the traces and is unaffected.
+        fig = px.area(
+            issue_frame(),
+            x="x",
+            y="y",
+            color="g",
+            groupnorm="percent",
+            line_shape="hv",
+        )
+        layer = only_layer(fig)
+        assert layer["stepDirection"] == "hv"
+        assert values(fig) == [[75.0, 25.0], [25.0, 75.0]]


### PR DESCRIPTION
## Summary

- `px.area(..., groupnorm="fraction"|"percent")` was typed `stacked_normalized_area` but its points carried the raw inputs, so a reader heard 30 on a chart whose axis runs 0..1 and whose band top sits at 0.75 (the area half of #409).
- `PlotlyAreaPlot._extract_plot_data` now rescales the drawn bands when, and only when, the layer is `NORMALIZED_AREA`, under plotly.js's scatter cross-trace rule: per x, total the finite values of every band in the stack (a band that skips an x contributes 0, plotly's default `stackgaps`), then divide by `(fraction ? total : total / 100) || 1`.
- The scale is read from the first trace in the stack that sets `groupnorm`, as plotly's `stack_defaults` does and as `area_plot_type` already did, so a setting on the second trace alone still governs.
- `barnorm.stack_shares` is deliberately not reused: a zero-total column divides by 1 and keeps its values (plotly's `|| 1`) rather than becoming a gap, and there is no per-sign / `barmode` split.

Closes #691

## Testing

- New tests in `tests/plotly/test_plotly_area.py`: on the issue's figure, fraction gives `[[0.75, 0.25], [0.25, 0.75]]` and percent `[[75, 25], [25, 75]]`; a band that skips an x contributes 0; a zero-total column keeps its values; a stack without `groupnorm` and a lone band are untouched; a `groupnorm` set only on the second trace still governs; a normalised step area keeps `stepDirection`.
- Fail-before verified: the layer tests failed on raw values before the one-line gate in `_extract_plot_data`.
- Rendered plain, stacked, stacked-step, two-group and area-beside-line figures before and after: byte-identical schema (ids stripped). Only `groupnorm` figures change.
- `pytest -q -x`: 3937 passed, 68 skipped. `ruff check` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_