### PR TITLE
fix(candlestick): name each candle's own paths when a gap row is left out

### DIFF
--- a/maidr/core/plot/candlestick.py
+++ b/maidr/core/plot/candlestick.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Union, Dict
+from typing import Dict, List, Optional, Union
 from matplotlib.axes import Axes
 import pandas as pd
 
@@ -40,6 +40,10 @@ class CandlestickPlot(MaidrPlot):
         self._maidr_wick_collection = kwargs.get("_maidr_wick_collection", None)
         self._maidr_body_collection = kwargs.get("_maidr_body_collection", None)
         self._maidr_original_data = kwargs.get("_maidr_original_data", None)
+
+        # Positions in the frame of the rows whose candles were emitted, set by
+        # `_extract_from_dataframe` and read by `_get_selector` (#749).
+        self._drawn_rows: Optional[List[int]] = None
 
         # Store the GID for selector generation
         self._maidr_gid = None
@@ -118,9 +122,10 @@ class CandlestickPlot(MaidrPlot):
         ``json.dumps`` writes a bare ``NaN`` token, ``JSON.parse`` rejects it,
         and the whole figure -- volume bars and moving averages included --
         loses its accessibility. The SVG still holds a body path and two wick
-        paths for the gap row, which is why `_get_selector` keeps counting
-        ``len(df)``.
+        paths for the gap row, so the position of every row that *was* emitted
+        is kept on ``_drawn_rows`` for `_get_selector` to name its paths by.
         """
+        self._drawn_rows = []
         try:
             columns = [
                 df[name].to_numpy() for name in ("Open", "High", "Low", "Close")
@@ -157,6 +162,7 @@ class CandlestickPlot(MaidrPlot):
             if not math.isfinite(volume):
                 volume = 0.0
 
+            self._drawn_rows.append(i)
             candles.append(
                 {
                     "value": date_value,
@@ -196,8 +202,13 @@ class CandlestickPlot(MaidrPlot):
             MaidrKey.Y: self._axis_config(label=y_label),
         }
 
-    def _get_selector(self) -> Union[str, Dict[str, str]]:
-        """Return selectors for highlighting candlestick elements."""
+    def _get_selector(self) -> Union[str, Dict[str, Union[str, List[str]]]]:
+        """Return selectors for highlighting candlestick elements.
+
+        Each of ``body``, ``wickLow`` and ``wickHigh`` is one selector for all
+        candles when every row of the frame became a candle, and a list with
+        one selector per candle otherwise -- see the comment in the body.
+        """
         # Modern path: build structured selectors using separate gids
         if (
             self._maidr_body_collection
@@ -229,10 +240,37 @@ class CandlestickPlot(MaidrPlot):
             if N is None:
                 raise ExtractionError(PlotType.CANDLESTICK, self._maidr_wick_collection)
 
+            body = f"g[id='{self._maidr_body_gid}'] > path"
+            wick = f"g[id='{self._maidr_wick_gid}'] > path"
+
+            # A row the extraction left out -- a gap, all four prices NaN --
+            # still has a body path and two wick paths in the SVG, so from the
+            # gap on `data[i]` and path `i` no longer name the same candle,
+            # and one selector per kind lands every later highlight one candle
+            # early (#749). Naming each emitted candle's own paths keeps the
+            # two in step: the core reads a list of selectors in order, so
+            # element `i` is candle `i` again.
+            #
+            # Emitting the gap as a null record instead would keep the counts
+            # equal but not the reading. The core keeps the `open` section only
+            # while every candle's open is a finite number, so one null would
+            # silence "open" for the whole chart; it takes the gap's high minus
+            # low as a volatility of 0; and it finds the chart's range with
+            # `Math.min` over the prices, where null counts as 0.
+            drawn = self._drawn_rows
+            if drawn is not None and len(drawn) != N:
+                return {
+                    "body": [f"{body}:nth-child({row + 1})" for row in drawn],
+                    "wickLow": [f"{wick}:nth-child({row + 1})" for row in drawn],
+                    "wickHigh": [
+                        f"{wick}:nth-child({N + row + 1})" for row in drawn
+                    ],
+                }
+
             selectors = {
-                "body": f"g[id='{self._maidr_body_gid}'] > path",
-                "wickLow": f"g[id='{self._maidr_wick_gid}'] > path:nth-child(-n+{N})",
-                "wickHigh": f"g[id='{self._maidr_wick_gid}'] > path:nth-child(n+{N + 1})",
+                "body": body,
+                "wickLow": f"{wick}:nth-child(-n+{N})",
+                "wickHigh": f"{wick}:nth-child(n+{N + 1})",
             }
             return selectors
 

--- a/tests/core/plot/test_candlestick_extraction.py
+++ b/tests/core/plot/test_candlestick_extraction.py
@@ -122,3 +122,15 @@ def test_a_non_finite_volume_is_reported_as_zero(extract):
     candles = extract(frame)
     assert len(candles) == 5
     assert candles[2] == dict(EXPECTED[2], volume=0.0)
+
+
+def test_a_skipped_row_is_left_out_of_the_drawn_rows(axes):
+    # The SVG keeps a body path and two wick paths for a row the loop skipped,
+    # so `_get_selector` names each candle's paths by the position of its row
+    # in the frame rather than by its index in the data (#749).
+    plot = CandlestickPlot([axes])
+    frame = _frame(Low=[0, np.nan, 2, 3, 4], High=[2.5, 3.5, 4.5, np.inf, 6.5])
+
+    plot._extract_from_dataframe(frame)
+
+    assert plot._drawn_rows == [0, 2, 4]

--- a/tests/core/plot/test_non_finite_coordinates.py
+++ b/tests/core/plot/test_non_finite_coordinates.py
@@ -218,10 +218,19 @@ class TestTheCandlestickWithAGap:
     ``NaN`` -- the #427 failure again, and worse here, because the volume
     bars and moving averages on the same figure share the payload and went
     dark with it (#706).
+
+    Leaving the row out of ``data`` fixed that and opened a quieter defect:
+    the SVG still holds the gap's body path and two wick paths, so from the
+    gap on ``data[i]`` and path ``i`` name different candles, and a highlight
+    for any later candle landed one candle early (#749). Emitting the gap as
+    a ``null`` record would keep the counts equal but not the reading -- the
+    core drops the ``open`` section for the whole chart unless every open is
+    a finite number, and its ``Math.min`` over the prices counts ``null`` as
+    0 -- so the fix names each emitted candle's own paths instead.
     """
 
     @staticmethod
-    def _frame():
+    def _frame(gap: int | None = 2):
         import pandas as pd
 
         frame = pd.DataFrame(
@@ -233,15 +242,38 @@ class TestTheCandlestickWithAGap:
             },
             index=pd.date_range("2026-01-01", periods=6),
         )
-        frame.iloc[2] = np.nan
+        if gap is not None:
+            frame.iloc[gap] = np.nan
         return frame
 
-    def _candlestick(self):
+    def _candlestick(self, gap: int | None = 2):
         mpf = pytest.importorskip("mplfinance")
-        frame = self._frame()
+        frame = self._frame(gap)
         fig, _ = mpf.plot(frame, type="candle", returnfig=True)
         plots = FigureManager.get_maidr(fig)._plots
         return frame, next(p for p in plots if p.type == PlotType.CANDLESTICK)
+
+    @staticmethod
+    def _svg(fig):
+        """The exported SVG, with namespaces stripped.
+
+        ``cssselect`` translates a selector into namespace-free XPath and the
+        core's ``querySelectorAll`` matches on local names, so stripping is
+        what makes the two resolve a selector the same way.
+        """
+        pytest.importorskip("cssselect")
+        from lxml import etree
+
+        import maidr
+
+        html = maidr.render(fig)._repr_html_()
+        start = html.index("<svg")
+        end = html.index("</svg>", start) + len("</svg>")
+        root = etree.fromstring(html[start:end].encode("utf-8"))
+        for element in root.iter():
+            if isinstance(element.tag, str) and "}" in element.tag:
+                element.tag = element.tag.split("}", 1)[1]
+        return root
 
     def test_its_payload_is_parseable(self):
         _, plot = self._candlestick()
@@ -263,14 +295,66 @@ class TestTheCandlestickWithAGap:
             if isinstance(value, float)
         )
 
-    def test_the_wick_selectors_still_count_every_row(self):
-        # The SVG keeps a body path and two wick paths for the gap row, so the
-        # nth-child split between low and high wicks must go on counting the
-        # frame, not the candles emitted. The cost is that a highlight after
-        # the gap lands one path early; before, there was no highlight at all.
-        frame, plot = self._candlestick()
+    def test_a_highlight_after_the_gap_lands_on_its_own_candle(self):
+        from lxml.cssselect import CSSSelector
+
+        frame, plot = self._candlestick(gap=1)
+        root = self._svg(plot.ax.get_figure())
+        tree = root.getroottree()
         selectors = plot.schema["selectors"]
 
-        assert len(plot._maidr_wick_collection.get_paths()) == 2 * len(frame)
+        # What mplfinance drew, in document order: a body and two wicks per
+        # source row -- the low wicks first, then the high ones -- with the
+        # gap row's among them as paths with no geometry.
+        bodies = CSSSelector(f"g[id='{plot._maidr_body_gid}'] > path")(root)
+        wicks = CSSSelector(f"g[id='{plot._maidr_wick_gid}'] > path")(root)
+        assert len(bodies) == len(frame)
+        assert len(wicks) == 2 * len(frame)
+        assert bodies[1].get("d") is None
+
+        # Data index 1 is source row 2, so its selectors have to name row 2's
+        # paths and not the gap's, which is where a count of the frame put
+        # them.
+        assert plot.schema["data"][1]["open"] == 3.0
+        for key, drawn in (
+            ("body", bodies[2]),
+            ("wickLow", wicks[2]),
+            ("wickHigh", wicks[len(frame) + 2]),
+        ):
+            found = CSSSelector(selectors[key][1])(root)
+            assert [tree.getpath(e) for e in found] == [tree.getpath(drawn)]
+
+    def test_every_candle_owns_one_body_and_two_wicks(self):
+        # The frame test above pins one index; this one walks them all. Each
+        # candle resolves to a single path with geometry for each kind, and
+        # its two wicks stand at the same x, so none of them is the gap's.
+        from lxml.cssselect import CSSSelector
+
+        _, plot = self._candlestick(gap=1)
+        root = self._svg(plot.ax.get_figure())
+        selectors = plot.schema["selectors"]
+        candles = plot.schema["data"]
+
+        assert all(len(selectors[key]) == len(candles) for key in selectors)
+        for index in range(len(candles)):
+            wick_x = set()
+            for key in ("body", "wickLow", "wickHigh"):
+                found = CSSSelector(selectors[key][index])(root)
+                assert len(found) == 1
+                geometry = found[0].get("d")
+                assert geometry is not None
+                if key != "body":
+                    wick_x.add(geometry.split()[1])
+            assert len(wick_x) == 1
+
+    def test_a_frame_without_a_gap_keeps_one_selector_per_kind(self):
+        # The list form is for the gap alone. A frame every row of which
+        # became a candle still addresses its paths with the nth-child split,
+        # which is the shape every candlestick chart has shipped with.
+        frame, plot = self._candlestick(gap=None)
+        selectors = plot.schema["selectors"]
+
+        assert len(plot.schema["data"]) == len(frame)
+        assert selectors["body"].endswith("> path")
         assert f"nth-child(-n+{len(frame)})" in selectors["wickLow"]
         assert f"nth-child(n+{len(frame) + 1})" in selectors["wickHigh"]


### PR DESCRIPTION
## Summary

#739 leaves a row mplfinance draws as a gap (all four prices NaN) out of the emitted `data`, but the SVG still holds that row's body path and two wick paths, and `_get_selector` kept splitting the wick paths by `len(df)`. From the gap on, `data[i]` and SVG path `i` named different candles, so a highlight for any candle after the gap landed one candle early.

The extraction now records the frame position of every row that became a candle, and when a row was left out the layer emits one selector per candle for `body`, `wickLow` and `wickHigh` (the core's `collectElements` reads a list in order). A gap-free frame keeps the `nth-child` split it has always shipped.

A `null` record for the gap was measured against the bundle and rejected: the core drops the `open` section for the whole chart unless every open is finite, reads the gap's volatility as 0, and its `Math.min` over the prices counts `null` as 0.

Closes #749

## Testing

- New: selector at data index 1 (gap at row 1) resolved with `lxml.cssselect` against the exported SVG matches the paths drawn for source row 2; every candle resolves to one body and two wicks with geometry at the same x; a gap-free frame keeps single selectors; `_drawn_rows` skips the dropped row.
- Before the fix: 3 failed / 25 passed in the two candlestick test files. After: 28 passed.
- `pytest tests/core/plot tests/util`: 1519 passed, 2 xfailed. `ruff check` clean. The #739 strict-JSON round trip still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9)_