### PR TITLE
docs: source the downloads badge from pepy instead of pypistats

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/maidr.svg)](https://pypi.org/project/maidr/)
 [![Python versions](https://img.shields.io/pypi/pyversions/maidr.svg)](https://pypi.org/project/maidr/)
-[![Downloads](https://img.shields.io/pypi/dm/maidr.svg)](https://pypistats.org/packages/maidr)
+[![Downloads](https://img.shields.io/pepy/dt/maidr.svg)](https://pepy.tech/project/maidr)
 [![CI](https://github.com/xability/py-maidr/actions/workflows/ci.yml/badge.svg)](https://github.com/xability/py-maidr/actions/workflows/ci.yml)
 [![License](https://img.shields.io/pypi/l/maidr.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-py.maidr.ai-1f6feb.svg)](https://py.maidr.ai/)


### PR DESCRIPTION
## Description

Follow-up to #765. The downloads badge added there resolves through `img.shields.io/pypi/dm`, which reads pypistats.org — and pypistats has been answering 429, so the badge renders as **"downloads: rate limited by upstream service"** rather than a number. Checked repeatedly over ~40 minutes with the same result, so this is not a passing blip. A visibly broken badge is worse than no badge.

`img.shields.io/pepy/dt/maidr` reads pepy.tech instead and currently renders **"downloads: 84k"**. The count is lifetime rather than monthly; for a package with 92 releases that is arguably the more useful number, and it is the one that actually renders.

Link target moves from `pypistats.org/packages/maidr` to `pepy.tech/project/maidr` to match the data source.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Verification

```
curl img.shields.io/pypi/dm/maidr.svg  -> <title>downloads: rate limited by upstream service</title>
curl img.shields.io/pepy/dt/maidr      -> <title>downloads: 84k</title>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
