### PR TITLE
fix(ci): stop the page-size report failing the docs build with SIGPIPE

### DIFF
--- a/docs/_scripts/check-page-sizes.sh
+++ b/docs/_scripts/check-page-sizes.sh
@@ -15,7 +15,11 @@ site="${1:?usage: check-page-sizes.sh <site-directory>}"
 limit=1900000
 
 echo "Five largest HTML files under ${site}:"
-find "${site}" -type f -name '*.html' -printf '%s %p\n' | sort -nr | head -n 5
+# awk rather than `head`: `head` closes the pipe once it has its five lines,
+# and `sort` then dies of SIGPIPE. Under the `pipefail` set above that is the
+# script's exit status, so the docs build fails intermittently on a report it
+# only prints for information. awk reads to the end, so `sort` always finishes.
+find "${site}" -type f -name '*.html' -printf '%s %p\n' | sort -nr | awk 'NR <= 5'
 
 too_big="$(find "${site}" -type f -name '*.html' -size +"${limit}"c -printf '%s %p\n' | sort -nr)"
 if [ -n "${too_big}" ]; then


### PR DESCRIPTION
## Description

Follow-up to #768, fixing a latent intermittent failure introduced with `docs/_scripts/check-page-sizes.sh` in that PR.

The script prints the five largest rendered pages for information:

```bash
find "${site}" -type f -name '*.html' -printf '%s %p\n' | sort -nr | head -n 5
```

`head` closes the pipe as soon as it has its five lines. `sort` is still writing at that point, so it dies of SIGPIPE and exits 141. The script sets `set -euo pipefail`, which makes that the script's exit status, so the docs build fails on a report that has no bearing on whether any page is actually too large.

The race is real rather than theoretical. Reproduced at exit 141 in **1 of 20 runs** over a 400-file tree. It surfaced because the sibling change in xability/r-maidr#299 printed `sort: write failed: 'standard output': Broken pipe` into a passing build log; that workflow step runs under the default `bash -e` without `pipefail`, so there the pipeline takes `head`'s status and the error is only noise. This script opts into `pipefail`, so the same race is a build failure.

Both jobs in `.github/workflows/docs.yml` call this script, the pull request render and the publish build, so a bad roll on the publish path blocks a site rebuild after a release.

## Changes Made

`awk 'NR <= 5'` in place of `head -n 5`. `awk` reads its input to the end, so `sort` always finishes writing and never sees a closed pipe. The printed output is identical.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Verification

- Reproduced the original failure: exit 141 in 1 of 20 runs of the old pipeline with `pipefail` on.
- Ran the fixed script 30 times over the same tree: no SIGPIPE, no stderr, exit 0 every time.
- Confirmed the guard still does its job: exits 1 and reports the file on a 1,900,001-byte page.
- `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqUywJzoCqyMGLFp8De1mn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqUywJzoCqyMGLFp8De1mn)_