### PR TITLE
docs: describe what py-maidr does in the README and package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,64 @@
 
 <hr style="color:transparent" />
 <br />
+
+[![PyPI](https://img.shields.io/pypi/v/maidr.svg)](https://pypi.org/project/maidr/)
+[![Python versions](https://img.shields.io/pypi/pyversions/maidr.svg)](https://pypi.org/project/maidr/)
+[![Downloads](https://img.shields.io/pypi/dm/maidr.svg)](https://pypistats.org/packages/maidr)
+[![CI](https://github.com/xability/py-maidr/actions/workflows/ci.yml/badge.svg)](https://github.com/xability/py-maidr/actions/workflows/ci.yml)
+[![License](https://img.shields.io/pypi/l/maidr.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-py.maidr.ai-1f6feb.svg)](https://py.maidr.ai/)
+
 </div>
 
 # py-maidr
 
-Python binder for maidr library
+Make matplotlib, seaborn, Plotly, and Altair charts accessible — MAIDR
+(Multimodal Access and Interactive Data Representation) for Python.
+
+## Overview
+
+py-maidr makes data visualizations accessible to blind and low-vision readers.
+`import maidr` and your existing plotting code renders an interactive figure that
+can be **navigated by keyboard**, **heard as sonification**, **read on a braille
+display**, and **described as text** — the same chart in four modalities instead
+of one.
+
+Nothing about how you plot changes. py-maidr patches matplotlib and seaborn at
+import time, so `plt.show()` produces accessible HTML instead of a static image;
+Plotly and Altair figures go through the same `maidr.show()` entry point. It
+works in a plain script, a Jupyter notebook, Quarto, Shiny, and Streamlit.
+
+## Quickstart
+
+```python
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+import maidr  # the whole integration
+
+penguins = sns.load_dataset("penguins")
+
+fig, ax = plt.subplots()
+sns.barplot(x="species", y="body_mass_g", data=penguins, ax=ax)
+
+maidr.show(fig)
+```
+
+`maidr.save_html(fig, "penguins.html")` writes the same plot to a standalone HTML
+file instead of displaying it. Because importing `maidr` also activates its
+matplotlib backend, a plain `plt.show()` renders accessible output too.
+
+## What is supported
+
+| | |
+|---|---|
+| **Plotting libraries** | matplotlib, seaborn (including `seaborn.objects`), Plotly, Altair, mplfinance |
+| **Environments** | Python scripts, Jupyter, Quarto, Shiny for Python, Streamlit |
+| **Plot types** | 38 — see [Plot Type Stability](https://py.maidr.ai/stability.html) for which fifteen are settled and which twenty-three are experimental |
+
+Plot types not yet supported fall back to a static image with a warning, so a
+plot is never lost.
 
 ## Install and Upgrade
 
@@ -24,7 +77,7 @@ pip install -U git+https://github.com/xability/py-maidr.git
 
 ## User Guide
 
-Please visit the [user guide](https://xability.github.io/py-maidr/) page.
+Please visit the [user guide](https://py.maidr.ai/) page.
 
 ## Offline and Restricted-Network Use
 
@@ -43,7 +96,7 @@ It is also the only one of the two that covers **Altair** charts: the Altair ada
 has no offline path and always references the CDN, so `MAIDR_USE_CDN=false` does not
 apply to it, while `MAIDR_CDN_VERSION=bundled` still removes the lookup.
 
-See [Offline Use and the JavaScript Bundle](https://xability.github.io/py-maidr/#offline-use-and-the-javascript-bundle) for the full set of options.
+See [Offline Use and the JavaScript Bundle](https://py.maidr.ai/#offline-use-and-the-javascript-bundle) for the full set of options.
 
 
 ## Example Code
@@ -54,3 +107,13 @@ Shiny support requires the optional extra `pip install "maidr[shiny]"`, which
 provides `output_maidr()` and `@render_maidr` in `maidr.widget.shiny`.
 Streamlit support requires `pip install "maidr[streamlit]"`, which provides
 `render_maidr()` and `maidr_html()` in `maidr.widget.streamlit`.
+
+## Contributing
+
+Bug reports, plot types and documentation fixes are all welcome — see
+[CONTRIBUTING.md](CONTRIBUTING.md) for how to set up a development environment
+and shape a change, and [CONDUCT.md](CONDUCT.md) for our code of conduct.
+
+## License
+
+GPL-3.0-or-later. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ matplotlib backend, a plain `plt.show()` renders accessible output too.
 
 | | |
 |---|---|
-| **Plotting libraries** | matplotlib, seaborn (including `seaborn.objects`), Plotly, Altair, mplfinance |
+| **Plotting libraries** | matplotlib, seaborn (including `seaborn.objects`), Plotly, Altair — plus mplfinance for financial charts (candlestick, volume, moving averages) |
 | **Environments** | Python scripts, Jupyter, Quarto, Shiny for Python, Streamlit |
 | **Plot types** | 38 — see [Plot Type Stability](https://py.maidr.ai/stability.html) for which fifteen are settled and which twenty-three are experimental |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "maidr"
 version = "1.23.0"
-description = "Multimodal Access and Interactive Data Representations"
+description = "Make matplotlib, seaborn, Plotly, and Altair charts accessible through sonification, braille, and screen reader support"
 authors = [
     { name = "JooYoung Seo", email = "jseo1005@illinois.edu" },
     { name = "Saairam Venkatesh", email = "saairam2@illinois.edu" },
@@ -15,7 +15,8 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 keywords = [
     "accessibility",
-    "visualization",
+    "a11y",
+    "screen reader",
     "sonification",
     "braille",
     "tactile",
@@ -24,21 +25,40 @@ keywords = [
     "blind",
     "low vision",
     "visual impairments",
+    "data visualization",
+    "visualization",
+    "charts",
+    "matplotlib",
+    "seaborn",
+    "plotly",
+    "altair",
+    "jupyter",
+    "quarto",
+    "shiny",
+    "streamlit",
 ]
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: Jupyter",
+    "Framework :: Matplotlib",
+    "Intended Audience :: Education",
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Financial and Insurance Industry",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Healthcare Industry",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Adaptive Technologies",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+    "Topic :: Multimedia :: Sound/Audio",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup :: HTML",
     "Topic :: Scientific/Engineering :: Visualization",
@@ -141,8 +161,11 @@ test = [
 maidr = "maidr.backend"
 
 [project.urls]
-Homepage = "https://xability.github.io/py-maidr"
+Homepage = "https://py.maidr.ai/"
+Documentation = "https://py.maidr.ai/"
 Repository = "https://github.com/xability/py-maidr"
+Issues = "https://github.com/xability/py-maidr/issues"
+Changelog = "https://github.com/xability/py-maidr/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Description

The README opened with **"Python binder for maidr library"** and the PyPI summary was the expanded acronym on its own. Neither said what the package does, and neither named a single plotting library it supports. Someone searching for an accessible matplotlib or seaborn chart had nothing to match on.

Prose, metadata and links only — no behaviour change.

### README

- **Badges**: PyPI version, Python versions, monthly downloads, CI, license, docs. There were none, which reads oddly for a package at 1.23.0 with 92 releases.
- **Tagline and overview**: names the four supported plotting libraries and the four output modalities, and says the integration is a single `import maidr`.
- **Quickstart**: the README had no runnable code at all. The example added here was executed against this branch before committing.
- **What is supported**: a table of libraries, environments and plot-type count that *links to* [Plot Type Stability](https://py.maidr.ai/stability.html) rather than duplicating its 38 rows, so there is no second copy to keep in step (per the note in `CLAUDE.md`).
- **Contributing / License** sections.

### pyproject.toml

- **`description`** rewritten — this is the one line PyPI shows in search results.
- **Keywords**: added the libraries and environments actually supported (`matplotlib`, `seaborn`, `plotly`, `altair`, `jupyter`, `quarto`, `shiny`, `streamlit`) plus `a11y`, `screen reader`, `data visualization`, `charts`.
- **Classifiers**: added `Topic :: Adaptive Technologies` (the classifier readers browse to find work like this), `Framework :: Matplotlib`, `Framework :: Jupyter`, `Topic :: Multimedia :: Sound/Audio`, `Operating System :: OS Independent`, `Intended Audience :: Education`, `Natural Language :: English`, and a `Development Status`.
- **Project URLs**: added Documentation, Issues and Changelog.

### Canonical docs URL

`docs/CNAME` says `py.maidr.ai`, but the README and `[project.urls].Homepage` pointed at `https://xability.github.io/py-maidr/`, which 301s to it. Every docs link now points at the canonical domain directly.

## One thing worth a second opinion

I set `Development Status :: 5 - Production/Stable`. There was no `Development Status` classifier before, so this is a new claim rather than a corrected one. It seemed right for 1.x with 92 releases and a documented stability policy, but `4 - Beta` is defensible given 23 of the 38 plot types are experimental. Happy to change it.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Verification

| check | result |
|---|---|
| `ruff check --diff` | clean |
| `uv lock --check` | passes |
| `uv build --wheel` | builds |
| `twine check` | PASSED |
| `pytest` (full suite) | 4337 passed, 69 skipped, 2 xfailed |

Three tests fail in my local Windows checkout (`test_collection_survives_missing_extras` ×2 and `test_shell_guard_matches_the_python_validator`). They fail identically on `main` at 16d1e21 with no changes applied, so they are pre-existing and environmental, not from this branch.

The README quickstart was run against this branch and produced a 26 KB accessible HTML file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
