### PR TITLE
fix(highlight): leave gids alone outside a render and keep a user-set gid inside one

### DIFF
--- a/maidr/core/context_manager.py
+++ b/maidr/core/context_manager.py
@@ -108,6 +108,15 @@ class HighlightContextManager:
     )
 
     @classmethod
+    def is_rendering(cls) -> bool:
+        """Whether a maidr render is writing its SVG in this context.
+
+        True only inside :meth:`set_maidr_elements`. Per-context, so a plain
+        draw on another thread during a render sees ``False``.
+        """
+        return cls._selector_by_element.get(None) is not None
+
+    @classmethod
     def is_maidr_element(cls, gid):
         return gid in cls._elements.get({})
 

--- a/maidr/patch/highlight.py
+++ b/maidr/patch/highlight.py
@@ -24,11 +24,24 @@ def inject_maidr_attribute(wrapped, instance, args, kwargs):
 
 
 def tag_elements(wrapped, instance, args, kwargs):
-    id = str(instance.get_gid())
-    if not id.startswith("maidr-"):
-        id = "maidr-" + str(uuid.uuid4())
-        instance.set_gid(id)
-    with HighlightContextManager.set_maidr_element(instance, id):
+    # The draw patches below are class-wide, so outside a render this must
+    # be a no-op: a plain `savefig` used to rewrite every artist's gid in the
+    # process, including ones the user set to target from their own CSS or
+    # JS, and on figures `FigureManager` never saw (#753). Nothing reads a
+    # gid minted outside a render.
+    if not HighlightContextManager.is_rendering():
+        return wrapped(*args, **kwargs)
+
+    # Inside a render an existing gid is kept: matplotlib writes it as the
+    # `<g id>` that `XMLWriter.start` keys on, so a user's gid resolves to
+    # its selector exactly as a minted one does. The mapping is set and
+    # deleted around each artist's own draw, so two artists sharing a gid
+    # do not collide in `elements`.
+    gid = instance.get_gid()
+    if gid is None:
+        gid = "maidr-" + str(uuid.uuid4())
+        instance.set_gid(gid)
+    with HighlightContextManager.set_maidr_element(instance, str(gid)):
         return wrapped(*args, **kwargs)
 
 

--- a/tests/core/test_highlight_context_manager.py
+++ b/tests/core/test_highlight_context_manager.py
@@ -13,10 +13,14 @@ artist never tagged is left alone, and a rendered chart carries exactly one
 ``maidr`` attribute per bar, with the layer's selector on each. One test
 pins the change itself: resolving an artist no longer compares it against
 the others, which is the scan that made a render quadratic.
+
+Two more pin #753: outside a render the class-wide ``draw`` patch touches no
+gid at all, and inside one a gid the user set is kept and keys its selector.
 """
 
 from __future__ import annotations
 
+import io
 import re
 
 import matplotlib
@@ -25,6 +29,7 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
 import pytest  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
 from matplotlib.patches import Rectangle  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
@@ -128,3 +133,48 @@ def test_a_rendered_bar_chart_carries_one_selector_per_bar():
         bar.get_gid() for bar in bars
     ], "every bar, in draw order, and nothing else"
     assert {selector for _, selector in tagged} == {selector_id}
+
+
+def test_a_plain_draw_mints_no_gid():
+    """Outside a render the class-wide ``draw`` patch leaves gids alone.
+
+    A plain ``savefig`` used to hand every Patch and Line2D in the process a
+    fresh ``maidr-<uuid>`` gid -- on a bare :class:`~matplotlib.figure.Figure`
+    that ``FigureManager`` never saw, and on a registered figure the user
+    only wanted a PNG of. Nothing reads a gid minted outside a render
+    (#753).
+    """
+    fig = Figure()
+    span = fig.add_subplot().axhspan(0, 1)
+    fig.savefig(io.BytesIO(), format="png")
+    assert span.get_gid() is None
+
+    fig, ax = plt.subplots()
+    bars = ax.bar(["a", "b"], [1, 2])
+    FigureManager.get_maidr(fig)  # registered, but never rendered
+    fig.savefig(io.BytesIO(), format="png")
+    assert [bar.get_gid() for bar in bars] == [None, None]
+
+
+def test_a_user_gid_survives_a_draw_and_keys_its_selector():
+    """A gid the user set is kept, and the render addresses the bar by it.
+
+    Matplotlib writes ``get_gid()`` as the ``<g id>`` that ``XMLWriter.start``
+    receives, so an existing gid resolves to its selector just as a minted
+    one does; only an artist with no gid gets a ``maidr-`` one (#753).
+    """
+    fig, ax = plt.subplots()
+    bars = ax.bar(["a", "b"], [1, 2])
+    bars[0].set_gid("my-first-bar")
+
+    fig.savefig(io.BytesIO(), format="png")
+    assert bars[0].get_gid() == "my-first-bar"
+
+    chart = FigureManager.get_maidr(fig)
+    html = str(chart._create_html_tag(use_iframe=False, use_cdn=True))
+
+    (selector_id,) = chart.selector_ids
+    assert bars[0].get_gid() == "my-first-bar"
+    assert f'<g id="my-first-bar" maidr="{selector_id}"' in html
+    assert bars[1].get_gid().startswith("maidr-")
+    assert f'<g id="{bars[1].get_gid()}" maidr="{selector_id}"' in html


### PR DESCRIPTION
## Summary

- `tag_elements` ran inside the class-wide `draw` patch of every Patch, Line2D and collection on every backend and figure, and minted a fresh `maidr-<uuid>` gid whenever the existing one did not start with `maidr-`. A plain `fig.savefig("chart.png")` silently rewrote every user-set gid, and a bare `Figure()` never registered with `FigureManager` was tagged too.
- Add `HighlightContextManager.is_rendering()` (true only inside `set_maidr_elements`, per context) and return early from `tag_elements` outside a render.
- Inside a render, mint only when `get_gid()` is `None` and key the per-artist mapping on the existing gid otherwise. matplotlib writes it as the `<g id>` that `XMLWriter.start` keys on, so a user's gid resolves to its layer selector exactly as a minted one does; this matches every other gid-minting site in the package, which already guards with `get_gid() is None`.
- A gid the user sets is now emitted verbatim as the SVG `<g id>`, so two artists sharing a user gid in one render produce duplicate `id` attributes, as matplotlib itself already allows; the per-artist mapping is set and deleted around each draw, so they do not collide in the highlight mapping.

Closes #753

## Testing

- New `test_a_plain_draw_mints_no_gid` and `test_a_user_gid_survives_a_draw_and_keys_its_selector` in `tests/core/test_highlight_context_manager.py`; both fail on `main` (`assert 'maidr-c567...' == 'my-first-bar'`) and pass here. The HTML carries `<g id="my-first-bar" maidr="<selector_id>">` and the sibling bar's minted gid is addressed by the same selector.
- Eight chart types (bar, line, scatter, hist, box, seaborn heatmap, stacked bar, fill_between area) rendered before and after produce identical schemas and identical `<g id="maidr-…" maidr="…">` counts once per-render UUIDs are normalised.
- `pytest tests/core -q -x`: 2287 passed, 1 skipped. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_