### PR TITLE
ci: keep the commit body out of the changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,10 @@ Types: `feat`, `fix`, `docs`, `perf`, `refactor`, `style`, `test`, `build`,
 `chore`, `ci`. Releases are cut automatically from `main` by semantic-release,
 so the type matters: `feat` makes a minor release and `fix` or `perf` a patch
 release. Pull requests are squash-merged and the PR title becomes the commit
-subject, so the title must follow the same format.
+subject, so the title must follow the same format. The title is also the
+whole of the pull request that reaches `CHANGELOG.md` and the GitHub release
+notes: the description becomes the commit body, which the changelog leaves
+out. Write the title as the one line a reader of the release notes sees.
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,15 @@ prerelease_token = "rc"
 prerelease = false
 
 [tool.semantic_release.changelog]
+# ``templates/`` is a copy of python-semantic-release 9.21.0's own Markdown
+# templates with one change: an entry is the commit's subject line, and the
+# body is left out.  Every commit on ``main`` is a squash merge whose body is
+# the whole pull request description, and the upstream template appends that
+# body to every entry.  ``templates`` is the default, written out so it is
+# visible; ``tests/core/test_changelog_template.py`` renders the directory
+# the way a release does.
+template_dir = "templates"
+
 # ``exclude_commit_patterns`` belongs to *this* table, not to
 # ``changelog.default_templates``.  python-semantic-release parses its config
 # with pydantic, which silently drops unknown keys, so while this list lived
@@ -274,7 +283,10 @@ lstrip_blocks = false
 newline_sequence = "\n"
 keep_trailing_newline = false
 extensions = []
-autoescape = true
+# The bundled template is rendered with escaping off regardless; a template
+# directory of our own is rendered with *this* environment, and with escaping
+# on the apostrophe in a subject reaches the Markdown as ``&#39;``.
+autoescape = false
 
 [tool.semantic_release.commit_author]
 env = "GIT_COMMIT_AUTHOR"

--- a/templates/.components/changelog_header.md.j2
+++ b/templates/.components/changelog_header.md.j2
@@ -1,0 +1,9 @@
+# CHANGELOG
+
+{%    if ctx.changelog_mode == "update"
+%}{#  # IMPORTANT: add insertion flag for next version update
+#}{{
+        insertion_flag ~ "\n"
+
+}}{%  endif
+%}

--- a/templates/.components/changelog_init.md.j2
+++ b/templates/.components/changelog_init.md.j2
@@ -1,0 +1,29 @@
+{#
+This changelog template initializes a full changelog for the project,
+it follows the following logic:
+  1. Header
+  2. Any Unreleased Details (uncommon)
+  3. all previous releases except the very first release
+  4. the first release
+
+#}{#
+   #    Header
+#}{%    include "changelog_header.md.j2"
+-%}{#
+   #    Any Unreleased Details (uncommon)
+#}{%    include "unreleased_changes.md.j2"
+-%}{#
+    #   Since this is initialization, we are generating all the previous
+    #   release notes per version. The very first release notes is specialized
+#}{%    if releases | length > 0
+%}{%      for release in releases
+%}{{        "\n"
+}}{%        if loop.last and ctx.mask_initial_release
+%}{%-         include "first_release.md.j2"
+-%}{%       else
+%}{%-         include "versioned_changes.md.j2"
+-%}{%       endif
+%}{{       "\n"
+}}{%      endfor
+%}{%    endif
+%}

--- a/templates/.components/changelog_update.md.j2
+++ b/templates/.components/changelog_update.md.j2
@@ -1,0 +1,71 @@
+{#
+This Update changelog template uses the following logic:
+
+  1. Read previous changelog file (ex. project_root/CHANGELOG.md)
+  2. Split on insertion flag (ex. <!-- version list -->)
+  3. Print top half of previous changelog
+  3. New Changes (unreleased commits & newly released)
+  4. Print bottom half of previous changelog
+
+  Note: if a previous file was not found, it does not write anything at the bottom
+        but render does NOT fail
+
+#}{%  set prev_changelog_contents = prev_changelog_file | read_file | safe
+%}{%  set changelog_parts = prev_changelog_contents.split(insertion_flag, maxsplit=1)
+%}{#
+#}{%  if changelog_parts | length < 2
+%}{#    # insertion flag was not found, check if the file was empty or did not exist
+#}{%    if prev_changelog_contents | length > 0
+%}{#      # File has content but no insertion flag, therefore, file will not be updated
+#}{{      changelog_parts[0]
+}}{%    else
+%}{#      # File was empty or did not exist, therefore, it will be created from scratch
+#}{%      include "changelog_init.md.j2"
+%}{%    endif
+%}{%  else
+%}{#
+   #    Previous Changelog Header
+   #      - Depending if there is header content, then it will separate the insertion flag
+   #        with a newline from header content, otherwise it will just print the insertion flag
+#}{%    set prev_changelog_top = changelog_parts[0] | trim
+%}{%    if prev_changelog_top | length > 0
+%}{{
+          "%s\n\n%s\n" | format(prev_changelog_top, insertion_flag | trim)
+
+}}{%    else
+%}{{
+          "%s\n" | format(insertion_flag | trim)
+
+}}{%    endif
+%}{#
+   #    Any Unreleased Details (uncommon)
+#}{%    include "unreleased_changes.md.j2"
+-%}{#
+#}{%    if releases | length > 0
+%}{#      # Latest Release Details
+#}{%      set release = releases[0]
+%}{#
+#}{%      if releases | length == 1 and ctx.mask_initial_release
+%}{#        # First Release detected
+#}{{        "\n"
+}}{%-       include "first_release.md.j2"
+-%}{{       "\n"
+}}{#
+#}{%      elif "# " ~ release.version.as_semver_tag() ~ " " not in changelog_parts[1]
+%}{#        # The release version is not already in the changelog so we add it
+#}{{        "\n"
+}}{%-       include "versioned_changes.md.j2"
+-%}{{       "\n"
+}}{#
+#}{%      endif
+%}{%    endif
+%}{#
+   #    Previous Changelog Footer
+   #      - skips printing footer if empty, which happens when the insertion_flag
+   #        was at the end of the file (ignoring whitespace)
+#}{%    set previous_changelog_bottom = changelog_parts[1] | trim
+%}{%    if previous_changelog_bottom | length > 0
+%}{{      "\n%s\n" | format(previous_changelog_bottom)
+}}{%    endif
+%}{%  endif
+%}

--- a/templates/.components/changes.md.j2
+++ b/templates/.components/changes.md.j2
@@ -1,0 +1,141 @@
+{%    from 'macros.md.j2' import apply_alphabetical_ordering_by_brk_descriptions
+%}{%  from 'macros.md.j2' import apply_alphabetical_ordering_by_descriptions
+%}{%  from 'macros.md.j2' import apply_alphabetical_ordering_by_release_notices
+%}{%  from 'macros.md.j2' import format_breaking_changes_description, format_commit_summary_line
+%}{%  from 'macros.md.j2' import format_release_notice
+%}{#
+EXAMPLE:
+
+### Features
+
+- Add new feature ([#10](https://domain.com/namespace/repo/pull/10),
+  [`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+- **scope**: Add new feature ([`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+### Bug Fixes
+
+- Fix bug ([#11](https://domain.com/namespace/repo/pull/11),
+  [`abcdef1`](https://domain.com/namespace/repo/commit/HASH))
+
+### Breaking Changes
+
+- With the change _____, the change causes ___ effect. Ultimately, this section
+  it is a more detailed description of the breaking change. With an optional
+  scope prefix like the commit messages above.
+
+- **scope**: this breaking change has a scope to identify the part of the code that
+  this breaking change applies to for better context.
+
+### Additional Release Information
+
+- This is a release note that provides additional information about the release
+  that is not a breaking change or a feature/bug fix.
+
+- **scope**: this release note has a scope to identify the part of the code that
+  this release note applies to for better context.
+
+#}{%  set max_line_width = max_line_width | default(100)
+%}{%  set hanging_indent = hanging_indent | default(2)
+%}{#
+#}{%  for type_, commits in commit_objects if type_ != "unknown"
+%}{#    PREPROCESS COMMITS (order by description & format description line)
+#}{%    set ns = namespace(commits=commits)
+%}{%    set _ = apply_alphabetical_ordering_by_descriptions(ns)
+%}{#
+#}{%    set commit_descriptions = []
+%}{#
+#}{%    for commit in ns.commits
+%}{#      # The subject line with its reference links, and nothing else.
+          #
+          # py-maidr's one change from the upstream template.  The default
+          # also appends ``commit.descriptions[1:]`` -- the commit body --
+          # "to make sure to not hide contents of squash commits".  Every
+          # commit on ``main`` is a squash merge whose body is the whole pull
+          # request description: the diagnosis, the design, the review
+          # history, and whatever the merge dialog added below it.  A release
+          # of a dozen entries ran to hundreds of lines, and the entry a
+          # reader wanted was hard to find.  The subject is the summary the
+          # PR title was written to be, and the PR link beside it leads to
+          # the rest.  A ``BREAKING CHANGE:`` paragraph is still printed in
+          # full, in its own section below.
+#}{%      set description = "- %s" | format(format_commit_summary_line(commit))
+%}{%      set description = description | autofit_text_width(max_line_width, hanging_indent)
+%}{%      set _ = commit_descriptions.append(description)
+%}{%    endfor
+%}{#
+   #    # PRINT SECTION (header & commits)
+#}{%    if commit_descriptions | length > 0
+%}{{      "\n"
+}}{{      "### %s\n" | format(type_ | title)
+}}{{      "\n"
+}}{{      "%s\n" | format(commit_descriptions | unique | join("\n\n"))
+}}{%    endif
+%}{%  endfor
+%}{#
+      # Determine if there are any breaking change commits by filtering the list by breaking descriptions
+      # commit_objects is a list of tuples [("Features", [ParsedCommit(), ...]), ("Bug Fixes", [ParsedCommit(), ...])]
+      # HOW: Filter out breaking change commits that have no breaking descriptions
+      #  1. Re-map the list to only the list of commits under the breaking category from the list of tuples
+      #  2. Peel off the outer list to get a list of ParsedCommit objects
+      #  3. Filter the list of ParsedCommits to only those with a breaking description
+#}{%  set breaking_commits = commit_objects | map(attribute="1.0")
+%}{%  set breaking_commits = breaking_commits | rejectattr("error", "defined") | selectattr("breaking_descriptions.0") | list
+%}{#
+#}{%  if breaking_commits | length > 0
+%}{#    PREPROCESS COMMITS
+#}{%    set brk_ns = namespace(commits=breaking_commits)
+%}{%    set _ = apply_alphabetical_ordering_by_brk_descriptions(brk_ns)
+%}{#
+#}{%    set brking_descriptions = []
+%}{#
+#}{%    for commit in brk_ns.commits
+%}{%      set full_description = "- %s" | format(
+            format_breaking_changes_description(commit).split("\n\n") | join("\n\n- ")
+          )
+%}{%      set _ = brking_descriptions.append(
+            full_description | autofit_text_width(max_line_width, hanging_indent)
+          )
+%}{%    endfor
+%}{#
+   #    # PRINT BREAKING CHANGE DESCRIPTIONS (header & descriptions)
+#}{{    "\n"
+}}{{    "### Breaking Changes\n"
+}}{{
+        "\n%s\n" | format(brking_descriptions | unique | join("\n\n"))
+}}{#
+#}{%  endif
+%}{#
+      # Determine if there are any commits with release notice information by filtering the list by release_notices
+      # commit_objects is a list of tuples [("Features", [ParsedCommit(), ...]), ("Bug Fixes", [ParsedCommit(), ...])]
+      # HOW: Filter out commits that have no release notices
+      #  1. Re-map the list to only the list of commits from the list of tuples
+      #  2. Peel off the outer list to get a list of ParsedCommit objects
+      #  3. Filter the list of ParsedCommits to only those with a release notice
+#}{%  set notice_commits = commit_objects | map(attribute="1.0")
+%}{%  set notice_commits = notice_commits | rejectattr("error", "defined") | selectattr("release_notices.0") | list
+%}{#
+#}{%  if notice_commits | length > 0
+%}{#    PREPROCESS COMMITS
+#}{%    set notice_ns = namespace(commits=notice_commits)
+%}{%    set _ = apply_alphabetical_ordering_by_release_notices(notice_ns)
+%}{#
+#}{%    set release_notices = []
+%}{#
+#}{%    for commit in notice_ns.commits
+%}{%      set full_description = "- %s" | format(
+            format_release_notice(commit).split("\n\n") | join("\n\n- ")
+          )
+%}{%      set _ = release_notices.append(
+            full_description | autofit_text_width(max_line_width, hanging_indent)
+          )
+%}{%    endfor
+%}{#
+   #    # PRINT RELEASE NOTICE INFORMATION (header & descriptions)
+#}{{    "\n"
+}}{{    "### Additional Release Information\n"
+}}{{
+        "\n%s\n" | format(release_notices | unique | join("\n\n"))
+}}{#
+#}{%  endif
+%}

--- a/templates/.components/first_release.md.j2
+++ b/templates/.components/first_release.md.j2
@@ -1,0 +1,18 @@
+{#  EXAMPLE:
+
+## vX.X.X (YYYY-MMM-DD)
+
+_This release is published under the MIT License._       # Release Notes Only
+
+- Initial Release
+
+#}{{
+"## %s (%s)\n" | format(
+    release.version.as_semver_tag(),
+    release.tagged_date.strftime("%Y-%m-%d")
+)
+}}{%  if license_name is defined and license_name
+%}{{    "\n_This release is published under the %s License._\n" | format(license_name)
+}}{%  endif
+%}
+- Initial Release

--- a/templates/.components/macros.md.j2
+++ b/templates/.components/macros.md.j2
@@ -1,0 +1,230 @@
+{#
+  MACRO: format a inline link reference in Markdown
+#}{%  macro format_link(link, label)
+%}{{    "[%s](%s)" | format(label, link)
+}}{%  endmacro
+%}
+
+
+{#
+  MACRO: commit message links or PR/MR links of commit
+#}{%  macro commit_msg_links(commit)
+%}{%    if commit.error is undefined
+%}{%      set commit_hash_link = format_link(
+            commit.hexsha | commit_hash_url,
+            "`%s`" | format(commit.short_hash)
+          )
+%}{#
+#}{%      set summary_line = commit.descriptions[0] | safe
+%}{%      set summary_line = [
+            summary_line.split(" ", maxsplit=1)[0] | capitalize,
+            summary_line.split(" ", maxsplit=1)[1]
+          ] | join(" ")
+%}{#
+#}{%      if commit.linked_merge_request != ""
+%}{#        # Add PR references with a link to the PR
+#}{%        set pr_num = commit.linked_merge_request
+%}{%        set pr_link = format_link(pr_num | pull_request_url, pr_num)
+%}{#
+   #        TODO: breaking change v10, remove summary line replacers as PSR will do it for us
+#}{%        set summary_line = summary_line | replace("(pull request", "(") | replace("(" ~ pr_num ~ ")", "") | trim
+%}{%        set summary_line = "%s (%s, %s)" | format(
+              summary_line,
+              pr_link,
+              commit_hash_link,
+            )
+%}{#
+          # DEFAULT: No PR identifier found, so just append commit hash as url to the commit summary_line
+#}{%      else
+%}{%        set summary_line = "%s (%s)" | format(summary_line, commit_hash_link)
+%}{%      endif
+%}{#
+          # Return the modified summary_line
+#}{{      summary_line
+}}{%    endif
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: format commit summary line
+#}{%  macro format_commit_summary_line(commit)
+%}{#    # Check for Parsing Error
+#}{%    if commit.error is undefined
+%}{#
+   #      # Add any message links to the commit summary line
+#}{%      set summary_line = commit_msg_links(commit)
+%}{#
+#}{%      if commit.scope
+%}{%        set summary_line = "**%s**: %s" | format(commit.scope, summary_line)
+%}{%      endif
+%}{#
+   #      # Return the modified summary_line
+#}{{      summary_line
+}}{#
+#}{%    else
+%}{#      # Return the first line of the commit if there was a Parsing Error
+#}{{      (commit.commit.message | string).split("\n", maxsplit=1)[0]
+}}{%    endif
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: format the breaking changes description by:
+  - Capitalizing the description
+  - Adding an optional scope prefix
+#}{%  macro format_breaking_changes_description(commit)
+%}{%    set ns = namespace(full_description="")
+%}{#
+#}{%    if commit.error is undefined
+%}{%      for paragraph in commit.breaking_descriptions
+%}{%        if paragraph | trim | length > 0
+%}{#
+#}{%          set paragraph_text = [
+                paragraph.split(" ", maxsplit=1)[0] | capitalize,
+                paragraph.split(" ", maxsplit=1)[1]
+              ] | join(" ") | trim | safe
+%}{#
+#}{%          set ns.full_description = [
+                ns.full_description,
+                paragraph_text
+              ] | join("\n\n")
+%}{#
+#}{%        endif
+%}{%      endfor
+%}{#
+#}{%      set ns.full_description = ns.full_description | trim
+%}{#
+#}{%      if commit.scope
+%}{%        set ns.full_description = "**%s**: %s" | format(
+              commit.scope, ns.full_description
+            )
+%}{%      endif
+%}{%    endif
+%}{#
+#}{{    ns.full_description
+}}{%  endmacro
+%}
+
+
+{#
+  MACRO: format the release notice by:
+  - Capitalizing the description
+  - Adding an optional scope prefix
+#}{%  macro format_release_notice(commit)
+%}{%    set ns = namespace(full_description="")
+%}{#
+#}{%    if commit.error is undefined
+%}{%      for paragraph in commit.release_notices
+%}{%        if paragraph | trim | length > 0
+%}{#
+#}{%          set paragraph_text = [
+                paragraph.split(" ", maxsplit=1)[0] | capitalize,
+                paragraph.split(" ", maxsplit=1)[1]
+              ] | join(" ") | trim | safe
+%}{#
+#}{%          set ns.full_description = [
+                ns.full_description,
+                paragraph_text
+              ] | join("\n\n")
+%}{#
+#}{%        endif
+%}{%      endfor
+%}{#
+#}{%      set ns.full_description = ns.full_description | trim
+%}{#
+#}{%      if commit.scope
+%}{%        set ns.full_description = "**%s**: %s" | format(
+              commit.scope, ns.full_description
+            )
+%}{%      endif
+%}{%    endif
+%}{#
+#}{{    ns.full_description
+}}{%  endmacro
+%}
+
+
+{#
+  MACRO: apply smart ordering of commits objects based on alphabetized summaries and then scopes
+  - Commits are sorted based on the commit type and the commit message
+  - Commits are grouped by the commit type
+  - parameter: ns (namespace) object with a commits list
+  - returns None but modifies the ns.commits list in place
+#}{%  macro apply_alphabetical_ordering_by_descriptions(ns)
+%}{%    set ordered_commits = []
+%}{#
+   #    # Eliminate any ParseError commits from input set
+#}{%    set filtered_commits = ns.commits | rejectattr("error", "defined") | list
+%}{#
+   #    # grab all commits with no scope and sort alphabetically by the first line of the commit message
+#}{%    for commit in filtered_commits | rejectattr("scope") | sort(attribute='descriptions.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%     endfor
+%}{#
+   #    # grab all commits with a scope and sort alphabetically by the scope and then the first line of the commit message
+#}{%    for commit in filtered_commits | selectattr("scope") | sort(attribute='scope,descriptions.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%    endfor
+%}{#
+   #    # Return the ordered commits
+#}{%    set ns.commits = ordered_commits
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: apply smart ordering of commits objects based on alphabetized breaking changes and then scopes
+  - Commits are sorted based on the commit type and the commit message
+  - Commits are grouped by the commit type
+  - parameter: ns (namespace) object with a commits list
+  - returns None but modifies the ns.commits list in place
+#}{%  macro apply_alphabetical_ordering_by_brk_descriptions(ns)
+%}{%    set ordered_commits = []
+%}{#
+   #    # Eliminate any ParseError commits from input set
+#}{%    set filtered_commits = ns.commits | rejectattr("error", "defined") | list
+%}{#
+   #    # grab all commits with no scope and sort alphabetically by the first line of the commit message
+#}{%    for commit in filtered_commits | rejectattr("scope") | sort(attribute='breaking_descriptions.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%     endfor
+%}{#
+   #    # grab all commits with a scope and sort alphabetically by the scope and then the first line of the commit message
+#}{%    for commit in filtered_commits | selectattr("scope") | sort(attribute='scope,breaking_descriptions.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%    endfor
+%}{#
+   #    # Return the ordered commits
+#}{%    set ns.commits = ordered_commits
+%}{%  endmacro
+%}
+
+
+{#
+  MACRO: apply smart ordering of commits objects based on alphabetized release notices and then scopes
+  - Commits are sorted based on the commit type and the commit message
+  - Commits are grouped by the commit type
+  - parameter: ns (namespace) object with a commits list
+  - returns None but modifies the ns.commits list in place
+#}{%  macro apply_alphabetical_ordering_by_release_notices(ns)
+%}{%    set ordered_commits = []
+%}{#
+   #    # Eliminate any ParseError commits from input set
+#}{%    set filtered_commits = ns.commits | rejectattr("error", "defined") | list
+%}{#
+   #    # grab all commits with no scope and sort alphabetically by the first line of the commit message
+#}{%    for commit in filtered_commits | rejectattr("scope") | sort(attribute='release_notices.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%     endfor
+%}{#
+   #    # grab all commits with a scope and sort alphabetically by the scope and then the first line of the commit message
+#}{%    for commit in filtered_commits | selectattr("scope") | sort(attribute='scope,release_notices.0')
+%}{{      ordered_commits.append(commit) | default("", true)
+}}{%    endfor
+%}{#
+   #    # Return the ordered commits
+#}{%    set ns.commits = ordered_commits
+%}{%  endmacro
+%}

--- a/templates/.components/unreleased_changes.md.j2
+++ b/templates/.components/unreleased_changes.md.j2
@@ -1,0 +1,7 @@
+{%    if unreleased_commits | length > 0
+%}{{    "\n## Unreleased\n"
+}}{%    set commit_objects = unreleased_commits
+%}{%    include "changes.md.j2"
+-%}{{   "\n"
+}}{%  endif
+%}

--- a/templates/.components/versioned_changes.md.j2
+++ b/templates/.components/versioned_changes.md.j2
@@ -1,0 +1,20 @@
+{#  EXAMPLE:
+
+## vX.X.X (YYYY-MMM-DD)
+
+_This release is published under the MIT License._            # Release Notes Only
+
+{{ change_sections }}
+
+#}{{
+"## %s (%s)\n" | format(
+  release.version.as_semver_tag(),
+  release.tagged_date.strftime("%Y-%m-%d")
+)
+}}{%  if license_name is defined and license_name
+%}{{    "\n_This release is published under the %s License._\n" | format(license_name)
+}}{%  endif
+%}{#
+#}{%  set commit_objects = release["elements"] | dictsort
+%}{%  include "changes.md.j2"
+-%}

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -1,0 +1,62 @@
+{#  EXAMPLE:
+
+## v1.0.0 (2020-01-01)
+
+_This release is published under the MIT License._
+
+### Features
+
+- Add new feature ([#10](https://domain.com/namespace/repo/pull/10), [`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+- **scope**: Add new feature ([`abcdef0`](https://domain.com/namespace/repo/commit/HASH))
+
+### Bug Fixes
+
+- Fix bug (#11, [`abcdef1`](https://domain.com/namespace/repo/commit/HASH))
+
+### Breaking Changes
+
+- With the change _____, the change causes ___ effect. Ultimately, this section it is a more detailed description of the breaking change. With an optional scope prefix like the commit messages above.
+
+- **scope**: this breaking change has a scope to identify the part of the code that this breaking change applies to for better context.
+
+### Additional Release Information
+
+- This is a release note that provides additional information about the release that is not a breaking change or a feature/bug fix.
+
+- **scope**: this release note has a scope to identify the part of the code that this release note applies to for better context.
+
+---
+
+**Detailed Changes**: [vX.X.X...vX.X.X](https://domain.com/namespace/repo/compare/vX.X.X...vX.X.X)
+
+#}{#  # Set line width to 1000 to avoid wrapping as GitHub will handle it
+#}{%  set max_line_width = max_line_width | default(1000)
+%}{%  set hanging_indent = hanging_indent | default(2)
+%}{%  set license_name = license_name | default("", True)
+%}{%  set releases = context.history.released.values() | list
+%}{%  set curr_release_index = releases.index(release)
+%}{#
+#}{%  if mask_initial_release and curr_release_index == releases | length - 1
+%}{#    # On a first release, generate our special message
+#}{%    include ".components/first_release.md.j2"
+%}{%  else
+%}{#    # Not the first release so generate notes normally
+#}{%    include ".components/versioned_changes.md.j2"
+-%}{#
+#}{%    set prev_release_index = curr_release_index + 1
+%}{#
+#}{%    if 'compare_url' is filter and prev_release_index < releases | length
+%}{%      set prev_version_tag = releases[prev_release_index].version.as_tag()
+%}{%      set new_version_tag = release.version.as_tag()
+%}{%      set version_compare_url = prev_version_tag | compare_url(new_version_tag)
+%}{%      set detailed_changes_link = '[{}...{}]({})'.format(
+            prev_version_tag, new_version_tag, version_compare_url
+          )
+%}{{      "\n"
+}}{{      "---\n"
+}}{{      "\n"
+}}{{      "**Detailed Changes**: %s" | format(detailed_changes_link)
+}}{%    endif
+%}{%  endif
+%}

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -1,0 +1,31 @@
+{#
+    py-maidr: this directory is python-semantic-release 9.21.0's
+    ``data/templates/angular/md`` (the set the ``conventional`` parser
+    renders with), copied whole because a template directory replaces the
+    bundled one outright -- an ``include`` cannot reach back into the
+    package.  The one deliberate difference from upstream is in
+    ``.components/changes.md.j2``, where the commit body is no longer
+    appended to each entry; a comment there says why.  Everything else is
+    verbatim, so that upgrading python-semantic-release is a matter of
+    re-copying and re-applying that one change.
+
+    This changelog template controls which changelog creation occurs
+    based on which mode is provided.
+
+    Modes:
+        - init: Initialize a full changelog from scratch
+        - update: Insert new version details where the placeholder exists in the current changelog
+
+#}{%  set insertion_flag = ctx.changelog_insertion_flag
+%}{%  set unreleased_commits = ctx.history.unreleased | dictsort
+%}{%  set releases = ctx.history.released.values() | list
+%}{#
+#}{%  if ctx.changelog_mode == "init"
+%}{%    include ".components/changelog_init.md.j2"
+%}{#
+#}{%  elif ctx.changelog_mode == "update"
+%}{%    set prev_changelog_file = ctx.prev_changelog_file
+%}{%    include ".components/changelog_update.md.j2"
+%}{#
+#}{%  endif
+%}

--- a/tests/core/test_changelog_template.py
+++ b/tests/core/test_changelog_template.py
@@ -17,6 +17,7 @@ package's own loader, context and filters, against a synthetic squash commit.
 
 from __future__ import annotations
 
+import re
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -40,6 +41,7 @@ pytest.importorskip(
     reason="rendering the templates needs python-semantic-release",
 )
 
+import semantic_release  # noqa: E402
 from git import Actor  # noqa: E402
 from semantic_release.changelog.context import (  # noqa: E402
     ChangelogMode,
@@ -50,7 +52,10 @@ from semantic_release.changelog.template import (  # noqa: E402
     environment,
     recursive_render,
 )
-from semantic_release.cli.changelog_writer import generate_release_notes  # noqa: E402
+from semantic_release.cli.changelog_writer import (  # noqa: E402
+    generate_release_notes,
+    get_default_tpl_dir,
+)
 from semantic_release.commit_parser.conventional import (  # noqa: E402
     ConventionalCommitParser,
     ConventionalCommitParserOptions,
@@ -60,6 +65,12 @@ from semantic_release.version.version import Version  # noqa: E402
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 TEMPLATE_DIR = PROJECT_ROOT / "templates"
+
+#: The two files that differ from upstream on purpose: the entry point
+#: carries a note saying where the copy came from, and ``changes.md.j2``
+#: carries the change.  Everything else must be the bundled file, byte for
+#: byte.
+CHANGED_FROM_UPSTREAM = {"CHANGELOG.md.j2", ".components/changes.md.j2"}
 
 #: A squash-merge commit as GitHub writes one: the pull request title as the
 #: subject, the pull request description as the body.
@@ -186,6 +197,59 @@ def test_psr_finds_the_templates() -> None:
     assert release_config()["changelog"]["template_dir"] == "templates"
     assert (TEMPLATE_DIR / "CHANGELOG.md.j2").is_file()
     assert (TEMPLATE_DIR / ".release_notes.md.j2").is_file()
+
+
+def test_the_copy_is_of_the_release_tooling_in_use() -> None:
+    """A python-semantic-release bump must not leave a stale copy behind.
+
+    Three places name the version: the ``dev`` dependency pin (what these
+    tests render with), the action tag in ``release.yml`` (what a release
+    renders with), and the note at the top of ``CHANGELOG.md.j2`` (what the
+    copy was taken from).  Bumping one without the others would render a
+    release with templates written for a different version, and nothing
+    else would say so.
+    """
+    installed = semantic_release.__version__
+
+    header = (TEMPLATE_DIR / "CHANGELOG.md.j2").read_text()
+    copied_from = re.search(r"python-semantic-release (\d+\.\d+\.\d+)", header)
+    assert copied_from is not None, "CHANGELOG.md.j2 must name its upstream version"
+    assert copied_from.group(1) == installed
+
+    workflow = (PROJECT_ROOT / ".github" / "workflows" / "release.yml").read_text()
+    action = re.search(
+        r"python-semantic-release/python-semantic-release@v(\d+\.\d+\.\d+)",
+        workflow,
+    )
+    assert action is not None, "release.yml must pin the release action"
+    assert action.group(1) == installed
+
+
+def test_everything_else_is_verbatim_upstream() -> None:
+    """Only the two files meant to differ may differ from the bundled set.
+
+    This is what makes the copy safe to keep: when a version bump changes a
+    bundled template, this fails on the file that changed, and the copy is
+    refreshed rather than quietly rendering an old layout.  It also catches
+    a drive-by edit to the one of the eight untouched files.
+    """
+    upstream = get_default_tpl_dir(style="angular", sub_dir="md")
+    upstream_files = {
+        str(path.relative_to(upstream))
+        for path in upstream.rglob("*")
+        if path.is_file()
+    }
+    copied_files = {
+        str(path.relative_to(TEMPLATE_DIR))
+        for path in TEMPLATE_DIR.rglob("*")
+        if path.is_file()
+    }
+    assert copied_files == upstream_files
+
+    for name in sorted(upstream_files - CHANGED_FROM_UPSTREAM):
+        assert (TEMPLATE_DIR / name).read_bytes() == (
+            upstream / name
+        ).read_bytes(), f"templates/{name} differs from the bundled file"
 
 
 def test_only_the_subject_reaches_the_changelog(tmp_path: Path) -> None:

--- a/tests/core/test_changelog_template.py
+++ b/tests/core/test_changelog_template.py
@@ -1,0 +1,259 @@
+"""Tests for the changelog templates in ``templates/``.
+
+python-semantic-release renders ``CHANGELOG.md`` and the GitHub release
+notes from ``templates/``, a copy of its own default templates with one
+change: an entry is the commit's subject line, not the subject followed by
+the whole body.  Every commit on ``main`` is a squash merge whose body is the
+pull request description, so with the upstream template a release of a dozen
+entries ran to hundreds of lines.
+
+Like ``test_changelog_filter.py``, this exists because nothing reads the
+release configuration back before a release: a template that quietly reverts
+to the upstream behaviour, or that python-semantic-release quietly stops
+picking up, is discovered in the published changelog.  The templates are
+rendered here the way ``semantic-release changelog`` renders them, with the
+package's own loader, context and filters, against a synthetic squash commit.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+try:  # Python 3.11 and later
+    import tomllib
+except ModuleNotFoundError:  # Python 3.9 and 3.10
+    tomllib = pytest.importorskip(
+        "tomli",
+        reason="reading pyproject.toml needs tomllib (3.11+) or tomli",
+    )
+
+# The release tooling is in the ``dev`` dependency group, which every
+# workflow that runs the suite installs.  Guarded all the same, for the
+# reason ``test_changelog_filter.py`` guards ``tomli``.
+pytest.importorskip(
+    "semantic_release",
+    reason="rendering the templates needs python-semantic-release",
+)
+
+from git import Actor  # noqa: E402
+from semantic_release.changelog.context import (  # noqa: E402
+    ChangelogMode,
+    make_changelog_context,
+)
+from semantic_release.changelog.release_history import ReleaseHistory  # noqa: E402
+from semantic_release.changelog.template import (  # noqa: E402
+    environment,
+    recursive_render,
+)
+from semantic_release.cli.changelog_writer import generate_release_notes  # noqa: E402
+from semantic_release.commit_parser.conventional import (  # noqa: E402
+    ConventionalCommitParser,
+    ConventionalCommitParserOptions,
+)
+from semantic_release.hvcs.github import Github  # noqa: E402
+from semantic_release.version.version import Version  # noqa: E402
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATE_DIR = PROJECT_ROOT / "templates"
+
+#: A squash-merge commit as GitHub writes one: the pull request title as the
+#: subject, the pull request description as the body.
+SUBJECT = "fix(seaborn): read a box chart's grouping from the legend that names it"
+BODY = [
+    "Three readers still asked `ax.get_legend()` directly after #672 moved "
+    "everything else onto `legend_of`.",
+    "The label and the levels now come from the same legend.",
+    "Closes #674.",
+    "Co-authored-by: Someone <someone@example.com>",
+]
+BREAKING = "`render()` no longer accepts a list of figures."
+
+
+def squash_commit(subject: str, *paragraphs: str, pr: int = 676) -> Mock:
+    """Build the commit object the parser and templates read.
+
+    Parameters
+    ----------
+    subject : str
+        The subject line, without the ``(#N)`` GitHub appends.
+    *paragraphs : str
+        Body paragraphs, joined by blank lines as git does.
+    pr : int
+        The pull request number appended to the subject.
+
+    Returns
+    -------
+    Mock
+        Standing in for ``git.Commit``: the parser reads ``message``,
+        ``hexsha`` and ``parents`` and nothing else.
+    """
+    message = "\n\n".join((f"{subject} (#{pr})", *paragraphs))
+    return Mock(message=message, hexsha="50b2197" + "0" * 33, parents=())
+
+
+def release_config() -> dict:
+    """Read ``[tool.semantic_release]`` rather than restating it."""
+    config = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text())
+    return config["tool"]["semantic_release"]
+
+
+def render(tmp_path: Path, *commits: Mock) -> tuple[str, str, list[str]]:
+    """Render the templates as ``semantic-release changelog`` would.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Stands in for the project root the rendered files land in.
+    *commits : Mock
+        The commits of the one release being rendered.
+
+    Returns
+    -------
+    tuple of (str, str, list of str)
+        The rendered ``CHANGELOG.md``, the rendered GitHub release notes,
+        and every path ``recursive_render`` wrote under ``tmp_path``.
+    """
+    config = release_config()
+    options = config["commit_parser_options"]
+    parser = ConventionalCommitParser(
+        ConventionalCommitParserOptions(
+            allowed_tags=tuple(options["allowed_tags"]),
+            minor_tags=tuple(options["minor_tags"]),
+            patch_tags=tuple(options["patch_tags"]),
+        )
+    )
+
+    elements: dict = defaultdict(list)
+    for commit in commits:
+        for result in parser.parse(commit):
+            elements[result.type].append(result)
+
+    someone = Actor("semantic-release", "semantic-release")
+    version = Version.parse("1.24.0", tag_format=config["tag_format"])
+    release = {
+        "tagger": someone,
+        "committer": someone,
+        "tagged_date": datetime(2026, 9, 5, tzinfo=timezone.utc),
+        "elements": elements,
+        "version": version,
+    }
+    history = ReleaseHistory(unreleased={}, released={version: release})
+    hvcs = Github(remote_url="https://github.com/xability/py-maidr.git")
+
+    context = make_changelog_context(
+        hvcs_client=hvcs,
+        release_history=history,
+        mode=ChangelogMode(config["changelog"].get("mode", "init")),
+        prev_changelog_file=tmp_path / "CHANGELOG.md",
+        insertion_flag=config["changelog"].get("insertion_flag", ""),
+        mask_initial_release=False,
+    )
+    # The environment python-semantic-release builds for a user template
+    # directory comes from ``[tool.semantic_release.changelog.environment]``,
+    # so the settings there -- ``autoescape`` above all -- are under test too.
+    env_options = {
+        key: value
+        for key, value in config["changelog"]["environment"].items()
+        if key != "extensions"
+    }
+    env = context.bind_to_environment(
+        environment(template_dir=TEMPLATE_DIR, **env_options)
+    )
+    written = recursive_render(TEMPLATE_DIR, environment=env, _root_dir=tmp_path)
+
+    notes = generate_release_notes(
+        hvcs,
+        release=release,
+        template_dir=TEMPLATE_DIR,
+        history=history,
+        style="angular",
+        mask_initial_release=False,
+    )
+    return (tmp_path / "CHANGELOG.md").read_text(), notes, written
+
+
+def test_psr_finds_the_templates() -> None:
+    """The directory must be the one python-semantic-release looks in.
+
+    With no ``.j2`` file there it silently renders its bundled default
+    instead, which is the template this directory exists to replace.
+    """
+    assert release_config()["changelog"]["template_dir"] == "templates"
+    assert (TEMPLATE_DIR / "CHANGELOG.md.j2").is_file()
+    assert (TEMPLATE_DIR / ".release_notes.md.j2").is_file()
+
+
+def test_only_the_subject_reaches_the_changelog(tmp_path: Path) -> None:
+    """The regression the file exists for: no commit body in an entry."""
+    changelog, notes, _ = render(tmp_path, squash_commit(SUBJECT, *BODY))
+
+    for rendered in (changelog, notes):
+        assert "## v1.24.0 (2026-09-05)" in rendered
+        assert "### Bug Fixes" in rendered
+        # Capitalised, scope split out, PR number turned into a link, as the
+        # upstream template does; the point is that this is the whole entry.
+        assert (
+            "**seaborn**: Read a box chart's grouping from the legend that names it"
+            " ([#676](https://github.com/xability/py-maidr/pull/676),"
+            " [`50b2197`](https://github.com/xability/py-maidr/commit/"
+        ) in rendered.replace("\n  ", " ")
+        for paragraph in BODY:
+            assert paragraph[:40] not in rendered
+
+
+def test_a_breaking_change_is_still_explained(tmp_path: Path) -> None:
+    """Dropping the body must not drop the ``BREAKING CHANGE:`` paragraph.
+
+    That paragraph is the one entry a reader of a major release needs; it
+    has its own section, and the section is what must survive.
+    """
+    changelog, notes, _ = render(
+        tmp_path,
+        squash_commit(
+            "feat(api)!: render one figure at a time",
+            *BODY,
+            f"BREAKING CHANGE: {BREAKING}",
+        ),
+    )
+
+    for rendered in (changelog, notes):
+        assert "### Breaking Changes" in rendered
+        assert f"**api**: {BREAKING}" in rendered
+        for paragraph in BODY:
+            assert paragraph[:40] not in rendered
+
+
+def test_a_subject_is_not_html_escaped(tmp_path: Path) -> None:
+    """``autoescape`` must be off for the user template environment.
+
+    python-semantic-release renders its bundled template with a fixed
+    environment, but a user template directory gets the one configured in
+    ``pyproject.toml``.  With Jinja's HTML escaping on there, the apostrophe
+    in "chart's" reaches the Markdown as ``&#39;``.
+    """
+    changelog, _, _ = render(tmp_path, squash_commit(SUBJECT))
+
+    assert "chart's" in changelog
+    assert "&#39;" not in changelog
+    assert "&quot;" not in changelog
+
+
+def test_only_the_changelog_is_written(tmp_path: Path) -> None:
+    """Rendering the directory must produce ``CHANGELOG.md`` and nothing else.
+
+    ``recursive_render`` walks the whole directory: a ``.j2`` file becomes a
+    file of the same name at the project root, and any *other* file is
+    copied there as it is.  A ``README.md`` explaining the templates would
+    overwrite the project's README at the next release.  Explanations go in
+    Jinja comments inside the templates, or under a dot-prefixed name, which
+    the walk skips.
+    """
+    _, _, written = render(tmp_path, squash_commit(SUBJECT))
+
+    assert written == [str(tmp_path / "CHANGELOG.md")]
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["CHANGELOG.md"]


### PR DESCRIPTION
## Description

`CHANGELOG.md` here is 6,900 lines where the JS binding's, on the same conventional commits and squash merges, is one line per entry. The difference is not the release process but the renderer: python-semantic-release's default Markdown template appends the commit body to every entry ("to make sure to not hide contents of squash commits"), while `conventional-changelog` in xability/maidr only prints the subject. Every commit on `main` is a squash merge whose body is the whole pull request description, so v1.23.0's twelve entries ran to some six hundred lines, complete with "Closes #N", `Co-authored-by` trailers and Claude Code session links.

This PR gives python-semantic-release its own template directory with that one block removed.

## Related Issues

None filed; raised in conversation.

## Changes Made

- **`templates/`**: a verbatim copy of python-semantic-release 9.21.0's `data/templates/angular/md` (the set the `conventional` parser renders with), because a template directory replaces the bundled one outright and an `include` cannot reach back into the package. The one deliberate difference is in `.components/changes.md.j2`, where `commit.descriptions[1:]` is no longer appended to each entry. The top of `CHANGELOG.md.j2` records the upstream version and where the difference lives, so upgrading PSR is re-copy plus re-apply. A `BREAKING CHANGE:` paragraph is still printed in full in its own section.
- **`pyproject.toml`**: `template_dir = "templates"` written out (it is the default) with a comment, and `autoescape = false`. A template directory is rendered with the configured environment, whereas the bundled one is rendered with escaping off regardless; with escaping on, the apostrophe in "chart's" came out as `&#39;`.
- **`tests/core/test_changelog_template.py`**: renders `templates/` the way `semantic-release changelog` does (PSR's own loader, context and GitHub filters) against a synthetic squash commit and holds the body out, the breaking-change paragraph in, the apostrophe unescaped, and the render to exactly one output file. That last one matters: `recursive_render` copies any non-`.j2` file in the directory to the project root, so a `README.md` explaining the templates would have overwritten the project's README at the next release.
- **`CONTRIBUTING.md`**: says the PR title is the whole of the PR that reaches the changelog.

**Verified** by rendering the full history with PSR 9.21.0's own code, first with the bundled template (reproduces the committed `CHANGELOG.md` byte for byte, plus an Unreleased section) and then with `templates/`:

| | lines | bytes |
|---|---|---|
| bundled template | 6,965 | 374,112 |
| `templates/` | 2,321 | 103,586 |

v1.23.0 after:

```
## v1.23.0 (2026-08-31)

### Bug Fixes

- **seaborn**: Read a box or boxen chart's grouping from the legend that names it
  ([#676](https://github.com/xability/py-maidr/pull/676),
  [`50b2197`](https://github.com/xability/py-maidr/commit/50b2197539de5c8bc14443e4246fa855cc1cf953))

- **seaborn-objects**: Name a colour split from the legend wherever it was put
  ([#673](https://github.com/xability/py-maidr/pull/673),
  [`c5c76f5`](https://github.com/xability/py-maidr/commit/c5c76f50ca3d27bd6953b1d24ca90828f1ce26f7))
```

The committed `CHANGELOG.md` is not touched here: the changelog runs in `init` mode with no insertion flag, so the next release regenerates the whole file and the history shrinks then, without a 4,600-line diff in this PR.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [ ] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass. (No manual browser test applies; `pytest tests/core/test_changelog_template.py tests/core/test_changelog_filter.py` passes, `ruff check --diff` is clean.)
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes

Both the changelog and the GitHub release notes share the same component, so release notes become subject-only too, matching xability/maidr's releases. Entries still wrap at 100 columns with a hanging indent, as upstream does; a one-line-per-entry layout like the JS changelog would be a further, separate change to the same template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mpt9bvWpGHew54YNysGT1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpt9bvWpGHew54YNysGT1o)_