### PR TITLE
fix(regplot): match a phrase keyword on word boundaries; pin autobin blank count

### DIFF
--- a/maidr/patch/regplot.py
+++ b/maidr/patch/regplot.py
@@ -341,10 +341,15 @@ def _looks_smooth(label: str) -> bool:
     with it: ``ax.plot(label="Profit"); ax.plot(label="Revenue")`` emitted
     one smooth layer and no Revenue at all (#710).
 
-    A multi-word keyword such as ``linear fit`` is still matched as a
-    phrase, since its words are the boundary; a single-word one has to be
-    a word of the label on its own. Tokens are runs of letters, so
-    ``Group 1 KDE`` and ``kde_1`` both still read as a fit.
+    A multi-word keyword such as ``linear fit`` is matched as a phrase that
+    starts on a word boundary. Its words are not a boundary on their own:
+    read as a plain substring, ``linear fit`` was found inside ``Nonlinear
+    fitness``, spanning the tail of one word and the head of the next, and
+    that label took its siblings with it exactly as Profit had. The phrase's
+    last word may still run on, so ``Linear fitting`` keeps reading as a
+    fit; a single-word keyword has to be a word of the label on its own.
+    Tokens are runs of letters, so ``Group 1 KDE`` and ``kde_1`` both still
+    read as a fit.
 
     Parameters
     ----------
@@ -359,7 +364,10 @@ def _looks_smooth(label: str) -> bool:
     text = label.lower()
     tokens = set(re.findall(r"[a-z]+", text))
     return any(
-        (key in text) if " " in key else (key in tokens) for key in SMOOTH_KEYWORDS
+        re.search(rf"\b{re.escape(key)}", text) is not None
+        if " " in key
+        else key in tokens
+        for key in SMOOTH_KEYWORDS
     )
 
 

--- a/tests/core/plot/test_smooth_label_match.py
+++ b/tests/core/plot/test_smooth_label_match.py
@@ -75,6 +75,18 @@ def test_a_label_that_is_a_keyword_is_still_a_fit(label):
     assert "smooth" in kinds
 
 
+def test_a_phrase_straddling_two_words_does_not_take_the_revenue_line_with_it():
+    # The same loss by another door. The phrase keyword "linear fit" was
+    # still a substring test, and "Nonlinear fitness" holds those letters
+    # across a word break -- so the line typed as a fit and Revenue went
+    # with it, exactly the reading #710 was about.
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [10, 12, 9], label="Nonlinear fitness")
+    ax.plot([1, 2, 3], [20, 25, 21], label="Revenue")
+
+    assert _layers(fig) == [("line", 2)]
+
+
 def test_a_profit_line_does_not_take_the_revenue_line_with_it():
     # The regression itself, by name. The mis-typing was the cause; the
     # missing sibling series is what a reader would have met.
@@ -96,8 +108,18 @@ def test_a_profit_line_does_not_take_the_revenue_line_with_it():
         ("kde_1", True),
         ("Density", True),
         ("linear regression", True),
-        # A multi-word keyword is a phrase, so its words are its boundary.
+        # A multi-word keyword is a phrase that starts on a word boundary. Its
+        # last word may run on, as a single-word keyword's may not.
+        ("Linear fit", True),
         ("Linear fitting", True),
+        ("a linear fit of y", True),
+        # The phrase's words are not a boundary of their own: as a substring,
+        # "linear fit" spans "...linear" and "fit..." here (#710, again).
+        ("Nonlinear fitness", False),
+        ("Nonlinear fits", False),
+        ("Nonlinear fitting", False),
+        # Though "fit" as a whole word of its own still is one.
+        ("Nonlinear fit", True),
         ("Fitness benefit", False),
         ("", False),
     ],

--- a/tests/plotly/test_plotly_histogram_bins.py
+++ b/tests/plotly/test_plotly_histogram_bins.py
@@ -668,6 +668,59 @@ class TestABlankIsNoObservation:
         assert blanked == finite
         assert finite[0][0] == -0.5
 
+    #: Eight even integers on the edges of a width-2 grid, one odd integer at
+    #: a midpoint, and a half that is neither -- so not every finite value is
+    #: an integer, and the integer branch above stays out of it.
+    ON_EDGES = [0, 2, 4, 6, 8, 10, 12, 14, 5, 0.5]
+
+    def test_the_thresholds_are_of_the_sample_without_its_blanks_too(self):
+        """The 10% and 30% tests read the same ``f``, blanks subtracted.
+
+        Derived from the bundle's rule rather than measured, on a sample
+        built so that the two lengths answer differently. The routine
+        shifts the start by half a width when ``o < f * .1`` and either
+        ``a > f * .3`` or an extreme sits on an edge, ``o`` and ``a`` being
+        the values within 1% of a bin midpoint and of a bin edge. A width
+        of 2 over ``ON_EDGES`` seeds the start at -2, so the eight evens are
+        on edges and the lone 5 is the one midpoint: ``o`` is 1 against ten
+        finite values, ``1 < 1.0`` fails, and the start stays at -2 -- whose
+        first bin, ``[-2, 0)``, holds nothing and is trimmed, so the chart is
+        drawn from 0. Seven ``None`` make the array seventeen long; were ``f``
+        that length, ``1 < 1.7`` and ``8 > 5.1`` would both hold and the
+        start would move to -1, a grid the chart does not draw.
+
+        A blank reaches the routine as ``undefined``: ``makeCalcdata`` maps
+        whatever is not numeric to ``BADNUM``, which fails ``%1===0``,
+        fails ``isNumeric`` and so is counted into ``l``, and fails
+        ``nearEdge`` on both counts. Running the bundle's function on the
+        array with seven ``undefined`` answers -2; on the finite ten alone,
+        -2 as well; with the length left whole, -1. The port answers the
+        same three ways, which is asserted first so a change to which
+        sample it is handed cannot pass by the figure agreeing by accident.
+        """
+        finite = np.array(self.ON_EDGES, dtype=float)
+        whole = np.concatenate([finite, np.full(7, np.nan)])
+
+        assert _auto_shift_bins(-2, finite, 2, 0, 14) == -2
+        assert _auto_shift_bins(-2, whole, 2, 0, 14) == -1
+
+        alone = bins(go.Figure(go.Histogram(x=self.ON_EDGES, xbins=dict(size=2))))
+        blanked = bins(
+            go.Figure(go.Histogram(x=self.ON_EDGES + [None] * 7, xbins=dict(size=2)))
+        )
+
+        assert blanked == alone
+        assert alone == [
+            (0.0, 2.0, 2),
+            (2.0, 4.0, 1),
+            (4.0, 6.0, 2),
+            (6.0, 8.0, 1),
+            (8.0, 10.0, 1),
+            (10.0, 12.0, 1),
+            (12.0, 14.0, 1),
+            (14.0, 16.0, 1),
+        ]
+
     def test_a_blank_still_counts_toward_the_width_exponent(self):
         """The one term plotly reads off the whole array, blanks included.
 


### PR DESCRIPTION
## Summary

Two residuals raised by the reviews of #733 and #729 after they merged.

- `_looks_smooth` matched multi-word keywords as substrings, so "Nonlinear fitness" / "Nonlinear fits" typed an `ax.plot` line as SMOOTH and the sibling-dropping rule then lost "Revenue", the shape #710 fixed for single words. A phrase now has to start on a word boundary; "Linear fitting", "a linear fit of y" and "Nonlinear fit" keep reading as fits (a trailing boundary would have stopped "Linear fitting", which the #733 tests pin as smooth).
- Verified against the bundled plotly.js 3.8.2 that `autoShiftNumericBins` subtracts blanks (`f = t.length - l`, blanks arriving as `BADNUM` via `Lib.cleanNumber`; the verbatim function run in node on the test sample agrees), so `compute_bin_edges` handing it the finite sample is already right and no code changes. A test pins it with a sample whose 41 % blanks would flip the 10 % / 30 % thresholds under the wrong length.

Refs #710 #699

## Testing

- `tests/core/plot -k "smooth or regplot"`: 128 passed; `tests/plotly`: 1499 passed; full suite: 3925 passed, 68 skipped; `ruff check` clean on changed files.
- The new regplot cases fail before the change (`_looks_smooth("Nonlinear fitness")` was True).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_