### PR TITLE
fix(dodged): read a hue level missing a category as a gap

### DIFF
--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from matplotlib.axes import Axes
+from matplotlib.category import StrCategoryLocator
 from matplotlib.container import BarContainer
 from matplotlib.patches import Rectangle
+from matplotlib.ticker import FixedLocator
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
@@ -24,16 +26,18 @@ from maidr.util.mixin import (
 DRAWN_GROUPS = "_maidr_bar_groups"
 
 
-def ragged(plot: list[BarContainer]) -> bool:
+def bars_are_ragged(plot: list[BarContainer]) -> bool:
     """
     Whether the containers of one layer hold different numbers of bars.
 
     ``seaborn.barplot(hue=)`` drops a row whose value is ``NaN`` before it
     draws, so a hue level that lacks one category comes out a bar short of
     its siblings (#752). Containers that are all the same length are not
-    ragged, however short of the axis they run: one bar per container is
-    the shape a hue that repeats the category draws, and it is read as a
-    plain bar layer, not as a grouped one with every other cell missing.
+    ragged, however short of the axis they run -- and that shape is two
+    things: a category missing from every hue level, or the hue that
+    repeats the category, which draws one bar per container. Raggedness
+    alone can only be the first, so it is evidence of a hue split on its
+    own; equal lengths need :func:`shares_a_category` to tell the two apart.
 
     Parameters
     ----------
@@ -46,6 +50,63 @@ def ragged(plot: list[BarContainer]) -> bool:
         True when at least two containers differ in length.
     """
     return len({len(container.patches) for container in plot}) > 1
+
+
+def ticks_are_categories(ax: Axes, key: MaidrKey) -> bool:
+    """
+    Whether the ticks on one axis are its categories, one per tick.
+
+    Placing bars against the ticks only means something when the ticks
+    were put there for the categories -- by ``seaborn``'s categorical axis
+    or matplotlib's, which lay them with a ``StrCategoryLocator``, or by a
+    caller's ``set_xticks``, which fixes them. A locator that chose its own
+    breaks lays ticks that are breaks, not categories: a stacked chart over
+    ``np.arange(len(species))`` has five of them in view for three bars
+    (#384), and placing the bars against those would announce ``"0.5"`` as
+    a category no bar was drawn for.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes to read.
+    key : MaidrKey
+        Which axis, ``X`` or ``Y``.
+
+    Returns
+    -------
+    bool
+        True when the ticks were fixed rather than chosen.
+    """
+    axis = ax.xaxis if key == MaidrKey.X else ax.yaxis
+    return isinstance(axis.get_major_locator(), (FixedLocator, StrCategoryLocator))
+
+
+def shares_a_category(rows: list[list[Rectangle | None]]) -> bool:
+    """
+    Whether some category holds bars of more than one container.
+
+    Side by side is what a dodged chart is, so a layer in which every
+    category holds one bar is not one: that is the hue that repeats the
+    category, which colours the bars a plain chart would have drawn anyway
+    and splits them one per container, with every container the same
+    length and short of the axis. A category missing from every hue level
+    leaves the containers that same shape (#752), and this is what tells
+    the two apart -- the hue levels still meet at the categories they
+    share.
+
+    Parameters
+    ----------
+    rows : list of list of Rectangle or None
+        The placement :func:`bars_by_category` returned.
+
+    Returns
+    -------
+    bool
+        True when a category holds bars from at least two containers.
+    """
+    return any(
+        sum(patch is not None for patch in column) > 1 for column in zip(*rows)
+    )
 
 
 def bars_by_category(
@@ -94,6 +155,8 @@ def bars_by_category(
             else:
                 centre = patch.get_x() + patch.get_width() / 2
             distances = [abs(position - centre) for position in positions]
+            # The nearest tick; on a tie the lower index wins, `index` being
+            # the first match.
             slot = distances.index(min(distances))
             if row[slot] is not None:
                 return None
@@ -274,6 +337,22 @@ class GroupedBarPlot(
                 # drawing (#752) -- is the same gap: `None`, which the core
                 # reads as "missing" and, having no element for it in the DOM,
                 # steps over when it pairs the bars with their rectangles.
+                #
+                # Checked against the bundle shipped in `maidr/static/maidr.js`
+                # rather than the core's source. Its segmented layer claims
+                # one element per cell off a single cursor `s`, and when the
+                # DOM holds fewer elements than there are cells (`r`) a cell
+                # that is zero or unmeasured (`Qo`, the source's
+                # `isDomOmittable`) takes an empty placeholder without
+                # advancing it::
+                #
+                #     function Qo(e){return e===0||!ao(e)}
+                #     ...s=0,c=(e,n)=>r&&Qo(this.barValues[e][n])||s>=t.length
+                #         ?M.createEmptyElement():t[s++];
+                #
+                # So the `null` consumes no rectangle and the bars after it
+                # still land on their own. One flat selector is therefore
+                # enough; a per-bar list is not needed for alignment.
                 if self._is_horizontal:
                     point = {
                         MaidrKey.X.value: self._magnitude_of(patch, horizontal=True),
@@ -319,15 +398,17 @@ class GroupedBarPlot(
         """
         One bar, or ``None`` for a gap, per announced label for every container.
 
-        Paired by position when the containers all run the same length,
-        which they do by construction for every layer that is not ragged:
-        each holds one bar per category, so the n-th bar is the n-th label.
-        That pairing was the only one, and a ragged layer -- ``seaborn``'s
-        hue with a ``NaN`` cell (#752) -- had nothing to be paired with, so
-        the layer gave up and the patch fell back to a plain bar layer whose
-        labels were the bars' fractional positions. The bars that were drawn
-        still sit against their category's tick, so a ragged layer is placed
-        against the ticks instead, by :func:`bars_by_category`.
+        Paired by position when every container holds one bar per label,
+        which is how every layer is drawn by construction until seaborn
+        drops a ``NaN`` cell before drawing (#752): the n-th bar is the n-th
+        label. That pairing was the only one, and a layer with a container
+        short of the labels had nothing to be paired with, so the layer
+        gave up and the patch fell back to a plain bar layer whose labels
+        were the bars' fractional positions. The bars that were drawn still
+        sit against their category's tick, so such a layer is placed against
+        the ticks instead, by :func:`bars_by_category` -- whether one
+        container is short or every one of them is, which is the layer a
+        category missing from every hue level leaves.
 
         Parameters
         ----------
@@ -343,10 +424,14 @@ class GroupedBarPlot(
             as one per category -- the caller turns that into an
             ``ExtractionError``, as the old length check did.
         """
-        if not ragged(plot):
-            if any(len(container.patches) != len(level) for container in plot):
-                return None
+        if all(len(container.patches) == len(level) for container in plot):
             return [list(container.patches) for container in plot]
+
+        # A tick the locator chose for itself is a break, not a category,
+        # and a bar has no business being placed against one; the labels
+        # are positional there, and paired above.
+        if not ticks_are_categories(self.ax, self._level_key):
+            return None
 
         # The positions are paired with the labels index for index by
         # `_ticks_in_view`; a count that disagrees means `extract_level` fell
@@ -379,10 +464,11 @@ class GroupedBarPlot(
         The first container is the one measured. Every container of a
         segmented layer holds one bar per category by construction, so they
         agree -- except when seaborn dropped a ``NaN`` cell before drawing
-        and left the containers ragged (#752). The tick labels are kept for
-        that layer too, because the bars it does have are placed against
-        the ticks by :meth:`_bars_for` rather than paired by position; the
-        gaps are what that placement is for.
+        and left a container short (#752). The tick labels are kept for
+        that layer too, whenever the ticks are the categories, because the
+        bars it does have are placed against the ticks by :meth:`_bars_for`
+        rather than paired by position; the gaps are what that placement is
+        for.
 
         Parameters
         ----------
@@ -396,7 +482,10 @@ class GroupedBarPlot(
         """
         level = self.extract_level(self.ax, self._level_key)
         first = plot[0].patches if plot else []
-        if level and (len(level) == len(first) or ragged(plot)):
+        if level and (
+            len(level) == len(first)
+            or ticks_are_categories(self.ax, self._level_key)
+        ):
             return level
 
         return [self._bar_position(patch) for patch in first]

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from matplotlib.axes import Axes
+from matplotlib.axis import Axis
 from matplotlib.category import StrCategoryLocator
 from matplotlib.container import BarContainer
 from matplotlib.patches import Rectangle
@@ -52,6 +53,25 @@ def bars_are_ragged(plot: list[BarContainer]) -> bool:
     return len({len(container.patches) for container in plot}) > 1
 
 
+def _axis_for(ax: Axes, key: MaidrKey) -> Axis:
+    """
+    The axis the bar labels sit on.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes to read.
+    key : MaidrKey
+        Which axis, ``X`` or ``Y``.
+
+    Returns
+    -------
+    Axis
+        ``ax.xaxis`` for ``X``, ``ax.yaxis`` otherwise.
+    """
+    return ax.xaxis if key == MaidrKey.X else ax.yaxis
+
+
 def ticks_are_categories(ax: Axes, key: MaidrKey) -> bool:
     """
     Whether the ticks on one axis are its categories, one per tick.
@@ -77,8 +97,8 @@ def ticks_are_categories(ax: Axes, key: MaidrKey) -> bool:
     bool
         True when the ticks were fixed rather than chosen.
     """
-    axis = ax.xaxis if key == MaidrKey.X else ax.yaxis
-    return isinstance(axis.get_major_locator(), (FixedLocator, StrCategoryLocator))
+    locator = _axis_for(ax, key).get_major_locator()
+    return isinstance(locator, (FixedLocator, StrCategoryLocator))
 
 
 def ticks_are_the_axis_categories(ax: Axes, key: MaidrKey) -> bool:
@@ -103,8 +123,7 @@ def ticks_are_the_axis_categories(ax: Axes, key: MaidrKey) -> bool:
     bool
         True when the axis itself holds the categories.
     """
-    axis = ax.xaxis if key == MaidrKey.X else ax.yaxis
-    return isinstance(axis.get_major_locator(), StrCategoryLocator)
+    return isinstance(_axis_for(ax, key).get_major_locator(), StrCategoryLocator)
 
 
 def shares_a_category(rows: list[list[Rectangle | None]]) -> bool:
@@ -213,6 +232,92 @@ def bars_by_category(
         rows.append(row)
 
     return rows
+
+
+def grouped_layout(
+    ax: Axes, containers: list[BarContainer], key: MaidrKey
+) -> tuple[list[str], list[list[Rectangle | None]]] | None:
+    """
+    The one reading of a grouped layer: its labels, and every container's
+    bar at each.
+
+    Decided here and nowhere else, for two callers that used to decide it
+    apart. :func:`maidr.patch.barplot._seaborn_bar_type` classifies a
+    layer when seaborn draws it and :class:`GroupedBarPlot` reads it when
+    the figure renders, and each re-derived the answer from the same
+    primitives with a check the other lacked -- so a layer classification
+    called grouped could be one extraction declined, and the decline was an
+    ``ExtractionError``, fatal to the whole figure. A layer is grouped if
+    and only if this returns a layout.
+
+    Three readings, tried in order:
+
+    1. The tick labels, paired by position, when every container holds one
+       bar per label. matplotlib puts exactly one tick per category on a
+       categorical axis, so the counts agree there by construction.
+    2. The tick labels, with each container's bars placed against the
+       ticks and ``None`` where it has none, when the ticks are categories
+       and no two bars of one container sit nearest one tick. This is the
+       layer seaborn leaves when it drops a ``NaN`` cell before drawing
+       (#752) -- one container short, or every one of them. A tick no
+       container claims is a gap in every series when the containers are
+       ragged, which is honest and the only reading ragged containers have;
+       and when the ticks are the axis's own categories, where it is a
+       category every level is empty at. Equal-length containers on ticks a
+       caller fixed by hand decline it: the half steps of
+       ``set_xticks([0, 0.5, 1, 1.5, 2])`` are breaks, not categories, and
+       announcing them would invent one the chart never drew -- and those
+       containers can be read by position instead.
+    3. None. On a numeric axis the tick locator picks its own breaks and
+       they have no reason to agree with the bars (#384); a caller of this
+       reads such a layer from the bars alone, or does not call it grouped.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes the layer was drawn on.
+    containers : list of BarContainer
+        The containers holding its series, one per group.
+    key : MaidrKey
+        The axis the bar labels sit on: ``Y`` for a horizontal layer,
+        ``X`` otherwise.
+
+    Returns
+    -------
+    tuple of (list of str, list of list of Rectangle or None), or None
+        One label per category and one row per container holding a bar or
+        ``None`` per category, or ``None`` when the containers cannot be
+        read as one bar per category.
+    """
+    level = LevelExtractorMixin.extract_level(ax, key)
+    if not level:
+        return None
+
+    if all(len(container.patches) == len(level) for container in containers):
+        return level, [list(container.patches) for container in containers]
+
+    if not ticks_are_categories(ax, key):
+        return None
+
+    # The positions are paired with the labels index for index by
+    # `_ticks_in_view`; a count that disagrees means `extract_level` fell
+    # back to a sibling axes' labels, whose positions these are not.
+    positions = LevelExtractorMixin.extract_level_positions(ax, key)
+    if positions is None or len(positions) != len(level):
+        return None
+
+    rows = bars_by_category(containers, positions, key == MaidrKey.Y)
+    if rows is None:
+        return None
+
+    if (
+        not bars_are_ragged(containers)
+        and not ticks_are_the_axis_categories(ax, key)
+        and not every_category_has_a_bar(rows)
+    ):
+        return None
+
+    return level, rows
 
 
 class GroupedBarPlot(
@@ -346,10 +451,9 @@ class GroupedBarPlot(
 
         self._orientation = self._extract_orientation(plot)
 
-        paired = self._labels_and_bars(plot)
-        if paired is None:
+        rows = self._labels_and_bars(plot)
+        if rows is None:
             return None
-        level, bars = paired
 
         data = []
 
@@ -360,7 +464,7 @@ class GroupedBarPlot(
         # Get hue categories from legend
         hue_categories = self._extract_hue_categories_from_legend()
 
-        for i, (container, row) in enumerate(zip(plot, bars)):
+        for i, (container, row) in enumerate(zip(plot, rows)):
             container_data = []
 
             # Use hue category if available, otherwise fall back to container label
@@ -368,7 +472,7 @@ class GroupedBarPlot(
                 hue_categories[i] if i < len(hue_categories) else container.get_label()
             )
 
-            for label, patch in zip(level, row):
+            for label, patch in row:
                 # A horizontal bar's magnitude runs along x and its label sits
                 # on y, which is the layout the renderer reads for a
                 # horizontal layer. The vertical layer is the mirror of that.
@@ -440,41 +544,27 @@ class GroupedBarPlot(
 
     def _labels_and_bars(
         self, plot: list[BarContainer]
-    ) -> tuple[list[str], list[list[Rectangle | None]]] | None:
+    ) -> list[list[tuple[str, Rectangle | None]]] | None:
         """
         What to announce alongside each bar of every series, and which bar.
 
-        Decided together, because the two are one decision: a label is only
-        the right one if the bar it is paired with was drawn for it. They
-        used to be decided apart, and the split let one half promise what
-        the other could not keep -- the labels chose the tick names because
-        the ticks were categories, the pairing then failed to place the bars
-        against them, and the layer raised where it had rendered before.
+        The layout :func:`grouped_layout` decides, which is the same one the
+        seaborn patch classified the layer by -- so a layer called grouped
+        at draw time reads as one here. When there is none, the layer is
+        read from its bars alone rather than raised on, since an
+        ``ExtractionError`` here is fatal to the whole figure: the ticks are
+        read afresh at render, and a caller's ``set_xticks`` between the two
+        may have moved them onto breaks the bars do not sit against, or two
+        of one container's bars onto one tick. ``maidr.stacked(ax)`` over a
+        numeric axis arrives the same way, never having had a layout (#384).
 
-        Three answers, tried in order:
-
-        1. The tick labels, paired by position, when every container holds
-           one bar per label. matplotlib puts exactly one tick per category
-           on a categorical axis, so the counts agree there by construction.
-        2. The tick labels, with each container's bars placed against the
-           ticks and ``None`` where it has none, when the ticks are
-           categories and every container fits them: no two bars of one
-           container on one tick, and -- on ticks a caller fixed by hand --
-           no tick that no container claims. This is the layer seaborn
-           leaves when it drops a ``NaN`` cell before drawing (#752) -- one
-           container short, or every one of them.
-        3. The positions the bars were drawn at, paired by position, when
-           every container holds the same number of bars. On a numeric axis
-           the tick locator picks its own breaks and they have no reason to
-           agree with the bars; this used to be an ``ExtractionError`` and
-           so an empty render -- a stacked chart over
-           ``np.arange(len(species))`` produced no HTML at all (#384), the
-           segmented half of #382.
-
-        The third is also where a categorical axis lands when its ticks do
-        not name the bars: two bars of one container nearest one tick, or a
-        tick no bar was drawn for. Announcing the tick names there would
-        either raise, or invent a category with nothing in it.
+        Read from the bars alone means the positions they were drawn at, the
+        first container's naming every series when they all run the same
+        length -- every series of a segmented chart shares one category
+        axis, so the announcement has to agree across them, and this is
+        what main emitted -- and, when they do not, each container's own.
+        The series then no longer share one axis, which is a lesser wrong
+        than no figure.
 
         Parameters
         ----------
@@ -483,69 +573,25 @@ class GroupedBarPlot(
 
         Returns
         -------
-        tuple of (list of str, list of list of Rectangle or None), or None
-            One label per category and one row per container holding a bar
-            or ``None`` per category; ``None`` when the containers cannot be
-            read as one bar per category any way -- the caller turns that
-            into an ``ExtractionError``, as the old length check did.
+        list of list of tuple, or None
+            One row per container of ``(label, bar)`` pairs, the bar
+            ``None`` for a gap; ``None`` only for no containers at all.
         """
-        level = self.extract_level(self.ax, self._level_key)
-        if level and all(len(container.patches) == len(level) for container in plot):
-            return level, [list(container.patches) for container in plot]
-
-        if level and ticks_are_categories(self.ax, self._level_key):
-            placed = self._placed_against_ticks(plot, level)
-            if placed is not None:
-                return level, placed
+        layout = grouped_layout(self.ax, plot, self._level_key)
+        if layout is not None:
+            level, rows = layout
+            return [list(zip(level, row)) for row in rows]
 
         first = plot[0].patches if plot else []
         labels = [self._bar_position(patch) for patch in first]
-        if any(len(container.patches) != len(labels) for container in plot):
-            return None
-        return labels, [list(container.patches) for container in plot]
+        if labels and all(len(c.patches) == len(labels) for c in plot):
+            return [list(zip(labels, container.patches)) for container in plot]
 
-    def _placed_against_ticks(
-        self, plot: list[BarContainer], level: list[str]
-    ) -> list[list[Rectangle | None]] | None:
-        """
-        Every container's bars against the ticks, or ``None`` if they do not fit.
-
-        Parameters
-        ----------
-        plot : list of BarContainer
-            The containers holding this layer's series.
-        level : list of str
-            The tick labels, one per category.
-
-        Returns
-        -------
-        list of list of Rectangle or None, or None
-            The placement :func:`bars_by_category` made, when every tick is
-            claimed by some container; ``None`` otherwise.
-        """
-        # The positions are paired with the labels index for index by
-        # `_ticks_in_view`; a count that disagrees means `extract_level` fell
-        # back to a sibling axes' labels, whose positions these are not.
-        positions = self.extract_level_positions(self.ax, self._level_key)
-        if positions is None or len(positions) != len(level):
-            return None
-
-        rows = bars_by_category(plot, positions, self._is_horizontal)
-        if rows is None:
-            return None
-
-        # A tick no container claims is two things. On the axis's own
-        # categories it is a category every level is empty at -- seaborn
-        # lists a category whose every value is NaN -- and a gap in every
-        # series says exactly that. On ticks a caller fixed by hand it is a
-        # tick that is no category at all, the half steps of
-        # `set_xticks([0, 0.5, 1, 1.5, 2])`, and announcing it would invent
-        # one the chart never drew.
-        if not every_category_has_a_bar(rows) and not ticks_are_the_axis_categories(
-            self.ax, self._level_key
-        ):
-            return None
-        return rows
+        rows = [
+            [(self._bar_position(patch), patch) for patch in container.patches]
+            for container in plot
+        ]
+        return rows if any(rows) else None
 
     def _extract_hue_categories_from_legend(self) -> list[str]:
         """

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -81,6 +81,32 @@ def ticks_are_categories(ax: Axes, key: MaidrKey) -> bool:
     return isinstance(axis.get_major_locator(), (FixedLocator, StrCategoryLocator))
 
 
+def ticks_are_the_axis_categories(ax: Axes, key: MaidrKey) -> bool:
+    """
+    Whether the ticks are the categories matplotlib registered on the axis.
+
+    A ``StrCategoryLocator`` lays one tick per category the axis was given,
+    and nothing else -- seaborn's categorical axis and ``ax.bar(["a", "b"])``
+    both go through it. A ``FixedLocator`` is a caller's ``set_xticks``, and
+    its ticks sit wherever the caller put them; :func:`ticks_are_categories`
+    admits both, and this is the narrower question.
+
+    Parameters
+    ----------
+    ax : Axes
+        The axes to read.
+    key : MaidrKey
+        Which axis, ``X`` or ``Y``.
+
+    Returns
+    -------
+    bool
+        True when the axis itself holds the categories.
+    """
+    axis = ax.xaxis if key == MaidrKey.X else ax.yaxis
+    return isinstance(axis.get_major_locator(), StrCategoryLocator)
+
+
 def shares_a_category(rows: list[list[Rectangle | None]]) -> bool:
     """
     Whether some category holds bars of more than one container.
@@ -107,6 +133,29 @@ def shares_a_category(rows: list[list[Rectangle | None]]) -> bool:
     return any(
         sum(patch is not None for patch in column) > 1 for column in zip(*rows)
     )
+
+
+def every_category_has_a_bar(rows: list[list[Rectangle | None]]) -> bool:
+    """
+    Whether every category holds a bar of at least one container.
+
+    A tick no container's bar is nearest to is not a category the chart
+    drew: place bars against ticks at ``0, 0.5, 1, 1.5, 2`` and the half
+    steps come out as categories with a gap in every series, which the
+    chart never showed. Placement is declined for such an axis, and the
+    layer announces the positions its bars were drawn at instead.
+
+    Parameters
+    ----------
+    rows : list of list of Rectangle or None
+        The placement :func:`bars_by_category` returned.
+
+    Returns
+    -------
+    bool
+        True when no column of ``rows`` is empty.
+    """
+    return all(any(patch is not None for patch in column) for column in zip(*rows))
 
 
 def bars_by_category(
@@ -297,13 +346,10 @@ class GroupedBarPlot(
 
         self._orientation = self._extract_orientation(plot)
 
-        level = self._labels_for(plot)
-        if not level:
+        paired = self._labels_and_bars(plot)
+        if paired is None:
             return None
-
-        bars = self._bars_for(plot, level)
-        if bars is None:
-            return None
+        level, bars = paired
 
         data = []
 
@@ -392,83 +438,43 @@ class GroupedBarPlot(
             return None
         return _magnitude(patch.get_width() if horizontal else patch.get_height())
 
-    def _bars_for(
-        self, plot: list[BarContainer], level: list[str]
-    ) -> list[list[Rectangle | None]] | None:
+    def _labels_and_bars(
+        self, plot: list[BarContainer]
+    ) -> tuple[list[str], list[list[Rectangle | None]]] | None:
         """
-        One bar, or ``None`` for a gap, per announced label for every container.
+        What to announce alongside each bar of every series, and which bar.
 
-        Paired by position when every container holds one bar per label,
-        which is how every layer is drawn by construction until seaborn
-        drops a ``NaN`` cell before drawing (#752): the n-th bar is the n-th
-        label. That pairing was the only one, and a layer with a container
-        short of the labels had nothing to be paired with, so the layer
-        gave up and the patch fell back to a plain bar layer whose labels
-        were the bars' fractional positions. The bars that were drawn still
-        sit against their category's tick, so such a layer is placed against
-        the ticks instead, by :func:`bars_by_category` -- whether one
-        container is short or every one of them is, which is the layer a
-        category missing from every hue level leaves.
+        Decided together, because the two are one decision: a label is only
+        the right one if the bar it is paired with was drawn for it. They
+        used to be decided apart, and the split let one half promise what
+        the other could not keep -- the labels chose the tick names because
+        the ticks were categories, the pairing then failed to place the bars
+        against them, and the layer raised where it had rendered before.
 
-        Parameters
-        ----------
-        plot : list of BarContainer
-            The containers holding this layer's series, one per group.
-        level : list of str
-            The labels :meth:`_labels_for` chose, one per category.
+        Three answers, tried in order:
 
-        Returns
-        -------
-        list of list of Rectangle or None, or None
-            One row per container, or ``None`` when the bars cannot be read
-            as one per category -- the caller turns that into an
-            ``ExtractionError``, as the old length check did.
-        """
-        if all(len(container.patches) == len(level) for container in plot):
-            return [list(container.patches) for container in plot]
+        1. The tick labels, paired by position, when every container holds
+           one bar per label. matplotlib puts exactly one tick per category
+           on a categorical axis, so the counts agree there by construction.
+        2. The tick labels, with each container's bars placed against the
+           ticks and ``None`` where it has none, when the ticks are
+           categories and every container fits them: no two bars of one
+           container on one tick, and -- on ticks a caller fixed by hand --
+           no tick that no container claims. This is the layer seaborn
+           leaves when it drops a ``NaN`` cell before drawing (#752) -- one
+           container short, or every one of them.
+        3. The positions the bars were drawn at, paired by position, when
+           every container holds the same number of bars. On a numeric axis
+           the tick locator picks its own breaks and they have no reason to
+           agree with the bars; this used to be an ``ExtractionError`` and
+           so an empty render -- a stacked chart over
+           ``np.arange(len(species))`` produced no HTML at all (#384), the
+           segmented half of #382.
 
-        # A tick the locator chose for itself is a break, not a category,
-        # and a bar has no business being placed against one; the labels
-        # are positional there, and paired above.
-        if not ticks_are_categories(self.ax, self._level_key):
-            return None
-
-        # The positions are paired with the labels index for index by
-        # `_ticks_in_view`; a count that disagrees means `extract_level` fell
-        # back to a sibling axes' labels, whose positions these are not.
-        positions = self.extract_level_positions(self.ax, self._level_key)
-        if positions is None or len(positions) != len(level):
-            return None
-
-        return bars_by_category(plot, positions, self._is_horizontal)
-
-    def _labels_for(self, plot: list[BarContainer]) -> list[str]:
-        """
-        What to announce alongside each bar of every series.
-
-        The tick labels when there is one per bar, and the positions the bars
-        were drawn at otherwise. Decided once for the layer rather than per
-        container, because every series of a segmented chart shares one
-        category axis -- so the announcement has to agree across them, and a
-        per-container answer could name a category in one series and a
-        position in the next.
-
-        matplotlib puts exactly one tick per category on a categorical axis,
-        so the counts agree there by construction; on a numeric axis the tick
-        locator picks its own breaks and they have no reason to. This used to
-        return ``None`` for that mismatch, which the caller turned into an
-        ``ExtractionError`` and so into an empty render -- a stacked chart
-        over ``np.arange(len(species))`` produced no HTML at all (#384), the
-        segmented half of #382.
-
-        The first container is the one measured. Every container of a
-        segmented layer holds one bar per category by construction, so they
-        agree -- except when seaborn dropped a ``NaN`` cell before drawing
-        and left a container short (#752). The tick labels are kept for
-        that layer too, whenever the ticks are the categories, because the
-        bars it does have are placed against the ticks by :meth:`_bars_for`
-        rather than paired by position; the gaps are what that placement is
-        for.
+        The third is also where a categorical axis lands when its ticks do
+        not name the bars: two bars of one container nearest one tick, or a
+        tick no bar was drawn for. Announcing the tick names there would
+        either raise, or invent a category with nothing in it.
 
         Parameters
         ----------
@@ -477,18 +483,69 @@ class GroupedBarPlot(
 
         Returns
         -------
-        list of str
-            One label per category, from the axis or from the bars.
+        tuple of (list of str, list of list of Rectangle or None), or None
+            One label per category and one row per container holding a bar
+            or ``None`` per category; ``None`` when the containers cannot be
+            read as one bar per category any way -- the caller turns that
+            into an ``ExtractionError``, as the old length check did.
         """
         level = self.extract_level(self.ax, self._level_key)
-        first = plot[0].patches if plot else []
-        if level and (
-            len(level) == len(first)
-            or ticks_are_categories(self.ax, self._level_key)
-        ):
-            return level
+        if level and all(len(container.patches) == len(level) for container in plot):
+            return level, [list(container.patches) for container in plot]
 
-        return [self._bar_position(patch) for patch in first]
+        if level and ticks_are_categories(self.ax, self._level_key):
+            placed = self._placed_against_ticks(plot, level)
+            if placed is not None:
+                return level, placed
+
+        first = plot[0].patches if plot else []
+        labels = [self._bar_position(patch) for patch in first]
+        if any(len(container.patches) != len(labels) for container in plot):
+            return None
+        return labels, [list(container.patches) for container in plot]
+
+    def _placed_against_ticks(
+        self, plot: list[BarContainer], level: list[str]
+    ) -> list[list[Rectangle | None]] | None:
+        """
+        Every container's bars against the ticks, or ``None`` if they do not fit.
+
+        Parameters
+        ----------
+        plot : list of BarContainer
+            The containers holding this layer's series.
+        level : list of str
+            The tick labels, one per category.
+
+        Returns
+        -------
+        list of list of Rectangle or None, or None
+            The placement :func:`bars_by_category` made, when every tick is
+            claimed by some container; ``None`` otherwise.
+        """
+        # The positions are paired with the labels index for index by
+        # `_ticks_in_view`; a count that disagrees means `extract_level` fell
+        # back to a sibling axes' labels, whose positions these are not.
+        positions = self.extract_level_positions(self.ax, self._level_key)
+        if positions is None or len(positions) != len(level):
+            return None
+
+        rows = bars_by_category(plot, positions, self._is_horizontal)
+        if rows is None:
+            return None
+
+        # A tick no container claims is two things. On the axis's own
+        # categories it is a category every level is empty at -- seaborn
+        # lists a category whose every value is NaN -- and a gap in every
+        # series says exactly that. On ticks a caller fixed by hand it is a
+        # tick that is no category at all, the half steps of
+        # `set_xticks([0, 0.5, 1, 1.5, 2])`, and announcing it would invent
+        # one the chart never drew.
+        if not every_category_has_a_bar(rows) and not ticks_are_the_axis_categories(
+            self.ax, self._level_key
+        ):
+            return None
+        return rows
 
     def _extract_hue_categories_from_legend(self) -> list[str]:
         """

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -478,6 +478,16 @@ class GroupedBarPlot(
         hue_categories = self._extract_hue_categories_from_legend()
 
         for i, (container, row) in enumerate(zip(plot, rows)):
+            # A container with no bars, read from the bars alone -- a hue
+            # level whose every value is NaN, on an axis whose ticks are not
+            # categories. There is nothing to announce for it and no
+            # position to place it at, so it is left out rather than
+            # emitted as an empty series; the level is still named in the
+            # legend, which is where a reader learns of it. On categorical
+            # ticks the same level is a row of gaps, and kept -- see
+            # `test_a_level_with_no_bars_at_all_is_an_all_null_series`.
+            if not row:
+                continue
             container_data = []
 
             # Use hue category if available, otherwise fall back to container label
@@ -577,7 +587,9 @@ class GroupedBarPlot(
         axis, so the announcement has to agree across them, and this is
         what main emitted -- and, when they do not, each container's own.
         The series then no longer share one axis, which is a lesser wrong
-        than no figure.
+        than no figure. A container with no bars at all has no position to
+        be read at and comes back as an empty row, which the caller leaves
+        out; the layer stands as long as some container has bars.
 
         Parameters
         ----------

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from matplotlib.axes import Axes
 from matplotlib.container import BarContainer
+from matplotlib.patches import Rectangle
 
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.plot import MaidrPlot
@@ -21,6 +22,85 @@ from maidr.util.mixin import (
 #: into *one* container, so the groups are synthesised from the bars' colours
 #: and are not on the axes to be found (#617).
 DRAWN_GROUPS = "_maidr_bar_groups"
+
+
+def ragged(plot: list[BarContainer]) -> bool:
+    """
+    Whether the containers of one layer hold different numbers of bars.
+
+    ``seaborn.barplot(hue=)`` drops a row whose value is ``NaN`` before it
+    draws, so a hue level that lacks one category comes out a bar short of
+    its siblings (#752). Containers that are all the same length are not
+    ragged, however short of the axis they run: one bar per container is
+    the shape a hue that repeats the category draws, and it is read as a
+    plain bar layer, not as a grouped one with every other cell missing.
+
+    Parameters
+    ----------
+    plot : list of BarContainer
+        The containers holding this layer's series, one per group.
+
+    Returns
+    -------
+    bool
+        True when at least two containers differ in length.
+    """
+    return len({len(container.patches) for container in plot}) > 1
+
+
+def bars_by_category(
+    plot: list[BarContainer], positions: list[float], horizontal: bool
+) -> list[list[Rectangle | None]] | None:
+    """
+    Place every container's bars against the shared category positions.
+
+    A bar seaborn did draw still sits against its category's tick, offset
+    by the dodge -- which is less than half the spacing between ticks -- so
+    the tick nearest each bar says which category it belongs to, and the
+    category no bar of a container is nearest to is that container's gap.
+    Read off the rectangles rather than the caller's arguments for the
+    reason :meth:`~maidr.util.mixin.BarPositionMixin._bar_position` gives:
+    the arguments are not available here, and the drawn centre is what the
+    value became.
+
+    Parameters
+    ----------
+    plot : list of BarContainer
+        The containers holding this layer's series, one per group.
+    positions : list of float
+        Where each category's tick sits on the label axis, in the order
+        the labels are announced.
+    horizontal : bool
+        Whether the bars grow along x, so their centres are read on y.
+
+    Returns
+    -------
+    list of list of Rectangle or None, or None
+        One row per container holding a bar, or ``None`` for a gap, per
+        category. ``None`` altogether when the bars cannot be placed -- two
+        bars of one container nearest the same tick is not one bar per
+        category, and there is nothing honest to pair such a container
+        with.
+    """
+    if not positions:
+        return None
+
+    rows: list[list[Rectangle | None]] = []
+    for container in plot:
+        row: list[Rectangle | None] = [None] * len(positions)
+        for patch in container.patches:
+            if horizontal:
+                centre = patch.get_y() + patch.get_height() / 2
+            else:
+                centre = patch.get_x() + patch.get_width() / 2
+            distances = [abs(position - centre) for position in positions]
+            slot = distances.index(min(distances))
+            if row[slot] is not None:
+                return None
+            row[slot] = patch
+        rows.append(row)
+
+    return rows
 
 
 class GroupedBarPlot(
@@ -158,6 +238,10 @@ class GroupedBarPlot(
         if not level:
             return None
 
+        bars = self._bars_for(plot, level)
+        if bars is None:
+            return None
+
         data = []
 
         self._elements.extend(
@@ -167,13 +251,7 @@ class GroupedBarPlot(
         # Get hue categories from legend
         hue_categories = self._extract_hue_categories_from_legend()
 
-        for i, container in enumerate(plot):
-            if len(level) != len(container.patches):
-                # Guarded above by `_labels_for`, which either found one tick
-                # per bar or built one label per bar. A container of a
-                # different length from its siblings would still land here,
-                # and there is nothing honest to pair it with.
-                return None
+        for i, (container, row) in enumerate(zip(plot, bars)):
             container_data = []
 
             # Use hue category if available, otherwise fall back to container label
@@ -181,7 +259,7 @@ class GroupedBarPlot(
                 hue_categories[i] if i < len(hue_categories) else container.get_label()
             )
 
-            for label, patch in zip(level, container.patches):
+            for label, patch in zip(level, row):
                 # A horizontal bar's magnitude runs along x and its label sits
                 # on y, which is the layout the renderer reads for a
                 # horizontal layer. The vertical layer is the mirror of that.
@@ -191,9 +269,14 @@ class GroupedBarPlot(
                 # `ax.bar(..., bottom=a)` over data with a gap emitted it as a
                 # bare `NaN` token that `JSON.parse` refuses, so the whole
                 # figure stopped initialising (#427, #696).
+                #
+                # A bar seaborn never drew -- the `NaN` cell it dropped before
+                # drawing (#752) -- is the same gap: `None`, which the core
+                # reads as "missing" and, having no element for it in the DOM,
+                # steps over when it pairs the bars with their rectangles.
                 if self._is_horizontal:
                     point = {
-                        MaidrKey.X.value: _magnitude(patch.get_width()),
+                        MaidrKey.X.value: self._magnitude_of(patch, horizontal=True),
                         MaidrKey.Z.value: fill_value,
                         MaidrKey.Y.value: label,
                     }
@@ -201,12 +284,78 @@ class GroupedBarPlot(
                     point = {
                         MaidrKey.X.value: label,
                         MaidrKey.Z.value: fill_value,
-                        MaidrKey.Y.value: _magnitude(patch.get_height()),
+                        MaidrKey.Y.value: self._magnitude_of(patch, horizontal=False),
                     }
                 container_data.append(point)
             data.append(container_data)
 
         return data
+
+    @staticmethod
+    def _magnitude_of(patch: Rectangle | None, horizontal: bool) -> float | None:
+        """
+        The magnitude of one bar, or ``None`` for a bar that was never drawn.
+
+        Parameters
+        ----------
+        patch : Rectangle or None
+            The bar, or ``None`` where the container has no bar for the
+            category.
+        horizontal : bool
+            Whether the bar grows along x, so its magnitude is its width.
+
+        Returns
+        -------
+        float or None
+            The bar's magnitude through :func:`_magnitude`, or ``None``.
+        """
+        if patch is None:
+            return None
+        return _magnitude(patch.get_width() if horizontal else patch.get_height())
+
+    def _bars_for(
+        self, plot: list[BarContainer], level: list[str]
+    ) -> list[list[Rectangle | None]] | None:
+        """
+        One bar, or ``None`` for a gap, per announced label for every container.
+
+        Paired by position when the containers all run the same length,
+        which they do by construction for every layer that is not ragged:
+        each holds one bar per category, so the n-th bar is the n-th label.
+        That pairing was the only one, and a ragged layer -- ``seaborn``'s
+        hue with a ``NaN`` cell (#752) -- had nothing to be paired with, so
+        the layer gave up and the patch fell back to a plain bar layer whose
+        labels were the bars' fractional positions. The bars that were drawn
+        still sit against their category's tick, so a ragged layer is placed
+        against the ticks instead, by :func:`bars_by_category`.
+
+        Parameters
+        ----------
+        plot : list of BarContainer
+            The containers holding this layer's series, one per group.
+        level : list of str
+            The labels :meth:`_labels_for` chose, one per category.
+
+        Returns
+        -------
+        list of list of Rectangle or None, or None
+            One row per container, or ``None`` when the bars cannot be read
+            as one per category -- the caller turns that into an
+            ``ExtractionError``, as the old length check did.
+        """
+        if not ragged(plot):
+            if any(len(container.patches) != len(level) for container in plot):
+                return None
+            return [list(container.patches) for container in plot]
+
+        # The positions are paired with the labels index for index by
+        # `_ticks_in_view`; a count that disagrees means `extract_level` fell
+        # back to a sibling axes' labels, whose positions these are not.
+        positions = self.extract_level_positions(self.ax, self._level_key)
+        if positions is None or len(positions) != len(level):
+            return None
+
+        return bars_by_category(plot, positions, self._is_horizontal)
 
     def _labels_for(self, plot: list[BarContainer]) -> list[str]:
         """
@@ -229,8 +378,11 @@ class GroupedBarPlot(
 
         The first container is the one measured. Every container of a
         segmented layer holds one bar per category by construction, so they
-        agree; a layer where they do not is caught by the length check at the
-        pairing loop, which has nothing honest to pair such a container with.
+        agree -- except when seaborn dropped a ``NaN`` cell before drawing
+        and left the containers ragged (#752). The tick labels are kept for
+        that layer too, because the bars it does have are placed against
+        the ticks by :meth:`_bars_for` rather than paired by position; the
+        gaps are what that placement is for.
 
         Parameters
         ----------
@@ -244,7 +396,7 @@ class GroupedBarPlot(
         """
         level = self.extract_level(self.ax, self._level_key)
         first = plot[0].patches if plot else []
-        if level and len(level) == len(first):
+        if level and (len(level) == len(first) or ragged(plot)):
             return level
 
         return [self._bar_position(patch) for patch in first]

--- a/maidr/core/plot/grouped_barplot.py
+++ b/maidr/core/plot/grouped_barplot.py
@@ -27,6 +27,15 @@ from maidr.util.mixin import (
 DRAWN_GROUPS = "_maidr_bar_groups"
 
 
+# How the helpers below fit together. `grouped_layout` is the one decision:
+# it asks `bars_are_ragged` whether every container is full, `ticks_are_categories`
+# and `ticks_are_the_axis_categories` what kind of ticks the axis has, then
+# `bars_by_category` to place each container's bars against those ticks, and
+# `shares_a_category` / `every_category_has_a_bar` to judge that placement.
+# The seaborn classifier and the extractor both call `grouped_layout` and
+# nothing else, so they cannot disagree.
+
+
 def bars_are_ragged(plot: list[BarContainer]) -> bool:
     """
     Whether the containers of one layer hold different numbers of bars.
@@ -310,6 +319,10 @@ def grouped_layout(
     if rows is None:
         return None
 
+    # Deliberately asymmetric -- see reading 2 in the docstring. Equal-length
+    # containers on hand-fixed ticks can be read by position, so an unclaimed
+    # tick sends them there; ragged containers have no positional reading, so
+    # the unclaimed tick is announced as a gap in every series.
     if (
         not bars_are_ragged(containers)
         and not ticks_are_the_axis_categories(ax, key)

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -11,7 +11,12 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS
-from maidr.core.plot.grouped_barplot import bars_by_category, ragged
+from maidr.core.plot.grouped_barplot import (
+    bars_are_ragged,
+    bars_by_category,
+    shares_a_category,
+    ticks_are_categories,
+)
 from maidr.patch.common import (
     _argument,
     _draw_quietly,
@@ -382,11 +387,11 @@ def _seaborn_bar_type(ax: Axes) -> PlotType:
     Classify a drawn seaborn bar layer as grouped or plain.
 
     A grouped layer draws one container per hue level, each holding one bar
-    per category -- or one bar short of it, where seaborn dropped a ``NaN``
-    cell before drawing (#752). Anything else — a single container, or
+    per category -- or short of it, where seaborn dropped a ``NaN`` cell
+    before drawing (#752). Anything else — a single container, or
     containers that do not line up with the categorical axis — is a plain
     bar layer. The bars are counted against the same tick labels
-    `GroupedBarPlot` pairs them with, and a ragged layer's bars are placed
+    `GroupedBarPlot` pairs them with, and a short layer's bars are placed
     against the same tick positions it places them by, so the layer is only
     called grouped when it can be read as one.
 
@@ -419,15 +424,15 @@ def _seaborn_bar_type(ax: Axes) -> PlotType:
     if all(len(container.patches) == len(levels) for container in containers):
         return PlotType.DODGED
 
-    # Containers of one length short of the axis are not a grouped layer:
-    # that is the shape a hue that repeats the category draws, one container
-    # per bar. Ragged ones are, when each container's bars sit against
-    # distinct ticks -- a hue level that lacks a category is one bar short,
-    # and `GroupedBarPlot` reads the bar it lacks as a gap (#752). This used
-    # to turn every ragged layer back, and the plain bar layer it fell to
-    # announced the bars' fractional positions, "-0.2", in place of their
-    # category and hue names.
-    if not ragged(containers):
+    # A container short of the axis is still a hue level when its bars sit
+    # against distinct ticks -- a level that lacks a category is a bar
+    # short, and `GroupedBarPlot` reads the bar it lacks as a gap (#752).
+    # This used to turn every such layer back, and the plain bar layer it
+    # fell to announced the bars' fractional positions, "-0.2", in place of
+    # their category and hue names. Only against ticks that are categories:
+    # `native_scale=True` leaves the locator to choose breaks, and a bar
+    # placed against a break is a bar placed against nothing.
+    if not ticks_are_categories(ax, level_key):
         return PlotType.BAR
 
     positions = LevelExtractorMixin.extract_level_positions(ax, level_key)
@@ -435,7 +440,16 @@ def _seaborn_bar_type(ax: Axes) -> PlotType:
         return PlotType.BAR
 
     horizontal = containers[0].orientation == "horizontal"
-    if bars_by_category(containers, positions, horizontal) is None:
+    rows = bars_by_category(containers, positions, horizontal)
+    if rows is None:
+        return PlotType.BAR
+
+    # Ragged containers can only be a hue split. Equal-length ones short of
+    # the axis are either that with a category missing from every level, or
+    # the hue that repeats the category -- one container per bar, colouring
+    # a plain chart. Side by side is what dodged means, so a category that
+    # holds bars of two containers is what tells them apart.
+    if not bars_are_ragged(containers) and not shares_a_category(rows):
         return PlotType.BAR
 
     return PlotType.DODGED

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -11,6 +11,7 @@ from maidr.core.context_manager import ContextManager
 from maidr.core.enum import MaidrKey, PlotType
 from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS
+from maidr.core.plot.grouped_barplot import bars_by_category, ragged
 from maidr.patch.common import (
     _argument,
     _draw_quietly,
@@ -381,10 +382,13 @@ def _seaborn_bar_type(ax: Axes) -> PlotType:
     Classify a drawn seaborn bar layer as grouped or plain.
 
     A grouped layer draws one container per hue level, each holding one bar
-    per category. Anything else — a single container, or containers that do
-    not line up with the categorical axis — is a plain bar layer. The bars
-    are counted against the same tick labels `GroupedBarPlot` pairs them
-    with, so the layer is only called grouped when it can be read as one.
+    per category -- or one bar short of it, where seaborn dropped a ``NaN``
+    cell before drawing (#752). Anything else — a single container, or
+    containers that do not line up with the categorical axis — is a plain
+    bar layer. The bars are counted against the same tick labels
+    `GroupedBarPlot` pairs them with, and a ragged layer's bars are placed
+    against the same tick positions it places them by, so the layer is only
+    called grouped when it can be read as one.
 
     Parameters
     ----------
@@ -412,7 +416,26 @@ def _seaborn_bar_type(ax: Axes) -> PlotType:
     if not levels:
         return PlotType.BAR
 
-    if any(len(container.patches) != len(levels) for container in containers):
+    if all(len(container.patches) == len(levels) for container in containers):
+        return PlotType.DODGED
+
+    # Containers of one length short of the axis are not a grouped layer:
+    # that is the shape a hue that repeats the category draws, one container
+    # per bar. Ragged ones are, when each container's bars sit against
+    # distinct ticks -- a hue level that lacks a category is one bar short,
+    # and `GroupedBarPlot` reads the bar it lacks as a gap (#752). This used
+    # to turn every ragged layer back, and the plain bar layer it fell to
+    # announced the bars' fractional positions, "-0.2", in place of their
+    # category and hue names.
+    if not ragged(containers):
+        return PlotType.BAR
+
+    positions = LevelExtractorMixin.extract_level_positions(ax, level_key)
+    if positions is None or len(positions) != len(levels):
+        return PlotType.BAR
+
+    horizontal = containers[0].orientation == "horizontal"
+    if bars_by_category(containers, positions, horizontal) is None:
         return PlotType.BAR
 
     return PlotType.DODGED

--- a/maidr/patch/barplot.py
+++ b/maidr/patch/barplot.py
@@ -13,9 +13,8 @@ from maidr.core.figure_manager import FigureManager
 from maidr.core.plot.barplot import DRAWN_BARS
 from maidr.core.plot.grouped_barplot import (
     bars_are_ragged,
-    bars_by_category,
+    grouped_layout,
     shares_a_category,
-    ticks_are_categories,
 )
 from maidr.patch.common import (
     _argument,
@@ -25,7 +24,6 @@ from maidr.patch.common import (
     plotter_panels,
     wrap_seaborn,
 )
-from maidr.util.mixin import LevelExtractorMixin
 
 
 def bar(
@@ -390,10 +388,10 @@ def _seaborn_bar_type(ax: Axes) -> PlotType:
     per category -- or short of it, where seaborn dropped a ``NaN`` cell
     before drawing (#752). Anything else — a single container, or
     containers that do not line up with the categorical axis — is a plain
-    bar layer. The bars are counted against the same tick labels
-    `GroupedBarPlot` pairs them with, and a short layer's bars are placed
-    against the same tick positions it places them by, so the layer is only
-    called grouped when it can be read as one.
+    bar layer. Whether the containers line up is
+    :func:`~maidr.core.plot.grouped_barplot.grouped_layout`'s answer, the
+    same one `GroupedBarPlot` reads the layer by, so the layer is only
+    called grouped when it will be read as one.
 
     Parameters
     ----------
@@ -417,32 +415,10 @@ def _seaborn_bar_type(ax: Axes) -> PlotType:
 
     # The bar labels sit on y when the bars grow along x.
     level_key = MaidrKey.Y if containers[0].orientation == "horizontal" else MaidrKey.X
-    levels = LevelExtractorMixin.extract_level(ax, level_key)
-    if not levels:
+    layout = grouped_layout(ax, containers, level_key)
+    if layout is None:
         return PlotType.BAR
-
-    if all(len(container.patches) == len(levels) for container in containers):
-        return PlotType.DODGED
-
-    # A container short of the axis is still a hue level when its bars sit
-    # against distinct ticks -- a level that lacks a category is a bar
-    # short, and `GroupedBarPlot` reads the bar it lacks as a gap (#752).
-    # This used to turn every such layer back, and the plain bar layer it
-    # fell to announced the bars' fractional positions, "-0.2", in place of
-    # their category and hue names. Only against ticks that are categories:
-    # `native_scale=True` leaves the locator to choose breaks, and a bar
-    # placed against a break is a bar placed against nothing.
-    if not ticks_are_categories(ax, level_key):
-        return PlotType.BAR
-
-    positions = LevelExtractorMixin.extract_level_positions(ax, level_key)
-    if positions is None or len(positions) != len(levels):
-        return PlotType.BAR
-
-    horizontal = containers[0].orientation == "horizontal"
-    rows = bars_by_category(containers, positions, horizontal)
-    if rows is None:
-        return PlotType.BAR
+    _, rows = layout
 
     # Ragged containers can only be a hue split. Equal-length ones short of
     # the axis are either that with a category missing from every level, or

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -50,6 +52,26 @@ class ContainerExtractorMixin:
 
         # Otherwise, return the first container of the specified type.
         return matches[0] if matches else None
+
+
+def _a_hair_from(position: float, bound: float) -> bool:
+    """
+    Whether a tick sits on a data bound to within a rounding error.
+
+    Parameters
+    ----------
+    position : float
+        The tick's position in data coordinates.
+    bound : float
+        The data limit it is measured against.
+
+    Returns
+    -------
+    bool
+        True when the two differ by no more than float noise -- one part in
+        a billion of the bound, or 1e-12 outright beside zero.
+    """
+    return math.isclose(position, bound, rel_tol=1e-9, abs_tol=1e-12)
 
 
 class LevelExtractorMixin:
@@ -131,18 +153,27 @@ class LevelExtractorMixin:
             span = ax.dataLim.height if hasattr(ax, "dataLim") else 0
             low = ax.dataLim.y0 if span else 0
 
-        # To within a hair of the span. A bar whose edge is meant to sit on a
-        # tick can land a float past it: seaborn dodges two hue levels to
-        # +-0.2 and draws each 0.4 wide, so the second level's first bar
-        # starts at `0.2 - 0.2`, which arrives as 5.6e-17 -- and when that
-        # bar is the only one at the first category, the tick at 0 sat
-        # outside its own data by that much and the category was dropped
-        # (#752). A tick a rounding error outside the data is not furniture.
-        slack = abs(span) * 1e-9
+        # To within a rounding error of either bound. A bar whose edge is
+        # meant to sit on a tick can land a float past it: seaborn dodges
+        # two hue levels to +-0.2 and draws each 0.4 wide, so the second
+        # level's first bar starts at `0.2 - 0.2`, which arrives as 5.6e-17
+        # -- and when that bar is the only one at the first category, the
+        # tick at 0 sat outside its own data by that much and the category
+        # was dropped (#752). A tick a rounding error outside the data is
+        # not furniture.
+        #
+        # Anchored on the bound, not on the span: a slack cut from the span
+        # is decades wide on a log axis running 1e-3 to 1e12, and admitted
+        # ticks at 1e-6 and 1e-4 that no data reaches. `isclose` against
+        # the bound itself keeps 5.6e-17 beside 0 and nothing beside 1e-3
+        # but 1e-3.
+        high = low + span
         kept = [
             index
             for index, position in enumerate(ticks)
-            if span == 0 or low - slack <= position <= low + span + slack
+            if span == 0
+            or (position >= low or _a_hair_from(position, low))
+            and (position <= high or _a_hair_from(position, high))
         ]
         return [
             (ticks[index], labels[index]) for index in kept if index < len(labels)

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -173,8 +173,10 @@ class LevelExtractorMixin:
             index
             for index, position in enumerate(ticks)
             if span == 0
-            or (position >= low or _within_tolerance_of(position, low))
-            and (position <= high or _within_tolerance_of(position, high))
+            or (
+                (position >= low or _within_tolerance_of(position, low))
+                and (position <= high or _within_tolerance_of(position, high))
+            )
         ]
         return [
             (ticks[index], labels[index]) for index in kept if index < len(labels)

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -54,7 +54,7 @@ class ContainerExtractorMixin:
         return matches[0] if matches else None
 
 
-def _a_hair_from(position: float, bound: float) -> bool:
+def _within_tolerance_of(position: float, bound: float) -> bool:
     """
     Whether a tick sits on a data bound to within a rounding error.
 
@@ -68,8 +68,9 @@ def _a_hair_from(position: float, bound: float) -> bool:
     Returns
     -------
     bool
-        True when the two differ by no more than float noise -- one part in
-        a billion of the bound, or 1e-12 outright beside zero.
+        True when the two differ by no more than float noise: one part in a
+        billion of the larger magnitude of the two, as ``math.isclose``
+        measures it, or 1e-12 outright beside zero.
     """
     return math.isclose(position, bound, rel_tol=1e-9, abs_tol=1e-12)
 
@@ -172,8 +173,8 @@ class LevelExtractorMixin:
             index
             for index, position in enumerate(ticks)
             if span == 0
-            or (position >= low or _a_hair_from(position, low))
-            and (position <= high or _a_hair_from(position, high))
+            or (position >= low or _within_tolerance_of(position, low))
+            and (position <= high or _within_tolerance_of(position, high))
         ]
         return [
             (ticks[index], labels[index]) for index in kept if index < len(labels)

--- a/maidr/util/mixin/extractor_mixin.py
+++ b/maidr/util/mixin/extractor_mixin.py
@@ -131,10 +131,18 @@ class LevelExtractorMixin:
             span = ax.dataLim.height if hasattr(ax, "dataLim") else 0
             low = ax.dataLim.y0 if span else 0
 
+        # To within a hair of the span. A bar whose edge is meant to sit on a
+        # tick can land a float past it: seaborn dodges two hue levels to
+        # +-0.2 and draws each 0.4 wide, so the second level's first bar
+        # starts at `0.2 - 0.2`, which arrives as 5.6e-17 -- and when that
+        # bar is the only one at the first category, the tick at 0 sat
+        # outside its own data by that much and the category was dropped
+        # (#752). A tick a rounding error outside the data is not furniture.
+        slack = abs(span) * 1e-9
         kept = [
             index
             for index, position in enumerate(ticks)
-            if span == 0 or low <= position <= low + span
+            if span == 0 or low - slack <= position <= low + span + slack
         ]
         return [
             (ticks[index], labels[index]) for index in kept if index < len(labels)

--- a/tests/browser/test_dodged_gap_highlight.py
+++ b/tests/browser/test_dodged_gap_highlight.py
@@ -1,0 +1,119 @@
+"""A gap in a dodged series does not shift the highlight of the bars after it.
+
+``sns.barplot(hue=)`` drops a ``NaN`` cell before drawing, so the series that
+lacks it is a rectangle short; the schema fills the cell with ``null`` (#752)
+and keeps one flat selector. That only reads right if the core, pairing the
+series' cells with the rectangles it finds in the DOM, hands the ``null`` a
+placeholder *without* taking a rectangle for it -- otherwise every bar after
+the gap is outlined one to the left, and the last one not at all.
+
+``maidr/core/plot/grouped_barplot.py`` quotes the shipped bundle's cursor to
+say that it does. This is what would catch a bundle bump changing it: a
+reader steps onto the missing cell, hears it named as missing, steps on, and
+the outline lands on the bar drawn for that cell.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+#: Installed on `window` by the bundle once the inlined JavaScript has parsed.
+_BUNDLE_READY = "() => window.maidrLive !== undefined"
+_PARSE_TIMEOUT_MS = 30_000
+
+#: Where the core writes what it announces for the current point.
+_TEXT = "#maidr-text-container"
+
+#: The rectangles matplotlib drew, in document order. The core stands a hidden
+#: clone beside each one when it initialises (`Svg.cloneHidden`), marked
+#: `data-maidr-owned`; those are not bars.
+_DRAWN_BARS = """() => [...document.querySelectorAll(
+  "g[maidr] > path:not([data-maidr-owned])"
+)].map((p) => p.getAttribute("d"))"""
+
+#: The outline the core draws for the current point: a clone of the bar's own
+#: path, so its `d` says which bar it copies.
+_HIGHLIGHTED = """() => [...document.querySelectorAll("[id^=maidr-highlight]")]
+  .map((e) => e.getAttribute("d"))"""
+
+
+@pytest.fixture
+def gapped_hue_chart(tmp_path) -> Path:
+    """``a``, ``b``, ``c`` split by ``g1``/``g2``, with ``(b, g2)`` NaN."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import pandas as pd
+    import seaborn as sns
+
+    import maidr
+
+    frame = pd.DataFrame(
+        {
+            "cat": ["a", "b", "c"] * 2,
+            "grp": ["g1"] * 3 + ["g2"] * 3,
+            "val": [1.0, 2.0, 3.0, 4.0, np.nan, 6.0],
+        }
+    )
+    fig, ax = plt.subplots()
+    sns.barplot(data=frame, x="cat", y="val", hue="grp", ax=ax)
+    path = tmp_path / "gapped_hue.html"
+    try:
+        # Bundled rather than CDN: the shipped bundle is the thing under test.
+        maidr.save_html(fig, file=str(path), use_cdn=False)
+    finally:
+        plt.close("all")
+    return path
+
+
+def _step(page, key: str) -> str:
+    page.keyboard.press(key)
+    page.wait_for_timeout(500)
+    return page.evaluate(f"document.querySelector('{_TEXT}')?.innerText") or ""
+
+
+def test_the_bar_after_a_gap_is_the_one_highlighted(browser, gapped_hue_chart):
+    page = browser.new_page()
+    errors: list[str] = []
+    page.on("pageerror", lambda e: errors.append(str(e).splitlines()[0]))
+    try:
+        page.goto(gapped_hue_chart.as_uri(), wait_until="load")
+        page.wait_for_function(_BUNDLE_READY, timeout=_PARSE_TIMEOUT_MS)
+        page.click("svg[maidr]", force=True)
+        page.keyboard.press("Enter")
+        page.wait_for_timeout(1_500)
+
+        # The premise: five rectangles, g1's three then g2's two, and none
+        # for (b, g2). Their `d` attributes differ, so a `d` names a bar.
+        bars = page.evaluate(_DRAWN_BARS)
+        assert len(bars) == 5 and len(set(bars)) == 5
+        a_g2, c_g2 = bars[3], bars[4]
+
+        # Onto (a, g1), then up onto the g2 series.
+        _step(page, "ArrowRight")
+        spoken = _step(page, "ArrowUp")
+        assert "g2" in spoken and "4" in spoken, spoken
+        assert page.evaluate(_HIGHLIGHTED) == [a_g2]
+
+        # The gap: named as missing, and no rectangle is outlined for it,
+        # since none was drawn.
+        spoken = _step(page, "ArrowRight")
+        assert "b" in spoken and "missing" in spoken, spoken
+        assert a_g2 not in page.evaluate(_HIGHLIGHTED)
+
+        # Past it: the rectangle for (c, g2), not (a, g2) again and not none.
+        spoken = _step(page, "ArrowRight")
+        assert "c" in spoken and "6" in spoken, spoken
+        assert page.evaluate(_HIGHLIGHTED) == [c_g2], (
+            "the outline after the gap is on the wrong bar: the core took a "
+            "rectangle for the null cell, so every bar after it is shifted."
+        )
+        assert not errors, errors
+    finally:
+        page.close()

--- a/tests/core/plot/test_bar_gaps.py
+++ b/tests/core/plot/test_bar_gaps.py
@@ -441,6 +441,53 @@ class TestASeabornHueMissingACategory:
         assert [point["x"] for point in points[0]] == [1.0, 2.0, None]
         assert [point["x"] for point in points[1]] == [None, 5.0, 6.0]
 
+    def test_a_level_with_no_bars_at_all_is_an_all_null_series(self):
+        # Every value of g2 is NaN, so seaborn draws an empty container for
+        # it and still lists it in the legend. The level is announced as a
+        # series of gaps rather than dropped: the legend names it, so a
+        # reader is told the group exists and has nothing in it, which is
+        # what a sighted reader sees.
+        frame = self._frame()
+        frame.loc[frame["grp"] == "g2", "val"] = np.nan
+        fig, ax = plt.subplots()
+        sns.barplot(data=frame, x="cat", y="val", hue="grp", ax=ax)
+        record = FigureManager.get_maidr(fig)
+        points = stacked_points(ax)
+
+        assert [len(c.patches) for c in ax.containers] == [3, 0]
+        assert record._plots[-1].type is PlotType.DODGED
+        assert [point["y"] for point in points[0]] == [1.0, 2.0, 3.0]
+        assert points[1] == [
+            {"x": "a", "z": "g2", "y": None},
+            {"x": "b", "z": "g2", "y": None},
+            {"x": "c", "z": "g2", "y": None},
+        ]
+        parses_as_strict_json(ax)
+
+    def test_a_category_empty_in_every_level_is_a_gap_in_every_series(self):
+        # "b" is NaN for g1 and g2 alike. Seaborn still lists it on the
+        # axis -- its categories are the data's, not the drawn bars' -- so
+        # it is a category the chart shows empty, and every series has a
+        # gap there. Not to be confused with a tick a caller fixed by hand
+        # that no bar was drawn for, which is no category at all and turns
+        # the placement down (see `test_numeric_segmented_bar_positions`).
+        frame = self._frame()
+        frame.loc[frame["cat"] == "b", "val"] = np.nan
+        fig, ax = plt.subplots()
+        sns.barplot(data=frame, x="cat", y="val", hue="grp", ax=ax)
+        record = FigureManager.get_maidr(fig)
+        points = stacked_points(ax)
+
+        assert [len(c.patches) for c in ax.containers] == [2, 2]
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["a", "b", "c"]
+        assert record._plots[-1].type is PlotType.DODGED
+        assert [[point["x"] for point in series] for series in points] == [
+            ["a", "b", "c"],
+            ["a", "b", "c"],
+        ]
+        assert [point["y"] for point in points[0]] == [1.0, None, 3.0]
+        assert [point["y"] for point in points[1]] == [4.0, None, 6.0]
+
     def test_a_hue_that_repeats_the_category_stays_a_plain_bar(self):
         # The control. Seaborn draws this one container per bar, all the
         # same length and short of the axis -- the shape above -- but no

--- a/tests/core/plot/test_bar_gaps.py
+++ b/tests/core/plot/test_bar_gaps.py
@@ -520,3 +520,65 @@ class TestASeabornHueMissingACategory:
 
         assert [point["x"] for point in points[0]] == ["0", "1", "2"]
         assert [point["y"] for point in points[1]] == [4.0, 5.0, 6.0]
+
+
+class TestTicksChangedAfterDrawing:
+    # A seaborn layer is classified when it is drawn and read when the
+    # figure renders, and the ticks are read afresh at both. The two used to
+    # decide from the same primitives with different checks, so a layer
+    # classified grouped could be one the reading declined -- and the
+    # decline was an `ExtractionError`, fatal to the whole figure. Both now
+    # come from `grouped_layout`; and when a caller's `set_xticks` between
+    # the two leaves ticks that no longer name the bars, the layer is read
+    # from its bars alone rather than raised on.
+
+    @staticmethod
+    def _ragged_with_ticks(ticks, labels):
+        ax = TestASeabornHueMissingACategory._hued()
+        ax.set_xticks(ticks, labels)
+        return ax
+
+    def test_a_tick_inside_the_data_no_bar_claims_is_a_gap_in_every_series(self):
+        # Hand-fixed ticks with one at 1.5 between "b" and "c". The
+        # containers are ragged, so there is no reading of them by position
+        # to fall back on; the unclaimed tick is announced as a category
+        # every series has a gap at, which is what the axis now shows.
+        ax = self._ragged_with_ticks([0, 1, 1.5, 2], ["a", "b", "bc", "c"])
+        record = FigureManager.get_maidr(ax.get_figure())
+        points = stacked_points(ax)
+
+        assert record._plots[-1].type is PlotType.DODGED
+        assert [[point["x"] for point in series] for series in points] == [
+            ["a", "b", "bc", "c"],
+            ["a", "b", "bc", "c"],
+        ]
+        assert [point["y"] for point in points[0]] == [1.0, 2.0, None, 3.0]
+        assert [point["y"] for point in points[1]] == [4.0, None, None, 6.0]
+        parses_as_strict_json(ax)
+
+    def test_a_tick_past_the_data_is_furniture(self):
+        # A fourth tick at 3, past every bar, is dropped by the data-limit
+        # filter before any of this, so the layer reads as it did.
+        ax = self._ragged_with_ticks([0, 1, 2, 3], ["a", "b", "c", "d"])
+        points = stacked_points(ax)
+
+        assert [point["x"] for point in points[1]] == ["a", "b", "c"]
+        assert [point["y"] for point in points[1]] == [4.0, None, 6.0]
+
+    def test_ticks_two_bars_share_read_each_series_from_its_bars(self):
+        # Two ticks for three categories put two of g1's bars nearest one
+        # tick, so no placement; the containers are ragged, so no pairing
+        # by position either. The last resort: each series' own bars at the
+        # positions they were drawn, which no longer share one axis but is
+        # a lesser wrong than no figure. This raised `ExtractionError`.
+        ax = self._ragged_with_ticks([0, 2], ["start", "end"])
+        record = FigureManager.get_maidr(ax.get_figure())
+        points = stacked_points(ax)
+
+        assert record._plots[-1].type is PlotType.DODGED
+        assert [[point["x"] for point in series] for series in points] == [
+            ["-0.2", "0.8", "1.8"],
+            ["0.2", "2.2"],
+        ]
+        assert [point["y"] for point in points[1]] == [4.0, 6.0]
+        parses_as_strict_json(ax)

--- a/tests/core/plot/test_bar_gaps.py
+++ b/tests/core/plot/test_bar_gaps.py
@@ -30,6 +30,8 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+import seaborn as sns  # noqa: E402
 
 import maidr  # noqa: E402
 from maidr.core.enum.plot_type import PlotType  # noqa: E402
@@ -198,7 +200,8 @@ class TestADodgedBarWithNoHeight:
     # stacked one's extractor and so its gap, and is reached by matplotlib's
     # own grouping idiom: numeric positions offset by a fraction, with a
     # narrow width. Seaborn's `hue=` cannot put a NaN bar here -- it drops
-    # the row before drawing -- so the chart is drawn by hand.
+    # the row before drawing, which is the next class's subject -- so the
+    # chart is drawn by hand.
 
     @staticmethod
     def _dodged():
@@ -254,4 +257,99 @@ class TestADodgedBarWithNoHeight:
         assert points[0][1]["x"] is None
         assert points[0][1]["y"] == "b"
         assert [point["x"] for point in points[1]] == [4.0, 5.0, 6.0]
+        parses_as_strict_json(ax)
+
+
+class TestASeabornHueMissingACategory:
+    # `sns.barplot(hue=)` cannot draw a NaN bar: it drops the row before
+    # drawing, so the hue level that lacks one category comes out a bar
+    # short and the containers are ragged. The grouped extractor paired bars
+    # with labels by position alone and gave that layer up, and the patch
+    # fell back to a plain bar layer whose labels were the bars' fractional
+    # positions -- "-0.2", "0.8" -- so a reader heard numbers where the
+    # chart shows groups (#752). The bar seaborn never drew is the same gap
+    # the hand-drawn chart above emits for a NaN height.
+
+    @staticmethod
+    def _frame(missing: str = "b") -> pd.DataFrame:
+        frame = pd.DataFrame(
+            {
+                "cat": ["a", "b", "c"] * 2,
+                "grp": ["g1"] * 3 + ["g2"] * 3,
+                "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            }
+        )
+        frame.loc[(frame["cat"] == missing) & (frame["grp"] == "g2"), "val"] = np.nan
+        return frame
+
+    @classmethod
+    def _hued(cls, missing: str = "b"):
+        fig, ax = plt.subplots()
+        sns.barplot(data=cls._frame(missing), x="cat", y="val", hue="grp", ax=ax)
+        # The premise: seaborn dropped the bar rather than drawing a gap.
+        assert [len(c.patches) for c in ax.containers] == [3, 2]
+        return ax
+
+    def test_it_is_a_dodged_layer(self):
+        ax = self._hued()
+        record = FigureManager.get_maidr(ax.get_figure())
+
+        assert record._plots[-1].type is PlotType.DODGED
+
+    def test_it_names_the_categories_and_the_groups(self):
+        # The whole of the complaint: "a", "b", "c" and "g1", "g2", which
+        # are what the chart shows, and not "-0.2", which is where the
+        # first bar happened to be drawn.
+        ax = self._hued()
+        points = stacked_points(ax)
+
+        assert [[point["x"] for point in series] for series in points] == [
+            ["a", "b", "c"],
+            ["a", "b", "c"],
+        ]
+        assert [[point["z"] for point in series] for series in points] == [
+            ["g1"] * 3,
+            ["g2"] * 3,
+        ]
+
+    def test_the_missing_bar_is_emitted_as_null(self):
+        ax = self._hued()
+
+        assert stacked_points(ax)[1][1]["y"] is None
+
+    def test_the_payload_is_loadable(self):
+        ax = self._hued()
+
+        parses_as_strict_json(ax)
+
+    def test_the_measured_bars_are_untouched(self):
+        ax = self._hued()
+        points = stacked_points(ax)
+
+        assert [point["y"] for point in points[0]] == [1.0, 2.0, 3.0]
+        assert [point["y"] for point in points[1]] == [4.0, None, 6.0]
+
+    @pytest.mark.parametrize("missing", ["a", "c"])
+    def test_a_gap_at_either_end_lands_on_its_own_category(self, missing: str):
+        # The bars are placed by the tick nearest each one rather than
+        # counted from the start, so a gap at the first or last category
+        # does not shift every bar after it by one.
+        ax = self._hued(missing)
+        points = stacked_points(ax)
+
+        assert [point["x"] for point in points[1]] == ["a", "b", "c"]
+        assert points[1][["a", "b", "c"].index(missing)]["y"] is None
+        assert sum(point["y"] is None for point in points[1]) == 1
+
+    def test_a_horizontal_layer_is_covered_too(self):
+        # The gap lands on x for a horizontal layer, as it does for every
+        # other one, and the bars are placed by their y centres.
+        fig, ax = plt.subplots()
+        sns.barplot(data=self._frame(), y="cat", x="val", hue="grp", ax=ax)
+        record = FigureManager.get_maidr(fig)
+        points = stacked_points(ax)
+
+        assert record._plots[-1].type is PlotType.DODGED
+        assert [point["y"] for point in points[1]] == ["a", "b", "c"]
+        assert [point["x"] for point in points[1]] == [4.0, None, 6.0]
         parses_as_strict_json(ax)

--- a/tests/core/plot/test_bar_gaps.py
+++ b/tests/core/plot/test_bar_gaps.py
@@ -353,3 +353,123 @@ class TestASeabornHueMissingACategory:
         assert [point["y"] for point in points[1]] == ["a", "b", "c"]
         assert [point["x"] for point in points[1]] == [4.0, None, 6.0]
         parses_as_strict_json(ax)
+
+    # Two hue levels each missing a *different* category -- containers of
+    # [2, 2] bars over 3 ticks -- are equal in length and short of the
+    # axis, which raggedness cannot see: the layer was still a plain bar
+    # labelled by position, "1.2" for g2's "b".
+    # It is the shape the hue that repeats the category draws as well, one
+    # container per bar, so the two are told apart by whether a category
+    # holds bars of two containers -- side by side is what dodged means.
+
+    @staticmethod
+    def _frame_short_everywhere(g1_lacks: str = "c", g2_lacks: str = "a"):
+        # Containers of two bars over three ticks. With the defaults they
+        # meet only at "b".
+        frame = pd.DataFrame(
+            {
+                "cat": ["a", "b", "c"] * 2,
+                "grp": ["g1"] * 3 + ["g2"] * 3,
+                "val": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            }
+        )
+        frame.loc[(frame["cat"] == g1_lacks) & (frame["grp"] == "g1"), "val"] = np.nan
+        frame.loc[(frame["cat"] == g2_lacks) & (frame["grp"] == "g2"), "val"] = np.nan
+        return frame
+
+    @pytest.mark.parametrize(
+        "g1_lacks, g2_lacks",
+        [
+            pytest.param("c", "a", id="meet-at-b"),
+            # The first category's only bar is g2's, dodged to +0.2 and 0.4
+            # wide, so its left edge is `0.2 - 0.2` -- a float hair past
+            # the tick at 0. The tick filter used to drop that category as
+            # outside the data, which left two labels for two bars and let
+            # the layer pair by position: g2's "a" was announced as "b".
+            pytest.param("a", "b", id="edge-a-hair-past-the-tick"),
+        ],
+    )
+    def test_two_levels_each_missing_a_different_category_are_grouped(
+        self, g1_lacks: str, g2_lacks: str
+    ):
+        fig, ax = plt.subplots()
+        sns.barplot(
+            data=self._frame_short_everywhere(g1_lacks, g2_lacks),
+            x="cat",
+            y="val",
+            hue="grp",
+            ax=ax,
+        )
+        # The premise: [2, 2] bars over three ticks, equal and both short.
+        assert [len(c.patches) for c in ax.containers] == [2, 2]
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["a", "b", "c"]
+        record = FigureManager.get_maidr(fig)
+        points = stacked_points(ax)
+
+        assert record._plots[-1].type is PlotType.DODGED
+        heights = {"a": [1.0, 4.0], "b": [2.0, 5.0], "c": [3.0, 6.0]}
+        assert points == [
+            [
+                {
+                    "x": cat,
+                    "z": "g1",
+                    "y": None if cat == g1_lacks else heights[cat][0],
+                }
+                for cat in ["a", "b", "c"]
+            ],
+            [
+                {
+                    "x": cat,
+                    "z": "g2",
+                    "y": None if cat == g2_lacks else heights[cat][1],
+                }
+                for cat in ["a", "b", "c"]
+            ],
+        ]
+        parses_as_strict_json(ax)
+
+    def test_two_levels_each_missing_a_different_category_sideways(self):
+        fig, ax = plt.subplots()
+        sns.barplot(
+            data=self._frame_short_everywhere(), y="cat", x="val", hue="grp", ax=ax
+        )
+        record = FigureManager.get_maidr(fig)
+        points = stacked_points(ax)
+
+        assert record._plots[-1].type is PlotType.DODGED
+        assert [point["y"] for point in points[1]] == ["a", "b", "c"]
+        assert [point["x"] for point in points[0]] == [1.0, 2.0, None]
+        assert [point["x"] for point in points[1]] == [None, 5.0, 6.0]
+
+    def test_a_hue_that_repeats_the_category_stays_a_plain_bar(self):
+        # The control. Seaborn draws this one container per bar, all the
+        # same length and short of the axis -- the shape above -- but no
+        # category holds two bars, so nothing about it is grouped, and the
+        # plain bar layer names the categories as it always did.
+        frame = pd.DataFrame({"cat": ["a", "b", "c"], "val": [1.0, 2.0, 3.0]})
+        fig, ax = plt.subplots()
+        sns.barplot(data=frame, x="cat", y="val", hue="cat", ax=ax)
+        record = FigureManager.get_maidr(fig)
+
+        assert [len(c.patches) for c in ax.containers] == [1, 1, 1]
+        assert record._plots[-1].type is PlotType.BAR
+        assert bar_points(ax) == [
+            {"x": "a", "y": 1.0},
+            {"x": "b", "y": 2.0},
+            {"x": "c", "y": 3.0},
+        ]
+
+    def test_a_numeric_axis_is_not_placed_against_its_breaks(self):
+        # The guard the placement needs. A stacked chart over
+        # `np.arange(3)` has more ticks in view than bars, all chosen by the
+        # locator; those are breaks, not categories, and the layer keeps
+        # announcing the positions its bars were drawn at (#384).
+        fig, ax = plt.subplots()
+        positions = np.arange(3)
+        ax.bar(positions, [1.0, 2.0, 3.0], label="lower")
+        ax.bar(positions, [4.0, 5.0, 6.0], bottom=[1.0, 2.0, 3.0], label="upper")
+        maidr.stacked(ax)
+        points = stacked_points(ax)
+
+        assert [point["x"] for point in points[0]] == ["0", "1", "2"]
+        assert [point["y"] for point in points[1]] == [4.0, 5.0, 6.0]

--- a/tests/core/plot/test_bar_gaps.py
+++ b/tests/core/plot/test_bar_gaps.py
@@ -488,6 +488,32 @@ class TestASeabornHueMissingACategory:
         assert [point["y"] for point in points[0]] == [1.0, None, 3.0]
         assert [point["y"] for point in points[1]] == [4.0, None, 6.0]
 
+    def test_a_level_with_no_bars_on_a_numeric_axis_is_left_out(self):
+        # The same all-NaN level over `native_scale=True`, whose ticks are
+        # the locator's own breaks rather than categories. There is no row
+        # of gaps to place it in and no position to read it at, so the
+        # bars-only reading leaves it out rather than emitting an empty
+        # series beside g1's -- and the layer stands on g1's bars.
+        frame = pd.DataFrame(
+            {
+                "x": [1, 2, 3] * 2,
+                "grp": ["g1"] * 3 + ["g2"] * 3,
+                "val": [1.0, 2.0, 3.0, np.nan, np.nan, np.nan],
+            }
+        )
+        fig, ax = plt.subplots()
+        sns.barplot(data=frame, x="x", y="val", hue="grp", native_scale=True, ax=ax)
+        # The premise: an empty container on an axis with chosen breaks.
+        assert [len(c.patches) for c in ax.containers] == [3, 0]
+        assert type(ax.xaxis.get_major_locator()).__name__ == "AutoLocator"
+        maidr.stacked(ax)
+        points = stacked_points(ax)
+
+        assert len(points) == 1
+        assert [point["z"] for point in points[0]] == ["g1"] * 3
+        assert [point["y"] for point in points[0]] == [1.0, 2.0, 3.0]
+        parses_as_strict_json(ax)
+
     def test_a_hue_that_repeats_the_category_stays_a_plain_bar(self):
         # The control. Seaborn draws this one container per bar, all the
         # same length and short of the axis -- the shape above -- but no

--- a/tests/core/plot/test_seaborn_grouped_bar.py
+++ b/tests/core/plot/test_seaborn_grouped_bar.py
@@ -168,15 +168,18 @@ def test_a_hue_that_repeats_the_category_stays_a_plain_bar_layer() -> None:
     ]
 
 
-def test_hue_groups_that_do_not_cover_every_category_stay_a_plain_bar_layer() -> None:
-    """The length check, reached with two containers rather than one.
+def test_hue_groups_that_do_not_cover_every_category_are_still_grouped() -> None:
+    """Ragged containers are a grouped layer with a gap, not a plain one.
 
     Seaborn draws no bar at all for a category and hue level that never
     occur together, so the containers come out ragged. `GroupedBarPlot`
-    cannot read those — it pairs bars with labels by position — so the
-    classification refuses to call them grouped. The layer does not render
-    either way; what is pinned here is that the guard is what turns it back,
-    not the container count.
+    used to pair bars with labels by position alone and could not read
+    those, so the classification turned the layer back to a plain bar --
+    whose labels were then the bars' fractional positions, "-0.2" for "a",
+    in place of the category and hue names a reader hears on the chart
+    (#752). The bars that were drawn still sit against their category's
+    tick, so the layer is placed against the ticks instead and the missing
+    bar is the same `null` gap a `NaN` height emits.
     """
     ragged = DATA[~((DATA["cat"] == "b") & (DATA["grp"] == "y"))]
     fig, ax = plt.subplots()
@@ -184,7 +187,17 @@ def test_hue_groups_that_do_not_cover_every_category_stay_a_plain_bar_layer() ->
         sns.barplot(data=ragged, x="cat", y="val", hue="grp", ax=ax)
         # The premise: seaborn dropped the bar rather than drawing a gap.
         assert [len(c.patches) for c in ax.containers] == [3, 2]
-        assert _layer_type(fig) is PlotType.BAR
+        schema = _schema(fig)
+
+        assert _layer_type(fig) is PlotType.DODGED
+        assert schema["data"] == [
+            GROUPED[0],
+            [
+                {"x": "a", "z": "y", "y": 2.0},
+                {"x": "b", "z": "y", "y": None},
+                {"x": "c", "z": "y", "y": 6.0},
+            ],
+        ]
     finally:
         plt.close(fig)
 

--- a/tests/core/test_numeric_segmented_bar_positions.py
+++ b/tests/core/test_numeric_segmented_bar_positions.py
@@ -203,3 +203,54 @@ def test_an_explicit_none_baseline_still_reaches_dodge_detection() -> None:
 
     assert "stacked_bar" not in types, "None is not a baseline"
     assert types == ["dodged_bar"], types
+
+
+def _dodged_with_ticks(ticks, labels):
+    """Two series dodged over ``np.arange(3)``, with ticks set by hand."""
+    fig, ax = plt.subplots()
+    positions = np.arange(3)
+    ax.bar(positions - 0.2, LOWER, width=0.4, label="lower")
+    ax.bar(positions + 0.2, UPPER, width=0.4, label="upper")
+    ax.set_xticks(ticks, labels)
+    maidr.stacked(ax)
+    return fig
+
+
+# The first series' positions name both, decided once for the layer: every
+# series of a segmented chart shares one category axis, so the announcement
+# has to agree across them. What main emitted, and what the fallback keeps.
+POSITIONAL = [["-0.2", "0.8", "1.8"], ["-0.2", "0.8", "1.8"]]
+
+
+def test_ticks_two_bars_share_fall_back_to_positions() -> None:
+    """Two ticks for three bars of each series: no tick names the bars.
+
+    Placing the bars against ``start`` and ``end`` puts two bars of one
+    series on one tick, which is not one bar per category. The layer used
+    to raise there -- the labels had already chosen the tick names -- where
+    it had announced the bars' positions before; it announces them again.
+    """
+    fig = _dodged_with_ticks([0.0, 2.0], ["start", "end"])
+
+    layer = _layer(fig)
+
+    # The width-0.4 idiom types the layer dodged on its own; what is at
+    # stake is the labels, and that it renders at all.
+    assert layer["type"].value == "dodged_bar"
+    assert [[point["x"] for point in series] for series in layer["data"]] == POSITIONAL
+    assert maidr.render(fig) is not None
+
+
+def test_ticks_no_bar_was_drawn_for_fall_back_to_positions() -> None:
+    """Five ticks for three bars: the half steps are not categories.
+
+    Placed against them, the layer announced ``a5`` and ``b5`` as
+    categories with a gap in every series -- five points where the chart
+    drew three. A tick no series claims declines the placement.
+    """
+    fig = _dodged_with_ticks([0, 0.5, 1, 1.5, 2], ["a", "a5", "b", "b5", "c"])
+
+    layer = _layer(fig)
+
+    assert [len(series) for series in layer["data"]] == [3, 3]
+    assert [[point["x"] for point in series] for series in layer["data"]] == POSITIONAL

--- a/tests/core/test_ticks_on_the_data_edge.py
+++ b/tests/core/test_ticks_on_the_data_edge.py
@@ -70,3 +70,21 @@ def test_the_y_axis_reads_the_same_way() -> None:
 
     assert ax.dataLim.y0 > 0
     assert _labels(ax, MaidrKey.Y) == ["a", "b", "c"]
+
+
+def test_a_log_axis_keeps_only_the_ticks_its_data_reaches() -> None:
+    # The tolerance is a rounding error beside each bound, not a slice of
+    # the span: cut from the span, it was decades wide here and admitted
+    # ticks at 1e-6 and 1e-4 that no data reaches.
+    fig, ax = plt.subplots()
+    ax.plot([1e-3, 1e12], [1, 2])
+    ax.set_xscale("log")
+    fig.canvas.draw()
+
+    ticks = LevelExtractorMixin._ticks_in_view(ax, MaidrKey.X)
+    positions = [position for position, _ in ticks]
+
+    # No tick sits at 1e-3 itself; the first the data reaches is 1e-2.
+    assert min(positions) == pytest.approx(1e-2)
+    assert max(positions) == pytest.approx(1e12)
+    assert all(1e-3 <= position <= 1e12 for position in positions)

--- a/tests/core/test_ticks_on_the_data_edge.py
+++ b/tests/core/test_ticks_on_the_data_edge.py
@@ -1,0 +1,72 @@
+"""A tick a rounding error outside the data is not furniture.
+
+``_ticks_in_view`` keeps the ticks that fall inside the data limits, so a
+tick drawn past the data -- furniture -- is not read as a category. The
+edge of a bar meant to sit on a tick can land a float hair past it: seaborn
+dodges two hue levels to ``+-0.2`` and draws each ``0.4`` wide, so the
+second level's first bar starts at ``0.2 - 0.2``, which arrives as
+``5.6e-17``. When that bar was the only one at the first category, the
+tick at ``0`` sat outside its own data by that much and the category was
+dropped -- and with two labels left for two bars, a grouped layer paired
+its bars by position and announced the first category as the second
+(#752).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+from maidr.core.enum import MaidrKey  # noqa: E402
+from maidr.util.mixin import LevelExtractorMixin  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _labels(ax, key=MaidrKey.X) -> list[str]:
+    return [label for _, label in LevelExtractorMixin._ticks_in_view(ax, key)]
+
+
+#: A centre one float past 0.2: with a width of 0.4 the bar's edge is one
+#: float past the tick at 0, which is where seaborn's offset arithmetic
+#: lands it. Spelled outright rather than as `0.2`, because matplotlib's own
+#: `0.2 - 0.2` is exactly zero and the premise below would not hold.
+A_HAIR_PAST = float(np.nextafter(0.2, 1))
+
+
+def test_a_bar_edge_a_hair_past_the_tick_keeps_the_tick() -> None:
+    # The only bar at the first category is the second hue level's, and
+    # matplotlib's data limits start at its edge rather than at 0.
+    fig, ax = plt.subplots()
+    ax.bar([A_HAIR_PAST, 0.8, 1.8], [1.0, 2.0, 3.0], width=0.4)
+    ax.set_xticks([0, 1, 2], ["a", "b", "c"])
+
+    assert ax.dataLim.x0 > 0, "the premise: the edge really is past the tick"
+    assert _labels(ax) == ["a", "b", "c"]
+
+
+def test_a_tick_past_the_data_is_still_dropped() -> None:
+    # The filter's reason to exist, which the slack must not swallow.
+    fig, ax = plt.subplots()
+    ax.bar([1, 2], [1.0, 2.0])
+    ax.set_xticks([0, 1, 2, 3], ["off", "a", "b", "off"])
+
+    assert _labels(ax) == ["a", "b"]
+
+
+def test_the_y_axis_reads_the_same_way() -> None:
+    fig, ax = plt.subplots()
+    ax.barh([A_HAIR_PAST, 0.8, 1.8], [1.0, 2.0, 3.0], height=0.4)
+    ax.set_yticks([0, 1, 2], ["a", "b", "c"])
+
+    assert ax.dataLim.y0 > 0
+    assert _labels(ax, MaidrKey.Y) == ["a", "b", "c"]


### PR DESCRIPTION
## Summary

`sns.barplot(hue=)` drops a NaN row before drawing, leaving ragged bar containers. The grouped extractor paired bars by position only and gave up, so the patch fell back to a plain `bar` layer labelled by fractional bar positions (`"-0.2"`, `"0.8"`). A reader heard numbers instead of category and hue names.

- One module-level `grouped_layout(ax, containers, key)` now holds the whole decision and is called from both the seaborn classifier at draw time and the extractor at render time, so the two cannot disagree: full containers pair with the tick labels by position; short or ragged containers on categorical ticks (`StrCategoryLocator`/`FixedLocator`) are placed against the ticks, nearest tick per bar (lower index on a tie), and the category a hue level has no bar for is emitted as `null`, the same gap the stacked and dodged extractors emit for a NaN height (#727). This covers the ragged case, equal-length short levels each missing a different category, a level with no bars at all (an all-null series, since the legend names it), and a category empty in every level. The hue-repeats-category idiom, where no category holds two containers' bars, stays a plain bar, and a numeric axis with an `AutoLocator` keeps its positional labels (#384).
- Hand-fixed ticks that do not name the bars (sparse `set_xticks`, or more ticks than bars) keep the positional labels and pairing they had before rather than raising or inventing categories. If the ticks change between draw and render, extraction still never raises: it falls back to positional pairing for equal-length containers and, as the last resort, to each container's own bars at their own positions, leaving out a container that has no bars at all.
- Found on the way: `_ticks_in_view` dropped a tick sitting a rounding error outside the data limits (a bar edge at `5.6e-17` left tick 0 out), which is what let the mislabelled layer through with matching counts. It now compares each bound with `math.isclose(rel_tol=1e-9, abs_tol=1e-12)`, anchored on the bound rather than the span, so a wide log axis admits nothing it did not before.
- The bundled core (maidr.js 4.6.0) hands a `null` cell a placeholder without advancing its element cursor, so the flat highlight selector stays aligned. That is no longer only a reading of the minified bundle: a browser test drives the gapped series with the arrow keys and asserts the highlight after the gap lands on the bar drawn after it and the gap is announced as missing.
- The `barh height=0.4` case from the issue was already fixed by #758 and is pinned by an existing test.

Closes #752

## Testing

- New `TestASeabornHueMissingACategory` and `TestTicksChangedAfterDrawing` in `tests/core/plot/test_bar_gaps.py`, fallback cases in `tests/core/test_numeric_segmented_bar_positions.py`, a rewritten case in `tests/core/plot/test_seaborn_grouped_bar.py`, `tests/core/test_ticks_on_the_data_edge.py`, and `tests/browser/test_dodged_gap_highlight.py`. Across the rounds, 19 of these fail on the unfixed source; all pass after.
- `pytest tests/core tests/patch`: 2445 passed, 1 skipped. `pytest tests/browser --run-browser -k dodged_gap`: 1 passed.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HX7HuY5rR8ZMqqXAMAAQS9