### PR TITLE
fix(bar): read a positional stacking baseline and a zero one as none

### DIFF
--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, Tuple, Union
 
+import numpy as np
 import wrapt
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
@@ -11,6 +12,7 @@ from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS
 from maidr.patch.common import (
+    _argument,
     _draw_quietly,
     common,
     plotter_panels,
@@ -27,12 +29,13 @@ def bar(
 
     This function patches the bar plotting functions to identify whether the
     plot should be rendered as a normal, stacked, or dodged bar plot.
-    It uses the 'bottom' keyword -- or 'left', which is how a horizontal bar
-    spells the same thing -- to identify stacked bar plots. For dodged
-    plots, it uses robust detection logic that considers both width and
-    context to avoid misclassifying simple bar plots with narrow widths as
-    dodged plots. Seaborn's bar plots do not come through here — they are
-    classified from the bars they drew, in `sns_bar` below.
+    It uses the 'bottom' argument -- or 'left', which is how a horizontal bar
+    spells the same thing -- to identify stacked bar plots, whether passed by
+    name or by position; a baseline of zeros is not one. For dodged plots, it
+    uses robust detection logic that considers both width and context to
+    avoid misclassifying simple bar plots with narrow widths as dodged plots.
+    Seaborn's bar plots do not come through here — they are classified from
+    the bars they drew, in `sns_bar` below.
 
     Parameters
     ----------
@@ -66,15 +69,32 @@ def bar(
     # The numbers were right and the layer count was plausible; what a reader
     # was not told is that the second bar sits on top of the first, which is
     # the whole content of a stacked chart (#385).
-    baseline = kwargs.get("bottom", kwargs.get("left"))
-    if baseline is not None:
+    #
+    # Read by name or by position, because both spellings are matplotlib's:
+    # `bottom` is the fourth parameter of `Axes.bar` and `left` the fourth of
+    # `Axes.barh`, and `ax.bar(x, b, 0.8, a)` said where its baseline was just
+    # as plainly as `bottom=a` -- yet arrived as a second plain bar layer, the
+    # same failure one argument over (#754).
+    #
+    # A baseline of zeros is where a bar starts anyway, so it says nothing
+    # about stacking: `bottom=0` is matplotlib's own default written out, and
+    # reading it as a stack announced a plain chart as a one-group stack named
+    # after its container. The first layer of a stack registers BAR either way
+    # and is superseded by the STACKED layer that follows it -- see
+    # `_drop_superseded_layers`, which records that idiom as the supported one.
+    baseline = _argument("bottom", wrapped, args, kwargs)
+    if baseline is None:
+        baseline = _argument("left", wrapped, args, kwargs)
+    if baseline is not None and not _is_zero_baseline(baseline):
         plot_type = PlotType.STACKED
     else:
-        # Extract width and align parameters
-        if len(args) >= 3:
-            real_width = args[2]
-        else:
-            real_width = kwargs.get("width", 0.8)
+        # The thickness across the bar, which is `height` on `barh` -- where
+        # `width` is the bar's length, and reading it compared two calls'
+        # values rather than their spacing.
+        thickness = "height" if getattr(wrapped, "__name__", "") == "barh" else "width"
+        real_width = _argument(thickness, wrapped, args, kwargs)
+        if real_width is None:
+            real_width = 0.8
 
         align = kwargs.get("align", "center")
 
@@ -97,6 +117,29 @@ def bar(
     # below, where no single container is the answer -- that path keeps the
     # sweep, which is right for it.
     return common(plot_type, wrapped, instance, args, kwargs, drawn_as=DRAWN_BARS)
+
+
+def _is_zero_baseline(baseline: Any) -> bool:
+    """
+    Whether a bar's baseline is zero everywhere, and so no baseline at all.
+
+    Parameters
+    ----------
+    baseline : Any
+        The ``bottom`` or ``left`` argument as the caller passed it: a
+        scalar, a sequence, or a column name resolved against ``data=``.
+
+    Returns
+    -------
+    bool
+        True for a scalar zero or an all-zero sequence. Anything that cannot
+        be read as numbers -- a column name, in particular -- is False, so it
+        keeps reading as the stack it names.
+    """
+    try:
+        return bool(np.all(np.asarray(baseline, dtype=float) == 0))
+    except (TypeError, ValueError):
+        return False
 
 
 def _should_classify_as_dodged(

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -161,7 +161,8 @@ def _should_classify_as_dodged(
     ax : Any
         The axes instance where the plot is being created.
     width : Any
-        The width parameter for the bar plot.
+        The thickness across the bar: ``width`` on ``bar``, ``height`` on
+        ``barh``, whichever the caller passed.
     align : str
         The alignment parameter for the bar plot.
     args : tuple

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -14,6 +14,7 @@ from maidr.core.plot.barplot import DRAWN_BARS
 from maidr.patch.common import (
     _argument,
     _draw_quietly,
+    _resolve,
     common,
     plotter_panels,
     wrap_seaborn,
@@ -85,6 +86,10 @@ def bar(
     baseline = _argument("bottom", wrapped, args, kwargs)
     if baseline is None:
         baseline = _argument("left", wrapped, args, kwargs)
+    # A name under `data=` is looked up before the zero test, so the two
+    # spellings of one chart -- `bottom="b", data=df` and `bottom=df["b"]` --
+    # read the same column and give the same answer.
+    baseline = _resolve(baseline, kwargs.get("data"))
     if baseline is not None and not _is_zero_baseline(baseline):
         plot_type = PlotType.STACKED
     else:
@@ -126,15 +131,15 @@ def _is_zero_baseline(baseline: Any) -> bool:
     Parameters
     ----------
     baseline : Any
-        The ``bottom`` or ``left`` argument as the caller passed it: a
-        scalar, a sequence, or a column name resolved against ``data=``.
+        The ``bottom`` or ``left`` argument, a scalar or a sequence, after
+        a name under ``data=`` has been resolved to its column.
 
     Returns
     -------
     bool
         True for a scalar zero or an all-zero sequence. Anything that cannot
-        be read as numbers -- a column name, in particular -- is False, so it
-        keeps reading as the stack it names.
+        be read as numbers -- a name that resolved to nothing, in particular
+        -- is False, so it keeps reading as the stack it names.
     """
     try:
         return bool(np.all(np.asarray(baseline, dtype=float) == 0))

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -146,6 +146,13 @@ def _argument(name: str, wrapped: Callable, args: tuple, kwargs: dict) -> Any:
             break
         positional.append(parameter_name)
 
+    # An unbound call, `Axes.bar(ax, ...)`, reaches the patch through wrapt's
+    # partial proxy, whose signature still opens with `self` although the
+    # instance is already out of `args`. Dropping it keeps each index on the
+    # argument it names; a bound call opens with `x` or `y` and is untouched.
+    if positional and positional[0] in ("self", "cls"):
+        positional.pop(0)
+
     if name not in positional:
         return None
 

--- a/maidr/patch/common.py
+++ b/maidr/patch/common.py
@@ -106,12 +106,16 @@ def _argument(name: str, wrapped: Callable, args: tuple, kwargs: dict) -> Any:
     name : str
         Name of the parameter to read.
     wrapped : Callable
-        The wrapped function, used for its parameter order. It is the bound
-        method, so ``self`` is not among its parameters. Matplotlib's, when
-        this was written; ``maidr/patch/violinplot.py`` now reads ``inner``
-        off ``_CategoricalPlotter.plot_violins`` through it as well, which
-        works for the same reason and is worth saying so a reader does not
-        assume matplotlib is the only caller.
+        The wrapped function, used for its parameter order. On a bound call
+        it is the bound method and ``self`` is not among its parameters; on
+        an unbound one, ``Axes.bar(ax, ...)``, wrapt's proxy still lists
+        ``self`` while the instance is already out of ``args``, and that
+        leading name is dropped below. Matplotlib's, when this was written;
+        ``maidr/patch/violinplot.py`` reads ``inner`` off
+        ``_CategoricalPlotter.plot_violins`` through it and
+        ``maidr/patch/barplot.py`` reads a bar's baseline and thickness,
+        which works for the same reason and is worth saying so a reader
+        does not assume matplotlib is the only caller.
     args : tuple
         Positional arguments the caller passed.
     kwargs : dict

--- a/maidr/patch/lineplot.py
+++ b/maidr/patch/lineplot.py
@@ -202,6 +202,9 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
     if before is None:
         series.extend(drawn)
     else:
+        # The set is taken once: `drawn` is a snapshot difference of
+        # `ax.get_lines()`, which never lists one artist twice, so the batch
+        # has nothing to check against itself.
         listed = {id(line) for line in series}
         series.extend(line for line in drawn if id(line) not in listed)
 

--- a/maidr/patch/lineplot.py
+++ b/maidr/patch/lineplot.py
@@ -185,11 +185,25 @@ def line(wrapped, instance, args, kwargs) -> Axes | list[Line2D]:
     # handed over by reference and extraction is lazy, so lines added after the
     # layer is registered still reach it -- which is what the sweep provided
     # and the only part of it worth keeping.
+    #
+    # Listing is by identity -- `Line2D` defines no `__eq__`, so that is all
+    # `in` ever tested -- and it is only the seaborn path that can list a line
+    # twice: its `drawn` is a diff against a snapshot, which can include an
+    # earlier call's lines when the axes snapshotted was not the one drawn
+    # on. `Axes.plot` hands back the lines it just made, none of which can be
+    # listed yet, so that path extends outright. Checking every line against
+    # the whole list cost a walk that grew with the axes -- 8 us per call over
+    # 1,000 lines, 77 us over 8,000 -- paid once per `ax.plot()` for nothing
+    # (#755).
     series = getattr(ax, DRAWN_SERIES, None)
     if series is None:
         series = []
         setattr(ax, DRAWN_SERIES, series)
-    series.extend(item for item in drawn if item not in series)
+    if before is None:
+        series.extend(drawn)
+    else:
+        listed = {id(line) for line in series}
+        series.extend(line for line in drawn if id(line) not in listed)
 
     # Check if a MAIDR plot already exists for this axes
     if not hasattr(ax, PLOT_CREATED):

--- a/maidr/patch/scatterplot.py
+++ b/maidr/patch/scatterplot.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import matplotlib.pyplot as plt
 import wrapt
 from matplotlib.axes import Axes
 from matplotlib.collections import PathCollection
@@ -9,7 +8,7 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.scatterplot import DRAWN_POINTS, HUE_GROUP, hue_groups
-from maidr.patch.common import drew_nothing
+from maidr.patch.common import drew_nothing, prospective_axes
 from maidr.patch.common import _draw_quietly, wrap_seaborn
 
 
@@ -73,10 +72,16 @@ def scatter(wrapped, instance, args, kwargs) -> Axes | PathCollection:
     # Guessed axes are not trusted: the count is used only when the axes
     # counted is the one the call came back with, which is exact. Anything
     # else declines to decide and registers as before.
-    counted = kwargs.get("ax")
-    if counted is None and plt.get_fignums():
-        counted = plt.gca()
-    before = len(counted.collections) if isinstance(counted, Axes) else None
+    #
+    # Which means it is only ever read for the seaborn binding, whose return
+    # value is the axes. `Axes.scatter` hands its collection back and its
+    # `instance` is the axes, so a count taken there could never be used --
+    # and asking pyplot for a current axes to take it had one effect only:
+    # `plt.gca()` on a pyplot figure with no axes creates one, so an
+    # object-oriented `ax.scatter()` put an empty panel on whatever unrelated
+    # pyplot figure happened to be current (#755).
+    counted = None if isinstance(instance, Axes) else prospective_axes(kwargs)
+    before = len(counted.collections) if counted is not None else None
 
     # Hand the layer the collection this call drew. `ScatterPlot` otherwise
     # takes the *first* `PathCollection` on the axes, which is right only

--- a/tests/core/plot/test_empty_drawing_call.py
+++ b/tests/core/plot/test_empty_drawing_call.py
@@ -176,3 +176,28 @@ def test_drew_nothing_declines_to_guess():
     assert drew_nothing(None) is False
     assert drew_nothing({}) is False
     assert drew_nothing("not an artist") is False
+
+
+def test_an_axes_scatter_leaves_the_current_pyplot_figure_alone():
+    """The count above is only ever read for the seaborn binding.
+
+    `Axes.scatter` returns its collection, so `counted is plot` can never
+    hold on that path and its snapshot was dead -- yet taking it asked
+    pyplot for a current axes, and `plt.gca()` on a figure with none
+    *creates* one. An object-oriented `ax.scatter()` on a figure pyplot has
+    never heard of therefore put an empty axes on whatever pyplot figure
+    happened to be current, which showed up as a blank panel the next time
+    that figure was saved (#755).
+    """
+    from matplotlib.figure import Figure
+
+    empty = plt.figure()
+    try:
+        fignums = plt.get_fignums()
+        axes = Figure().add_subplot()
+        axes.scatter([1.0, 2.0], [3.0, 4.0])
+
+        assert plt.get_fignums() == fignums
+        assert empty.axes == []
+    finally:
+        plt.close(empty)

--- a/tests/core/test_bar_baseline_spelling.py
+++ b/tests/core/test_bar_baseline_spelling.py
@@ -30,6 +30,7 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
 import pytest  # noqa: E402
+from matplotlib.axes import Axes  # noqa: E402
 
 import maidr  # noqa: F401,E402  # activates patches
 from maidr.core.figure_manager import FigureManager  # noqa: E402
@@ -136,6 +137,47 @@ def test_a_zero_first_baseline_still_collapses_into_the_stack() -> None:
     assert _registered(fig) == ["bar", "stacked_bar"]
     assert [kind for kind, _ in _emitted(fig)] == ["stacked_bar"]
     assert len(_emitted(fig)[0][1]) == 2
+
+
+def test_an_unbound_call_reads_its_arguments_at_the_same_indices() -> None:
+    """``Axes.bar(ax, x, h, w, b)`` binds ``b`` to ``bottom`` too.
+
+    The unbound spelling reaches the patch through wrapt's partial proxy,
+    whose signature still opens with ``self`` while the instance is already
+    out of ``args``. Read naively, every index lands one argument early:
+    the width was found at the baseline's slot, so two side-by-side calls
+    stopped reading as dodged, and a positional baseline was not found at
+    all. Both have to read exactly as the bound call does.
+    """
+    positions = np.arange(len(CATEGORIES))
+
+    dodged, dodged_ax = plt.subplots()
+    Axes.bar(dodged_ax, positions + 0.2, SERIES_0, 0.4, label="s0")
+    Axes.bar(dodged_ax, positions - 0.2, SERIES_1, 0.4, label="s1")
+
+    stacked, stacked_ax = plt.subplots()
+    Axes.bar(stacked_ax, CATEGORIES, SERIES_0, label="s0")
+    Axes.bar(stacked_ax, CATEGORIES, SERIES_1, 0.8, SERIES_0, label="s1")
+
+    assert _registered(dodged) == ["dodged_bar", "dodged_bar"]
+    assert _registered(stacked) == ["bar", "stacked_bar"]
+
+
+def test_a_zero_baseline_named_in_data_is_a_plain_bar() -> None:
+    """``bottom="b", data=df`` with a column of zeros reads as the bare call.
+
+    The name is looked up before the zero test, so the two spellings of one
+    chart -- the column by name and the column by value -- agree.
+    """
+    frame = pd.DataFrame({"x": CATEGORIES, "h": SERIES_0, "b": np.zeros(3)})
+    fig, ax = plt.subplots()
+    ax.bar("x", "h", bottom="b", data=frame)
+
+    bare, bare_ax = plt.subplots()
+    bare_ax.bar(CATEGORIES, SERIES_0)
+
+    assert _registered(fig) == ["bar"]
+    assert _emitted(fig) == _emitted(bare)
 
 
 def test_a_baseline_named_in_data_still_stacks() -> None:

--- a/tests/core/test_bar_baseline_spelling.py
+++ b/tests/core/test_bar_baseline_spelling.py
@@ -1,0 +1,174 @@
+"""A stacked bar's baseline is read however matplotlib lets it be written.
+
+``Axes.bar(x, height, width=0.8, bottom=None)`` takes its baseline as the
+fourth positional argument and ``Axes.barh`` takes ``left`` the same way, but
+the patch read the two names off ``kwargs`` alone. Measured on the two
+spellings of one chart (#754)::
+
+    ax.bar(x, a); ax.bar(x, b, bottom=a)    ['bar', 'stacked_bar'] -> stacked_bar
+    ax.bar(x, a); ax.bar(x, b, 0.8, a)      ['bar', 'bar']         -> bar, bar
+
+The numbers were right both ways. What the positional spelling withheld from
+a reader is that the second series sits on the first, which is the whole
+content of a stacked chart -- the #385 failure again, one argument over.
+
+Two neighbours of the same read. ``bottom=0`` is matplotlib's own default
+written out, and it registered a one-group stack whose only group wore
+matplotlib's container label ``_container0``. And the thickness that decides
+whether two calls are dodged was read as ``width`` for both orientations, so
+``ax.barh(..., height=0.4)`` twice compared the bar *lengths* and read as two
+plain layers where ``ax.bar(..., width=0.4)`` twice reads as dodged.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pandas as pd
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+
+CATEGORIES = ["a", "b", "c"]
+SERIES_0 = np.array([10.0, 20.0, 30.0])
+SERIES_1 = np.array([30.0, 20.0, 10.0])
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _registered(fig) -> list[str]:
+    """The types of every layer registered on the figure, in call order."""
+    return [plot.type.value for plot in FigureManager.get_maidr(fig).plots]
+
+
+def _emitted(fig) -> list[tuple[str, object]]:
+    """``(type, data)`` of every layer the first subplot cell emits.
+
+    The data and not only the type, because a stack with the wrong number of
+    groups and a stack with the right number are the same word.
+    """
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return [
+        (layer["type"].value, layer["data"]) for layer in grid[0][0].get("layers", [])
+    ]
+
+
+def test_a_positional_baseline_reads_as_a_stack() -> None:
+    """The reproduction: ``bottom`` as the fourth positional argument.
+
+    Asserted against the keyword spelling of the same chart rather than
+    against a literal, since the two are one chart and a reader must be
+    told the same thing about both.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, label="s0")
+    ax.bar(CATEGORIES, SERIES_1, 0.8, SERIES_0, label="s1")
+
+    reference, reference_ax = plt.subplots()
+    reference_ax.bar(CATEGORIES, SERIES_0, label="s0")
+    reference_ax.bar(CATEGORIES, SERIES_1, 0.8, bottom=SERIES_0, label="s1")
+
+    assert _registered(fig) == ["bar", "stacked_bar"]
+    assert _emitted(fig) == _emitted(reference)
+    assert [kind for kind, _ in _emitted(fig)] == ["stacked_bar"]
+    assert len(_emitted(fig)[0][1]) == 2, "both series are groups of the stack"
+
+
+def test_a_positional_left_reads_barh_as_a_stack() -> None:
+    """``left`` is ``barh``'s spelling of the baseline, positional as well."""
+    fig, ax = plt.subplots()
+    ax.barh(CATEGORIES, SERIES_0, label="s0")
+    ax.barh(CATEGORIES, SERIES_1, 0.8, SERIES_0, label="s1")
+
+    assert _registered(fig) == ["bar", "stacked_bar"]
+    assert [kind for kind, _ in _emitted(fig)] == ["stacked_bar"]
+    assert len(_emitted(fig)[0][1]) == 2
+
+
+@pytest.mark.parametrize(
+    "baseline",
+    [
+        pytest.param(0, id="int"),
+        pytest.param(0.0, id="float"),
+        pytest.param(np.zeros(len(CATEGORIES)), id="zeros"),
+    ],
+)
+def test_a_zero_baseline_is_a_plain_bar(baseline) -> None:
+    """A baseline of zeros is where a bar starts anyway.
+
+    ``bottom=0`` used to register a stack of one group, named after the
+    container matplotlib minted for it, so a plain chart was announced as
+    a stacked one. Each spelling of zero has to read exactly as the bare
+    call does.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, bottom=baseline)
+
+    bare, bare_ax = plt.subplots()
+    bare_ax.bar(CATEGORIES, SERIES_0)
+
+    assert _registered(fig) == ["bar"]
+    assert _emitted(fig) == _emitted(bare)
+
+
+def test_a_zero_first_baseline_still_collapses_into_the_stack() -> None:
+    """The idiom every older test wrote, kept working.
+
+    ``bottom=0`` on the first call now registers ``BAR`` rather than
+    ``STACKED``, which is the shape matplotlib's own gallery example already
+    has -- and the segmented layer that follows supersedes it, so the chart
+    still emits as one stack of two groups.
+    """
+    fig, ax = plt.subplots()
+    ax.bar(CATEGORIES, SERIES_0, bottom=0, label="s0")
+    ax.bar(CATEGORIES, SERIES_1, bottom=SERIES_0, label="s1")
+
+    assert _registered(fig) == ["bar", "stacked_bar"]
+    assert [kind for kind, _ in _emitted(fig)] == ["stacked_bar"]
+    assert len(_emitted(fig)[0][1]) == 2
+
+
+def test_a_baseline_named_in_data_still_stacks() -> None:
+    """``bottom="col", data=df`` names a column, which is not a zero.
+
+    The zero test must not swallow a string: a name that cannot be read as
+    numbers is a baseline like any other, and the call stacks.
+    """
+    frame = pd.DataFrame({"x": CATEGORIES, "h": SERIES_1, "b": SERIES_0})
+    fig, ax = plt.subplots()
+    ax.bar("x", "h", bottom="b", data=frame)
+
+    assert _registered(fig) == ["stacked_bar"]
+
+
+def test_barh_height_keyword_reads_dodged_like_the_positional_spelling() -> None:
+    """The thickness of a horizontal bar is its ``height``.
+
+    Read as ``width`` -- the bar's length on ``barh`` -- two side-by-side
+    horizontal bars compared the wrong number and came out as two plain
+    layers, while the same chart drawn vertically, or with the thickness
+    passed positionally, reads as dodged.
+    """
+    positions = np.arange(len(CATEGORIES))
+
+    horizontal, ax = plt.subplots()
+    ax.barh(positions + 0.2, SERIES_0, height=0.4, label="s0")
+    ax.barh(positions - 0.2, SERIES_1, height=0.4, label="s1")
+
+    vertical, ax = plt.subplots()
+    ax.bar(positions + 0.2, SERIES_0, width=0.4, label="s0")
+    ax.bar(positions - 0.2, SERIES_1, width=0.4, label="s1")
+
+    assert _registered(vertical) == ["dodged_bar", "dodged_bar"]
+    assert _registered(horizontal) == _registered(vertical)
+    assert [kind for kind, _ in _emitted(horizontal)] == ["dodged_bar"]

--- a/tests/patch/test_common.py
+++ b/tests/patch/test_common.py
@@ -1,0 +1,72 @@
+"""``_argument`` reads a positional argument at the index its name binds to.
+
+wrapt hands an unbound call, ``Axes.bar(ax, ...)``, to a patch through its
+partial proxy: the instance is already out of ``args`` while the signature
+``_argument`` inspects still opens with ``self``. Read naively, every index
+landed one argument early, so a positional ``width`` was found in the
+baseline's slot and a positional baseline was not found at all (#758).
+"""
+
+from __future__ import annotations
+
+import wrapt
+
+from maidr.patch.common import _argument
+
+
+def _patched(name: str):
+    """A class whose ``bar`` is patched the way ``Axes.bar`` is.
+
+    Returns the class and the dict the patch records ``_argument``'s reading
+    of ``name`` into, so a test can call ``bar`` bound or unbound and see
+    what the patch saw.
+    """
+    seen = {}
+
+    class Plotter:
+        def bar(self, x, height, width=0.8, bottom=None):
+            return x, height, width, bottom
+
+    def patch(wrapped, instance, args, kwargs):
+        seen["value"] = _argument(name, wrapped, args, kwargs)
+        return wrapped(*args, **kwargs)
+
+    wrapt.wrap_function_wrapper(Plotter, "bar", patch)
+    return Plotter, seen
+
+
+def test_a_bound_call_reads_a_positional_argument_by_its_index() -> None:
+    Plotter, seen = _patched("bottom")
+    Plotter().bar([0, 1], [2, 3], 0.4, [5, 6])
+
+    assert seen["value"] == [5, 6]
+
+
+def test_an_unbound_call_reads_the_same_argument_at_the_same_index() -> None:
+    Plotter, seen = _patched("bottom")
+    Plotter.bar(Plotter(), [0, 1], [2, 3], 0.4, [5, 6])
+
+    assert seen["value"] == [5, 6]
+
+
+def test_an_unbound_call_does_not_read_the_width_as_the_baseline() -> None:
+    # The shape #758 measured: one slot early, the width landed on the
+    # baseline's index and two side-by-side calls stopped reading as dodged.
+    Plotter, seen = _patched("width")
+    Plotter.bar(Plotter(), [0, 1], [2, 3], 0.4)
+
+    assert seen["value"] == 0.4
+
+
+def test_a_keyword_wins_over_the_position() -> None:
+    Plotter, seen = _patched("width")
+    Plotter().bar([0, 1], [2, 3], width=0.2)
+
+    assert seen["value"] == 0.2
+
+
+def test_an_argument_the_caller_left_out_is_none() -> None:
+    Plotter, seen = _patched("bottom")
+    Plotter().bar([0, 1], [2, 3])
+
+    assert seen["value"] is None

--- a/tests/patch/test_line_series.py
+++ b/tests/patch/test_line_series.py
@@ -1,0 +1,103 @@
+"""Each ``ax.plot()`` call lists its own lines once, and only those.
+
+``line()`` accumulates the lines a layer's calls drew on the axes, so that
+several ``ax.plot()`` calls read as one multi-series layer. Appending used to
+test ``item not in series`` for every line, an identity walk over everything
+already listed -- so an axes built from thousands of ``ax.plot()`` calls paid
+a scan per call that grew with the axes (#755).
+
+On the ``Axes.plot`` path that walk could never find anything: matplotlib
+hands back the lines it just made, none of which can be listed yet. The
+seaborn path is the only one whose ``drawn`` is a diff against a snapshot and
+so can overlap an earlier call's lines. These tests pin the invariant the
+scan was upholding -- one entry per line, whichever path listed it -- so the
+faster append cannot quietly start listing a line twice.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+import numpy as np
+import pandas as pd
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pytest  # noqa: E402
+import seaborn as sns  # noqa: E402
+
+import maidr  # noqa: F401,E402  # activates patches
+from maidr.core.figure_manager import FigureManager  # noqa: E402
+from maidr.patch.lineplot import DRAWN_SERIES  # noqa: E402
+
+X = np.arange(4)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close every figure a test opened, so state cannot leak between them."""
+    yield
+    plt.close("all")
+
+
+def _series(ax) -> list:
+    """The lines the axes' layer lists, in the order they were listed."""
+    return list(getattr(ax, DRAWN_SERIES))
+
+
+def _emitted(fig) -> list[dict]:
+    """Every layer the first subplot cell emits."""
+    grid = FigureManager.get_maidr(fig)._flatten_maidr()["subplots"]
+    return grid[0][0].get("layers", [])
+
+
+def test_each_plot_call_lists_its_lines_once() -> None:
+    """Five calls, five lines; a call drawing two lines lists both."""
+    fig, ax = plt.subplots()
+    for offset in range(5):
+        ax.plot(X, X + offset)
+    ax.plot(X, X + 5, X, X + 6)
+
+    series = _series(ax)
+    assert len(series) == 7
+    assert len({id(line) for line in series}) == 7
+    assert series == list(ax.get_lines())
+
+    (layer,) = _emitted(fig)
+    assert layer["type"].value == "line"
+    assert len(layer["data"]) == 7
+
+
+def test_a_second_seaborn_lineplot_adds_only_its_own_line() -> None:
+    """The path whose ``drawn`` is a diff against a snapshot.
+
+    The second call's snapshot holds the first call's line, so the diff is
+    the second line alone -- and the list must not grow by more than that,
+    with or without ``ax=``, which is what decides which axes is snapshotted.
+    """
+    first = pd.DataFrame({"x": X, "y": X})
+    second = pd.DataFrame({"x": X, "y": X * 2})
+
+    fig, ax = plt.subplots()
+    sns.lineplot(data=first, x="x", y="y", ax=ax)
+    sns.lineplot(data=second, x="x", y="y", ax=ax)
+    assert len(_series(ax)) == 2
+    assert len({id(line) for line in _series(ax)}) == 2
+    plt.close(fig)
+
+    plt.figure()
+    sns.lineplot(data=first, x="x", y="y")
+    sns.lineplot(data=second, x="x", y="y")
+    assert len(_series(plt.gca())) == 2
+    assert len({id(line) for line in _series(plt.gca())}) == 2
+
+
+def test_a_step_layer_over_a_plot_call_still_reads_its_own_series() -> None:
+    """The type is asked of ``series``, so what it holds decides the layer."""
+    fig, ax = plt.subplots()
+    ax.step(X, X, where="post")
+    ax.step(X, X * 2, where="post")
+
+    assert len(_series(ax)) == 2
+    (layer,) = _emitted(fig)
+    assert layer["type"].value == "step"


### PR DESCRIPTION
## Summary

Three patch-layer fixes in how `maidr/patch/` reads the arguments of the calls it wraps.

- **Bar baseline is read through `_argument`**, so a stacking baseline passed positionally (`ax.bar(x, h, w, bottom)`) is seen as one, the same way a keyword `bottom=` already was. A baseline of all zeros, which matplotlib treats as no baseline, is read as none too (`_is_zero_baseline()`), so a plain bar with `bottom=0` stays a bar rather than becoming a one-layer stacked chart. `barh` reads its `height` the same way `bar` reads `width`. A baseline named under `data=` is resolved to its column before the zero test, so the two spellings of one chart agree.
- **`_argument` aligns an unbound call.** `Axes.bar(ax, ...)` reaches the patch through wrapt's partial proxy, whose signature still opens with `self` while the instance is already out of `args`, so every positional index landed one argument early: two side-by-side unbound calls stopped reading as dodged and a positional baseline was not found. A leading `self`/`cls` is dropped now; bound calls are untouched.
- **`Axes.scatter` no longer calls `plt.gca()`** to find the axes it is counting. When the wrapped instance is an `Axes`, that instance is the answer; only the pyplot path resolves prospective axes from the kwargs. This stops a scatter on a figure that is not current from creating or activating a pyplot figure as a side effect.
- **Line series extend without a rescan.** Each patched line call appends the lines it produced to the figure's series list directly, and the seaborn path keeps a per-call id set, instead of rescanning every line on the axes after every call.

Closes #754
Closes #755

## Testing

- New `tests/core/test_bar_baseline_spelling.py` covers positional and keyword `bottom`, an all-zero baseline, a zero baseline named under `data=`, the unbound `Axes.bar(ax, ...)` spelling for dodged and stacked, and `barh` `height`.
- New `test_an_axes_scatter_leaves_the_current_pyplot_figure_alone` pins the scatter change.
- New `tests/patch/test_line_series.py` pins that the series list matches a rescan for matplotlib and seaborn line calls.
- `uv run pytest tests/core tests/patch -q`: 1341 passed on the final head for `tests/core/plot`, `tests/patch` and the new file; full suite 4048 passed, 68 skipped before the last commit.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9